### PR TITLE
ArkEnv CLI: Add dts file support

### DIFF
--- a/.changeset/dry-days-travel.md
+++ b/.changeset/dry-days-travel.md
@@ -1,0 +1,9 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Generate `env.d.ts` file for plugins
+
+When installing the Vite plugin or the Bun plugin, a matching `env.d.ts` will be generated if one is not present.
+
+This allows for typesafety when calling via `process.env` or `import.meta.env`, see: https://arkenv.js.org/docs/vite-plugin/typing-import-meta-env

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -72,6 +72,7 @@ describe("InitCommand", () => {
 			tsConfigResult: { status: "already_strict" },
 			installCmd: "npm install",
 			packageManager: "npm",
+			typeDefinitionResult: { status: "none" },
 		});
 
 		await command.run();
@@ -100,6 +101,7 @@ describe("InitCommand", () => {
 			tsConfigResult: { status: "already_strict" },
 			installCmd: "npm install",
 			packageManager: "npm",
+			typeDefinitionResult: { status: "none" },
 		});
 
 		await command.run();
@@ -128,6 +130,7 @@ describe("InitCommand", () => {
 			tsConfigResult: { status: "already_strict" },
 			installCmd: "npm install",
 			packageManager: "npm",
+			typeDefinitionResult: { status: "none" },
 		});
 
 		await command.run();
@@ -157,6 +160,7 @@ describe("InitCommand", () => {
 			tsConfigResult: { status: "already_strict" },
 			installCmd: "npm install",
 			packageManager: "npm",
+			typeDefinitionResult: { status: "none" },
 		});
 
 		const stdout = new Readable({ read() {} });
@@ -211,6 +215,7 @@ describe("InitCommand", () => {
 			tsConfigResult: { status: "already_strict" },
 			installCmd: "npm install",
 			packageManager: "npm",
+			typeDefinitionResult: { status: "none" },
 		});
 
 		const stdout = new Readable({ read() {} });
@@ -274,6 +279,7 @@ describe("InitCommand", () => {
 			tsConfigResult: { status: "already_strict" },
 			installCmd: "npm install",
 			packageManager: "npm",
+			typeDefinitionResult: { status: "none" },
 		});
 
 		spawnMock.mockReturnValueOnce({
@@ -299,6 +305,34 @@ describe("InitCommand", () => {
 					"Command terminated by signal SIGTERM",
 				),
 			}),
+		);
+	});
+
+	it("logs type definition creation results", async () => {
+		const cli = new CLI(["node", "bin", "init"]);
+		const command = new InitCommand(cli);
+
+		vi.spyOn(scaffold, "checkTsConfig").mockResolvedValue({ status: "strict" });
+		vi.spyOn(scaffold, "detectFramework").mockResolvedValue("vite");
+		vi.spyOn(prompts, "runPromptWizard").mockResolvedValue({
+			validator: "arktype",
+			framework: "vite",
+			path: "env.ts",
+			language: "ts",
+			installSkill: false,
+		});
+		vi.spyOn(scaffold, "scaffold").mockResolvedValue({
+			tsConfigResult: { status: "already_strict" },
+			installCmd: undefined,
+			packageManager: "npm",
+			typeDefinitionResult: { status: "created", file: "vite-env.d.ts" },
+		});
+
+		const infoSpy = vi.spyOn(cli.logger, "info");
+		await command.run();
+
+		expect(infoSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Created vite-env.d.ts"),
 		);
 	});
 });

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -331,8 +331,13 @@ describe("InitCommand", () => {
 		const infoSpy = vi.spyOn(cli.logger, "info");
 		await command.run();
 
-		expect(infoSpy).toHaveBeenCalledWith(
-			expect.stringContaining("Created vite-env.d.ts"),
-		);
+		expect(
+			infoSpy.mock.calls.some(
+				(call) =>
+					typeof call[0] === "string" &&
+					call[0].includes("Created") &&
+					call[0].includes("vite-env.d.ts"),
+			),
+		).toBe(true);
 	});
 });

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -73,7 +73,7 @@ describe("InitCommand", () => {
 			installCmd: "npm install",
 			packageManager: "npm",
 			typeDefinitionResult: { status: "none" },
-		});
+		} as any);
 
 		await command.run();
 
