### PR TITLE
Changes from background agent bc-0576b958-3bf0-48b9-9af4-23f9d614b0af

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.21
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install Dependencies
         run: pnpm install
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.21
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install dependencies
         run: pnpm install
 

--- a/examples/with-bun/package.json
+++ b/examples/with-bun/package.json
@@ -4,7 +4,8 @@
 	"type": "module",
 	"scripts": {
 		"start": "bun run index.ts",
-		"dev": "bun --watch run index.ts"
+		"dev": "bun --watch run index.ts",
+		"build": "bun build index.ts --outdir ./dist"
 	},
 	"dependencies": {
 		"arkenv": "^0.1.3",


### PR DESCRIPTION
Add Bun installation to CI and a build script to the `with-bun` example to fix CI build failures.

The CI build was failing for the `with-bun` example because the `bun` runtime was not available in the GitHub Actions environment, and the `examples/with-bun/package.json` was missing a `build` script that Turborepo expected to execute. This PR resolves both issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-0576b958-3bf0-48b9-9af4-23f9d614b0af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0576b958-3bf0-48b9-9af4-23f9d614b0af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

