### PR TITLE
Fix build for bundlers targetting browsers

### DIFF
--- a/packages/arkenv/package.json
+++ b/packages/arkenv/package.json
@@ -3,6 +3,9 @@
 	"type": "module",
 	"version": "0.9.3",
 	"description": "Typesafe environment variables parsing and validation with ArkType",
+	"browser": {
+		"node:module": false
+	},
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.mts",

--- a/packages/arkenv/src/utils/load-arktype-bundle.test.ts
+++ b/packages/arkenv/src/utils/load-arktype-bundle.test.ts
@@ -96,9 +96,7 @@ console.log(typeof arkenv);`,
 		} catch (e) {
 			const error = e as { stdout?: string; stderr?: string; message: string };
 			const message = error.stderr || error.stdout || error.message;
-			throw new Error(
-				`Browser bundle failed (issue #791): ${message}`,
-			);
+			throw new Error(`Browser bundle failed (issue #791): ${message}`);
 		} finally {
 			// Cleanup
 			if (existsSync(tempDir)) {


### PR DESCRIPTION
While ArkEnv is not written for browsers directly (it's written as a Node.js package ) - it's a good idea to write it in a way that still works on browsers, especially for upcoming integrations (e.g. #655)

This closes #791 since the usage there is a client-side Next.js bundle (via Webpack).