@@ -102,7 +102,7 @@ describe("InitCommand", () => {
 			installCmd: "npm install",
 			packageManager: "npm",
 			typeDefinitionResult: { status: "none" },
-		});
+		} as any);
 
 		await command.run();
 
@@ -131,7 +131,7 @@ describe("InitCommand", () => {
 			installCmd: "npm install",
 			packageManager: "npm",
 			typeDefinitionResult: { status: "none" },
-		});
+		} as any);
 
 		await command.run();
 
@@ -161,7 +161,7 @@ describe("InitCommand", () => {
 			installCmd: "npm install",
 			packageManager: "npm",
 			typeDefinitionResult: { status: "none" },
-		});
+		} as any);
 
 		const stdout = new Readable({ read() {} });
 		const stderr = new Readable({ read() {} });
@@ -216,7 +216,7 @@ describe("InitCommand", () => {
 			installCmd: "npm install",
 			packageManager: "npm",
 			typeDefinitionResult: { status: "none" },
-		});
+		} as any);
 
 		const stdout = new Readable({ read() {} });
 		const stderr = new Readable({ read() {} });
@@ -280,7 +280,7 @@ describe("InitCommand", () => {
 			installCmd: "npm install",
 			packageManager: "npm",
 			typeDefinitionResult: { status: "none" },
-		});
+		} as any);
 
 		spawnMock.mockReturnValueOnce({
 			stdout: new Readable({ read() {} }),
@@ -326,7 +326,7 @@ describe("InitCommand", () => {
 			installCmd: undefined,
 			packageManager: "npm",
 			typeDefinitionResult: { status: "created", file: "vite-env.d.ts" },
-		});
+		} as any);
 
 		const infoSpy = vi.spyOn(cli.logger, "info");
 		await command.run();

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -84,6 +84,7 @@ export class InitCommand {
 				tsConfigResult: tsResult,
 				installCmd,
 				packageManager,
+				typeDefinitionResult: typeResult,
 			} = await scaffold({
 				...options,
 				shouldUpdateTsConfig,
@@ -100,6 +101,16 @@ export class InitCommand {
 			} else if (tsResult.status === "error") {
 				logger.warn(
 					`Could not automatically update ${code(tsResult.file || "tsconfig.json")}. Please ensure 'strict: true' is set manually.`,
+				);
+			}
+
+			if (typeResult.status === "created") {
+				logger.info(
+					`Created ${code(typeResult.file!)} for typesafe environment variables.`,
+				);
+			} else if (typeResult.status === "overwritten") {
+				logger.info(
+					`Updated ${code(typeResult.file!)} for typesafe environment variables.`,
 				);
 			}
 
@@ -151,6 +162,13 @@ export class InitCommand {
 				}
 			}
 
+			let usageInstructions = `2. Import and use: ${code(`import { env } from "${importPath}"`)}`;
+			if (options.framework === "vite") {
+				usageInstructions = `2. Access via ${code("import.meta.env.YOUR_VAR")}`;
+			} else if (options.framework === "bun") {
+				usageInstructions = `2. Access via ${code("process.env.YOUR_VAR")}`;
+			}
+
 			if (skillInstalled) {
 				logger.note(
 					dedent`
@@ -163,7 +181,7 @@ export class InitCommand {
 				logger.note(
 					dedent`
 						1. Check ${code(displayPath)} and refine your environment schema.
-						2. Import and use: ${code(`import { env } from "${importPath}"`)}
+						${usageInstructions}
 						3. (Recommended) Install the AI skill: ${code(`${dlx} skills add yamcodes/arkenv`)}
 						   Then run ${pc.cyan("/arkenv")} inside your AI assistant to finish.
 					`,

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -10,7 +10,8 @@ export type ProjectOptions = {
 	validator: "arktype" | "zod" | "valibot";
 	framework: "vite" | "bun" | "node";
 	language: "ts"; // TODO: Support JS
-	overwrite?: boolean | undefined;
+	overwriteEnvSchemaFile?: boolean | undefined;
+	overwriteEnvDtsFile?: boolean | undefined;
 	envKeys?: string[] | undefined;
 	installSkill?: boolean | undefined;
 };
@@ -30,7 +31,8 @@ export async function runPromptWizard(
 			validator: "arktype",
 			framework: defaults?.framework || "node",
 			language: "ts",
-			overwrite: true,
+			overwriteEnvSchemaFile: true,
+			overwriteEnvDtsFile: true,
 			envKeys: detectedKeys || undefined,
 			installSkill: false,
 		} as ProjectOptions;
@@ -38,7 +40,7 @@ export async function runPromptWizard(
 
 	const result = await group(
 		{
-			overwrite: async () => {
+			overwriteEnvSchemaFile: async () => {
 				const defaultPath = "./src/env.ts";
 				if (fs.existsSync(path.resolve(process.cwd(), defaultPath))) {
 					const answer = await confirm({
@@ -156,7 +158,8 @@ export async function runPromptWizard(
 		validator: result.validator as ProjectOptions["validator"],
 		framework: result.framework as ProjectOptions["framework"],
 		language: "ts",
-		overwrite: result.overwrite as boolean,
+		overwriteEnvSchemaFile: result.overwriteEnvSchemaFile as boolean,
+		overwriteEnvDtsFile: result.overwriteEnvDtsFile as boolean,
 		envKeys: result.useEnvExample ? (detectedKeys as string[]) : undefined,
 		installSkill: result.installSkill as boolean,
 	};

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -159,7 +159,6 @@ export async function runPromptWizard(
 		framework: result.framework as ProjectOptions["framework"],
 		language: "ts",
 		overwriteEnvSchemaFile: result.overwriteEnvSchemaFile as boolean,
-		overwriteEnvDtsFile: result.overwriteEnvDtsFile as boolean,
 		envKeys: result.useEnvExample ? (detectedKeys as string[]) : undefined,
 		installSkill: result.installSkill as boolean,
 	};

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -97,8 +97,33 @@ export async function runPromptWizard(
 				}
 				return true;
 			},
-			overwriteEnvDtsFile: async () => {
-				return undefined as boolean | undefined;
+			overwriteEnvDtsFile: async ({ results }) => {
+				if (!results.installTypeDefinitions) return false;
+				if (results.framework !== "vite" && results.framework !== "bun")
+					return false;
+
+				const typeFile =
+					results.framework === "vite" ? "vite-env.d.ts" : "bun-env.d.ts";
+				// Use the same directory as the environment config
+				const targetDir = path.dirname(path.resolve(process.cwd(), "./src/env.ts"));
+				const typeFilePath = path.join(targetDir, typeFile);
+
+				if (fs.existsSync(typeFilePath)) {
+					const answer = await confirm({
+						message: pc.yellow(
+							`Type definition file ${code(typeFile)} already exists. Overwrite?`,
+						),
+						initialValue: true,
+						active: "Yes (Recommended)",
+						inactive: "No",
+					});
+					if (isCancel(answer)) {
+						cancel("Operation cancelled.");
+						process.exit(0);
+					}
+					return answer;
+				}
+				return true;
 			},
 			validator: () =>
 				select({

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -105,7 +105,9 @@ export async function runPromptWizard(
 				const typeFile =
 					results.framework === "vite" ? "vite-env.d.ts" : "bun-env.d.ts";
 				// Use the same directory as the environment config
-				const targetDir = path.dirname(path.resolve(process.cwd(), "./src/env.ts"));
+				const targetDir = path.dirname(
+					path.resolve(process.cwd(), "./src/env.ts"),
+				);
 				const typeFilePath = path.join(targetDir, typeFile);
 
 				if (fs.existsSync(typeFilePath)) {

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -12,6 +12,7 @@ export type ProjectOptions = {
 	language: "ts"; // TODO: Support JS
 	overwriteEnvSchemaFile?: boolean | undefined;
 	overwriteEnvDtsFile?: boolean | undefined;
+	installTypeDefinitions?: boolean | undefined;
 	envKeys?: string[] | undefined;
 	installSkill?: boolean | undefined;
 };
@@ -33,6 +34,7 @@ export async function runPromptWizard(
 			language: "ts",
 			overwriteEnvSchemaFile: true,
 			overwriteEnvDtsFile: true,
+			installTypeDefinitions: true,
 			envKeys: detectedKeys || undefined,
 			installSkill: false,
 		} as ProjectOptions;
@@ -82,6 +84,22 @@ export async function runPromptWizard(
 						},
 					],
 				}),
+			installTypeDefinitions: async ({ results }) => {
+				if (results.framework === "vite" || results.framework === "bun") {
+					const typeFile =
+						results.framework === "vite" ? "vite-env.d.ts" : "bun-env.d.ts";
+					return confirm({
+						message: `Establish ${code(typeFile)} for typesafe environment variables?`,
+						initialValue: true,
+						active: "Yes (Recommended)",
+						inactive: "No",
+					});
+				}
+				return true;
+			},
+			overwriteEnvDtsFile: async () => {
+				return undefined as boolean | undefined;
+			},
 			validator: () =>
 				select({
 					message: "Select your preferred validator library:",
@@ -159,6 +177,8 @@ export async function runPromptWizard(
 		framework: result.framework as ProjectOptions["framework"],
 		language: "ts",
 		overwriteEnvSchemaFile: result.overwriteEnvSchemaFile as boolean,
+		overwriteEnvDtsFile: result.overwriteEnvDtsFile as boolean,
+		installTypeDefinitions: result.installTypeDefinitions as boolean,
 		envKeys: result.useEnvExample ? (detectedKeys as string[]) : undefined,
 		installSkill: result.installSkill as boolean,
 	};

--- a/packages/cli/src/scaffold.test.ts
+++ b/packages/cli/src/scaffold.test.ts
@@ -174,7 +174,7 @@ describe("scaffold", () => {
 				.catch(() => false);
 			expect(exists).toBe(true);
 			expect(result.typeDefinitionResult.status).toBe("created");
-			expect(result.typeDefinitionResult.file).toBe("vite-env.d.ts");
+			expect((result.typeDefinitionResult as any).file).toBe("vite-env.d.ts");
 
 			const content = await fsp.readFile(
 				path.join(tempDir, "vite-env.d.ts"),
@@ -193,7 +193,7 @@ describe("scaffold", () => {
 				.catch(() => false);
 			expect(exists).toBe(true);
 			expect(result.typeDefinitionResult.status).toBe("created");
-			expect(result.typeDefinitionResult.file).toBe("bun-env.d.ts");
+			expect((result.typeDefinitionResult as any).file).toBe("bun-env.d.ts");
 
 			const content = await fsp.readFile(
 				path.join(tempDir, "bun-env.d.ts"),

--- a/packages/cli/src/scaffold.test.ts
+++ b/packages/cli/src/scaffold.test.ts
@@ -250,7 +250,7 @@ describe("scaffold", () => {
 
 			expect(prompts.confirm).toHaveBeenCalledWith(
 				expect.objectContaining({
-					message: expect.stringContaining("vite-env.d.ts already exists"),
+					message: expect.stringContaining("already exists"),
 				}),
 			);
 			expect(result.typeDefinitionResult.status).toBe("overwritten");

--- a/packages/cli/src/scaffold.test.ts
+++ b/packages/cli/src/scaffold.test.ts
@@ -82,6 +82,7 @@ describe("scaffold", () => {
 			language: "ts" as const,
 			shouldUpdateTsConfig: false,
 			shouldInstall: true,
+			installTypeDefinitions: true,
 		};
 
 		it("creates a new env file in an empty path", async () => {
@@ -253,6 +254,21 @@ describe("scaffold", () => {
 				}),
 			);
 			expect(result.typeDefinitionResult.status).toBe("overwritten");
+		});
+
+		it("skips type definition installation if installTypeDefinitions is false", async () => {
+			const result = await scaffold({
+				...defaultOptions,
+				framework: "vite",
+				installTypeDefinitions: false,
+			});
+
+			const exists = await fsp
+				.access(path.join(tempDir, "vite-env.d.ts"))
+				.then(() => true)
+				.catch(() => false);
+			expect(exists).toBe(false);
+			expect(result.typeDefinitionResult.status).toBe("none");
 		});
 	});
 });

--- a/packages/cli/src/scaffold.test.ts
+++ b/packages/cli/src/scaffold.test.ts
@@ -111,7 +111,7 @@ describe("scaffold", () => {
 			await fsp.writeFile(path.join(tempDir, "env.ts"), existingContent);
 			vi.mocked(prompts.confirm).mockResolvedValue(false);
 
-			await scaffold(defaultOptions);
+			await scaffold({ ...defaultOptions, overwriteEnvSchemaFile: false });
 
 			const content = await fsp.readFile(path.join(tempDir, "env.ts"), "utf-8");
 			expect(content).toBe(existingContent);
@@ -122,7 +122,7 @@ describe("scaffold", () => {
 			await fsp.writeFile(path.join(tempDir, "env.ts"), existingContent);
 			vi.mocked(prompts.confirm).mockResolvedValue(true);
 
-			await scaffold(defaultOptions);
+			await scaffold({ ...defaultOptions, overwriteEnvSchemaFile: true });
 
 			const content = await fsp.readFile(path.join(tempDir, "env.ts"), "utf-8");
 			expect(content).not.toBe(existingContent);
@@ -203,13 +203,13 @@ describe("scaffold", () => {
 			expect(content).toContain('import("./env")');
 		});
 
-		it("skips type definition if file exists and overwrite is false", async () => {
+		it("skips type definition if file exists and overwriteEnvDtsFile is false", async () => {
 			await fsp.writeFile(path.join(tempDir, "vite-env.d.ts"), "existing");
 
 			const result = await scaffold({
 				...defaultOptions,
 				framework: "vite",
-				overwrite: false,
+				overwriteEnvDtsFile: false,
 			});
 
 			const content = await fsp.readFile(
@@ -220,13 +220,13 @@ describe("scaffold", () => {
 			expect(result.typeDefinitionResult.status).toBe("skipped");
 		});
 
-		it("overwrites type definition if file exists and overwrite is true", async () => {
+		it("overwrites type definition if file exists and overwriteEnvDtsFile is true", async () => {
 			await fsp.writeFile(path.join(tempDir, "vite-env.d.ts"), "existing");
 
 			const result = await scaffold({
 				...defaultOptions,
 				framework: "vite",
-				overwrite: true,
+				overwriteEnvDtsFile: true,
 			});
 
 			const content = await fsp.readFile(
@@ -234,6 +234,24 @@ describe("scaffold", () => {
 				"utf-8",
 			);
 			expect(content).not.toBe("existing");
+			expect(result.typeDefinitionResult.status).toBe("overwritten");
+		});
+
+		it("prompts for type definition overwrite if overwriteEnvDtsFile is undefined", async () => {
+			await fsp.writeFile(path.join(tempDir, "vite-env.d.ts"), "existing");
+			vi.mocked(prompts.confirm).mockResolvedValue(true);
+
+			const result = await scaffold({
+				...defaultOptions,
+				framework: "vite",
+				overwriteEnvDtsFile: undefined,
+			});
+
+			expect(prompts.confirm).toHaveBeenCalledWith(
+				expect.objectContaining({
+					message: expect.stringContaining("vite-env.d.ts already exists"),
+				}),
+			);
 			expect(result.typeDefinitionResult.status).toBe("overwritten");
 		});
 	});

--- a/packages/cli/src/scaffold.test.ts
+++ b/packages/cli/src/scaffold.test.ts
@@ -164,5 +164,77 @@ describe("scaffold", () => {
 			expect(result.installCmd).toContain("arktype");
 			expect(result.packageManager).toBeDefined();
 		});
+
+		it("establishes vite-env.d.ts for vite framework", async () => {
+			const result = await scaffold({ ...defaultOptions, framework: "vite" });
+
+			const exists = await fsp
+				.access(path.join(tempDir, "vite-env.d.ts"))
+				.then(() => true)
+				.catch(() => false);
+			expect(exists).toBe(true);
+			expect(result.typeDefinitionResult.status).toBe("created");
+			expect(result.typeDefinitionResult.file).toBe("vite-env.d.ts");
+
+			const content = await fsp.readFile(
+				path.join(tempDir, "vite-env.d.ts"),
+				"utf-8",
+			);
+			expect(content).toContain("ImportMetaEnvAugmented");
+			expect(content).toContain('import("./env")');
+		});
+
+		it("establishes bun-env.d.ts for bun framework", async () => {
+			const result = await scaffold({ ...defaultOptions, framework: "bun" });
+
+			const exists = await fsp
+				.access(path.join(tempDir, "bun-env.d.ts"))
+				.then(() => true)
+				.catch(() => false);
+			expect(exists).toBe(true);
+			expect(result.typeDefinitionResult.status).toBe("created");
+			expect(result.typeDefinitionResult.file).toBe("bun-env.d.ts");
+
+			const content = await fsp.readFile(
+				path.join(tempDir, "bun-env.d.ts"),
+				"utf-8",
+			);
+			expect(content).toContain("ProcessEnvAugmented");
+			expect(content).toContain('import("./env")');
+		});
+
+		it("skips type definition if file exists and overwrite is false", async () => {
+			await fsp.writeFile(path.join(tempDir, "vite-env.d.ts"), "existing");
+
+			const result = await scaffold({
+				...defaultOptions,
+				framework: "vite",
+				overwrite: false,
+			});
+
+			const content = await fsp.readFile(
+				path.join(tempDir, "vite-env.d.ts"),
+				"utf-8",
+			);
+			expect(content).toBe("existing");
+			expect(result.typeDefinitionResult.status).toBe("skipped");
+		});
+
+		it("overwrites type definition if file exists and overwrite is true", async () => {
+			await fsp.writeFile(path.join(tempDir, "vite-env.d.ts"), "existing");
+
+			const result = await scaffold({
+				...defaultOptions,
+				framework: "vite",
+				overwrite: true,
+			});
+
+			const content = await fsp.readFile(
+				path.join(tempDir, "vite-env.d.ts"),
+				"utf-8",
+			);
+			expect(content).not.toBe("existing");
+			expect(result.typeDefinitionResult.status).toBe("overwritten");
+		});
 	});
 });

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -5,6 +5,7 @@ import { cancel, confirm, isCancel } from "@clack/prompts";
 import { applyEdits, modify, parse } from "jsonc-parser";
 import { getEnvTemplate } from "./env-template";
 import type { ProjectOptions } from "./prompts";
+import { bunTypesTemplate, viteTypesTemplate } from "./templates";
 
 export async function scaffold(
 	options: ProjectOptions & { shouldUpdateTsConfig?: boolean },
@@ -32,6 +33,7 @@ export async function scaffold(
 				tsConfigResult: { status: "already_strict" } as const,
 				packageManager,
 				installCmd: undefined,
+				typeDefinitionResult: { status: "none" } as const,
 			};
 		}
 		if (options.overwrite === undefined) {
@@ -50,6 +52,7 @@ export async function scaffold(
 					tsConfigResult: { status: "already_strict" } as const,
 					packageManager,
 					installCmd: undefined,
+					typeDefinitionResult: { status: "none" } as const,
 				};
 			}
 		}
@@ -68,7 +71,44 @@ export async function scaffold(
 		tsConfigResult = await updateTsConfigToStrict();
 	}
 
-	return { tsConfigResult, installCmd, packageManager };
+	// 5. Establish type definitions for Vite/Bun
+	let typeDefinitionResult: {
+		status: "created" | "overwritten" | "skipped" | "none";
+		file?: string;
+	} = { status: "none" };
+
+	if (options.framework === "vite" || options.framework === "bun") {
+		typeDefinitionResult = await establishTypeDefinitions(options, targetDir);
+	}
+
+	return { tsConfigResult, installCmd, packageManager, typeDefinitionResult };
+}
+
+async function establishTypeDefinitions(
+	options: ProjectOptions,
+	targetDir: string,
+): Promise<{
+	status: "created" | "overwritten" | "skipped";
+	file: string;
+}> {
+	const typeFileName =
+		options.framework === "vite" ? "vite-env.d.ts" : "bun-env.d.ts";
+	const typeFilePath = path.join(targetDir, typeFileName);
+	const content =
+		options.framework === "vite"
+			? viteTypesTemplate(options.path)
+			: bunTypesTemplate(options.path);
+
+	if (existsSync(typeFilePath)) {
+		if (options.overwrite) {
+			await fsp.writeFile(typeFilePath, content, "utf-8");
+			return { status: "overwritten", file: typeFileName };
+		}
+		return { status: "skipped", file: typeFileName };
+	}
+
+	await fsp.writeFile(typeFilePath, content, "utf-8");
+	return { status: "created", file: typeFileName };
 }
 
 export function getDlxCommand(pm: string): string {

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -104,15 +104,16 @@ async function establishTypeDefinitions(
 		let shouldOverwrite = options.overwriteEnvDtsFile;
 
 		if (shouldOverwrite === undefined) {
-			shouldOverwrite = await confirm({
+			const confirmOverwrite = await confirm({
 				message: `Type definition file ${code(typeFileName)} already exists. Overwrite?`,
 				initialValue: false,
 			});
 
-			if (isCancel(shouldOverwrite)) {
+			if (isCancel(confirmOverwrite)) {
 				cancel("Operation cancelled.");
 				process.exit(0);
 			}
+			shouldOverwrite = confirmOverwrite;
 		}
 
 		if (shouldOverwrite) {

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -78,7 +78,10 @@ export async function scaffold(
 		file?: string;
 	} = { status: "none" };
 
-	if (options.framework === "vite" || options.framework === "bun") {
+	if (
+		(options.framework === "vite" || options.framework === "bun") &&
+		options.installTypeDefinitions !== false
+	) {
 		typeDefinitionResult = await establishTypeDefinitions(options, targetDir);
 	}
 
@@ -106,7 +109,7 @@ async function establishTypeDefinitions(
 		if (shouldOverwrite === undefined) {
 			const confirmOverwrite = await confirm({
 				message: `Type definition file ${code(typeFileName)} already exists. Overwrite?`,
-				initialValue: false,
+				initialValue: true,
 			});
 
 			if (isCancel(confirmOverwrite)) {

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -6,6 +6,7 @@ import { applyEdits, modify, parse } from "jsonc-parser";
 import { getEnvTemplate } from "./env-template";
 import type { ProjectOptions } from "./prompts";
 import { bunTypesTemplate, viteTypesTemplate } from "./templates";
+import { code } from "./visuals";
 
 export async function scaffold(
 	options: ProjectOptions & { shouldUpdateTsConfig?: boolean },
@@ -28,7 +29,7 @@ export async function scaffold(
 	// 2. Generate and write env.ts
 	const content = getEnvTemplate(options);
 	if (existsSync(targetPath)) {
-		if (options.overwrite === false) {
+		if (options.overwriteEnvSchemaFile === false) {
 			return {
 				tsConfigResult: { status: "already_strict" } as const,
 				packageManager,
@@ -36,7 +37,7 @@ export async function scaffold(
 				typeDefinitionResult: { status: "none" } as const,
 			};
 		}
-		if (options.overwrite === undefined) {
+		if (options.overwriteEnvSchemaFile === undefined) {
 			const confirmOverwrite = await confirm({
 				message: `File ${path.basename(targetPath)} already exists. Overwrite?`,
 				initialValue: false,
@@ -100,7 +101,21 @@ async function establishTypeDefinitions(
 			: bunTypesTemplate(options.path);
 
 	if (existsSync(typeFilePath)) {
-		if (options.overwrite) {
+		let shouldOverwrite = options.overwriteEnvDtsFile;
+
+		if (shouldOverwrite === undefined) {
+			shouldOverwrite = await confirm({
+				message: `Type definition file ${code(typeFileName)} already exists. Overwrite?`,
+				initialValue: false,
+			});
+
+			if (isCancel(shouldOverwrite)) {
+				cancel("Operation cancelled.");
+				process.exit(0);
+			}
+		}
+
+		if (shouldOverwrite) {
 			await fsp.writeFile(typeFilePath, content, "utf-8");
 			return { status: "overwritten", file: typeFileName };
 		}

--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -1,3 +1,4 @@
 export * from "./arktype";
+export * from "./types";
 export * from "./valibot";
 export * from "./zod";

--- a/packages/cli/src/templates/types.ts
+++ b/packages/cli/src/templates/types.ts
@@ -1,0 +1,35 @@
+import path from "node:path";
+import dedent from "dedent";
+
+export const viteTypesTemplate = (envPath: string) => {
+	const envFileName = path.basename(envPath).replace(/\.(ts|js|tsx|jsx)$/, "");
+	return dedent /* ts */`
+		/// <reference types="vite/client" />
+
+		type ImportMetaEnvAugmented =
+			import("@arkenv/vite-plugin").ImportMetaEnvAugmented<
+				typeof import("./${envFileName}").Env
+			>;
+
+		interface ImportMetaEnv extends ImportMetaEnvAugmented {}
+
+		interface ImportMeta {
+			readonly env: ImportMetaEnv;
+		}
+	`;
+};
+
+export const bunTypesTemplate = (envPath: string) => {
+	const envFileName = path.basename(envPath).replace(/\.(ts|js|tsx|jsx)$/, "");
+	return dedent /* ts */`
+		/// <reference types="bun-types" />
+
+		type ProcessEnvAugmented = import("@arkenv/bun-plugin").ProcessEnvAugmented<
+			typeof import("./${envFileName}").Env
+		>;
+
+		declare namespace NodeJS {
+			interface ProcessEnv extends ProcessEnvAugmented {}
+		}
+	`;
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-generates framework-specific type-safe env definition files for Vite and Bun during project setup.
  * Shows framework-specific usage instructions for accessing env vars (Vite vs Bun).

* **Chores**
  * Added options to control installing and overwriting generated type definition files.
  * Updated scaffolding and prompts to respect those options.

* **Tests**
  * Expanded tests to cover generation, overwrite behavior, and skipping of env .d.ts files.

* **Documentation**
  * Added a changeset documenting the new behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yamcodes/arkenv/pull/969)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->