### PR TITLE
Expose type function

### DIFF
--- a/.changeset/large-taxis-check.md
+++ b/.changeset/large-taxis-check.md
@@ -1,0 +1,25 @@
+---
+"arkenv": minor
+---
+
+#### Expose `type` function
+
+ArkEnv now exposes a `type` function with built-in ArkEnv scope, providing access to environment-specific types like `string.host` and `number.port`.
+
+```ts
+import { type } from "arkenv";
+
+const env = type({
+  NODE_ENV: "string",
+  HOST: "string.host",
+  PORT: "number.port",
+});
+
+const result = env.assert({
+  NODE_ENV: "development",
+  HOST: "localhost", 
+  PORT: "3000",
+});
+```
+
+This extends ArkType's `type` function with ArkEnv-specific validations for common environment variable patterns.

--- a/apps/www/content/docs/guides/type-function.mdx
+++ b/apps/www/content/docs/guides/type-function.mdx
@@ -1,0 +1,275 @@
+---
+title: "Type Function"
+description: "Learn about ArkEnv's advanced type function for runtime validation with built-in environment-specific types."
+---
+
+# Type Function
+
+> [!NOTE]
+> **For most use cases, you should use the default `arkenv` export (which uses `createEnv` under the hood).** The `type` function is useful when you want to separate schema definition from validation.
+
+> [!TIP]
+> **New to ArkEnv?** Start with the [Quickstart guide](/docs/quickstart) to learn the basics with the default `arkenv` export. This guide is for when you need to separate schema definition from validation.
+
+ArkEnv exposes a `type` function that extends ArkType's type system with environment-specific validations. This function is useful when you want to define your schema in one place and validate environment variables at a different time or location.
+
+## Basic Usage
+
+```ts
+import { type } from "arkenv";
+
+const env = type({
+  NODE_ENV: "string",
+  HOST: "string.host",
+  PORT: "number.port",
+});
+
+// Validate and transform environment variables
+const result = env.assert({
+  NODE_ENV: "development",
+  HOST: "localhost",
+  PORT: "3000", // String input, number output
+});
+
+console.log(result);
+// { NODE_ENV: "development", HOST: "localhost", PORT: 3000 }
+```
+
+## Separation of Schema Definition and Validation
+
+The main benefit of the `type` function is that you can define your schema in one place and validate environment variables elsewhere:
+
+```ts
+// config/env-schema.ts
+import { type } from "arkenv";
+
+export const envSchema = type({
+  NODE_ENV: "string",
+  HOST: "string.host",
+  PORT: "number.port",
+  API_KEY: "string?",
+});
+```
+
+```ts
+// config/env.ts
+import { envSchema } from "./env-schema";
+
+// Validate environment variables using the schema
+export const env = envSchema.assert(process.env);
+```
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import arkenv from "@arkenv/vite-plugin";
+import { envSchema } from "./config/env-schema";
+
+export default defineConfig({
+  plugins: [arkenv(envSchema)],
+});
+```
+
+This approach allows you to:
+- **Reuse the same schema** across different parts of your application
+- **Define schema once** and validate in multiple places
+- **Keep configuration modular** and organized
+
+## Built-in Environment Types
+
+### `string.host`
+
+Validates hostnames and IP addresses:
+
+```ts
+const env = type({
+  API_HOST: "string.host",
+  DB_HOST: "string.host",
+});
+
+// Valid inputs
+env.assert({ API_HOST: "localhost" });
+env.assert({ API_HOST: "127.0.0.1" });
+env.assert({ API_HOST: "api.example.com" });
+
+// Invalid inputs
+env.assert({ API_HOST: "invalid-host" }); // ❌ Throws error
+```
+
+### `number.port`
+
+Validates and converts port numbers:
+
+```ts
+const env = type({
+  PORT: "number.port",
+  API_PORT: "number.port",
+});
+
+// Valid inputs (strings from environment variables)
+const result = env.assert({ PORT: "3000" });
+console.log(result.PORT); // 3000 (number)
+
+// Valid port range: 1-65535
+env.assert({ PORT: "8080" }); // ✅ Valid
+env.assert({ PORT: "65535" }); // ✅ Valid
+
+// Invalid inputs
+env.assert({ PORT: "0" }); // ❌ Too low
+env.assert({ PORT: "65536" }); // ❌ Too high
+env.assert({ PORT: "invalid" }); // ❌ Not a number
+```
+
+## Advanced Usage
+
+### Optional Fields
+
+```ts
+const env = type({
+  REQUIRED: "string",
+  OPTIONAL: "string?",
+  PORT: "number.port?",
+});
+
+// Works with all fields
+env.assert({
+  REQUIRED: "value",
+  OPTIONAL: "optional",
+  PORT: "3000",
+});
+
+// Works with only required fields
+env.assert({
+  REQUIRED: "value",
+  // OPTIONAL and PORT are omitted
+});
+```
+
+### Nested Objects
+
+```ts
+const env = type({
+  DATABASE: {
+    HOST: "string.host",
+    PORT: "number.port",
+    NAME: "string",
+  },
+  API: {
+    HOST: "string.host",
+    PORT: "number.port",
+  },
+});
+
+const result = env.assert({
+  DATABASE: {
+    HOST: "localhost",
+    PORT: "5432",
+    NAME: "myapp",
+  },
+  API: {
+    HOST: "api.example.com",
+    PORT: "443",
+  },
+});
+```
+
+### Arrays
+
+```ts
+const env = type({
+  ALLOWED_ORIGINS: "string[]",
+  PORTS: "number[]",
+});
+
+const result = env.assert({
+  ALLOWED_ORIGINS: ["localhost", "127.0.0.1"],
+  PORTS: [3000, 8080, 9000],
+});
+```
+
+## Error Handling
+
+The `type` function provides detailed error messages for validation failures:
+
+```ts
+const env = type({
+  HOST: "string.host",
+  PORT: "number.port",
+});
+
+try {
+  env.assert({
+    HOST: "invalid-host",
+    PORT: "99999",
+  });
+} catch (error) {
+  console.error(error.message);
+  // HOST must be a valid hostname or IP address (was "invalid-host")
+  // PORT must be a valid port number (was "99999")
+}
+```
+
+## When to Use `type` vs `arkenv` (default export)
+
+> [!IMPORTANT]
+> **Most users should use the default `arkenv` export for environment variables.** Only use `type` when you need to separate schema definition from validation.
+
+| Feature | `type` | `arkenv` (default) |
+|---------|--------|-------------------|
+| **Primary Use Case** | Schema definition separate from validation | Environment variable handling with immediate validation |
+| **Input** | Any object (usually environment variables) | `process.env` or custom object |
+| **Output** | Validated object | Parsed environment variables |
+| **When to Use** | When you want to define schema in one file and validate in another | Environment variables (most common) |
+| **Recommended for** | Advanced users, modular architecture | **Most users** |
+
+```ts
+// ✅ RECOMMENDED: Using arkenv for immediate validation
+import arkenv from "arkenv";
+
+const env = arkenv({
+  HOST: "string.host",
+  PORT: "number.port",
+});
+
+// ✅ ADVANCED: Using type to separate schema definition from validation
+import { type } from "arkenv";
+
+// Define schema in one file
+const envSchema = type({
+  HOST: "string.host",
+  PORT: "number.port",
+});
+
+// Validate in another file or at a later time
+const validated = envSchema.assert(process.env);
+```
+
+### Common Use Cases for `type`:
+
+- **Modular Architecture**: Define schema in a shared config file, validate in different modules
+- **Delayed Validation**: Define schema early but validate environment variables later in your application lifecycle
+- **Schema Reuse**: Use the same schema definition for different validation scenarios
+- **Testing**: Define schema once and use it for testing different environment configurations
+
+## Integration with Vite
+
+The `type` function works seamlessly with the Vite plugin:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import arkenv from "@arkenv/vite-plugin";
+import { type } from "arkenv";
+
+const envSchema = type({
+  VITE_API_URL: "string",
+  VITE_HOST: "string.host",
+  VITE_PORT: "number.port",
+});
+
+export default defineConfig({
+  plugins: [arkenv(envSchema)],
+});
+```
+
+This ensures your environment variables are validated at build time with the same type definitions you use for runtime validation.

