### PR TITLE
Migrate from `npx`

### DIFF
--- a/.github/actions/size-limit/src/size-limit/package.ts
+++ b/.github/actions/size-limit/src/size-limit/package.ts
@@ -113,7 +113,7 @@ export const runSizeLimitOnPackage = async (
 	// Create a temporary package.json with size-limit config and dependencies
 	// We need to preserve the package name, main/module fields, and dependencies for size-limit to work
 	// Also need to include the preset in devDependencies so size-limit can find it
-	// Include peerDependencies as regular dependencies since npm install won't install them automatically
+	// Include peerDependencies as regular dependencies since bun install won't install them automatically
 	const tempPackageJson = {
 		name: packageJson.name,
 		version: packageJson.version,
@@ -152,7 +152,7 @@ export const runSizeLimitOnPackage = async (
 		// Install all dependencies (production + dev) from package.json
 		// This includes both the package's dependencies (needed for bundling) and size-limit plugins
 		console.log(`📦 Installing dependencies for ${packageName}...`);
-		const installProc = spawn(["npm", "install"], {
+		const installProc = spawn(["bun", "install"], {
 			cwd: packageDir,
 			stdout: "pipe",
 			stderr: "pipe",
@@ -167,12 +167,12 @@ export const runSizeLimitOnPackage = async (
 			console.log(
 				`⚠️ Failed to install dependencies: ${installStderr || installStdout}`,
 			);
-			// Continue anyway - npx might still work
+			// Continue anyway - bunx might still work
 		}
 
 		// Run size-limit on this package
 		console.log(`🔍 Running size-limit on ${packageName}...`);
-		const proc = spawn(["npx", "--yes", "size-limit", "--json"], {
+		const proc = spawn(["bunx", "size-limit", "--json"], {
 			cwd: packageDir,
 			stdout: "pipe",
 			stderr: "pipe",

--- a/apps/www/bin/build.js
+++ b/apps/www/bin/build.js
@@ -25,7 +25,7 @@ if (majorVersion >= 25) {
 const [, , ...args] = process.argv;
 
 // Spawn the command with the appropriate NODE_OPTIONS
-const child = spawn("npx", args, {
+const child = spawn("pnpm", ["exec", ...args], {
 	stdio: "inherit",
 	shell: process.platform === "win32",
 });

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"build": "node ./bin/build next build",
-		"dev": "conc -n Next.js,next-video 'next dev' 'npx next-video sync -w'",
+		"dev": "conc -n Next.js,next-video 'next dev' 'pnpm exec next-video sync -w'",
 		"start": "next start",
 		"postinstall": "node ./bin/postinstall",
 		"clean": "rimraf node_modules .next .source",


### PR DESCRIPTION
Closes #432 

- Changed package installation commands from npm to bun in the size-limit action for better compatibility.
- Updated development script in package.json to utilize pnpm for executing next-video sync.
- Modified build script to spawn commands using pnpm instead of npx, ensuring consistency in package management across the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and development workflow tooling to use alternative package managers for improved build execution and dependency management consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->