### PR TITLE
docs(cli): fix typo 'frameowkr' -> 'framework' in README.md

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -47,7 +47,7 @@ bunx @arkenv/cli@latest init
 - **Interactive Scaffolding**: A guided setup process using `@clack/prompts`.
 - **Zero Dependencies**: Lightweight and fast, perfect for one-off project initialization.
 - **Multiple Validation Libraries**: Support for [ArkType](https://arktype.io), [Zod](https://zod.dev), and [Valibot](https://valibot.dev).
-- **Framework Detection**: Automatically detects your frameowkr and runtime (Node, Bun, Vite).
+- **Framework Detection**: Automatically detects your framework and runtime (Node, Bun, Vite).
 
 ## Usage
 


### PR DESCRIPTION
Fixes #914

Simple 1-word typo fix in the CLI README.md:
- `frameowkr` → `framework` (line 50)
- One file, one line changed
- GH007 compliant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Framework Detection feature details in CLI README, highlighting support for Node, Bun, and Vite.
  * Fixed a typographical error in the features list.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yamcodes/arkenv/pull/915)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->