### PR TITLE
Fallback to demo gif on mp4 load failure

### DIFF
--- a/apps/www/components/page/video-demo.test.tsx
+++ b/apps/www/components/page/video-demo.test.tsx
@@ -213,4 +213,50 @@ describe("VideoDemo", () => {
 			"noopener,noreferrer",
 		);
 	});
+
+	it("falls back to demo.gif when video fails to load", () => {
+		render(<VideoDemo />);
+
+		const button = screen.getByRole("button");
+		const video = button.querySelector("video");
+
+		// Initially, video should be present
+		expect(video).toBeInTheDocument();
+
+		// Simulate video error
+		fireEvent.error(video!);
+
+		// After error, video should be replaced with img
+		expect(button.querySelector("video")).not.toBeInTheDocument();
+		const img = button.querySelector("img");
+		expect(img).toBeInTheDocument();
+		expect(img).toHaveAttribute("src", "/assets/demo.gif");
+		expect(img).toHaveAttribute("alt", "ArkEnv Demo");
+		expect(img).toHaveAttribute("width", "958");
+		expect(img).toHaveClass(
+			"block",
+			"max-h-[600px]",
+			"sm:max-h-[1000px]",
+			"object-contain",
+		);
+	});
+
+	it("maintains button click behavior after fallback to demo.gif", () => {
+		render(<VideoDemo />);
+
+		const button = screen.getByRole("button");
+		const video = button.querySelector("video");
+
+		// Simulate video error
+		fireEvent.error(video!);
+
+		// Button should still be clickable and open StackBlitz URL
+		fireEvent.click(button);
+
+		expect(mockWindowOpen).toHaveBeenCalledWith(
+			"https://stackblitz.com/github/yamcodes/arkenv/tree/main/examples/basic?file=index.ts",
+			"_blank",
+			"noopener,noreferrer",
+		);
+	});
 });

--- a/apps/www/components/page/video-demo.tsx
+++ b/apps/www/components/page/video-demo.tsx
@@ -1,10 +1,18 @@
 "use client";
 
+import { useState } from "react";
+
 export function VideoDemo() {
+	const [videoError, setVideoError] = useState(false);
+
 	const handleVideoClick = () => {
 		const stackblitzUrl =
 			"https://stackblitz.com/github/yamcodes/arkenv/tree/main/examples/basic?file=index.ts";
 		window.open(stackblitzUrl, "_blank", "noopener,noreferrer");
+	};
+
+	const handleVideoError = () => {
+		setVideoError(true);
 	};
 
 	return (
@@ -16,21 +24,31 @@ export function VideoDemo() {
 				onClick={handleVideoClick}
 				aria-label="Open interactive demo in a new tab"
 			>
-				<video
-					autoPlay
-					loop
-					muted
-					playsInline
-					width={958}
-					poster="/assets/demo.png"
-					className="block max-h-[600px] sm:max-h-[1000px] object-contain"
-				>
-					<source
-						src="https://x9fkbqb4whr3w456.public.blob.vercel-storage.com/hero.mp4"
-						type="video/mp4"
+				{videoError ? (
+					<img
+						src="/assets/demo.gif"
+						alt="ArkEnv Demo"
+						width={958}
+						className="block max-h-[600px] sm:max-h-[1000px] object-contain"
 					/>
-					You need a browser that supports HTML5 video to view this video.
-				</video>
+				) : (
+					<video
+						autoPlay
+						loop
+						muted
+						playsInline
+						width={958}
+						poster="/assets/demo.png"
+						className="block max-h-[600px] sm:max-h-[1000px] object-contain"
+						onError={handleVideoError}
+					>
+						<source
+							src="https://x9fkbqb4whr3w456.public.blob.vercel-storage.com/hero.mp4"
+							type="video/mp4"
+						/>
+						You need a browser that supports HTML5 video to view this video.
+					</video>
+				)}
 			</button>
 		</div>
 	);


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-1a169c30-e18b-4474-aebf-d4007c7be30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1a169c30-e18b-4474-aebf-d4007c7be30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add GIF fallback to VideoDemo on video load error and tests to verify behavior and click-through.
> 
> - **Frontend**:
>   - **`apps/www/components/page/video-demo.tsx`**: Add GIF fallback for video load errors using `useState` (`videoError`) and `onError` on `video`; renders `/assets/demo.gif` with matching dimensions/styles; preserves existing click-to-open StackBlitz behavior.
> - **Tests**:
>   - **`apps/www/components/page/video-demo.test.tsx`**: Add tests verifying fallback to `img` on video error and that button click still opens the StackBlitz URL after fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53f7b99062c7a95fc5174d0137fa7d28206dce9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video demo now gracefully handles load failures by displaying a fallback image instead of a broken video, while maintaining button functionality.

* **Tests**
  * Added test coverage for video fallback UI behavior.
  * Added test coverage for button interaction during fallback state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->