### PR TITLE
refactor: use vi.stubEnv instead of process.env

### DIFF
--- a/apps/www/components/page/copy-button.test.tsx
+++ b/apps/www/components/page/copy-button.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { CopyButton } from "./copy-button";
 
 // Mock the useToast hook

--- a/apps/www/components/page/sail-button.test.tsx
+++ b/apps/www/components/page/sail-button.test.tsx
@@ -1,6 +1,6 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { SailButton } from "./sail-button";
 
 // Mock Next.js router

--- a/apps/www/components/page/star-us-button.test.tsx
+++ b/apps/www/components/page/star-us-button.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { StarUsButton } from "./star-us-button";
 
 // Mock fetch to avoid real API calls

--- a/apps/www/components/page/video-demo.test.tsx
+++ b/apps/www/components/page/video-demo.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { VideoDemo } from "./video-demo";
 
 // Mock window.open

--- a/apps/www/components/ui/heading.test.tsx
+++ b/apps/www/components/ui/heading.test.tsx
@@ -1,6 +1,6 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Heading } from "./heading";
 
 // Mock the useIsMobile hook

--- a/apps/www/hooks/use-is-mobile.test.ts
+++ b/apps/www/hooks/use-is-mobile.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { useIsMobile } from "./use-is-mobile";
 
 // Mock window.matchMedia

