### PR TITLE
Investigate github issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"test:e2e:ui": "turbo run test:e2e:ui",
 		"test:e2e:update": "turbo run test:e2e:update",
 		"changeset": "changeset",
-		"size": "turbo run size"
+		"size": "turbo run size --filter=arkenv"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.4",


### PR DESCRIPTION
Update the root `size` script to scope `turbo run size` to the `arkenv` package.

Defining a global `size` task in `turbo.json` causes Turborepo to create virtual `size` tasks for all workspaces. Since `size` depends on `build`, this triggers builds in all packages with a `build` script, even if they don't have a real `size` script. The `--filter=arkenv` flag ensures that only `arkenv#build` (as a dependency) and `arkenv#size` (the actual task) are executed.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8094b0b-1af6-48f1-bd7b-96a9bdc486cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8094b0b-1af6-48f1-bd7b-96a9bdc486cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

