### PR TITLE
Add auto-sync job for Renovate bot and conditionally skip sync checks

### DIFF
--- a/.github/workflows/sync-examples.yml
+++ b/.github/workflows/sync-examples.yml
@@ -46,7 +46,7 @@ jobs:
         run: pnpm sync:examples:check
 
   auto-sync:
-    if: github.actor == 'renovate[bot]'
+    if: github.actor == 'renovate[bot]' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
- Introduced a new job `auto-sync` that runs when the actor is `renovate[bot]`, allowing it to generate a GitHub App token, check out the repository, install dependencies, build packages, and sync examples.
- Added a condition to skip the `check-sync` job if the actor is `renovate[bot]` to prevent unnecessary checks during automated updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a dedicated concurrency group for CI sync runs with cancel-in-progress disabled.
  * Added an auto-sync job for dependency-update bot runs that obtains a token, checks out code, sets up Node/pnpm, builds and syncs examples, and commits/pushes updates with error and no-change handling.
  * Existing check-sync now skips when triggered by the dependency-update bot.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->