### PR TITLE
Add `typecheck` to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,29 @@ jobs:
 
       - name: Run test
         run: pnpm turbo run test
+
+  test-typesafety:
+    runs-on: ubuntu-latest
+    steps:
+      - id: checkout
+        name: Checkout
+        uses: actions/checkout@v5
+        
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        
+      - name: Use Node.js 22
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run typecheck
+        run: pnpm run typecheck
+
   test-build:
     runs-on: ubuntu-latest
     

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -4,10 +4,16 @@ import { createMDX } from "fumadocs-mdx/next";
 import type { NextConfig } from "next";
 
 const config = {
-	reactStrictMode: true,
-	cleanDistDir: true,
 	outputFileTracingRoot: path.join(__dirname, "../../"),
 	serverExternalPackages: ["typescript", "twoslash", "ts-morph"],
+	eslint: {
+		// We don't use eslint, we use biome on ci
+		ignoreDuringBuilds: true,
+	},
+	typescript: {
+		// We check typesafety on ci
+		ignoreBuildErrors: true,
+	},
 } as const satisfies NextConfig;
 
 const sentryConfig = {

--- a/package.json
+++ b/package.json
@@ -28,17 +28,14 @@
 	},
 	"packageManager": "pnpm@10.18.2",
 	"pnpm": {
-		"ignoredBuiltDependencies": [
-			"esbuild",
-			"sharp"
-		],
 		"onlyBuiltDependencies": [
 			"@biomejs/biome",
 			"@sentry/cli",
 			"@swc/core",
 			"@tailwindcss/oxide",
-			"@vercel/speed-insights"
+			"@vercel/speed-insights",
+			"esbuild",
+			"sharp"
 		]
-	},
-	"version": "0.0.1"
+	}
 }


### PR DESCRIPTION
- Added `esbuild` and `sharp` to the `onlyBuiltDependencies` in package.json.
- Introduced a new CI job for type safety checks, including steps for installing dependencies and running type checks.
- Updated Next.js configuration to ignore ESLint and TypeScript build errors during CI.

These changes enhance the project's build process and ensure better type safety checks in the CI pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added a CI job to run type-safety checks, catching typing issues earlier.

- Chores
  - Adjusted build settings to improve build stability and speed.
  - Shifted linting and type checks to CI to avoid blocking builds locally.
  - Refined dependency build configuration for more reliable installations.

- User Impact
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->