--- a/apps/www/content/docs/index.mdx
+++ b/apps/www/content/docs/index.mdx
@@ -12,6 +12,7 @@ ArkEnv is a powerful TypeScript-first environment variable management library th
 - 🔒 **Typesafe**: Full TypeScript support with precise type inference
 - 🚀 **Runtime validation**: Catch missing or invalid environment variables early in development
 - 💪 **Powered by ArkType**: Built on top of ArkType's powerful type system
+- 🛠️ **Type function**: Use `type()` to separate schema definition from validation
 - 🪶 **Lightweight**: Only a single dependency ([see size](https://bundlephobia.com/package/arkenv))
 - ⚡ **Fast**: Optimized for performance with minimal overhead
 

--- a/apps/www/content/docs/meta.json
+++ b/apps/www/content/docs/meta.json
@@ -6,6 +6,7 @@
 		"examples",
 		"---Guides---",
 		"guides/import-options",
+		"guides/type-function",
 		"guides/environment-configuration"
 	]
 }

--- a/apps/www/content/docs/quickstart.mdx
+++ b/apps/www/content/docs/quickstart.mdx
@@ -119,6 +119,11 @@ description: Let's get you started with a few simple steps
     description="Get syntax highlighting and enhanced developer experience with the ArkType VS Code extension"
   />
   <Card 
