### PR TITLE
feat(skills,cli): adapt ArkEnv skill and CLI for framework plugins

### DIFF
--- a/.changeset/tough-papers-argue.md
+++ b/.changeset/tough-papers-argue.md
@@ -2,4 +2,4 @@
 "@arkenv/cli": patch
 ---
 
-feat: adapt CLI templates for framework plugins (Vite/Bun)
+#### Adapt CLI templates for framework plugins (Vite/Bun)

--- a/.changeset/tough-papers-argue.md
+++ b/.changeset/tough-papers-argue.md
@@ -1,0 +1,5 @@
+---
+"@arkenv/cli": patch
+---
+
+feat: adapt CLI templates for framework plugins (Vite/Bun)

--- a/.github/workflows/preview-www.yml
+++ b/.github/workflows/preview-www.yml
@@ -147,8 +147,6 @@ jobs:
                 '>',
                 '> We enforce hourly and daily rate limits to ensure stability and fair usage of resources.',
                 '>',
-                '> Please see our [FAQ](https://docs.arkenv.dev/faq) for further information.',
-                '>',
                 '> </details>',
                 ''
               ].join('\n');

--- a/packages/cli/src/env-template.test.ts
+++ b/packages/cli/src/env-template.test.ts
@@ -32,6 +32,22 @@ describe("env-template", () => {
 			expect(template).toContain("export const Env = type({");
 		});
 
