### PR TITLE
fix(tests): enhance reliability of homepage navigation test

### DIFF
--- a/tooling/playwright-www/tests/docs-navigation.test.ts
+++ b/tooling/playwright-www/tests/docs-navigation.test.ts
@@ -57,14 +57,15 @@ test.describe("Documentation Navigation", () => {
 
 	test("should navigate from homepage to quickstart", async ({ page }) => {
 		await page.goto("/");
-		await page.waitForLoadState("networkidle");
-
-		// Click the "Set sail" button
+		// Wait for the button to be visible instead of networkidle (more reliable, especially on webkit)
 		const sailButton = page.locator("a[href='/docs/quickstart']");
 		await expect(sailButton).toBeVisible();
+
+		// Click the "Set sail" button
 		await sailButton.click();
 
-		// Verify navigation
+		// Wait for navigation to complete with timeout
+		await page.waitForURL("**/docs/quickstart", { timeout: 30000 });
 		await expect(page).toHaveURL("/docs/quickstart");
 		await expect(page.locator("body")).toBeVisible();
 	});


### PR DESCRIPTION
Updated the homepage to quickstart navigation test to wait for the "Set sail" button to be visible instead of relying on the "networkidle" state. Added a timeout for the navigation verification to improve test reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for documentation navigation by optimizing wait conditions and timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->