### PR TITLE
ci: restrict www deployment triggers to relevant packages

### DIFF
--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -10,7 +10,11 @@ on:
       - main
     paths:
       - "apps/www/**"
-      - "packages/**"
+      - "packages/arkenv/**"
+      - "packages/vite-plugin/**"
+      - "packages/bun-plugin/**"
+      - "packages/fumadocs-ui/**"
+      - "packages/internal/**"
       - ".github/workflows/deploy-www.yml"
       - "pnpm-lock.yaml"
 

--- a/.github/workflows/preview-www.yml
+++ b/.github/workflows/preview-www.yml
@@ -11,7 +11,11 @@ on:
     types: [opened, synchronize, ready_for_review, labeled]
     paths:
       - "apps/www/**"
-      - "packages/**"
+      - "packages/arkenv/**"
+      - "packages/vite-plugin/**"
+      - "packages/bun-plugin/**"
+      - "packages/fumadocs-ui/**"
+      - "packages/internal/**"
       - ".github/workflows/preview-www.yml"
       - "pnpm-lock.yaml"
 

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -18,6 +18,7 @@
 	},
 	"dependencies": {
 		"@ark/util": "0.56.0",
+		"@arkenv/bun-plugin": "workspace:*",
 		"@arkenv/fumadocs-ui": "workspace:*",
 		"@arkenv/vite-plugin": "workspace:*",
 		"@fumadocs/mdx-remote": "1.4.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,6 +459,9 @@ importers:
       '@ark/util':
         specifier: 0.56.0
         version: 0.56.0
+      '@arkenv/bun-plugin':
+        specifier: workspace:*
+        version: link:../../packages/bun-plugin
       '@arkenv/fumadocs-ui':
         specifier: workspace:*
         version: link:../../packages/fumadocs-ui


### PR DESCRIPTION
Closes #1006.

This PR restricts the Vercel deployment workflows (`preview-www.yml` and `deploy-www.yml`) to only trigger when files in `apps/www` or its actual dependencies (`arkenv`, `vite-plugin`, `bun-plugin`, `fumadocs-ui`, and `internal`) are modified. 

Changes to unrelated packages like `@arkenv/cli` will no longer trigger these deployments.

Additionally, `@arkenv/bun-plugin` has been explicitly added to `apps/www`'s dependencies for consistency and to ensure Twoslash documentation is always up to date.