### PR TITLE
Fix issue 961

### DIFF
--- a/.github/actions/size-limit/src/results.ts
+++ b/.github/actions/size-limit/src/results.ts
@@ -25,13 +25,14 @@ export const calculateDiffs = (
 
 			// If still not found, try to find any file for this package
 			// This handles cases where filename format changed between baseline and current
+			// We only do this if there is exactly one baseline entry for this package to avoid ambiguity
 			if (baselineSize === undefined) {
-				for (const [baselineKey, size] of baselineSizes.entries()) {
-					if (baselineKey.startsWith(`${result.package}:`)) {
-						baselineSize = size;
-						matchedKey = baselineKey;
-						break;
-					}
+				const matches = Array.from(baselineSizes.keys()).filter((k) =>
+					k.startsWith(`${result.package}:`),
+				);
+				if (matches.length === 1) {
+					matchedKey = matches[0]!;
+					baselineSize = baselineSizes.get(matchedKey);
 				}
 			}
 		}

--- a/.github/actions/size-limit/src/utils/parser.test.ts
+++ b/.github/actions/size-limit/src/utils/parser.test.ts
@@ -47,7 +47,7 @@ arkenv:size:   Size:       441 B with all dependencies, minified and brotlied
 		});
 	});
 
-	it("should handle mixed output from different packages", () => {
+	it("should handle mixed output and filter irrelevant packages", () => {
 		const sampleOutput = `
 arkenv:size: arkenv
 arkenv:size: Size limit: 2 kB
@@ -56,11 +56,12 @@ other-pkg:size: other-pkg
 other-pkg:size: Size limit: 5 kB
 other-pkg:size: Size: 2 kB
 `;
-		const relevantPackages = ["arkenv", "other-pkg"];
+		const relevantPackages = ["arkenv"];
 		const results = parseSizeLimitOutput(sampleOutput, relevantPackages);
 
-		expect(results).toHaveLength(2);
-		expect(results.find((r) => r.package === "arkenv")?.size).toBe("1 kB");
-		expect(results.find((r) => r.package === "other-pkg")?.size).toBe("2 kB");
+		expect(results).toHaveLength(1);
+		expect(results[0].package).toBe("arkenv");
+		expect(results[0].size).toBe("1 kB");
+		expect(results.find((r) => r.package === "other-pkg")).toBeUndefined();
 	});
 });

--- a/.github/actions/size-limit/src/utils/parser.test.ts
+++ b/.github/actions/size-limit/src/utils/parser.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { parseSizeLimitOutput } from "./parser.ts";
+
+describe("parseSizeLimitOutput", () => {
+	it("should correctly parse multiple entries for the same package", () => {
+		const sampleOutput = `
+arkenv:size: ✔ Adding to empty esbuild project
+arkenv:size:   
+arkenv:size:   arkenv
+arkenv:size:   Size limit: 2 kB
+arkenv:size:   Size:       1.77 kB with all dependencies, minified and brotlied
+arkenv:size:   
+arkenv:size:   arkenv/standard
+arkenv:size:   Size limit: 1.1 kB
+arkenv:size:   Size:       1.03 kB with all dependencies, minified and brotlied
+arkenv:size:   
+arkenv:size:   arkenv/core
+arkenv:size:   Package size is 59 B less than limit
+arkenv:size:   Size limit: 500 B
+arkenv:size:   Size:       441 B with all dependencies, minified and brotlied
+`;
+
+		const relevantPackages = ["arkenv"];
+		const results = parseSizeLimitOutput(sampleOutput, relevantPackages);
+
+		expect(results).toHaveLength(3);
+
+		expect(results[0]).toMatchObject({
+			package: "arkenv",
+			file: "arkenv",
+			size: "1.77 kB",
+			limit: "2 kB",
+		});
+
+		expect(results[1]).toMatchObject({
+			package: "arkenv",
+			file: "arkenv/standard",
+			size: "1.03 kB",
+			limit: "1.1 kB",
+		});
+
+		expect(results[2]).toMatchObject({
+			package: "arkenv",
+			file: "arkenv/core",
+			size: "441 B",
+			limit: "500 B",
+		});
+	});
+
+	it("should handle mixed output from different packages", () => {
+		const sampleOutput = `
+arkenv:size: arkenv
+arkenv:size: Size limit: 2 kB
+arkenv:size: Size: 1 kB
+other-pkg:size: other-pkg
+other-pkg:size: Size limit: 5 kB
+other-pkg:size: Size: 2 kB
+`;
+		const relevantPackages = ["arkenv", "other-pkg"];
+		const results = parseSizeLimitOutput(sampleOutput, relevantPackages);
+
+		expect(results).toHaveLength(2);
+		expect(results.find((r) => r.package === "arkenv")?.size).toBe("1 kB");
+		expect(results.find((r) => r.package === "other-pkg")?.size).toBe("2 kB");
+	});
+});

