### PR TITLE
feat(cli): recommend adding arkenv agent skill as a next step

### DIFF
--- a/.changeset/solid-bananas-smile.md
+++ b/.changeset/solid-bananas-smile.md
@@ -1,0 +1,5 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Add ArkEnv Agent Skill as recommended next step

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,12 @@ import { cancel, confirm, isCancel, log, outro, spinner } from "@clack/prompts";
 import pc from "picocolors";
 import { version } from "../package.json";
 import { runPromptWizard } from "./prompts";
-import { checkTsConfig, detectFramework, scaffold } from "./scaffold";
+import {
+	checkTsConfig,
+	detectFramework,
+	getDlxCommand,
+	scaffold,
+} from "./scaffold";
 import { code, symbol } from "./visuals";
 
 async function main() {
@@ -127,8 +132,10 @@ async function main() {
 		log.step(
 			`2. Import and use your environment variables: ${code(`import { env } from "${importPath}"`)} → ${code("env.VAR_NAME")}`,
 		);
+
+		const dlx = getDlxCommand(packageManager);
 		log.step(
-			`3. Install the ArkEnv Agent Skill for AI assistance: ${code("npx skills add yamcodes/arkenv")}`,
+			`3. Install the ArkEnv Agent Skill for AI assistance: ${code(`${dlx} skills add yamcodes/arkenv`)}`,
 		);
 
 		outro(`${symbol} ${pc.dim("Happy coding!")}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -127,6 +127,9 @@ async function main() {
 		log.step(
 			`2. Import and use your environment variables: ${code(`import { env } from "${importPath}"`)} → ${code("env.VAR_NAME")}`,
 		);
+		log.step(
+			`3. Install the ArkEnv Agent Skill for AI assistance: ${code("npx skills add yamcodes/arkenv")}`,
+		);
 
 		outro(`${symbol} ${pc.dim("Happy coding!")}`);
 	} catch (error) {

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -63,6 +63,19 @@ export async function scaffold(
 	return { tsConfigResult, installCmd, packageManager };
 }
 
+export function getDlxCommand(pm: string): string {
+	switch (pm) {
+		case "pnpm":
+			return "pnpm dlx";
+		case "yarn":
+			return "yarn dlx";
+		case "bun":
+			return "bunx";
+		default:
+			return "npx";
+	}
+}
+
 async function findTsConfig(): Promise<string | null> {
 	const filenames = [
 		"tsconfig.app.json",


### PR DESCRIPTION
Fixes #942

Adds a new recommended next step to the CLI output that suggests installing the ArkEnv agent skill. The command is now dynamically generated based on the detected package manager (e.g., `pnpm dlx`, `bunx`, `yarn dlx`, or `npx`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI scaffolding now displays an additional recommended step guiding users to install the ArkEnv Agent Skill using their package manager after project setup completes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yamcodes/arkenv/pull/944)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->