--- a/apps/www/lib/utils/github.test.ts
+++ b/apps/www/lib/utils/github.test.ts
@@ -56,7 +56,7 @@ describe("github utilities", () => {
 		});
 
 		it("should throw error when no URL is configured", () => {
-			vi.stubEnv("NEXT_PUBLIC_GITHUB_URL", undefined);
+			vi.unstubAllEnvs();
 
 			expect(() => breakDownGithubUrl()).toThrow(
 				"NEXT_PUBLIC_GITHUB_URL is not configured",
@@ -143,7 +143,7 @@ describe("github utilities", () => {
 		});
 
 		it("should throw error when no URL is configured", () => {
-			vi.stubEnv("NEXT_PUBLIC_GITHUB_URL", undefined);
+			vi.unstubAllEnvs();
 
 			expect(() => getLinkTitleAndHref("test.md")).toThrow(
 				"NEXT_PUBLIC_GITHUB_URL is not configured",

--- a/apps/www/lib/utils/github.test.ts
+++ b/apps/www/lib/utils/github.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { breakDownGithubUrl, getLinkTitleAndHref } from "./github";
 
 describe("github utilities", () => {

--- a/apps/www/lib/utils/github.test.ts
+++ b/apps/www/lib/utils/github.test.ts
@@ -2,15 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { breakDownGithubUrl, getLinkTitleAndHref } from "./github";
 
 describe("github utilities", () => {
-	const originalEnv = process.env;
-
 	beforeEach(() => {
 		vi.resetModules();
-		process.env = { ...originalEnv };
-	});
-
-	afterEach(() => {
-		process.env = originalEnv;
 	});
 
 	describe("breakDownGithubUrl", () => {
@@ -35,7 +28,7 @@ describe("github utilities", () => {
 		});
 
 		it("should use environment variable when no URL provided", () => {
-			process.env.NEXT_PUBLIC_GITHUB_URL = "https://github.com/example/repo";
+			vi.stubEnv("NEXT_PUBLIC_GITHUB_URL", "https://github.com/example/repo");
 
 			const result = breakDownGithubUrl();
 
@@ -47,8 +40,11 @@ describe("github utilities", () => {
 		});
 
 		it("should use custom branch from environment variable", () => {
-			process.env.NEXT_PUBLIC_GITHUB_URL = "https://github.com/yamcodes/arkenv";
-			process.env.NEXT_PUBLIC_GITHUB_BRANCH = "develop";
+			vi.stubEnv(
+				"NEXT_PUBLIC_GITHUB_URL",
+				"https://github.com/yamcodes/arkenv",
+			);
+			vi.stubEnv("NEXT_PUBLIC_GITHUB_BRANCH", "develop");
 
 			const result = breakDownGithubUrl();
 
@@ -60,7 +56,7 @@ describe("github utilities", () => {
 		});
 
 		it("should throw error when no URL is configured", () => {
-			delete process.env.NEXT_PUBLIC_GITHUB_URL;
+			vi.stubEnv("NEXT_PUBLIC_GITHUB_URL", undefined);
 
 			expect(() => breakDownGithubUrl()).toThrow(
 				"NEXT_PUBLIC_GITHUB_URL is not configured",
@@ -121,7 +117,7 @@ describe("github utilities", () => {
 		});
 
 		it("should use environment variable when no URL provided", () => {
-			process.env.NEXT_PUBLIC_GITHUB_URL = "https://github.com/example/repo";
+			vi.stubEnv("NEXT_PUBLIC_GITHUB_URL", "https://github.com/example/repo");
 
 			const result = getLinkTitleAndHref("test.md");
 
@@ -132,8 +128,11 @@ describe("github utilities", () => {
 		});
 
 		it("should use custom branch from environment variable", () => {
-			process.env.NEXT_PUBLIC_GITHUB_URL = "https://github.com/yamcodes/arkenv";
-			process.env.NEXT_PUBLIC_GITHUB_BRANCH = "develop";
+			vi.stubEnv(
+				"NEXT_PUBLIC_GITHUB_URL",
+				"https://github.com/yamcodes/arkenv",
+			);
+			vi.stubEnv("NEXT_PUBLIC_GITHUB_BRANCH", "develop");
 
 			const result = getLinkTitleAndHref("package.json");
 
@@ -144,7 +143,7 @@ describe("github utilities", () => {
 		});
 
 		it("should throw error when no URL is configured", () => {
-			delete process.env.NEXT_PUBLIC_GITHUB_URL;
+			vi.stubEnv("NEXT_PUBLIC_GITHUB_URL", undefined);
 
 			expect(() => getLinkTitleAndHref("test.md")).toThrow(
 				"NEXT_PUBLIC_GITHUB_URL is not configured",

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -14,5 +14,6 @@ export default defineProject({
 		environment: "jsdom",
 		setupFiles: ["./tests/setup.ts"],
 		restoreMocks: true,
+		unstubEnvs: true,
 	},
 });

--- a/packages/arkenv/src/index.test.ts
+++ b/packages/arkenv/src/index.test.ts
@@ -10,15 +10,6 @@ import {
 import arkenv, { createEnv } from "./index";
 
 describe("index.ts exports", () => {
-	beforeEach(() => {
-		// Clear environment variables for each test
-		vi.stubEnv("TEST_DEFAULT_IMPORT", undefined);
-		vi.stubEnv("TEST_NAMED_IMPORT", undefined);
-		vi.stubEnv("COMPARISON_TEST", undefined);
-		vi.stubEnv("MISSING_DEFAULT_VAR", undefined);
-		vi.stubEnv("MISSING_NAMED_VAR", undefined);
-	});
-
 	afterEach(() => {
 		// Restore mocks and unstub all environment variables
 		vi.restoreAllMocks();

--- a/packages/arkenv/src/index.test.ts
+++ b/packages/arkenv/src/index.test.ts
@@ -1,12 +1,4 @@
-import {
-	afterEach,
-	beforeEach,
-	describe,
-	expect,
-	expectTypeOf,
-	it,
-	vi,
-} from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import arkenv, { createEnv } from "./index";
 
 describe("index.ts exports", () => {

--- a/packages/arkenv/src/index.test.ts
+++ b/packages/arkenv/src/index.test.ts
@@ -9,19 +9,20 @@ import {
 } from "vitest";
 import arkenv, { createEnv } from "./index";
 
-// Capture snapshot of process.env at module level
-const originalEnv = { ...process.env };
-
 describe("index.ts exports", () => {
 	beforeEach(() => {
-		// Replace with a clean environment for each test
-		process.env = {};
+		// Clear environment variables for each test
+		vi.stubEnv("TEST_DEFAULT_IMPORT", undefined);
+		vi.stubEnv("TEST_NAMED_IMPORT", undefined);
+		vi.stubEnv("COMPARISON_TEST", undefined);
+		vi.stubEnv("MISSING_DEFAULT_VAR", undefined);
+		vi.stubEnv("MISSING_NAMED_VAR", undefined);
 	});
 
 	afterEach(() => {
-		// Restore mocks and reset process.env to captured snapshot
+		// Restore mocks and unstub all environment variables
 		vi.restoreAllMocks();
-		process.env = { ...originalEnv };
+		vi.unstubAllEnvs();
 	});
 
 	it("should export createEnv as default export", () => {
@@ -40,7 +41,7 @@ describe("index.ts exports", () => {
 
 	it("should work with default import", () => {
 		// Set test environment variable
-		process.env.TEST_DEFAULT_IMPORT = "test-value";
+		vi.stubEnv("TEST_DEFAULT_IMPORT", "test-value");
 
 		const env = arkenv({
 			TEST_DEFAULT_IMPORT: "string",
@@ -52,7 +53,7 @@ describe("index.ts exports", () => {
 
 	it("should work with named import", () => {
 		// Set test environment variable
-		process.env.TEST_NAMED_IMPORT = "test-value";
+		vi.stubEnv("TEST_NAMED_IMPORT", "test-value");
 
 		const env = createEnv({
 			TEST_NAMED_IMPORT: "string",
@@ -80,7 +81,7 @@ describe("index.ts exports", () => {
 
 	it("should have same behavior for both default and named imports", () => {
 		// Set test environment variable
-		process.env.COMPARISON_TEST = "same-value";
+		vi.stubEnv("COMPARISON_TEST", "same-value");
 
 		const envFromDefault = arkenv({
 			COMPARISON_TEST: "string",

--- a/packages/arkenv/vitest.config.ts
+++ b/packages/arkenv/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineProject } from "vitest/config";
 
 export default defineProject({
 	test: {
-		name: "@arkenv/vite-plugin",
+		name: "arkenv",
 	},
 });

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -20,6 +20,7 @@
 		"tsup": "^8.5.0",
 		"typescript": "^5.9.3",
 		"vite": "^7.1.9",
+		"vite-tsconfig-paths": "^5.1.4",
 		"vitest": "^3.2.4"
 	},
 	"peerDependencies": {

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -12,9 +12,6 @@ vi.mock("arkenv", () => ({
 
 import arkenvPlugin from "./index.js";
 
-// Capture snapshot of process.env at module level
-const ORIGINAL_ENV = { ...process.env };
-
 const fixturesDir = join(__dirname, "__fixtures__");
 
 // Get the mocked functions
@@ -28,14 +25,14 @@ for (const name of readdirSync(fixturesDir)) {
 
 	describe(`Fixture: ${name}`, () => {
 		beforeEach(() => {
-			// Clean environment start and mock cleanup
-			process.env = { ...ORIGINAL_ENV };
+			// Clear environment variables and mock cleanup
+			vi.unstubAllEnvs();
 			mockCreateEnv.mockClear();
 		});
 
 		afterEach(() => {
 			// Complete cleanup: restore environment and reset mocks
-			process.env = { ...ORIGINAL_ENV };
+			vi.unstubAllEnvs();
 			mockCreateEnv.mockReset();
 		});
 
@@ -44,7 +41,9 @@ for (const name of readdirSync(fixturesDir)) {
 
 			// Set up environment variables from the fixture
 			if (config.envVars) {
-				Object.assign(process.env, config.envVars);
+				for (const [key, value] of Object.entries(config.envVars)) {
+					vi.stubEnv(key, value);
+				}
 			}
 
 			await expect(
@@ -77,12 +76,12 @@ for (const name of readdirSync(fixturesDir)) {
 // Unit tests for plugin functionality
 describe("Plugin Unit Tests", () => {
 	beforeEach(() => {
-		process.env = { ...ORIGINAL_ENV };
+		vi.unstubAllEnvs();
 		mockCreateEnv.mockClear();
 	});
 
 	afterEach(() => {
-		process.env = { ...ORIGINAL_ENV };
+		vi.unstubAllEnvs();
 		mockCreateEnv.mockReset();
 	});
 

--- a/packages/vite-plugin/vitest.config.ts
+++ b/packages/vite-plugin/vitest.config.ts
@@ -1,7 +1,13 @@
+import path from "node:path";
 import { defineProject } from "vitest/config";
 
 export default defineProject({
 	test: {
 		name: "@arkenv/vite-plugin",
+	},
+	resolve: {
+		alias: {
+			arkenv: path.resolve(__dirname, "../arkenv/src/index.ts"),
+		},
 	},
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       vite:
         specifier: ^7.1.9
         version: 7.1.9(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.9.3)(vite@7.1.9(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.6.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,5 +28,6 @@ export default defineConfig({
 				"**/public/**",
 			],
 		},
+		unstubEnvs: true,
 	},
 });


### PR DESCRIPTION
- Replaced direct process.env assignments
- Used vi.stubEnv for test environment
- Added unstubEnvs: true to vitest config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Standardized env-var handling in tests using Vitest stubs for better isolation.
  - Simplified setup/teardown across test suites and reduced unused test imports.

- Chores
  - Adopted project-based Vitest configs and enabled env-unstubbing.
  - Added a dev dependency to improve TypeScript path resolution.

- Impact
  - No production behavior changes; improvements affect test infra and developer experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->