### PR TITLE
Analyze github context for user query

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,29 +40,44 @@
 		},
 		// By Package Manager
 		{
-			// Group pnpm workspace updates (minor/patch) across selected dirs
-			"groupName": "pnpm",
-			"matchManagers": ["pnpm"],
+			// Group bun dependencies (minor/patch) in bun projects
+			// Note: Must come before npm group to avoid conflicts
+			"groupName": "bun",
+			"matchManagers": ["bun", "npm"],
 			"matchFileNames": [
-				"packages/**",
-				"apps/**",
-				"tooling/**",
-				"examples/**",
-				"package.json" // Root package.json
-			],
-			"matchUpdateTypes": ["minor", "patch"],
-			"matchCurrentVersion": ">=1.0.0"
-		},
-		{
-			"groupName": "bun-action",
-			"matchManagers": ["bun"],
-			"matchFileNames": [
-				".github/actions/size-limit/package.json", // Bun script
+				".github/actions/size-limit/package.json",
 				"apps/playgrounds/**/*bun*/**",
 				"examples/**/*bun*/**"
 			],
 			"matchUpdateTypes": ["minor", "patch"],
 			"matchCurrentVersion": ">=1.0.0"
+		},
+		{
+			// Group npm dependencies (minor/patch) across selected dirs
+			// Note: npm dependencies in pnpm workspaces use "npm" manager, not "pnpm"
+			// Excludes bun-specific files to avoid conflicts
+			"groupName": "npm",
+			"matchManagers": ["npm"],
+			"matchFileNames": [
+				"packages/**",
+				"apps/**",
+				"tooling/**",
+				"examples/**",
+				"package.json"
+			],
+			"excludeFileNames": [
+				".github/actions/size-limit/package.json",
+				"apps/playgrounds/**/*bun*/**",
+				"examples/**/*bun*/**"
+			],
+			"matchUpdateTypes": ["minor", "patch"],
+			"matchCurrentVersion": ">=1.0.0"
+		},
+		{
+			// Group pnpm package manager version updates
+			"groupName": "pnpm",
+			"matchManagers": ["pnpm"],
+			"matchUpdateTypes": ["minor", "patch"]
 		},
 		{
 			"groupName": "actions",


### PR DESCRIPTION
Correct Renovate grouping for npm and bun dependencies.

The previous configuration used `matchManagers: ["pnpm"]` for npm dependencies in pnpm workspaces, which only matches the pnpm package manager version itself. This PR updates the config to use `matchManagers: ["npm"]` for these dependencies and refines bun grouping to prevent conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-532ca19c-b0e0-4ef1-a6c2-db8be274c258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-532ca19c-b0e0-4ef1-a6c2-db8be274c258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

