### PR TITLE
fix(cli): prevent duplicate type injections in env.d.ts

### DIFF
--- a/.changeset/bugfix-prevent-duplicate-types.md
+++ b/.changeset/bugfix-prevent-duplicate-types.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Prevent duplicate ArkEnv type injections in `env.d.ts`
+
+Fixed an issue where the CLI would append ArkEnv type definitions multiple times if the `// @arkenv-types` marker was missing but the types were already present. The CLI now detects existing `ImportMetaEnvAugmented` (Vite) and `ProcessEnvAugmented` (Bun) definitions to avoid duplication.

--- a/packages/cli/src/utils/injection.test.ts
+++ b/packages/cli/src/utils/injection.test.ts
@@ -68,6 +68,42 @@ describe("safeAppend", () => {
 		expect(content).toBe(initialContent);
 	});
 
+	it("skips if Vite types are already present without marker", async () => {
+		const dtsPath = path.join(tempDir, "vite-env.d.ts");
+		const schemaPath = path.join(tempDir, "env.ts");
+
+		const initialContent = `
+type ImportMetaEnvAugmented = import("@arkenv/vite-plugin").ImportMetaEnvAugmented<
+	typeof import("./env").Env
+>;
+`;
+		await fsp.writeFile(dtsPath, initialContent);
+
+		const result = await safeAppend(dtsPath, schemaPath, "vite");
+
+		expect(result).toBe(false);
+		const content = await fsp.readFile(dtsPath, "utf-8");
+		expect(content).toBe(initialContent);
+	});
+
+	it("skips if Bun types are already present without marker", async () => {
+		const dtsPath = path.join(tempDir, "bun-env.d.ts");
+		const schemaPath = path.join(tempDir, "env.ts");
+
+		const initialContent = `
+type ProcessEnvAugmented = import("@arkenv/bun-plugin").ProcessEnvAugmented<
+	typeof import("./env").Env
+>;
+`;
+		await fsp.writeFile(dtsPath, initialContent);
+
+		const result = await safeAppend(dtsPath, schemaPath, "bun");
+
+		expect(result).toBe(false);
+		const content = await fsp.readFile(dtsPath, "utf-8");
+		expect(content).toBe(initialContent);
+	});
+
 	it("correctly calculates complex relative paths", async () => {
 		const dtsPath = path.join(tempDir, "deep", "nested", "vite-env.d.ts");
 		const schemaPath = path.join(tempDir, "src", "config", "env.ts");

--- a/packages/cli/src/utils/injection.ts
+++ b/packages/cli/src/utils/injection.ts
@@ -11,7 +11,10 @@ export async function safeAppend(
 ): Promise<boolean> {
 	try {
 		const content = await fsp.readFile(dtsPath, "utf-8");
-		if (content.includes(MARKER)) {
+		const existingType =
+			framework === "vite" ? "ImportMetaEnvAugmented" : "ProcessEnvAugmented";
+
+		if (content.includes(MARKER) || content.includes(existingType)) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #983\n\nThis PR improves the `safeAppend` utility to detect existing ArkEnv type definitions (`ImportMetaEnvAugmented` for Vite and `ProcessEnvAugmented` for Bun) even if the `// @arkenv-types` marker is missing. This prevents duplicate declarations and subsequent TypeScript errors when the CLI is run on a project that already has these types defined (e.g., via manual setup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced detection of previously-injected type definitions to prevent duplicate additions during setup.

* **Tests**
  * Added test cases verifying idempotent behavior when framework-specific type definitions are already present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yamcodes/arkenv/pull/987)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->