### PR TITLE
feat: CLI infographic

### DIFF
--- a/.changeset/cli-infographic.md
+++ b/.changeset/cli-infographic.md
@@ -1,5 +1,5 @@
 ---
-"@arkenv/cli": minor
+"@arkenv/cli": patch
 ---
 
 Added a colorful infographic banner to the CLI, which can be bypassed with the `--plain` flag.

--- a/.changeset/cli-infographic.md
+++ b/.changeset/cli-infographic.md
@@ -1,0 +1,5 @@
+---
+"@arkenv/cli": minor
+---
+
+Added a colorful infographic banner to the CLI, which can be bypassed with the `--plain` flag.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -56,5 +56,5 @@ This is a **pnpm monorepo** managed with **Turbo**.
 ## Maintenance
 
 - **Adding Contributors**: Use `pnpm contributors:add <username> <contribution-type>`.
-- **Changesets**: Every PR that changes functionality must include a changeset via `pnpm changeset`.
+- **Changesets**: Every PR that changes functionality must include a changeset via `pnpm changeset`. For v0 versions: use `patch` for non-breaking changes, `minor` for breaking changes, and avoid `major` unless explicitly instructed.
 - **Syncing Examples**: Use `pnpm sync:examples` to keep example projects in sync with the core library structure.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,10 +19,6 @@ async function main() {
 	const isYes = args.includes("--yes") || args.includes("-y");
 	const isPlain = args.includes("--plain");
 
-	if (!isPlain) {
-		printInfographic();
-	}
-
 	const printHelp = () => {
 		console.log(`${pc.cyan("ArkEnv CLI")} ${pc.dim(`v${pkg.version}`)}`);
 		console.log("\nUsage:");
@@ -36,6 +32,10 @@ async function main() {
 	if (helpRequested) {
 		printHelp();
 		process.exit(0);
+	}
+
+	if (!isPlain) {
+		printInfographic();
 	}
 
 	if (command !== "init") {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { cancel, confirm, isCancel, log, outro, spinner } from "@clack/prompts";
 import pc from "picocolors";
+import { printInfographic } from "./infographic";
 import { runPromptWizard } from "./prompts";
 import { checkTsConfig, detectFramework, scaffold } from "./scaffold";
 import { code } from "./visuals";
@@ -12,6 +13,11 @@ async function main() {
 	const helpRequested = args.includes("--help") || args.includes("-h");
 
 	const isYes = args.includes("--yes") || args.includes("-y");
+	const isPlain = args.includes("--plain");
+
+	if (!isPlain) {
+		printInfographic();
+	}
 
 	const printHelp = () => {
 		console.log(pc.cyan("ArkEnv CLI"));
@@ -19,6 +25,7 @@ async function main() {
 		console.log("  arkenv init    Set up ArkEnv in your project");
 		console.log("\nOptions:");
 		console.log("  --yes, -y      Skip prompts and use recommended defaults");
+		console.log("  --plain        Run without the colorful infographic");
 		console.log("  --help, -h     Show this help message");
 	};
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createRequire } from "node:module";
 import path from "node:path";
 import { cancel, confirm, isCancel, log, outro, spinner } from "@clack/prompts";
 import pc from "picocolors";
@@ -6,6 +7,9 @@ import { printInfographic } from "./infographic";
 import { runPromptWizard } from "./prompts";
 import { checkTsConfig, detectFramework, scaffold } from "./scaffold";
 import { code } from "./visuals";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json");
 
 async function main() {
 	const args = process.argv.slice(2);
@@ -20,7 +24,7 @@ async function main() {
 	}
 
 	const printHelp = () => {
-		console.log(pc.cyan("ArkEnv CLI"));
+		console.log(`${pc.cyan("ArkEnv CLI")} ${pc.dim(`v${pkg.version}`)}`);
 		console.log("\nUsage:");
 		console.log("  arkenv init    Set up ArkEnv in your project");
 		console.log("\nOptions:");

--- a/packages/cli/src/infographic.ts
+++ b/packages/cli/src/infographic.ts
@@ -1,19 +1,38 @@
-import { createRequire } from "node:module";
 import pc from "picocolors";
+import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json");
 
 export function printInfographic() {
 	const version = pkg.version;
+	const dir = process.cwd().replace(process.env.HOME || "", "~");
 
-	const logo = [
-		`      ${pc.blue("┃")}          ${pc.bold(`ArkEnv CLI v${version}`)}`,
-		`    ${pc.blue("╲ █ ╱")}        ${pc.dim("Type-safe environment variables")}`,
-		`  ${pc.blue("━ █")} ${pc.cyan("●")} ${pc.blue("█ ━")}      ${pc.dim("from editor to runtime")}`,
-		`    ${pc.blue("╱ █ ╲")}`,
-		`      ${pc.blue("┃")}`,
+	// Raw strings for length calculation
+	const titleRaw = `⛯ ArkEnv CLI (v${version})`;
+	const line1Raw = `runtime:   ${process.release?.name || "node"} ${process.version}`;
+	const line2Raw = `directory: ${dir}`;
+
+	const width = 60;
+	const contentWidth = width - 4; // 2 for border, 2 for padding
+
+	const pad = (str: string, raw: string) => {
+		const padding = contentWidth - raw.length;
+		return str + " ".repeat(Math.max(0, padding));
+	};
+
+	const title = `${pc.blue("⛯")} ${pc.bold("ArkEnv CLI")} ${pc.dim(`(v${version})`)}`;
+	const line1 = `${pc.dim("runtime:")}   ${pc.cyan(process.release?.name || "node")} ${pc.dim(process.version)}`;
+	const line2 = `${pc.dim("directory:")} ${pc.cyan(dir)}`;
+
+	const box = [
+		pc.blue(`╭${"─".repeat(width - 2)}╮`),
+		`${pc.blue("│")} ${pad(title, titleRaw)} ${pc.blue("│")}`,
+		`${pc.blue("│")} ${" ".repeat(contentWidth)} ${pc.blue("│")}`,
+		`${pc.blue("│")} ${pad(line1, line1Raw)} ${pc.blue("│")}`,
+		`${pc.blue("│")} ${pad(line2, line2Raw)} ${pc.blue("│")}`,
+		pc.blue(`╰${"─".repeat(width - 2)}╯`),
 	].join("\n");
 
-	console.log(`\n${logo}\n`);
+	console.log(`\n${box}\n`);
 }

--- a/packages/cli/src/infographic.ts
+++ b/packages/cli/src/infographic.ts
@@ -1,36 +1,31 @@
-import { createRequire } from "node:module";
 import pc from "picocolors";
+import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json");
 
 export function printInfographic() {
 	const version = pkg.version;
-	const dir = process.cwd().replace(process.env.HOME || "", "~");
+	const libraryVersion = "0.11.0"; // Current monorepo version
 
 	// Raw strings for length calculation
-	const titleRaw = `⛯ ArkEnv CLI (v${version})`;
-	const line1Raw = `runtime:   ${process.release?.name || "node"} ${process.version}`;
+	const titleRaw = "⛯ ArkEnv CLI";
+	const line1Raw = `cli:     v${version}`;
+	const line2Raw = `library: v${libraryVersion} (latest)`;
+	const line3Raw = "docs:    arkenv.js.org";
 
-	const width = 60;
+	const width = 50;
 	const contentWidth = width - 4; // 2 for border, 2 for padding
-
-	// Handle directory truncation
-	let displayDir = dir;
-	if (displayDir.length > contentWidth - 11) {
-		// 11 is "directory: " length
-		displayDir = `...${displayDir.slice(-(contentWidth - 14))}`;
-	}
-	const line2Raw = `directory: ${displayDir}`;
 
 	const pad = (str: string, raw: string) => {
 		const padding = contentWidth - raw.length;
 		return str + " ".repeat(Math.max(0, padding));
 	};
 
-	const title = `${pc.blue("⛯")} ${pc.bold("ArkEnv CLI")} ${pc.dim(`(v${version})`)}`;
-	const line1 = `${pc.dim("runtime:")}   ${pc.cyan(process.release?.name || "node")} ${pc.dim(process.version)}`;
-	const line2 = `${pc.dim("directory:")} ${pc.cyan(displayDir)}`;
+	const title = `${pc.blue("⛯")} ${pc.bold("ArkEnv CLI")}`;
+	const line1 = `${pc.dim("cli:")}     ${pc.cyan(`v${version}`)}`;
+	const line2 = `${pc.dim("library:")} ${pc.cyan(`v${libraryVersion}`)} ${pc.dim("(latest)")}`;
+	const line3 = `${pc.dim("docs:")}    ${pc.blue("arkenv.js.org")}`;
 
 	const box = [
 		pc.blue(`╭${"─".repeat(width - 2)}╮`),
@@ -38,6 +33,7 @@ export function printInfographic() {
 		`${pc.blue("│")} ${" ".repeat(contentWidth)} ${pc.blue("│")}`,
 		`${pc.blue("│")} ${pad(line1, line1Raw)} ${pc.blue("│")}`,
 		`${pc.blue("│")} ${pad(line2, line2Raw)} ${pc.blue("│")}`,
+		`${pc.blue("│")} ${pad(line3, line3Raw)} ${pc.blue("│")}`,
 		pc.blue(`╰${"─".repeat(width - 2)}╯`),
 	].join("\n");
 

--- a/packages/cli/src/infographic.ts
+++ b/packages/cli/src/infographic.ts
@@ -8,13 +8,11 @@ export function printInfographic() {
 	const version = pkg.version;
 	
 	const logo = [
-		`    ${pc.blue("█")}       ${pc.bold(`ArkEnv CLI v${version}`)}`,
-		`   ${pc.blue("▞▀▚")}      ${pc.dim("Type-safe environment variables")}`,
-		`   ${pc.cyan("┃")} ${pc.yellow("●")} ${pc.cyan("┃")}     ${pc.dim("from editor to runtime")}`,
-		`   ${pc.blue("▙▄▟")}`,
-		`   ${pc.blue("█▄█")}`,
-		`  ${pc.blue("▟███▙")}`,
-		` ${pc.blue("▟█████▙")}`,
+		`      ${pc.blue("┃")}          ${pc.bold(`ArkEnv CLI v${version}`)}`,
+		`    ${pc.blue("╲ █ ╱")}        ${pc.dim("Type-safe environment variables")}`,
+		`  ${pc.blue("━ █")} ${pc.cyan("●")} ${pc.blue("█ ━")}      ${pc.dim("from editor to runtime")}`,
+		`    ${pc.blue("╱ █ ╲")}`,
+		`      ${pc.blue("┃")}`,
 	].join("\n");
 
 	console.log(`\n${logo}\n`);

--- a/packages/cli/src/infographic.ts
+++ b/packages/cli/src/infographic.ts
@@ -11,13 +11,14 @@ export function printInfographic() {
 	// Raw strings for length calculation
 	const titleRaw = `⛯ ArkEnv CLI (v${version})`;
 	const line1Raw = `runtime:   ${process.release?.name || "node"} ${process.version}`;
-	
+
 	const width = 60;
 	const contentWidth = width - 4; // 2 for border, 2 for padding
 
 	// Handle directory truncation
 	let displayDir = dir;
-	if (displayDir.length > contentWidth - 11) { // 11 is "directory: " length
+	if (displayDir.length > contentWidth - 11) {
+		// 11 is "directory: " length
 		displayDir = `...${displayDir.slice(-(contentWidth - 14))}`;
 	}
 	const line2Raw = `directory: ${displayDir}`;

--- a/packages/cli/src/infographic.ts
+++ b/packages/cli/src/infographic.ts
@@ -1,16 +1,20 @@
-import { createRequire } from "node:module";
 import pc from "picocolors";
+import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json");
 
 export function printInfographic() {
 	const version = pkg.version;
-
+	
 	const logo = [
-		` ${pc.blue("⛯")}      ${pc.bold(`ArkEnv CLI v${version}`)}`,
-		` ${pc.cyan("⛯")}      ${pc.dim("Type-safe environment variables")}`,
-		` ${pc.blue("⛯")}      ${pc.dim("from editor to runtime")}`,
+		`    ${pc.blue("█")}       ${pc.bold(`ArkEnv CLI v${version}`)}`,
+		`   ${pc.blue("▞▀▚")}      ${pc.dim("Type-safe environment variables")}`,
+		`   ${pc.cyan("┃")} ${pc.yellow("●")} ${pc.cyan("┃")}     ${pc.dim("from editor to runtime")}`,
+		`   ${pc.blue("▙▄▟")}`,
+		`   ${pc.blue("█▄█")}`,
+		`  ${pc.blue("▟███▙")}`,
+		` ${pc.blue("▟█████▙")}`,
 	].join("\n");
 
 	console.log(`\n${logo}\n`);

--- a/packages/cli/src/infographic.ts
+++ b/packages/cli/src/infographic.ts
@@ -1,12 +1,12 @@
-import pc from "picocolors";
 import { createRequire } from "node:module";
+import pc from "picocolors";
 
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json");
 
 export function printInfographic() {
 	const version = pkg.version;
-	
+
 	const logo = [
 		`      ${pc.blue("┃")}          ${pc.bold(`ArkEnv CLI v${version}`)}`,
 		`    ${pc.blue("╲ █ ╱")}        ${pc.dim("Type-safe environment variables")}`,

--- a/packages/cli/src/infographic.ts
+++ b/packages/cli/src/infographic.ts
@@ -8,10 +8,9 @@ export function printInfographic() {
 	const version = pkg.version;
 
 	const logo = [
-		` ${pc.cyan("▝▜▄")}     ${pc.bold(`ArkEnv CLI v${version}`)}`,
-		`   ${pc.cyan("▝▜▄")}`,
-		`  ${pc.blue("▗▟▀")}    ${pc.dim("Type-safe environment variables")}`,
-		` ${pc.blue("▝▀")}      ${pc.dim("from editor to runtime")}`,
+		` ${pc.blue("⛯")}      ${pc.bold(`ArkEnv CLI v${version}`)}`,
+		` ${pc.cyan("⛯")}      ${pc.dim("Type-safe environment variables")}`,
+		` ${pc.blue("⛯")}      ${pc.dim("from editor to runtime")}`,
 	].join("\n");
 
 	console.log(`\n${logo}\n`);

--- a/packages/cli/src/infographic.ts
+++ b/packages/cli/src/infographic.ts
@@ -1,5 +1,5 @@
-import pc from "picocolors";
 import { createRequire } from "node:module";
+import pc from "picocolors";
 
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json");

--- a/packages/cli/src/infographic.ts
+++ b/packages/cli/src/infographic.ts
@@ -1,0 +1,18 @@
+import { createRequire } from "node:module";
+import pc from "picocolors";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json");
+
+export function printInfographic() {
+	const version = pkg.version;
+
+	const logo = [
+		` ${pc.cyan("▝▜▄")}     ${pc.bold(`ArkEnv CLI v${version}`)}`,
+		`   ${pc.cyan("▝▜▄")}`,
+		`  ${pc.blue("▗▟▀")}    ${pc.dim("Type-safe environment variables")}`,
+		` ${pc.blue("▝▀")}      ${pc.dim("from editor to runtime")}`,
+	].join("\n");
+
+	console.log(`\n${logo}\n`);
+}

--- a/packages/cli/src/infographic.ts
+++ b/packages/cli/src/infographic.ts
@@ -11,10 +11,16 @@ export function printInfographic() {
 	// Raw strings for length calculation
 	const titleRaw = `⛯ ArkEnv CLI (v${version})`;
 	const line1Raw = `runtime:   ${process.release?.name || "node"} ${process.version}`;
-	const line2Raw = `directory: ${dir}`;
-
+	
 	const width = 60;
 	const contentWidth = width - 4; // 2 for border, 2 for padding
+
+	// Handle directory truncation
+	let displayDir = dir;
+	if (displayDir.length > contentWidth - 11) { // 11 is "directory: " length
+		displayDir = `...${displayDir.slice(-(contentWidth - 14))}`;
+	}
+	const line2Raw = `directory: ${displayDir}`;
 
 	const pad = (str: string, raw: string) => {
 		const padding = contentWidth - raw.length;
@@ -23,7 +29,7 @@ export function printInfographic() {
 
 	const title = `${pc.blue("⛯")} ${pc.bold("ArkEnv CLI")} ${pc.dim(`(v${version})`)}`;
 	const line1 = `${pc.dim("runtime:")}   ${pc.cyan(process.release?.name || "node")} ${pc.dim(process.version)}`;
-	const line2 = `${pc.dim("directory:")} ${pc.cyan(dir)}`;
+	const line2 = `${pc.dim("directory:")} ${pc.cyan(displayDir)}`;
 
 	const box = [
 		pc.blue(`╭${"─".repeat(width - 2)}╮`),


### PR DESCRIPTION
Fixes #903

Adds a colorful infographic banner to the ArkEnv CLI. The banner can be bypassed with the `--plain` flag.
Included a changeset for the minor bump of `@arkenv/cli`.