### PR TITLE
fix(cli): handle multi-word dlx commands to prevent ENOENT on spawn

### DIFF
--- a/.changeset/fix-dlx-spawn-enoent.md
+++ b/.changeset/fix-dlx-spawn-enoent.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Fix `spawn` ENOENT error for multi-word dlx commands
+
+Fixed an issue where the CLI failed to install the ArkEnv agent skill using package managers like `pnpm` or `yarn` (e.g., `pnpm dlx`). The CLI now correctly splits the dlx command and its arguments when calling Node's `spawn` with `shell: false`.

--- a/packages/cli/src/features/scaffold/executor.test.ts
+++ b/packages/cli/src/features/scaffold/executor.test.ts
@@ -118,4 +118,23 @@ describe("Executor", () => {
 			"vite",
 		);
 	});
+
+	it("installs skill when planned", async () => {
+		const plan: ScaffoldingPlan = {
+			...defaultPlan,
+			skill: {
+				dlxCommand: ["pnpm", "dlx"],
+				packageName: "yamcodes/arkenv",
+				isYes: true,
+			},
+		};
+		await executor.execute(plan);
+		expect(mockWorkspace.execute).toHaveBeenCalledWith("pnpm", [
+			"dlx",
+			"skills",
+			"add",
+			"yamcodes/arkenv",
+			"--yes",
+		]);
+	});
 });

--- a/packages/cli/src/features/scaffold/executor.ts
+++ b/packages/cli/src/features/scaffold/executor.ts
@@ -140,11 +140,12 @@ export class Executor {
 			if (plan.skill && process.env.SKIP_INSTALL !== "true") {
 				this.reporter.step("Installing ArkEnv agent skill...");
 				try {
-					const args = ["skills", "add", plan.skill.packageName];
+					const [cmd, ...baseArgs] = plan.skill.dlxCommand;
+					const args = [...baseArgs, "skills", "add", plan.skill.packageName];
 					if (plan.skill.isYes) {
 						args.push("--yes");
 					}
-					await this.workspace.execute(plan.skill.dlxCommand, args);
+					await this.workspace.execute(cmd, args);
 					skillInstalled = true;
 				} catch (err: unknown) {
 					const message = err instanceof Error ? err.message : String(err);
@@ -199,7 +200,7 @@ export class Executor {
 				"Next steps",
 			);
 		} else {
-			const dlx = plan.skill?.dlxCommand || "npx";
+			const dlx = plan.skill?.dlxCommand.join(" ") || "npx";
 			const packageName = plan.skill?.packageName || "yamcodes/arkenv";
 			this.reporter.note(
 				dedent`

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -41,7 +41,7 @@ export type ScaffoldingPlan = {
 	};
 	/** Optional skill installation */
 	skill?: {
-		dlxCommand: string;
+		dlxCommand: string[];
 		packageName: string;
 		isYes: boolean;
 	};

--- a/packages/cli/src/features/scaffold/planner.test.ts
+++ b/packages/cli/src/features/scaffold/planner.test.ts
@@ -102,6 +102,7 @@ describe("Planner", () => {
 		const plan = createPlan(state);
 		expect(plan.skill).toBeDefined();
 		expect(plan.skill?.packageName).toBe("yamcodes/arkenv");
+		expect(plan.skill?.dlxCommand).toEqual(["pnpm", "dlx"]);
 	});
 
 	it("normalizes metadata paths", () => {

--- a/packages/cli/src/features/scaffold/scaffold.ts
+++ b/packages/cli/src/features/scaffold/scaffold.ts
@@ -6,18 +6,18 @@ import { applyEdits, modify, parse } from "jsonc-parser";
  * Returns the appropriate 'dlx' or 'exec' command for the given package manager.
  *
  * @param pm The package manager name (e.g., "pnpm", "bun").
- * @returns The dlx command string.
+ * @returns The dlx command array.
  */
-export function getDlxCommand(pm: string): string {
+export function getDlxCommand(pm: string): string[] {
 	switch (pm) {
 		case "pnpm":
-			return "pnpm dlx";
+			return ["pnpm", "dlx"];
 		case "yarn":
-			return "yarn dlx";
+			return ["yarn", "dlx"];
 		case "bun":
-			return "bunx";
+			return ["bunx"];
 		default:
-			return "npx";
+			return ["npx"];
 	}
 }
 

--- a/packages/cli/src/shared/ports/workspace.port.ts
+++ b/packages/cli/src/shared/ports/workspace.port.ts
@@ -21,6 +21,11 @@ export type FileSystemPort = {
 	readFile(path: string): Promise<string>;
 	writeFile(path: string, content: string): Promise<void>;
 	mkdir(path: string, recursive?: boolean): Promise<void>;
+	/**
+	 * Executes a command without a shell (`shell: false`).
+	 * For this reason, `command` MUST be strictly the executable name (e.g., "pnpm", not "pnpm dlx")
+	 * and any subsequent arguments must be passed in the `args` array.
+	 */
 	execute(command: string, args?: string[]): Promise<void>;
 };
 


### PR DESCRIPTION
- Split dlxCommand into array to work with spawn { shell: false }
- Correctly join dlxCommand in reporter output
- Add regression tests in planner and executor

Fixes #1004