### PR TITLE
feat: add automatic 'needs triage' labeling for new issues

### DIFF
--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -90,7 +90,7 @@ jobs:
           )"
 
           # Combine and deduplicate
-          ISSUES="$(jq -n \
+          ISSUES="$(jq -c -n \
             --argjson unlabeled "$UNLABELED_ISSUES" \
             --argjson needs_triage "$NEEDS_TRIAGE_ISSUES" \
             '$unlabeled + $needs_triage | unique_by(.number)')"

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -71,13 +71,29 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN || github.token }}'
         run: |-
           echo '🔍 Finding unlabeled issues and issues marked for triage...'
-          ISSUES="$(gh issue list \
+          # Find issues with no labels
+          UNLABELED_ISSUES="$(gh issue list \
             --state 'open' \
-            --search 'no:label label:"status/needs-triage"' \
+            --search 'no:label' \
             --json number,title,body \
             --limit '100' \
             --repo "${GITHUB_REPOSITORY}"
           )"
+
+          # Find issues with "needs triage" label
+          NEEDS_TRIAGE_ISSUES="$(gh issue list \
+            --state 'open' \
+            --label 'needs triage' \
+            --json number,title,body \
+            --limit '100' \
+            --repo "${GITHUB_REPOSITORY}"
+          )"
+
+          # Combine and deduplicate
+          ISSUES="$(jq -n \
+            --argjson unlabeled "$UNLABELED_ISSUES" \
+            --argjson needs_triage "$NEEDS_TRIAGE_ISSUES" \
+            '$unlabeled + $needs_triage | unique_by(.number)')"
 
           echo '📝 Setting output for GitHub Actions...'
           echo "issues_to_triage=${ISSUES}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/issue-triage-labeler.yml
+++ b/.github/workflows/issue-triage-labeler.yml
@@ -1,0 +1,40 @@
+name: '🏷️ Issue Triage Labeler'
+
+on:
+  issues:
+    types:
+      - 'opened'
+
+jobs:
+  label:
+    runs-on: 'ubuntu-latest'
+    permissions:
+      issues: 'write'
+    steps:
+      - name: 'Add needs triage label'
+        uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # ratchet:actions/github-script@v8.0.0
+        with:
+          script: |-
+            const issue = context.payload.issue;
+            const stateLabels = [
+              'needs more info',
+              'ready for agent',
+              'ready for human',
+              'wontfix',
+              'meta'
+            ];
+            
+            const currentLabels = issue.labels.map(l => l.name);
+            const hasStateLabel = currentLabels.some(l => stateLabels.includes(l));
+            
+            if (!hasStateLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['needs triage']
+              });
+              core.info(`Added 'needs triage' to issue #${issue.number}`);
+            } else {
+              core.info(`Issue #${issue.number} already has a state label: ${currentLabels.filter(l => stateLabels.includes(l)).join(', ')}`);
+            }


### PR DESCRIPTION
Fixes #985

This PR adds a new workflow `.github/workflows/issue-triage-labeler.yml` that automatically adds the `needs triage` label to all new issues that don't already have one of the other state machine labels (`needs more info`, `ready for agent`, `ready for human`, `wontfix`) or the `meta` label.

It also fixes a bug in `.github/workflows/gemini-scheduled-triage.yml` where it was searching for a non-existent label `status/needs-triage` instead of `needs triage`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Enhanced the detection and identification of untriaged issues through improved query logic and better handling of duplicate entries
* Automated the issue triage labeling process by applying "needs triage" status to newly created issues that haven't been assigned initial state categorization, helping streamline the review workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yamcodes/arkenv/pull/994)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->