+		it("returns arktype template for bun when validator is arktype", () => {
+			const options = {
+				validator: "arktype" as any,
+				framework: "bun" as any,
+				path: ".env.config.ts",
+				language: "ts" as const,
+				shouldUpdateTsConfig: false,
+				shouldInstall: false,
+			};
+			const template = getEnvTemplate(options);
+			expect(template).toContain('import { type } from "arkenv"');
+			expect(template).not.toContain("export const env = arkenv(Env)");
+			expect(template).toContain("export const Env = type({");
+			expect(template).toContain("In Bun, use @arkenv/bun-plugin");
+		});
+
 		it("returns zod template when validator is zod", () => {
 			const options = {
 				validator: "zod" as any,

--- a/packages/cli/src/env-template.test.ts
+++ b/packages/cli/src/env-template.test.ts
@@ -14,6 +14,22 @@ describe("env-template", () => {
 			};
 			const template = getEnvTemplate(options);
 			expect(template).toContain('import arkenv, { type } from "arkenv"');
+			expect(template).toContain("export const env = arkenv(Env)");
+		});
+
+		it("returns arktype template for vite when validator is arktype", () => {
+			const options = {
+				validator: "arktype" as any,
+				framework: "vite" as any,
+				path: ".env.config.ts",
+				language: "ts" as const,
+				shouldUpdateTsConfig: false,
+				shouldInstall: false,
+			};
+			const template = getEnvTemplate(options);
+			expect(template).toContain('import { type } from "arkenv"');
+			expect(template).not.toContain("export const env = arkenv(Env)");
+			expect(template).toContain("export const Env = type({");
 		});
 
 		it("returns zod template when validator is zod", () => {

--- a/packages/cli/src/env-template.test.ts
+++ b/packages/cli/src/env-template.test.ts
@@ -46,6 +46,7 @@ describe("env-template", () => {
 			expect(template).not.toContain("export const env = arkenv(Env)");
 			expect(template).toContain("export const Env = type({");
 			expect(template).toContain("In Bun, use @arkenv/bun-plugin");
+			expect(template).toContain("validate these at build-time");
 		});
 
 		it("returns zod template when validator is zod", () => {

--- a/packages/cli/src/env-template.test.ts
+++ b/packages/cli/src/env-template.test.ts
@@ -30,6 +30,8 @@ describe("env-template", () => {
 			expect(template).toContain('import { type } from "arkenv"');
 			expect(template).not.toContain("export const env = arkenv(Env)");
 			expect(template).toContain("export const Env = type({");
+			expect(template).toContain("use `@arkenv/vite-plugin` to validate these");
+			expect(template).toContain("typesafety for `@import.meta.env`".replace("@", ""));
 		});
 
 		it("returns arktype template for bun when validator is arktype", () => {
@@ -45,8 +47,9 @@ describe("env-template", () => {
 			expect(template).toContain('import { type } from "arkenv"');
 			expect(template).not.toContain("export const env = arkenv(Env)");
 			expect(template).toContain("export const Env = type({");
-			expect(template).toContain("In Bun, use @arkenv/bun-plugin");
+			expect(template).toContain("In Bun, use \\`@arkenv/bun-plugin\\`".replace(/\\/g, ""));
 			expect(template).toContain("validate these at build-time");
+			expect(template).toContain("typesafety for \\`process.env\\`".replace(/\\/g, ""));
 		});
 
 		it("returns zod template when validator is zod", () => {

--- a/packages/cli/src/env-template.test.ts
+++ b/packages/cli/src/env-template.test.ts
@@ -31,7 +31,9 @@ describe("env-template", () => {
 			expect(template).not.toContain("export const env = arkenv(Env)");
 			expect(template).toContain("export const Env = type({");
 			expect(template).toContain("use `@arkenv/vite-plugin` to validate these");
-			expect(template).toContain("typesafety for `@import.meta.env`".replace("@", ""));
+			expect(template).toContain(
+				"typesafety for `@import.meta.env`".replace("@", ""),
+			);
 		});
 
 		it("returns arktype template for bun when validator is arktype", () => {
@@ -47,9 +49,13 @@ describe("env-template", () => {
 			expect(template).toContain('import { type } from "arkenv"');
 			expect(template).not.toContain("export const env = arkenv(Env)");
 			expect(template).toContain("export const Env = type({");
-			expect(template).toContain("In Bun, use \\`@arkenv/bun-plugin\\`".replace(/\\/g, ""));
+			expect(template).toContain(
+				"In Bun, use \\`@arkenv/bun-plugin\\`".replace(/\\/g, ""),
+			);
 			expect(template).toContain("validate these at build-time");
-			expect(template).toContain("typesafety for \\`process.env\\`".replace(/\\/g, ""));
+			expect(template).toContain(
+				"typesafety for \\`process.env\\`".replace(/\\/g, ""),
+			);
 		});
 
 		it("returns zod template when validator is zod", () => {

--- a/packages/cli/src/env-template.ts
+++ b/packages/cli/src/env-template.ts
@@ -2,15 +2,15 @@ import type { ProjectOptions } from "./prompts";
 import { arktypeTemplate, valibotTemplate, zodTemplate } from "./templates";
 
 export function getEnvTemplate(options: ProjectOptions): string {
-	const { validator, envKeys } = options;
+	const { validator, envKeys, framework } = options;
 
 	switch (validator) {
 		case "arktype":
-			return arktypeTemplate(envKeys) + "\n";
+			return arktypeTemplate(envKeys, framework) + "\n";
 		case "zod":
-			return zodTemplate(envKeys) + "\n";
+			return zodTemplate(envKeys, framework) + "\n";
 		case "valibot":
-			return valibotTemplate(envKeys) + "\n";
+			return valibotTemplate(envKeys, framework) + "\n";
 		default:
 			throw new Error(`Unsupported validator: ${validator}`);
 	}

--- a/packages/cli/src/templates/arktype.ts
+++ b/packages/cli/src/templates/arktype.ts
@@ -19,8 +19,8 @@ export const arktypeTemplate = (envKeys?: string[], framework?: string) => {
 
 		/**
 		 * Environment variable schema.
-		 * In Vite, use @arkenv/vite-plugin to validate these at build-time
-		 * and provide typesafety for import.meta.env.
+		 * In Vite, use \`@arkenv/vite-plugin\` to validate these at build-time
+		 * and provide typesafety for \`import.meta.env\`.
 		 */
 		export const Env = type({
 ${schemaFields}
@@ -34,8 +34,8 @@ ${schemaFields}
 
 		/**
 		 * Environment variable schema.
-		 * In Bun, use @arkenv/bun-plugin to validate these at build-time
-		 * and provide typesafety for process.env.
+		 * In Bun, use \`@arkenv/bun-plugin\` to validate these at build-time
+		 * and provide typesafety for \`process.env\`.
 		 */
 		export const Env = type({
 ${schemaFields}

--- a/packages/cli/src/templates/arktype.ts
+++ b/packages/cli/src/templates/arktype.ts
@@ -34,7 +34,7 @@ ${schemaFields}
 
 		/**
 		 * Environment variable schema.
-		 * In Bun, use @arkenv/bun-plugin to validate these at runtime
+		 * In Bun, use @arkenv/bun-plugin to validate these at build-time
 		 * and provide typesafety for process.env.
 		 */
 		export const Env = type({

--- a/packages/cli/src/templates/arktype.ts
+++ b/packages/cli/src/templates/arktype.ts
@@ -28,6 +28,21 @@ ${schemaFields}
 		`;
 	}
 
+	if (framework === "bun") {
+		return dedent /* ts */`
+		import { type } from "arkenv";
+
+		/**
+		 * Environment variable schema.
+		 * In Bun, use @arkenv/bun-plugin to validate these at runtime
+		 * and provide typesafety for process.env.
+		 */
+		export const Env = type({
+${schemaFields}
+		});
+		`;
+	}
+
 	return dedent /* ts */`
 	import arkenv, { type } from "arkenv";
 

--- a/packages/cli/src/templates/arktype.ts
+++ b/packages/cli/src/templates/arktype.ts
@@ -4,18 +4,34 @@ import dedent from "dedent";
  * Generates a TypeScript template string for an ArkType environment configuration.
  *
  * @param envKeys - Optional array of environment variable keys to include in the schema.
+ * @param framework - The framework being used (vite, bun, or node).
  * @returns The generated TypeScript template string.
  */
-export const arktypeTemplate = (envKeys?: string[]) => {
+export const arktypeTemplate = (envKeys?: string[], framework?: string) => {
 	const schemaFields = envKeys?.length
 		? envKeys.map((key) => `\t\t${key}: "string",`).join("\n")
 		: `\t\tNODE_ENV: "'development' | 'production' | 'test'",
 		PORT: "number.port",`;
 
+	if (framework === "vite") {
+		return dedent /* ts */`
+		import { type } from "arkenv";
+
+		/**
+		 * Environment variable schema.
+		 * In Vite, use @arkenv/vite-plugin to validate these at build-time
+		 * and provide typesafety for import.meta.env.
+		 */
+		export const Env = type({
+${schemaFields}
+		});
+		`;
+	}
+
 	return dedent /* ts */`
 	import arkenv, { type } from "arkenv";
 
-	const Env = type({
+	export const Env = type({
 ${schemaFields}
 	});
 

--- a/packages/cli/src/templates/valibot.ts
+++ b/packages/cli/src/templates/valibot.ts
@@ -4,19 +4,35 @@ import dedent from "dedent";
  * Generates a TypeScript template string for a Valibot environment configuration.
  *
  * @param envKeys - Optional array of environment variable keys to include in the schema.
+ * @param framework - The framework being used (vite, bun, or node).
  * @returns The generated TypeScript template string.
  */
-export const valibotTemplate = (envKeys?: string[]) => {
+export const valibotTemplate = (envKeys?: string[], framework?: string) => {
 	const schemaFields = envKeys?.length
 		? envKeys.map((key) => `\t\t${key}: v.string(),`).join("\n")
 		: `\t\tNODE_ENV: v.picklist(["development", "production", "test"]),
 		PORT: v.pipe(v.string(), v.transform(Number), v.number(), v.minValue(1)),`;
 
+	if (framework === "vite") {
+		return dedent /* ts */`
+		import * as v from "valibot";
+
+		/**
+		 * Environment variable schema.
+		 * In Vite, use @arkenv/vite-plugin to validate these at build-time
+		 * and provide typesafety for import.meta.env.
+		 */
+		export const Env = v.object({
+${schemaFields}
+		});
+		`;
+	}
+
 	return dedent /* ts */`
 	import arkenv from "arkenv/standard";
 	import * as v from "valibot";
 
-	const Env = v.object({
+	export const Env = v.object({
 ${schemaFields}
 	});
 

--- a/packages/cli/src/templates/valibot.ts
+++ b/packages/cli/src/templates/valibot.ts
@@ -34,7 +34,7 @@ ${schemaFields}
 
 		/**
 		 * Environment variable schema.
-		 * In Bun, use @arkenv/bun-plugin to validate these at runtime
+		 * In Bun, use @arkenv/bun-plugin to validate these at build-time
 		 * and provide typesafety for process.env.
 		 */
 		export const Env = v.object({

--- a/packages/cli/src/templates/valibot.ts
+++ b/packages/cli/src/templates/valibot.ts
@@ -28,6 +28,21 @@ ${schemaFields}
 		`;
 	}
 
+	if (framework === "bun") {
+		return dedent /* ts */`
+		import * as v from "valibot";
+
+		/**
+		 * Environment variable schema.
+		 * In Bun, use @arkenv/bun-plugin to validate these at runtime
+		 * and provide typesafety for process.env.
+		 */
+		export const Env = v.object({
+${schemaFields}
+		});
+		`;
+	}
+
 	return dedent /* ts */`
 	import arkenv from "arkenv/standard";
 	import * as v from "valibot";

--- a/packages/cli/src/templates/valibot.ts
+++ b/packages/cli/src/templates/valibot.ts
@@ -19,8 +19,8 @@ export const valibotTemplate = (envKeys?: string[], framework?: string) => {
 
 		/**
 		 * Environment variable schema.
-		 * In Vite, use @arkenv/vite-plugin to validate these at build-time
-		 * and provide typesafety for import.meta.env.
+		 * In Vite, use \`@arkenv/vite-plugin\` to validate these at build-time
+		 * and provide typesafety for \`import.meta.env\`.
 		 */
 		export const Env = v.object({
 ${schemaFields}
@@ -34,8 +34,8 @@ ${schemaFields}
 
 		/**
 		 * Environment variable schema.
-		 * In Bun, use @arkenv/bun-plugin to validate these at build-time
-		 * and provide typesafety for process.env.
+		 * In Bun, use \`@arkenv/bun-plugin\` to validate these at build-time
+		 * and provide typesafety for \`process.env\`.
 		 */
 		export const Env = v.object({
 ${schemaFields}

--- a/packages/cli/src/templates/zod.ts
+++ b/packages/cli/src/templates/zod.ts
@@ -34,7 +34,7 @@ ${schemaFields}
 
 		/**
 		 * Environment variable schema.
-		 * In Bun, use @arkenv/bun-plugin to validate these at runtime
+		 * In Bun, use @arkenv/bun-plugin to validate these at build-time
 		 * and provide typesafety for process.env.
 		 */
 		export const Env = z.object({

--- a/packages/cli/src/templates/zod.ts
+++ b/packages/cli/src/templates/zod.ts
@@ -19,8 +19,8 @@ export const zodTemplate = (envKeys?: string[], framework?: string) => {
 
 		/**
 		 * Environment variable schema.
-		 * In Vite, use @arkenv/vite-plugin to validate these at build-time
-		 * and provide typesafety for import.meta.env.
+		 * In Vite, use \`@arkenv/vite-plugin\` to validate these at build-time
+		 * and provide typesafety for \`import.meta.env\`.
 		 */
 		export const Env = z.object({
 ${schemaFields}
@@ -34,8 +34,8 @@ ${schemaFields}
 
 		/**
 		 * Environment variable schema.
-		 * In Bun, use @arkenv/bun-plugin to validate these at build-time
-		 * and provide typesafety for process.env.
+		 * In Bun, use \`@arkenv/bun-plugin\` to validate these at build-time
+		 * and provide typesafety for \`process.env\`.
 		 */
 		export const Env = z.object({
 ${schemaFields}

--- a/packages/cli/src/templates/zod.ts
+++ b/packages/cli/src/templates/zod.ts
@@ -28,6 +28,21 @@ ${schemaFields}
 		`;
 	}
 
+	if (framework === "bun") {
+		return dedent /* ts */`
+		import { z } from "zod";
+
+		/**
+		 * Environment variable schema.
+		 * In Bun, use @arkenv/bun-plugin to validate these at runtime
+		 * and provide typesafety for process.env.
+		 */
+		export const Env = z.object({
+${schemaFields}
+		});
+		`;
+	}
+
 	return dedent /* ts */`
 	import arkenv from "arkenv/standard";
 	import { z } from "zod";

--- a/packages/cli/src/templates/zod.ts
+++ b/packages/cli/src/templates/zod.ts
@@ -4,19 +4,35 @@ import dedent from "dedent";
  * Generates a TypeScript template string for a Zod environment configuration.
  *
  * @param envKeys - Optional array of environment variable keys to include in the schema.
+ * @param framework - The framework being used (vite, bun, or node).
  * @returns The generated TypeScript template string.
  */
-export const zodTemplate = (envKeys?: string[]) => {
+export const zodTemplate = (envKeys?: string[], framework?: string) => {
 	const schemaFields = envKeys?.length
 		? envKeys.map((key) => `\t\t${key}: z.string(),`).join("\n")
 		: `\t\tNODE_ENV: z.enum(["development", "production", "test"]),
 		PORT: z.coerce.number().positive(),`;
 
+	if (framework === "vite") {
+		return dedent /* ts */`
+		import { z } from "zod";
+
+		/**
+		 * Environment variable schema.
+		 * In Vite, use @arkenv/vite-plugin to validate these at build-time
+		 * and provide typesafety for import.meta.env.
+		 */
+		export const Env = z.object({
+${schemaFields}
+		});
+		`;
+	}
+
 	return dedent /* ts */`
 	import arkenv from "arkenv/standard";
 	import { z } from "zod";
 
-	const Env = z.object({
+	export const Env = z.object({
 ${schemaFields}
 	});
 

--- a/skills/arkenv/SKILL.md
+++ b/skills/arkenv/SKILL.md
@@ -19,7 +19,7 @@ ArkEnv is a typesafe environment variable validator for modern JavaScript runtim
 ### Framework Integration
 
 - **Vite**: Build-time validation and `import.meta.env` type augmentation via `@arkenv/vite-plugin`.
-- **Bun**: Runtime validation and `process.env` type augmentation via `@arkenv/bun-plugin`.
+- **Bun**: Build-time/Runtime validation and `process.env` type augmentation via `@arkenv/bun-plugin`.
 - **Node.js**: Standard `process.env` validation and coercion.
 
 ### CLI (Setup & DevOps)

--- a/skills/arkenv/SKILL.md
+++ b/skills/arkenv/SKILL.md
@@ -16,79 +16,115 @@ ArkEnv is a typesafe environment variable validator for modern JavaScript runtim
 - Configure automatic coercion and default values.
 - Follow best practices for schema organization.
 
+### Framework Integration
+
+- **Vite**: Build-time validation and `import.meta.env` type augmentation via `@arkenv/vite-plugin`.
+- **Bun**: Runtime validation and `process.env` type augmentation via `@arkenv/bun-plugin`.
+- **Node.js**: Standard `process.env` validation and coercion.
+
 ### CLI (Setup & DevOps)
 
 - Initialize ArkEnv in new or existing projects using `pnpm dlx @arkenv/cli@latest init`.
 - Scaffold schema files and detect framework-specific configurations (Vite, Bun, etc.).
-- Automatically configure `tsconfig.json` for optimal typesafety.
+- Automatically configure `tsconfig.json` and environment types for optimal typesafety.
 
 ## Operational Logic
 
-1. **Detection**: Look for `env.ts` or ArkEnv imports to understand existing schema.
+1. **Detection**:
+   - Look for `env.ts` or ArkEnv imports to understand existing schema.
+   - Check for framework config files (`vite.config.ts`, `bunfig.toml`, `package.json` scripts) to recommend appropriate plugins.
 2. **Setup**: If ArkEnv is not present, recommend using the CLI: `pnpm dlx @arkenv/cli@latest init`.
 3. **Pattern Enforcement**:
-   - Always export the `env` object from a central file (usually `env.ts`).
-   - Prefer ArkType strings for concise definitions.
-   - Use `.env` files for local development but never commit them.
-   - Ensure `strict` mode is enabled in `tsconfig.json`.
+   - **Centralize Schema**: Always define the schema in a central file (e.g., `env.ts`).
+   - **Frontend (Vite/Bun)**:
+     - Use the appropriate plugin for build-time validation.
+     - Access variables via native primitives (`import.meta.env` for Vite, `process.env` for Bun).
+     - Use **Type Augmentation** to make native primitives typesafe.
+   - **Backend (Node.js)**:
+     - Export a validated `env` object using `arkenv(schema)`.
+   - **Type Safety**: Ensure `strict` mode is enabled in `tsconfig.json`.
 
 ## Core Concepts
 
 ### Defining a Schema
 
-The main entry point is the `arkenv` function (or `createEnv`).
+The best practice is to export a schema definition using `type`.
 
 ```ts
-import arkenv, { type } from 'arkenv';
+import { type } from 'arkenv';
 
-export const env = arkenv({
-  // Automatic inference for simple literals
+export const Env = type({
   NODE_ENV: "'development' | 'production' | 'test' = 'development'",
-
-  // Database configuration
-  DATABASE_HOST: "string.host",
-  DATABASE_PORT: "number.port = 5432",
-
-  // Complex types and arrays via ArkType
-  ALLOWED_ORIGINS: type("string[]").default(() => ["localhost"]),
-
-  // Optional environment variable
-  "API_KEY?": 'string'
+  VITE_API_URL: "string",
+  PORT: "number.port = 3000"
 });
 ```
 
-### Loading environment variables
+### Usage: Node.js (Standard)
 
-ArkEnv automatically loads environment variables from `process.env` (Node.js) or `import.meta.env` (Vite) depending on the environment.
-
-### Using environment variables
-
-The returned `env` object is fully typed based on your schema.
+In Node.js, you validate the environment at runtime and export the result.
 
 ```ts
-import { env } from './env';
+import arkenv from 'arkenv';
+import { Env } from './env';
 
-const port = env.DATABASE_PORT; // typed as number
+export const env = arkenv(Env);
+
+// Usage
+const port = env.PORT; // typed as number
+```
+
+### Usage: Vite (Frontend)
+
+Vite requires build-time injection. Use the plugin in `vite.config.ts` and augment `ImportMetaEnv`.
+
+```ts
+// vite.config.ts
+import arkenv from '@arkenv/vite-plugin';
+import { Env } from './env';
+
+export default defineConfig({
+  plugins: [arkenv(Env)]
+});
+```
+
+```ts
+// src/vite-env.d.ts
+import type { ImportMetaEnvAugmented } from "@arkenv/vite-plugin";
+import type { Env } from "../env";
+
+interface ImportMetaEnv extends ImportMetaEnvAugmented<typeof Env> {}
+```
+
+### Usage: Bun
+
+Bun can use either runtime validation or a plugin for type augmentation.
+
+```ts
+// src/env.d.ts
+import type { ProcessEnvAugmented } from "@arkenv/bun-plugin";
+import type { Env } from "./env";
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv extends ProcessEnvAugmented<typeof Env> {}
+  }
+}
 ```
 
 ## CLI Commands
 
 ### `init`
 
-Set up ArkEnv in your project.
+Set up ArkEnv in your project. It detects your framework and configures the appropriate plugin and type augmentations.
 
 ```bash
 pnpm dlx @arkenv/cli@latest init
 ```
 
-#### Options
-
-- `--yes`, `-y`: Skip prompts and use recommended defaults.
-- `--help`, `-h`: Show help message.
-
 ## Best Practices
 
-1. **Keep schema in one file**: Usually `env.ts` or `src/env.ts`.
-2. **Export the `env` object**: Don't call `arkenv` multiple times; export the validated object.
-3. **Use the CLI for setup**: It ensures all necessary dependencies and configurations are in place.
-4. **Integration**: Use `@arkenv/vite-plugin` for Vite or `@arkenv/bun-plugin` for Bun.
+1. **Avoid `import { env }` in Frontend**: In Vite, `import.meta.env` should be used because variables are statically replaced. Importing a runtime-validated `env` object can lead to issues with static analysis and bundle size.
+2. **Use Type Augmentation**: This is the "cleanest" way to get typesafety for `import.meta.env` or `process.env`.
+3. **Re-use Schema**: Define your schema once and use it for both the plugin (build-time) and runtime validation if needed.
+4. **Coercion**: ArkEnv automatically coerces strings from `.env` files (e.g., `"3000"` becomes `3000`).

--- a/skills/arkenv/SKILL.md
+++ b/skills/arkenv/SKILL.md
@@ -124,7 +124,11 @@ pnpm dlx @arkenv/cli@latest init
 
 ## Best Practices
 
-1. **Avoid `import { env }` in Frontend**: In Vite, `import.meta.env` should be used because variables are statically replaced. Importing a runtime-validated `env` object can lead to issues with static analysis and bundle size.
-2. **Use Type Augmentation**: This is the "cleanest" way to get typesafety for `import.meta.env` or `process.env`.
-3. **Re-use Schema**: Define your schema once and use it for both the plugin (build-time) and runtime validation if needed.
-4. **Coercion**: ArkEnv automatically coerces strings from `.env` files (e.g., `"3000"` becomes `3000`).
+1. **Prefer Native Primitives**: To leverage the full power of ArkEnv plugins, you should access environment variables through the runtime's native primitives.
+   - **Vite**: Use `import.meta.env`.
+   - **Bun**: Use `process.env`.
+   - This ensures that build-time validation, static replacement (Vite), and runtime optimizations (Bun) work as intended while remaining fully typesafe via type augmentation.
+2. **Avoid `import { env }` in Plugin-managed Projects**: In projects using `@arkenv/vite-plugin` or `@arkenv/bun-plugin`, you should generally avoid importing a runtime-validated `env` object. Using native primitives is the "cleanest" way to get typesafety and ensures consistency with framework-specific behavior.
+3. **Use Type Augmentation**: This is the recommended way to make `import.meta.env` or `process.env` typesafe. It connects your schema definition to the native primitives without adding runtime overhead to your application logic.
+4. **Re-use Schema**: Define your schema once and use it for both the plugin (build-time/config) and runtime validation if needed.
+5. **Coercion**: ArkEnv automatically coerces strings from `.env` files (e.g., `"3000"` becomes `3000`).

--- a/skills/arkenv/SKILL.md
+++ b/skills/arkenv/SKILL.md
@@ -5,13 +5,13 @@ description: "Answer questions about ArkEnv and help implement environment varia
 
 # ArkEnv
 
-ArkEnv is a typesafe environment variable validator for modern JavaScript runtimes. It uses ArkType by default for schema definition but supports any Standard Schema validator (like Zod or Valibot).
+ArkEnv is a typesafe environment variable validator for modern JavaScript runtimes. It uses `ArkType` by default for schema definition but supports any `Standard Schema` validator (like `Zod` or `Valibot`).
 
 ## Capabilities
 
 ### Core Usage
 
-- Define typesafe schemas using ArkType notation or any Standard Schema validator.
+- Define typesafe schemas using `ArkType` notation or any `Standard Schema` validator.
 - Implement complex types, arrays, and unions.
 - Configure automatic coercion and default values.
 - Follow best practices for schema organization.
@@ -25,13 +25,13 @@ ArkEnv is a typesafe environment variable validator for modern JavaScript runtim
 ### CLI (Setup & DevOps)
 
 - Initialize ArkEnv in new or existing projects using `pnpm dlx @arkenv/cli@latest init`.
-- Scaffold schema files and detect framework-specific configurations (Vite, Bun, etc.).
+- Scaffold schema files and detect framework-specific configurations (`Vite`, `Bun`, etc.).
 - Automatically configure `tsconfig.json` and environment types for optimal typesafety.
 
 ## Operational Logic
 
 1. **Detection**:
-   - Look for `env.ts` or ArkEnv imports to understand existing schema.
+   - Look for `env.ts` or `arkenv` imports to understand existing schema.
    - Check for framework config files (`vite.config.ts`, `bunfig.toml`, `package.json` scripts) to recommend appropriate plugins.
 2. **Setup**: If ArkEnv is not present, recommend using the CLI: `pnpm dlx @arkenv/cli@latest init`.
 3. **Pattern Enforcement**:


### PR DESCRIPTION
Fixes #940

This PR updates the ArkEnv skill and the CLI to follow best practices for framework plugins (Vite/Bun).

Key changes:
- **SKILL.md**: Updated to recommend using `@arkenv/vite-plugin` and `@arkenv/bun-plugin`, emphasizing type augmentation for `import.meta.env` and `process.env`.
- **CLI Templates**: Modified to export only the schema (`Env`) for Vite projects, discouraging the use of runtime-validated `env` imports in the frontend.
- **CLI improvements**: The schema (`Env`) is now exported by default in all templates to allow easy integration with plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment templates now adapt to framework: Vite and Bun receive augmentation-focused templates; Node retains runtime export behavior.

* **Documentation**
  * Expanded integration guide with framework-specific setup, examples, and best practices for schema export and usage.

* **Tests**
  * Added/extended tests covering template generation across frameworks and validators.

* **Chores**
  * Release changeset added; CI workflow comment behavior slightly refined.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yamcodes/arkenv/pull/943)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->