### PR TITLE
fix: clarify TypeScript recommendation vs requirement

### DIFF
--- a/apps/www/content/docs/arkenv/faq.mdx
+++ b/apps/www/content/docs/arkenv/faq.mdx
@@ -67,6 +67,12 @@ Using "raw" Zod for environment variables often leads to a lot of boilerplate:
 
 [//]: # "3. Frameworks & Comparisons"
 
+## Can I use ArkEnv with plain JavaScript?
+
+Yes! ArkEnv works with plain JavaScript.
+
+While we strongly recommend using TypeScript for the best experience (including editor autocomplete and runtime-to-editor typesafety), it is not required. See our [basic-js example](https://github.com/yamcodes/arkenv/tree/main/examples/basic-js) for details and tradeoffs.
+
 ## Is ArkEnv only for Vite and Bun?
 
 No! ArkEnv is designed to be **completely agnostic**. We officially support and provide first-class toolkits for:

--- a/apps/www/content/docs/arkenv/quickstart.mdx
+++ b/apps/www/content/docs/arkenv/quickstart.mdx
@@ -67,11 +67,11 @@ The easiest way to get started is with the [ArkEnv CLI](/docs/cli). It automatic
       </Step>
 
       <Step>
-        ### Configure TypeScript
+        ### Configure TypeScript (Recommended)
 
-        ArkEnv requires **TypeScript >= 5.1** and `strict` mode in your `tsconfig.json`.
+        ArkEnv expects **TypeScript >= 5.1** and `strict` mode in your `tsconfig.json`.
 
-        You're also required to use a [modern TypeScript module resolution](https://www.typescriptlang.org/tsconfig/#moduleResolution).
+        You're also expected to use a [modern TypeScript module resolution](https://www.typescriptlang.org/tsconfig/#moduleResolution).
 
         ```json title="tsconfig.json"
         // [!code word:config]
@@ -82,6 +82,9 @@ The easiest way to get started is with the [ArkEnv CLI](/docs/cli). It automatic
           }
         }
         ```
+
+        > [!NOTE]
+        > While ArkEnv [can](https://github.com/yamcodes/arkenv/tree/main/examples/basic-js) work with plain JavaScript, TypeScript is strongly recommended for the best experience.
       </Step>
 
       <Step>

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -58,10 +58,10 @@ The `init` command is the primary entry point for the CLI. It will:
 
 The CLI supports the following flags to customize the behavior:
 
-| Flag            | Description                                                                                                    |
-| --------------- | -------------------------------------------------------------------------------------------------------------- |
-| `--yes`, `-y`   | Skip all prompts and use defaults. Also passes the `--yes` flag to underlying processes (like skill installs). |
-| `--quiet`, `-q` | Quiet mode. Suppresses output unless a command fails, in which case buffered logs are shown for debugging.     |
-| `--json`, `-j`  | Emit a structured JSON summary to `stdout` upon completion (all other output is sent to `stderr`).             |
-| `--agent`, `-a` | For agents. Macro for `--quiet --json --yes`, also skip the agent install step.                                |
-| `--help`, `-h`  | Show the help message.                                                                                         |
+| Flag      | Alias | Description                                                                                                    |
+| --------- | ----- | -------------------------------------------------------------------------------------------------------------- |
+| `--yes`   | `-y`  | Skip all prompts and use defaults. Also passes the `--yes` flag to underlying processes (like skill installs). |
+| `--quiet` | `-q`  | Quiet mode. Suppresses output unless a command fails, in which case buffered logs are shown for debugging.     |
+| `--json`  | `-j`  | Emit a structured JSON summary to `stdout` upon completion (all other output is sent to `stderr`).             |
+| `--agent` | `-a`  | For agents. Macro for `--quiet --json --yes`, also skip the agent install step.                                |
+| `--help`  | `-h`  | Show the help message.                                                                                         |


### PR DESCRIPTION
Fixes #965 #964 

This PR streamlines the documentation to clarify that while TypeScript is strongly recommended for the best experience, it is not strictly required for ArkEnv to function. 

Changes:
- Updated `quickstart.mdx` to label the TypeScript configuration step as recommended and specify requirements only when using TS.
- Added a FAQ entry in `faq.mdx` explicitly addressing plain JavaScript support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ entry clarifying ArkEnv compatibility with plain JavaScript
  * Updated TypeScript configuration guidance to highlight it as recommended
  * Reformatted CLI options table to include command aliases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yamcodes/arkenv/pull/967)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->