### PR TITLE
refactor(ui): replace `getModifierKey` with `useEffect`-based state for hotkey detection

### DIFF
--- a/apps/www/components/ui/search-toggle.test.tsx
+++ b/apps/www/components/ui/search-toggle.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SearchToggle } from "./search-toggle";
+
+vi.mock("fumadocs-ui/contexts/search", () => ({
+	useSearchContext: () => ({
+		setOpenSearch: vi.fn(),
+	}),
+}));
+
+describe("SearchToggle", () => {
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it("shows Ctrl on non-Mac platforms", () => {
+		vi.stubGlobal("navigator", {
+			userAgent: "Windows NT 10.0",
+		});
+
+		render(<SearchToggle />);
+
+		// It should stay as Ctrl
+		const modifier = screen.getAllByText("Ctrl");
+		expect(modifier.length).toBeGreaterThan(0);
+	});
+
+	it("shows ⌘ on Mac platforms", async () => {
+		vi.stubGlobal("navigator", {
+			userAgent: "Macintosh; Intel Mac OS X 10_15_7",
+		});
+
+		render(<SearchToggle />);
+
+		// It should update to ⌘ after useEffect
+		const modifier = await screen.findByText("⌘");
+		expect(modifier).toBeInTheDocument();
+	});
+
+	it("shows ⌘ on iPad", async () => {
+		vi.stubGlobal("navigator", {
+			userAgent: "iPad; CPU OS 13_2_3 like Mac OS X",
+		});
+
+		render(<SearchToggle />);
+
+		const modifier = await screen.findByText("⌘");
+		expect(modifier).toBeInTheDocument();
+	});
+});

--- a/apps/www/components/ui/search-toggle.test.tsx
+++ b/apps/www/components/ui/search-toggle.test.tsx
@@ -12,6 +12,7 @@ describe("SearchToggle", () => {
 	afterEach(() => {
 		cleanup();
 		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
 	});
 
 	it("shows Ctrl on non-Mac platforms", () => {

--- a/apps/www/components/ui/search-toggle.tsx
+++ b/apps/www/components/ui/search-toggle.tsx
@@ -2,15 +2,16 @@
 
 import { useSearchContext } from "fumadocs-ui/contexts/search";
 import { Search } from "lucide-react";
-
-function getModifierKey() {
-	if (typeof window === "undefined") return "Ctrl";
-	return window.navigator.userAgent.includes("Mac") ? "⌘" : "Ctrl";
-}
+import { useEffect, useState } from "react";
 
 export function SearchToggle() {
 	const { setOpenSearch } = useSearchContext();
-	const modifier = getModifierKey();
+	const [modifier, setModifier] = useState("Ctrl");
+
+	useEffect(() => {
+		const isMac = /Mac|iPhone|iPod|iPad/i.test(navigator.userAgent);
+		setModifier(isMac ? "⌘" : "Ctrl");
+	}, []);
 
 	return (
 		<>
@@ -36,10 +37,7 @@ export function SearchToggle() {
 				<Search className="size-4 shrink-0" />
 				<span className="flex-1 text-start">Search</span>
 				<span className="inline-flex gap-0.5">
-					<kbd
-						suppressHydrationWarning
-						className="rounded border bg-fd-background px-1.5 font-sans text-xs"
-					>
+					<kbd className="rounded border bg-fd-background px-1.5 font-sans text-xs">
 						{modifier}
 					</kbd>
 					<kbd className="rounded border bg-fd-background px-1.5 font-sans text-xs">


### PR DESCRIPTION
- Updated `SearchToggle` component to dynamically detect and set the modifier key (`⌘` on Mac, `Ctrl` on others) using `useEffect` and `useState`.
- Removed unused `getModifierKey` function.

Closes #909 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the search toggle component, validating keyboard modifier display across Windows/Linux and macOS/iPad platforms.

* **Bug Fixes**
  * Updated search toggle component's keyboard modifier detection to resolve hydration mismatch issues by moving initialization to client-side.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yamcodes/arkenv/pull/917)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->