+    title="Type Function" 
+    href="/docs/guides/type-function" 
+    description="Learn how to separate schema definition from validation using ArkEnv's type function"
+  />
+  <Card 
     title="Loading environment variables" 
     href="/docs/guides/environment-configuration" 
     description="Learn how to manage environment variables across different environments and deployment scenarios"

--- a/packages/arkenv/src/index.ts
+++ b/packages/arkenv/src/index.ts
@@ -1,6 +1,4 @@
-// Type exports
 export type { EnvSchema } from "./create-env";
-// Named exports
 export * from "./create-env";
-// Export createEnv as the main default export
 export { createEnv as default } from "./create-env";
+export * from "./type";

--- a/packages/arkenv/src/type.test.ts
+++ b/packages/arkenv/src/type.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { type } from "./type";
+
+describe("type", () => {
+	it("should create a type from a simple string schema", () => {
+		const envType = type({ NODE_ENV: "string" });
+		const result = envType.assert({ NODE_ENV: "development" });
+		expect(result.NODE_ENV).toBe("development");
+	});
+
+	it("should create a type from a number schema", () => {
+		const envType = type({ PORT: "number" });
+		const result = envType.assert({ PORT: 3000 });
+		expect(result.PORT).toBe(3000);
+	});
+
+	it("should create a type from a boolean schema", () => {
+		const envType = type({ DEBUG: "boolean" });
+		const result = envType.assert({ DEBUG: true });
+		expect(result.DEBUG).toBe(true);
+	});
+
+	it("should create a type with optional fields", () => {
+		const envType = type({
+			REQUIRED: "string",
+			OPTIONAL: "string?",
+		});
+
+		// Should work with both fields
+		const result1 = envType.assert({
+			REQUIRED: "value",
+			OPTIONAL: "optional-value",
+		});
+		expect(result1.REQUIRED).toBe("value");
+		expect(result1.OPTIONAL).toBe("optional-value");
+
+		// Should work with only required field
+		const result2 = envType.assert({ REQUIRED: "value" });
+		expect(result2.REQUIRED).toBe("value");
+		expect(result2.OPTIONAL).toBeUndefined();
+	});
+
+	it("should create a type with arkenv-specific host validation", () => {
+		const envType = type({ HOST: "string.host" });
+
+		// Valid IP addresses
+		const result1 = envType.assert({ HOST: "127.0.0.1" });
+		expect(result1.HOST).toBe("127.0.0.1");
+
+		const result2 = envType.assert({ HOST: "192.168.1.1" });
+		expect(result2.HOST).toBe("192.168.1.1");
+
+		// Valid hostname
+		const result3 = envType.assert({ HOST: "localhost" });
+		expect(result3.HOST).toBe("localhost");
+
+		// Should throw for invalid host
+		expect(() => envType.assert({ HOST: "invalid-host" })).toThrow();
+	});
+
+	it("should create a type with arkenv-specific port validation", () => {
+		const envType = type({ PORT: "number.port" });
+
+		// Valid ports (as strings, like from environment variables)
+		const result1 = envType.assert({ PORT: "3000" });
+		expect(result1.PORT).toBe(3000);
+
+		const result2 = envType.assert({ PORT: "8080" });
+		expect(result2.PORT).toBe(8080);
+
+		const result3 = envType.assert({ PORT: "65535" });
+		expect(result3.PORT).toBe(65535);
+
+		// Should throw for invalid ports
+		expect(() => envType.assert({ PORT: "invalid" })).toThrow();
+		expect(() => envType.assert({ PORT: "-1" })).toThrow();
+		expect(() => envType.assert({ PORT: "65536" })).toThrow();
+	});
+
+	it("should create a complex type with multiple validations", () => {
+		const envType = type({
+			API_URL: "string",
+			HOST: "string.host",
+			PORT: "number.port",
+			DEBUG: "boolean",
+			API_KEY: "string?",
+		});
+
+		const result = envType.assert({
+			API_URL: "https://api.example.com",
+			HOST: "localhost",
+			PORT: "3000",
+			DEBUG: true,
+			// API_KEY is optional, so we can omit it
+		});
+
+		expect(result.API_URL).toBe("https://api.example.com");
+		expect(result.HOST).toBe("localhost");
+		expect(result.PORT).toBe(3000);
+		expect(result.DEBUG).toBe(true);
+		expect(result.API_KEY).toBeUndefined();
+	});
+
+	it("should throw when required fields are missing", () => {
+		const envType = type({
+			REQUIRED: "string",
+			ALSO_REQUIRED: "number",
+		});
+
+		expect(() => envType.assert({ REQUIRED: "value" })).toThrow();
+		expect(() => envType.assert({ ALSO_REQUIRED: "123" })).toThrow();
+		expect(() => envType.assert({})).toThrow();
+	});
+
+	it("should throw when field types are invalid", () => {
+		const envType = type({
+			PORT: "number",
+			DEBUG: "boolean",
+		});
+
+		expect(() => envType.assert({ PORT: "not-a-number" })).toThrow();
+		expect(() => envType.assert({ DEBUG: "not-a-boolean" })).toThrow();
+		expect(() => envType.assert({ PORT: "123", DEBUG: true })).toThrow();
+	});
+
+	it("should work with nested object types", () => {
+		const envType = type({
+			DATABASE: {
+				HOST: "string.host",
+				PORT: "number.port",
+				NAME: "string",
+			},
+		});
+
+		const result = envType.assert({
+			DATABASE: {
+				HOST: "localhost",
+				PORT: "5432",
+				NAME: "myapp",
+			},
+		});
+
+		expect(result.DATABASE.HOST).toBe("localhost");
+		expect(result.DATABASE.PORT).toBe(5432);
+		expect(result.DATABASE.NAME).toBe("myapp");
+	});
+
+	it("should work with array types", () => {
+		const envType = type({
+			ALLOWED_ORIGINS: "string[]",
+		});
+
+		const result = envType.assert({
+			ALLOWED_ORIGINS: ["localhost", "127.0.0.1", "example.com"],
+		});
+
+		expect(Array.isArray(result.ALLOWED_ORIGINS)).toBe(true);
+		expect(result.ALLOWED_ORIGINS).toEqual([
+			"localhost",
+			"127.0.0.1",
+			"example.com",
+		]);
+	});
+
+	it("should validate that the type function returns a proper ArkType", () => {
+		const envType = type({
+			STRING_VALUE: "string",
+			NUMBER_VALUE: "number",
+			BOOLEAN_VALUE: "boolean",
+		});
+
+		// Test that it's a proper ArkType with assert method
+		expect(typeof envType.assert).toBe("function");
+
+		const result = envType.assert({
+			STRING_VALUE: "hello",
+			NUMBER_VALUE: 42,
+			BOOLEAN_VALUE: true,
+		});
+
+		expect(result.STRING_VALUE).toBe("hello");
+		expect(result.NUMBER_VALUE).toBe(42);
+		expect(result.BOOLEAN_VALUE).toBe(true);
+	});
+});

--- a/packages/arkenv/src/type.ts
+++ b/packages/arkenv/src/type.ts
@@ -1,0 +1,3 @@
+import { $ } from "./scope";
+
+export const type = $.type;

--- a/packages/vite-plugin/src/__fixtures__/basic/config.ts
+++ b/packages/vite-plugin/src/__fixtures__/basic/config.ts
@@ -1,5 +1,4 @@
-// TODO: import this from arkenv
-import { type } from "arktype";
+import { type } from "arkenv";
 
 export const envSchema = type({
 	VITE_API_URL: "string",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a public type() API for defining environment schemas with ArkEnv-specific types (e.g., string.host, number.port) and validating with env.assert.

- Documentation
  - Added a comprehensive guide for the Type Function, including examples, advanced usage, and Vite integration.
  - Updated key features to highlight type().
  - Added “Type Function” cards to Quickstart and linked it in navigation.

- Tests
  - Added extensive tests covering scalar, optional, nested, array, and ArkEnv-specific validations.

- Chores
  - Added a changeset announcing the new public API surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->