### PR TITLE
Remove "Documentation" button in the sidebar

### DIFF
--- a/apps/www/app/(home)/layout.tsx
+++ b/apps/www/app/(home)/layout.tsx
@@ -3,5 +3,18 @@ import type { ReactNode } from "react";
 import { baseOptions } from "~/app/layout.config";
 
 export default function Layout({ children }: { children: ReactNode }) {
-	return <HomeLayout {...baseOptions}>{children}</HomeLayout>;
+	return (
+		<HomeLayout
+			{...baseOptions}
+			links={[
+				{
+					text: "Documentation",
+					url: "/docs",
+					active: "none",
+				},
+			]}
+		>
+			{children}
+		</HomeLayout>
+	);
 }

--- a/apps/www/app/layout.config.tsx
+++ b/apps/www/app/layout.config.tsx
@@ -13,11 +13,4 @@ export const baseOptions: BaseLayoutProps = {
 		title: <Logo className="text-xl mb-1" />,
 	},
 	githubUrl: process.env.NEXT_PUBLIC_GITHUB_URL,
-	links: [
-		{
-			text: "Documentation",
-			url: "/docs",
-			active: "none",
-		},
-	],
 };


### PR DESCRIPTION
- Reintroduced the "Documentation" link in the HomeLayout component by integrating it directly into the layout configuration.
- This change enhances navigation by providing users with easy access to the documentation from the home layout.

Closes #166 