### PR TITLE
refactor: simplify accessibility smoke tests by removing disabled rules

### DIFF
--- a/tooling/playwright-www/tests/a11y.test.ts
+++ b/tooling/playwright-www/tests/a11y.test.ts
@@ -155,24 +155,7 @@ test.describe("A11y Smoke Tests", () => {
 			await page.waitForLoadState("networkidle");
 
 			// Page-level smoke test with rules disabled for known issues
-			await assertNoA11yViolations(page, {
-				disableRules: [
-					// Known issues from third-party libraries
-					// TODO: Re-enable once fumadocs-twoslash fixes aria-allowed-attr violation
-					// fumadocs-twoslash renders <span class="twoslash-hover" type="button"> which is invalid HTML
-					// Should use <button> element instead of <span> for interactive hover triggers
-					// Track: https://github.com/fuma-nama/fumadocs/issues/2574
-					"aria-allowed-attr", // shiki-twoslash
-					// TODO: Re-enable once fumadocs-ui fixes scrollable-region-focusable
-					// code block containers need keyboard focus
-					// Track: https://github.com/fuma-nama/fumadocs/issues/2573
-					"scrollable-region-focusable",
-					// TODO: Re-enable once fumadocs-ui fixes listitem issue
-					// fumadocs-ui renders secondary nav items in <div> instead of <ul>
-					// Track: https://github.com/fuma-nama/fumadocs/issues/2566
-					"listitem",
-				],
-			});
+			await assertNoA11yViolations(page);
 		}
 	});
 


### PR DESCRIPTION
- Removed specific disabled rules from the accessibility smoke tests to streamline the assertion process.
- This change enhances the clarity of the tests and focuses on current accessibility compliance without known issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified accessibility violation assertion API by removing per-call configuration options.

* **Tests**
  * Updated accessibility tests to align with the revised assertion interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->