--- a/.github/actions/size-limit/src/utils/parser.ts
+++ b/.github/actions/size-limit/src/utils/parser.ts
@@ -124,57 +124,90 @@ export function parseSizeLimitOutput(
 	const lines = output.split("\n");
 	const packageStates = new Map<string, SizeLimitState>();
 
-	const getOrCreateState = (pkgName: string): SizeLimitState => {
-		const existing = packageStates.get(pkgName);
+	const getOrCreateState = (
+		pkgName: string,
+		entryName: string | null,
+	): SizeLimitState => {
+		const key = entryName ? `${pkgName}:${entryName}` : pkgName;
+		const existing = packageStates.get(key);
 		if (existing) return existing;
 
 		const newState: SizeLimitState = {
 			package: pkgName,
+			file: entryName || undefined,
 			status: "✅",
 		};
-		packageStates.set(pkgName, newState);
+		packageStates.set(key, newState);
 		return newState;
 	};
 
 	let lastPackage: string | null = null;
+	let lastEntryName: string | null = null;
 
 	const parseMessageLine = (pkgName: string, message: string) => {
-		const state = getOrCreateState(pkgName);
 		const cleanMessage = message.trim();
+		if (!cleanMessage) return;
+
+		// Detect sub-package name/entry name
+		const entryNameMatch = cleanMessage.match(
+			/^(?:[a-z]+[:#]\s*)?([@a-z0-9/._-]+)$/i,
+		);
+		if (entryNameMatch) {
+			const entryName = entryNameMatch[1];
+			if (
+				entryName &&
+				!entryName.toLowerCase().includes("size") &&
+				!entryName.toLowerCase().includes("limit") &&
+				!entryName.toLowerCase().includes("exceeded") &&
+				!entryName.toLowerCase().includes("failed")
+			) {
+				lastEntryName = entryName;
+				return;
+			}
+		}
+
+		const state = getOrCreateState(pkgName, lastEntryName);
 
 		const sizeMatch = cleanMessage.match(
-			/size:\s*([0-9.]+\s*(?:[kKmMgG](?:i)?[bB]|[bB]))/i,
+			/size:\s*([0-9.]+\s*(?:[kKmMgG]i?[bB]|[bB]))/i,
 		);
 		if (sizeMatch?.[1]) {
 			state.size = sizeMatch[1];
 		}
 
 		const limitMatch = cleanMessage.match(
-			/size\s*limit:\s*([0-9.]+\s*(?:[kKmMgG](?:i)?[bB]|[bB]))/i,
+			/size\s*limit:\s*([0-9.]+\s*(?:[kKmMgG]i?[bB]|[bB]))/i,
 		);
 		if (limitMatch?.[1]) {
 			state.limit = limitMatch[1];
 		}
 
 		const tableMatch = cleanMessage.match(
-			/^([@a-z0-9/._-]+)\s+([0-9.]+\s*(?:[kKmMgG](?:i)?[bB]|[bB]))\s+([0-9.]+\s*(?:[kKmMgG](?:i)?[bB]|[bB]))/i,
+			/^([@a-z0-9/._-]+)\s+([0-9.]+\s*(?:[kKmMgG]i?[bB]|[bB]))\s+([0-9.]+\s*(?:[kKmMgG]i?[bB]|[bB]))/i,
 		);
 		if (tableMatch?.[1] && tableMatch?.[2] && tableMatch?.[3]) {
 			const matchedPkgName = tableMatch[1] as string;
 			let actualPkg = normalizePackageName(matchedPkgName);
+			let tableEntryName: string | null = null;
+
 			for (const rp of relevantPackages) {
 				if (rp === actualPkg || rp.endsWith(`/${actualPkg}`)) {
 					actualPkg = rp;
 					break;
 				}
+				if (actualPkg.startsWith(`${rp}/`)) {
+					tableEntryName = actualPkg;
+					actualPkg = rp;
+					break;
+				}
 			}
-			const matchedState = getOrCreateState(actualPkg);
+			const matchedState = getOrCreateState(actualPkg, tableEntryName);
 			matchedState.size = tableMatch[2];
 			matchedState.limit = tableMatch[3];
 		}
 
 		const directMatch = cleanMessage.match(
-			/([^\s]+\.(?:js|ts|jsx|tsx|cjs|mjs|d\.ts)):\s+([0-9.]+\s*(?:[kKmMgG](?:i)?[bB]|[bB]))\s*\(limit:\s*([0-9.]+\s*(?:[kKmMgG](?:i)?[bB]|[bB]))\)/i,
+			/([^\s]+\.(?:js|ts|jsx|tsx|cjs|mjs|d\.ts)):\s+([0-9.]+\s*(?:[kKmMgG]i?[bB]|[bB]))\s*\(limit:\s*([0-9.]+\s*(?:[kKmMgG]i?[bB]|[bB]))/i,
 		);
 		if (directMatch?.[1] && directMatch?.[2] && directMatch?.[3]) {
 			state.file = directMatch[1];
@@ -219,6 +252,7 @@ export function parseSizeLimitOutput(
 					}
 				}
 				lastPackage = fullPkg;
+				lastEntryName = null;
 				continue;
 			}
 		}
@@ -230,13 +264,26 @@ export function parseSizeLimitOutput(
 			const pkgPart = headerMatch[1] as string;
 			const pkgName = normalizePackageName(pkgPart);
 			let fullPkg = pkgName;
+			let entryName: string | null = null;
+
 			for (const rp of relevantPackages) {
 				if (rp === pkgName || rp.endsWith(`/${pkgName}`)) {
 					fullPkg = rp;
 					break;
 				}
+				if (pkgName.startsWith(`${rp}/`)) {
+					entryName = pkgName;
+					fullPkg = rp;
+					break;
+				}
 			}
-			lastPackage = fullPkg;
+			if (lastPackage !== fullPkg) {
+				lastPackage = fullPkg;
+				lastEntryName = entryName;
+			} else if (entryName !== null) {
+				lastEntryName = entryName;
+			}
+
 			if (headerMatch[2]) {
 				parseMessageLine(fullPkg, headerMatch[2]);
 			}
@@ -255,7 +302,10 @@ export function parseSizeLimitOutput(
 						const message = strippedLine
 							.substring(prefix.length + 1)
 							.replace(/^[:#\s]*/, "");
-						lastPackage = pkg;
+						if (lastPackage !== pkg) {
+							lastPackage = pkg;
+							lastEntryName = null;
+						}
 						parseMessageLine(pkg, message);
 						return true;
 					}
@@ -273,6 +323,7 @@ export function parseSizeLimitOutput(
 					strippedLine.toLowerCase().includes(unscoped.toLowerCase())
 				) {
 					lastPackage = pkg;
+					lastEntryName = null;
 					break;
 				}
 			}
@@ -284,10 +335,10 @@ export function parseSizeLimitOutput(
 	}
 
 	const results: SizeLimitResult[] = [];
-	for (const [pkgName, state] of packageStates) {
+	for (const state of packageStates.values()) {
 		if (state.size && state.limit) {
 			results.push({
-				package: pkgName,
+				package: state.package,
 				file: state.file || "index.js",
 				size: state.size,
 				limit: state.limit,

--- a/.github/actions/size-limit/src/utils/parser.ts
+++ b/.github/actions/size-limit/src/utils/parser.ts
@@ -263,7 +263,7 @@ export function parseSizeLimitOutput(
 		if (headerMatch) {
 			const pkgPart = headerMatch[1] as string;
 			const pkgName = normalizePackageName(pkgPart);
-			let fullPkg = pkgName;
+			let fullPkg: string | null = null;
 			let entryName: string | null = null;
 
 			for (const rp of relevantPackages) {
@@ -277,15 +277,22 @@ export function parseSizeLimitOutput(
 					break;
 				}
 			}
-			if (lastPackage !== fullPkg) {
-				lastPackage = fullPkg;
-				lastEntryName = entryName;
-			} else if (entryName !== null) {
-				lastEntryName = entryName;
-			}
 
-			if (headerMatch[2]) {
-				parseMessageLine(fullPkg, headerMatch[2]);
+			if (fullPkg) {
+				if (lastPackage !== fullPkg) {
+					lastPackage = fullPkg;
+					lastEntryName = entryName;
+				} else if (entryName !== null) {
+					lastEntryName = entryName;
+				}
+
+				if (headerMatch[2]) {
+					parseMessageLine(fullPkg, headerMatch[2]);
+				}
+			} else {
+				// Not a relevant package, reset state
+				lastPackage = null;
+				lastEntryName = null;
 			}
 			continue;
 		}


### PR DESCRIPTION
Fixes #961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Baseline size matching now only uses a candidate when a single unambiguous match exists, preventing ambiguous baseline selection.

* **New Features**
  * Parser now tracks per-entry names for packages, enabling more granular size/result attribution.

* **Tests**
  * Added unit tests covering multi-entry parsing and package-level filtering of parsed output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yamcodes/arkenv/pull/975)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->