### PR TITLE
Fix "Size-limit action shows "—" diff instead of percentage in Version Packages PR"

### DIFF
--- a/.github/actions/size-limit/src/size-limit/package.ts
+++ b/.github/actions/size-limit/src/size-limit/package.ts
@@ -41,7 +41,7 @@ export const runSizeLimitOnPackage = async (
 	// This prevents bundling errors when size-limit tries to bundle Node.js built-in modules
 	const enhancedSizeLimitConfig = sizeLimitConfig.map((config) => {
 		// If webpack is explicitly enabled, preserve the webpack configuration
-		if (config.webpack === true) {
+		if (config.webpack !== undefined) {
 			return config;
 		}
 
@@ -99,7 +99,11 @@ export const runSizeLimitOnPackage = async (
 			// This tells esbuild not to try to bundle these modules
 			// size-limit passes this to esbuild's external option
 			ignore: [
-				...(Array.isArray(config.ignore) ? config.ignore : []),
+				...(config.ignore
+					? Array.isArray(config.ignore)
+						? config.ignore
+						: [config.ignore]
+					: []),
 				...nodeBuiltinModules.map((m) => `node:${m}`),
 				...nodeBuiltinModules,
 			],


### PR DESCRIPTION
Extract size data from failed size-limit checks and mark Node.js built-in modules as external to fix '—' output and bundling errors.

The "—" output occurred because the action would exit early if `size-limit` failed, preventing the extraction of size data needed for comparison. By parsing the JSON output even on failure, we can still get the size information. The bundling errors were due to `size-limit` (using esbuild) attempting to bundle Node.js core modules, which are external to browser/frontend bundles. Explicitly marking them as `external` resolves this.

Closes #362 

---
<a href="https://cursor.com/background-agent?bcId=bc-4672ef90-8a69-4315-8f8c-5d9081657ea3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4672ef90-8a69-4315-8f8c-5d9081657ea3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Size checks now attempt to parse and return results even if the check process exits with an error; clearer per-result and error logging prevents silent failures.
  * Added a robust fallback parsing path to handle varied output formats.

* **Improvements**
  * Enhanced default size-check configuration to better ignore built-in modules and enforce consistent bundling behavior for Node packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->