### PR TITLE
Move "Bun fullstack dev server" to be its own thing separate from "Vanilla"

### DIFF
--- a/.changeset/1015-separate-bun-server-and-bundler.md
+++ b/.changeset/1015-separate-bun-server-and-bundler.md
@@ -4,11 +4,11 @@
 
 #### Refine Bun detection and scaffolding in `arkenv init`
 
-The `arkenv init` command now distinguishes between Bun's Fullstack dev server (`Bun.serve`) and programmatic Bundler (`Bun.build`).
+The `arkenv init` command now distinguishes between standard Bun runtime usage and fullstack/frontend bundling via Bun's dev server (`Bun.serve`) or programmatic Bundler (`Bun.build`).
 
 - **Refined Detection**: Automatically detect usage of `Bun.serve` or `Bun.build` in your project.
-- **Interactive Wizard**: If Bun is detected, use the new multi-select step to choose exactly which Bun-specific APIs you want to integrate.
+- **Improved Wizard Flow**: For Bun projects, the wizard now defaults to a standard runtime-only integration. Use the optional multi-select step to enable `@arkenv/bun-plugin` only when build-time inlining of `PUBLIC_` variables is required for fullstack or frontend code.
 - **Composable Scaffolding**: 
-    - Select `Bun.serve` to add the ArkEnv plugin to your `bunfig.toml`.
-    - Select `Bun.build` to receive a code snippet for your programmatic build script.
-    - If no specific Bun APIs are used, ArkEnv proceeds with a standard Node-compatible setup without the Bun plugin.
+    - Standard integration provides instructions for direct `process.env` usage.
+    - Fullstack dev server integration provides configuration for `bunfig.toml`.
+    - Programmatic Bundler integration provides snippets for custom build scripts.

--- a/.changeset/1015-separate-bun-server-and-bundler.md
+++ b/.changeset/1015-separate-bun-server-and-bundler.md
@@ -2,13 +2,18 @@
 "@arkenv/cli": minor
 ---
 
-#### Refine Bun detection and scaffolding in `arkenv init`
+#### Refine framework terminology and detection in `arkenv init`
 
-The `arkenv init` command now distinguishes between Vanilla Bun runtime usage and fullstack/frontend bundling via Bun's dev server (`Bun.serve`) or programmatic Bundler (`Bun.build`).
+The `arkenv init` command now uses clearer terminology and more robust detection to distinguish between server-side runtime usage and client-side bundling integrations.
 
-- **Refined Detection**: Automatically detect usage of `Bun.serve` or `Bun.build` in your project.
-- **Improved Wizard Flow**: For Bun projects, the wizard now defaults to a **Vanilla** runtime-only integration. Use the optional multi-select step to enable `@arkenv/bun-plugin` only when static inlining of environment variables (e.g. using a `PUBLIC_` prefix) is required for full-stack or frontend code.
-- **Composable Scaffolding**: 
-    - **Vanilla integration** provides instructions for type-safe usage via the `env` object.
-    - **Fullstack dev server integration** provides configuration for `bunfig.toml` to support environment variable inlining.
-    - **Fullstack programmatic bundler integration** provides snippets for custom build scripts to support environment variable inlining.
+- **Refined Terminology**:
+    - **Vanilla**: Renamed from "Node.js" to reflect runtime-only usage across Node.js, Bun, and Deno. Focused on **server-side** validation.
+    - **Bun Fullstack**: Dedicated flow for Bun applications involving **client-side** bundling.
+    - **Vite**: Focused on **client-side** and build-time validation.
+- **Robust Detection**:
+    - Improved detection of **Bun Fullstack** setups by scanning for `Bun.serve` or `Bun.build` usage.
+    - If no bundling features are detected, the CLI defaults to **Vanilla** (even when running on Bun) to avoid unnecessary plugin overhead.
+- **Streamlined Wizard Flow**:
+    - The initial question now asks for your "framework or build tool" with clear hints for **server-side** vs **client-side** usage.
+    - The Bun Fullstack flow is now more focused: it defaults to a `Bun.serve` integration and provides an optional step to bootstrap a `Bun.build` script.
+- **Improved Scaffolding**: Generated code templates now include helpful comments clarifying whether the configuration is intended for server-side or client-side validation.

--- a/.changeset/1015-separate-bun-server-and-bundler.md
+++ b/.changeset/1015-separate-bun-server-and-bundler.md
@@ -7,8 +7,8 @@
 The `arkenv init` command now distinguishes between Vanilla Bun runtime usage and fullstack/frontend bundling via Bun's dev server (`Bun.serve`) or programmatic Bundler (`Bun.build`).
 
 - **Refined Detection**: Automatically detect usage of `Bun.serve` or `Bun.build` in your project.
-- **Improved Wizard Flow**: For Bun projects, the wizard now defaults to a **Vanilla** runtime-only integration. Use the optional multi-select step to enable `@arkenv/bun-plugin` only when build-time inlining of `PUBLIC_` variables is required for full-stack or frontend code.
+- **Improved Wizard Flow**: For Bun projects, the wizard now defaults to a **Vanilla** runtime-only integration. Use the optional multi-select step to enable `@arkenv/bun-plugin` only when build-time inlining of environment variables (e.g. using a `PUBLIC_` prefix) is required for full-stack or frontend code.
 - **Composable Scaffolding**: 
     - **Vanilla integration** provides instructions for type-safe usage via the `env` object.
-    - **Fullstack dev server integration** provides configuration for `bunfig.toml`.
-    - **Programmatic Bundler integration** provides snippets for custom build scripts.
+    - **Fullstack dev server integration** provides configuration for `bunfig.toml` to support environment variable inlining.
+    - **Programmatic Bundler integration** provides snippets for custom build scripts to support environment variable inlining.

--- a/.changeset/1015-separate-bun-server-and-bundler.md
+++ b/.changeset/1015-separate-bun-server-and-bundler.md
@@ -7,7 +7,7 @@
 The `arkenv init` command now distinguishes between Vanilla Bun runtime usage and fullstack/frontend bundling via Bun's dev server (`Bun.serve`) or programmatic Bundler (`Bun.build`).
 
 - **Refined Detection**: Automatically detect usage of `Bun.serve` or `Bun.build` in your project.
-- **Improved Wizard Flow**: For Bun projects, the wizard now defaults to a **Vanilla** runtime-only integration. Use the optional multi-select step to enable `@arkenv/bun-plugin` only when build-time inlining of environment variables (e.g. using a `PUBLIC_` prefix) is required for full-stack or frontend code.
+- **Improved Wizard Flow**: For Bun projects, the wizard now defaults to a **Vanilla** runtime-only integration. Use the optional multi-select step to enable `@arkenv/bun-plugin` only when static inlining of environment variables (e.g. using a `PUBLIC_` prefix) is required for full-stack or frontend code.
 - **Composable Scaffolding**: 
     - **Vanilla integration** provides instructions for type-safe usage via the `env` object.
     - **Fullstack dev server integration** provides configuration for `bunfig.toml` to support environment variable inlining.

--- a/.changeset/1015-separate-bun-server-and-bundler.md
+++ b/.changeset/1015-separate-bun-server-and-bundler.md
@@ -11,4 +11,4 @@ The `arkenv init` command now distinguishes between Vanilla Bun runtime usage an
 - **Composable Scaffolding**: 
     - **Vanilla integration** provides instructions for type-safe usage via the `env` object.
     - **Fullstack dev server integration** provides configuration for `bunfig.toml` to support environment variable inlining.
-    - **Programmatic Bundler integration** provides snippets for custom build scripts to support environment variable inlining.
+    - **Fullstack programmatic bundler integration** provides snippets for custom build scripts to support environment variable inlining.

--- a/.changeset/1015-separate-bun-server-and-bundler.md
+++ b/.changeset/1015-separate-bun-server-and-bundler.md
@@ -4,11 +4,11 @@
 
 #### Refine Bun detection and scaffolding in `arkenv init`
 
-The `arkenv init` command now distinguishes between Bun's Fullstack Server (`Bun.serve`) and programmatic Bundler (`Bun.build`).
+The `arkenv init` command now distinguishes between Bun's Fullstack dev server (`Bun.serve`) and programmatic Bundler (`Bun.build`).
 
-- **Refined Detection**: Automatically detects usage of `Bun.serve` or `Bun.build` in your project.
-- **Interactive Wizard**: If Bun is detected, a new multi-select step allows you to choose exactly which Bun-specific APIs you want to integrate.
+- **Refined Detection**: Automatically detect usage of `Bun.serve` or `Bun.build` in your project.
+- **Interactive Wizard**: If Bun is detected, use the new multi-select step to choose exactly which Bun-specific APIs you want to integrate.
 - **Composable Scaffolding**: 
-    - Selecting `Bun.serve` adds the ArkEnv plugin to your `bunfig.toml`.
-    - Selecting `Bun.build` provides a code snippet for your programmatic build script.
+    - Select `Bun.serve` to add the ArkEnv plugin to your `bunfig.toml`.
+    - Select `Bun.build` to receive a code snippet for your programmatic build script.
     - If no specific Bun APIs are used, ArkEnv proceeds with a standard Node-compatible setup without the Bun plugin.

--- a/.changeset/1015-separate-bun-server-and-bundler.md
+++ b/.changeset/1015-separate-bun-server-and-bundler.md
@@ -4,11 +4,11 @@
 
 #### Refine Bun detection and scaffolding in `arkenv init`
 
-The `arkenv init` command now distinguishes between standard Bun runtime usage and fullstack/frontend bundling via Bun's dev server (`Bun.serve`) or programmatic Bundler (`Bun.build`).
+The `arkenv init` command now distinguishes between Vanilla Bun runtime usage and fullstack/frontend bundling via Bun's dev server (`Bun.serve`) or programmatic Bundler (`Bun.build`).
 
 - **Refined Detection**: Automatically detect usage of `Bun.serve` or `Bun.build` in your project.
-- **Improved Wizard Flow**: For Bun projects, the wizard now defaults to a standard runtime-only integration. Use the optional multi-select step to enable `@arkenv/bun-plugin` only when build-time inlining of `PUBLIC_` variables is required for fullstack or frontend code.
+- **Improved Wizard Flow**: For Bun projects, the wizard now defaults to a **Vanilla** runtime-only integration. Use the optional multi-select step to enable `@arkenv/bun-plugin` only when build-time inlining of `PUBLIC_` variables is required for full-stack or frontend code.
 - **Composable Scaffolding**: 
-    - Standard integration provides instructions for direct `process.env` usage.
-    - Fullstack dev server integration provides configuration for `bunfig.toml`.
-    - Programmatic Bundler integration provides snippets for custom build scripts.
+    - **Vanilla integration** provides instructions for type-safe usage via the `env` object.
+    - **Fullstack dev server integration** provides configuration for `bunfig.toml`.
+    - **Programmatic Bundler integration** provides snippets for custom build scripts.

--- a/.changeset/1015-separate-bun-server-and-bundler.md
+++ b/.changeset/1015-separate-bun-server-and-bundler.md
@@ -1,0 +1,14 @@
+---
+"@arkenv/cli": minor
+---
+
+#### Refine Bun detection and scaffolding in `arkenv init`
+
+The `arkenv init` command now distinguishes between Bun's Fullstack Server (`Bun.serve`) and programmatic Bundler (`Bun.build`).
+
+- **Refined Detection**: Automatically detects usage of `Bun.serve` or `Bun.build` in your project.
+- **Interactive Wizard**: If Bun is detected, a new multi-select step allows you to choose exactly which Bun-specific APIs you want to integrate.
+- **Composable Scaffolding**: 
+    - Selecting `Bun.serve` adds the ArkEnv plugin to your `bunfig.toml`.
+    - Selecting `Bun.build` provides a code snippet for your programmatic build script.
+    - If no specific Bun APIs are used, ArkEnv proceeds with a standard Node-compatible setup without the Bun plugin.

--- a/.changeset/1015-separate-bun-server-and-bundler.md
+++ b/.changeset/1015-separate-bun-server-and-bundler.md
@@ -2,18 +2,8 @@
 "@arkenv/cli": minor
 ---
 
-#### Refine framework terminology and detection in `arkenv init`
+### Refined setup experience in `arkenv init`
 
-The `arkenv init` command now uses clearer terminology and more robust detection to distinguish between server-side runtime usage and client-side bundling integrations.
-
-- **Refined Terminology**:
-    - **Vanilla**: Renamed from "Node.js" to reflect runtime-only usage across Node.js, Bun, and Deno. Focused on **server-side** validation.
-    - **Bun Fullstack**: Dedicated flow for Bun applications involving **client-side** bundling.
-    - **Vite**: Focused on **client-side** and build-time validation.
-- **Robust Detection**:
-    - Improved detection of **Bun Fullstack** setups by scanning for `Bun.serve` or `Bun.build` usage.
-    - If no bundling features are detected, the CLI defaults to **Vanilla** (even when running on Bun) to avoid unnecessary plugin overhead.
-- **Streamlined Wizard Flow**:
-    - The initial question now asks for your "framework or build tool" with clear hints for **server-side** vs **client-side** usage.
-    - The Bun Fullstack flow is now more focused: it defaults to a `Bun.serve` integration and provides an optional step to bootstrap a `Bun.build` script.
-- **Improved Scaffolding**: Generated code templates now include helpful comments clarifying whether the configuration is intended for server-side or client-side validation.
+- **Clearer Framework Options**: Updated terminology to better distinguish between server-side runtime validation and client-side bundling integrations.
+- **Architecture Detection**: Improved detection logic recommends the most efficient configuration based on your project's features.
+- **Better In-File Guidance**: Generated templates now include comments clarifying validation behavior for your specific environment.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -190,16 +190,17 @@ pnpm run test:e2e                     # E2E tests
 
 **Framework & Runtime Integrations:**
 
-- **Vanilla (Runtime-only)**: The default for Node.js, Bun, and Deno. Uses `import { env } from "./env"`. Validated environment variables are accessed directly from the returned `env` object for type safety (e.g., `env.PORT`). No plugins are required.
-- **Vite**: Integrated via `@arkenv/vite-plugin`. Validates environment variables at build-time and inlines `import.meta.env` variables for browser-side usage.
-- **Bun Full-Stack Application**:
-  - **Fullstack dev server (Bun.serve)**: Integrated via `@arkenv/bun-plugin` in `bunfig.toml`. Required when using Bun's unified `Bun.serve` to bundle frontend assets and inline environment variables (e.g., using a `PUBLIC_` prefix) via static replacement during bundling.
-  - **Fullstack programmatic bundler (Bun.build)**: Integrated via `@arkenv/bun-plugin` in the `Bun.build` plugins array. Used for custom build scripts targeting the browser in a full-stack context.
+- **Vanilla**: The default runtime-only core module for Node.js, Bun, and Deno. Uses `import { env } from "./env"`. Validated environment variables are accessed directly from the returned `env` object for typesafety. Primarily used for **server-side** or runtime-only validation. No plugins are required.
+- **Vite**: Integrated via `@arkenv/vite-plugin`. Validates environment variables at build-time and inlines `import.meta.env` variables for **client-side** (browser) usage.
+- **Bun fullstack dev server**:
+  - **Bun.serve**: Integrated via `@arkenv/bun-plugin` in `bunfig.toml`. Required when using Bun's unified `Bun.serve` to bundle frontend assets and inline environment variables (e.g., using a `PUBLIC_` prefix) via static replacement during bundling. Primarily used for **client-side** bundling integration.
+  - **Bun.build**: Integrated via `@arkenv/bun-plugin` in the `Bun.build` plugins array. Used for custom build scripts targeting the browser in a fullstack context.
 
 **Preferred Bun Vocabulary:**
 
-- **Fullstack dev server (Bun.serve)**: The unified Bun process that handles both API routes and integrated frontend bundling.
-- **Fullstack programmatic bundler (Bun.build)**: The programmatic API for creating custom frontend build pipelines.
+- **Bun fullstack dev server**: also known as "Bun development server", the unified terminology for Bun applications that involve frontend bundling or integrated dev servers.
+  - **Bun.serve**: The unified Bun process that handles both API routes and integrated frontend bundling.
+  - **Bun.build**: The programmatic API for creating custom frontend build pipelines.
 - **Frontend / Client-side**: Code intended to run in the browser, where environment variables must be **inlined** during bundling.
 - **Backend / Server-side**: Code running in the Bun runtime, where environment variables are accessed directly from the environment.
 - **Static Inlining**: The process where a bundler replaces `process.env.VAR` with a literal value. In Bun, this is configured via the `env` option in `bunfig.toml` or `Bun.build`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -190,10 +190,11 @@ pnpm run test:e2e                     # E2E tests
 
 **Framework & Runtime Integrations:**
 
-- **Standard (Runtime-only)**: The default for Node.js, Bun, and Deno. Uses `import { env } from "./env"`. Environment variables are accessed directly from the runtime (e.g., `process.env`). No build-time plugins are required.
+- **Vanilla (Runtime-only)**: The default for Node.js, Bun, and Deno. Uses `import { env } from "./env"`. Validated environment variables are accessed directly from the returned `env` object for type safety (e.g., `env.PORT`). No build-time plugins are required.
 - **Vite**: Integrated via `@arkenv/vite-plugin`. Validates environment variables at build-time and inlines `import.meta.env` variables for browser-side usage.
-- **Bun Fullstack dev server**: Integrated via `@arkenv/bun-plugin` in `bunfig.toml`. Required when using Bun's unified `Bun.serve` to bundle frontend assets and inline `PUBLIC_` variables via build-time replacement.
-- **Bun Programmatic Bundler**: Integrated via `@arkenv/bun-plugin` in the `Bun.build` plugins array. Used for custom build scripts targeting the browser.
+- **Bun Full-Stack Application**:
+  - **Fullstack dev server**: Integrated via `@arkenv/bun-plugin` in `bunfig.toml`. Required when using Bun's unified `Bun.serve` to bundle frontend assets and inline `PUBLIC_` variables via build-time replacement.
+  - **Programmatic Bundler**: Integrated via `@arkenv/bun-plugin` in the `Bun.build` plugins array. Used for custom build scripts targeting the browser.
 
 **Preferred Bun Vocabulary:**
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -193,12 +193,13 @@ pnpm run test:e2e                     # E2E tests
 - **Vanilla (Runtime-only)**: The default for Node.js, Bun, and Deno. Uses `import { env } from "./env"`. Validated environment variables are accessed directly from the returned `env` object for type safety (e.g., `env.PORT`). No build-time plugins are required.
 - **Vite**: Integrated via `@arkenv/vite-plugin`. Validates environment variables at build-time and inlines `import.meta.env` variables for browser-side usage.
 - **Bun Full-Stack Application**:
-  - **Fullstack dev server**: Integrated via `@arkenv/bun-plugin` in `bunfig.toml`. Required when using Bun's unified `Bun.serve` to bundle frontend assets and inline environment variables (e.g., using a `PUBLIC_` prefix) via build-time replacement.
-  - **Programmatic Bundler**: Integrated via `@arkenv/bun-plugin` in the `Bun.build` plugins array. Used for custom build scripts targeting the browser.
+  - **Fullstack dev server (Bun.serve)**: Integrated via `@arkenv/bun-plugin` in `bunfig.toml`. Required when using Bun's unified `Bun.serve` to bundle frontend assets and inline environment variables (e.g., using a `PUBLIC_` prefix) via build-time replacement.
+  - **Fullstack programmatic bundler (Bun.build)**: Integrated via `@arkenv/bun-plugin` in the `Bun.build` plugins array. Used for custom build scripts targeting the browser in a full-stack context.
 
 **Preferred Bun Vocabulary:**
 
-- **Fullstack dev server**: The unified Bun process (`Bun.serve`) that handles both API routes and integrated frontend bundling.
+- **Fullstack dev server (Bun.serve)**: The unified Bun process that handles both API routes and integrated frontend bundling.
+- **Fullstack programmatic bundler (Bun.build)**: The programmatic API for creating custom frontend build pipelines.
 - **Frontend / Client-side**: Code intended to run in the browser, where environment variables must be **inlined** at build-time.
 - **Backend / Server-side**: Code running in the Bun runtime, where environment variables are accessed directly from the environment.
 - **Build-time Inlining**: The process where a bundler replaces `process.env.VAR` with a literal value. In Bun, this is configured via the `env` option in `bunfig.toml` or `Bun.build`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -190,19 +190,19 @@ pnpm run test:e2e                     # E2E tests
 
 **Framework & Runtime Integrations:**
 
-- **Vanilla (Runtime-only)**: The default for Node.js, Bun, and Deno. Uses `import { env } from "./env"`. Validated environment variables are accessed directly from the returned `env` object for type safety (e.g., `env.PORT`). No build-time plugins are required.
+- **Vanilla (Runtime-only)**: The default for Node.js, Bun, and Deno. Uses `import { env } from "./env"`. Validated environment variables are accessed directly from the returned `env` object for type safety (e.g., `env.PORT`). No plugins are required.
 - **Vite**: Integrated via `@arkenv/vite-plugin`. Validates environment variables at build-time and inlines `import.meta.env` variables for browser-side usage.
 - **Bun Full-Stack Application**:
-  - **Fullstack dev server (Bun.serve)**: Integrated via `@arkenv/bun-plugin` in `bunfig.toml`. Required when using Bun's unified `Bun.serve` to bundle frontend assets and inline environment variables (e.g., using a `PUBLIC_` prefix) via build-time replacement.
+  - **Fullstack dev server (Bun.serve)**: Integrated via `@arkenv/bun-plugin` in `bunfig.toml`. Required when using Bun's unified `Bun.serve` to bundle frontend assets and inline environment variables (e.g., using a `PUBLIC_` prefix) via static replacement during bundling.
   - **Fullstack programmatic bundler (Bun.build)**: Integrated via `@arkenv/bun-plugin` in the `Bun.build` plugins array. Used for custom build scripts targeting the browser in a full-stack context.
 
 **Preferred Bun Vocabulary:**
 
 - **Fullstack dev server (Bun.serve)**: The unified Bun process that handles both API routes and integrated frontend bundling.
 - **Fullstack programmatic bundler (Bun.build)**: The programmatic API for creating custom frontend build pipelines.
-- **Frontend / Client-side**: Code intended to run in the browser, where environment variables must be **inlined** at build-time.
+- **Frontend / Client-side**: Code intended to run in the browser, where environment variables must be **inlined** during bundling.
 - **Backend / Server-side**: Code running in the Bun runtime, where environment variables are accessed directly from the environment.
-- **Build-time Inlining**: The process where a bundler replaces `process.env.VAR` with a literal value. In Bun, this is configured via the `env` option in `bunfig.toml` or `Bun.build`.
+- **Static Inlining**: The process where a bundler replaces `process.env.VAR` with a literal value. In Bun, this is configured via the `env` option in `bunfig.toml` or `Bun.build`.
 
 **Type System:**
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -193,7 +193,7 @@ pnpm run test:e2e                     # E2E tests
 - **Vanilla (Runtime-only)**: The default for Node.js, Bun, and Deno. Uses `import { env } from "./env"`. Validated environment variables are accessed directly from the returned `env` object for type safety (e.g., `env.PORT`). No build-time plugins are required.
 - **Vite**: Integrated via `@arkenv/vite-plugin`. Validates environment variables at build-time and inlines `import.meta.env` variables for browser-side usage.
 - **Bun Full-Stack Application**:
-  - **Fullstack dev server**: Integrated via `@arkenv/bun-plugin` in `bunfig.toml`. Required when using Bun's unified `Bun.serve` to bundle frontend assets and inline `PUBLIC_` variables via build-time replacement.
+  - **Fullstack dev server**: Integrated via `@arkenv/bun-plugin` in `bunfig.toml`. Required when using Bun's unified `Bun.serve` to bundle frontend assets and inline environment variables (e.g., using a `PUBLIC_` prefix) via build-time replacement.
   - **Programmatic Bundler**: Integrated via `@arkenv/bun-plugin` in the `Bun.build` plugins array. Used for custom build scripts targeting the browser.
 
 **Preferred Bun Vocabulary:**
@@ -201,7 +201,7 @@ pnpm run test:e2e                     # E2E tests
 - **Fullstack dev server**: The unified Bun process (`Bun.serve`) that handles both API routes and integrated frontend bundling.
 - **Frontend / Client-side**: Code intended to run in the browser, where environment variables must be **inlined** at build-time.
 - **Backend / Server-side**: Code running in the Bun runtime, where environment variables are accessed directly from the environment.
-- **Build-time Inlining**: The process where a bundler replaces `process.env.VAR` with a literal value. In Bun, this is configured via the `[serve.static]` section in `bunfig.toml`.
+- **Build-time Inlining**: The process where a bundler replaces `process.env.VAR` with a literal value. In Bun, this is configured via the `env` option in `bunfig.toml` or `Bun.build`.
 
 **Type System:**
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -188,6 +188,20 @@ pnpm run test:e2e                     # E2E tests
   - `boolean` - Validates boolean values
 - The `$` variable naming convention is used for the root scope (ArkType convention)
 
+**Framework & Runtime Integrations:**
+
+- **Standard (Runtime-only)**: The default for Node.js, Bun, and Deno. Uses `import { env } from "./env"`. Environment variables are accessed directly from the runtime (e.g., `process.env`). No build-time plugins are required.
+- **Vite**: Integrated via `@arkenv/vite-plugin`. Validates environment variables at build-time and inlines `import.meta.env` variables for browser-side usage.
+- **Bun Fullstack dev server**: Integrated via `@arkenv/bun-plugin` in `bunfig.toml`. Required when using Bun's unified `Bun.serve` to bundle frontend assets and inline `PUBLIC_` variables via build-time replacement.
+- **Bun Programmatic Bundler**: Integrated via `@arkenv/bun-plugin` in the `Bun.build` plugins array. Used for custom build scripts targeting the browser.
+
+**Preferred Bun Vocabulary:**
+
+- **Fullstack dev server**: The unified Bun process (`Bun.serve`) that handles both API routes and integrated frontend bundling.
+- **Frontend / Client-side**: Code intended to run in the browser, where environment variables must be **inlined** at build-time.
+- **Backend / Server-side**: Code running in the Bun runtime, where environment variables are accessed directly from the environment.
+- **Build-time Inlining**: The process where a bundler replaces `process.env.VAR` with a literal value. In Bun, this is configured via the `[serve.static]` section in `bunfig.toml`.
+
 **Type System:**
 
 - Uses `const` type parameters for better type inference

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -193,8 +193,8 @@ pnpm run test:e2e                     # E2E tests
 - **Vanilla**: The default runtime-only core module for Node.js, Bun, and Deno. Uses `import { env } from "./env"`. Validated environment variables are accessed directly from the returned `env` object for typesafety. Primarily used for **server-side** or runtime-only validation. No plugins are required.
 - **Vite**: Integrated via `@arkenv/vite-plugin`. Validates environment variables at build-time and inlines `import.meta.env` variables for **client-side** (browser) usage.
 - **Bun fullstack dev server**:
-  - **Bun.serve**: Integrated via `@arkenv/bun-plugin` in `bunfig.toml`. Required when using Bun's unified `Bun.serve` to bundle frontend assets and inline environment variables (e.g., using a `PUBLIC_` prefix) via static replacement during bundling. Primarily used for **client-side** bundling integration.
-  - **Bun.build**: Integrated via `@arkenv/bun-plugin` in the `Bun.build` plugins array. Used for custom build scripts targeting the browser in a fullstack context.
+  - **Bun.serve**: An HTTP server runtime that integrates with Bun's built-in bundler to scan HTML files, trigger on-demand bundling, and serve resulting assets. It does not perform bundling itself; rather, it coordinates with Bun's bundler (configured via `@arkenv/bun-plugin` in `bunfig.toml`) to inline environment variables (e.g., using a `PUBLIC_` prefix) via static replacement. Primarily used for **client-side** bundling integration.
+  - **Bun.build**: Bun's programmatic bundling API. Integrated via `@arkenv/bun-plugin` in the `Bun.build` plugins array. Used for custom build scripts targeting the browser in a fullstack context.
 
 **Preferred Bun Vocabulary:**
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,6 +21,14 @@ npx @arkenv/cli@latest init
 - [ArkEnv](https://arkenv.js.org) - Core library and docs
 - [ArkType](https://arktype.io/) - Underlying validator / type system
 
+## Architecture
+
+This CLI is built with a port-and-adapter architecture to remain flexible and testable.
+
+### Local Environment Adapters (`Node*`)
+
+Implementations prefixed with `Node` (e.g., `NodeWorkspace`, `NodeProjectScanner`) represent the standard local development environment. They utilize standard `node:*` APIs (like `node:fs` and `node:child_process`) which are universally supported across modern runtimes including Node.js, Bun, and Deno. This naming reflects the API standard used rather than a runtime restriction.
+
 ## License
 
 MIT

--- a/packages/cli/src/adapters/injection.test.ts
+++ b/packages/cli/src/adapters/injection.test.ts
@@ -44,7 +44,7 @@ describe("safeAppend", () => {
 		const initialContent = '/// <reference types="bun-types" />\n';
 		await fsp.writeFile(dtsPath, initialContent);
 
-		const result = await safeAppend(dtsPath, schemaPath, "bun");
+		const result = await safeAppend(dtsPath, schemaPath, "bun-fullstack");
 
 		expect(result).toBe(true);
 		const content = await fsp.readFile(dtsPath, "utf-8");
@@ -97,7 +97,7 @@ type ProcessEnvAugmented = import("@arkenv/bun-plugin").ProcessEnvAugmented<
 `;
 		await fsp.writeFile(dtsPath, initialContent);
 
-		const result = await safeAppend(dtsPath, schemaPath, "bun");
+		const result = await safeAppend(dtsPath, schemaPath, "bun-fullstack");
 
 		expect(result).toBe(false);
 		const content = await fsp.readFile(dtsPath, "utf-8");

--- a/packages/cli/src/adapters/injection.ts
+++ b/packages/cli/src/adapters/injection.ts
@@ -7,7 +7,7 @@ const MARKER = "// @arkenv-types";
 export async function safeAppend(
 	dtsPath: string,
 	schemaPath: string,
-	framework: "vite" | "bun",
+	framework: "vite" | "bun-fullstack",
 ): Promise<boolean> {
 	try {
 		const content = await fsp.readFile(dtsPath, "utf-8");

--- a/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.test.ts
+++ b/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.test.ts
@@ -108,7 +108,10 @@ API_KEY=
 
 	describe("detectBunFeatures", () => {
 		it("detects serve feature from bunfig.toml", async () => {
-			await fsp.writeFile(path.join(tempDir, "bunfig.toml"), "[serve.static]\n");
+			await fsp.writeFile(
+				path.join(tempDir, "bunfig.toml"),
+				"[serve.static]\n",
+			);
 			const result = await scanner.detectBunFeatures(tempDir);
 			expect(result).toContain("serve");
 		});

--- a/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.test.ts
+++ b/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.test.ts
@@ -63,9 +63,9 @@ API_KEY=
 	});
 
 	describe("detectFramework", () => {
-		it("defaults to node when no signals are found", async () => {
+		it("defaults to vanilla when no signals are found", async () => {
 			const result = await scanner.detectFramework(tempDir);
-			expect(result).toBe("node");
+			expect(result).toBe("vanilla");
 		});
 
 		it("detects vite from vite.config.ts", async () => {
@@ -82,9 +82,37 @@ API_KEY=
 			const result = await scanner.detectFramework(tempDir, tsConfig);
 			expect(result).toBe("vite");
 		});
+
+		it("detects bun-fullstack from tsconfig types and feature presence", async () => {
+			await fsp.writeFile(
+				path.join(tempDir, "server.ts"),
+				'import { serve } from "bun"; serve({});',
+			);
+			const tsConfig = {
+				path: path.join(tempDir, "tsconfig.json"),
+				compilerOptions: { types: ["bun"] },
+			};
+			const result = await scanner.detectFramework(tempDir, tsConfig);
+			expect(result).toBe("bun-fullstack");
+		});
+
+		it("detects vanilla even if bun types exist but no features found", async () => {
+			const tsConfig = {
+				path: path.join(tempDir, "tsconfig.json"),
+				compilerOptions: { types: ["bun"] },
+			};
+			const result = await scanner.detectFramework(tempDir, tsConfig);
+			expect(result).toBe("vanilla");
+		});
 	});
 
 	describe("detectBunFeatures", () => {
+		it("detects serve feature from bunfig.toml", async () => {
+			await fsp.writeFile(path.join(tempDir, "bunfig.toml"), "[serve.static]\n");
+			const result = await scanner.detectBunFeatures(tempDir);
+			expect(result).toContain("serve");
+		});
+
 		it("detects serve and build features", async () => {
 			await fsp.writeFile(
 				path.join(tempDir, "server.ts"),

--- a/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.test.ts
+++ b/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.test.ts
@@ -84,6 +84,32 @@ API_KEY=
 		});
 	});
 
+	describe("detectBunFeatures", () => {
+		it("detects serve and build features", async () => {
+			await fsp.writeFile(
+				path.join(tempDir, "server.ts"),
+				'import { serve } from "bun"; serve({});',
+			);
+			await fsp.writeFile(
+				path.join(tempDir, "build.ts"),
+				"Bun.build({ entrypoints: [] });",
+			);
+
+			const result = await scanner.detectBunFeatures(tempDir);
+			expect(result).toContain("serve");
+			expect(result).toContain("build");
+		});
+
+		it("returns empty array when no bun features are used", async () => {
+			await fsp.writeFile(
+				path.join(tempDir, "index.ts"),
+				"console.log('hello')",
+			);
+			const result = await scanner.detectBunFeatures(tempDir);
+			expect(result).toEqual([]);
+		});
+	});
+
 	describe("suggestDefaultEnvPath", () => {
 		it("suggests path based on rootDir in tsconfig", async () => {
 			const tsConfig = {

--- a/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.ts
+++ b/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.ts
@@ -1,5 +1,6 @@
 import type { ParsedTsConfig, ProjectScannerPort } from "@/shared/ports";
 import {
+	detectBunFeatures,
 	detectFramework,
 	detectPackageManager,
 	suggestDefaultEnvPath,
@@ -50,6 +51,13 @@ export class NodeProjectScannerAdapter implements ProjectScannerPort {
 		tsConfig?: ParsedTsConfig | null,
 	): Promise<"vite" | "bun" | "node"> {
 		return detectFramework(cwd, tsConfig);
+	}
+
+	async detectBunFeatures(
+		cwd = process.cwd(),
+		tsConfig?: ParsedTsConfig | null,
+	): Promise<("serve" | "build")[]> {
+		return detectBunFeatures(cwd, tsConfig);
 	}
 
 	async detectPackageManager(

--- a/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.ts
+++ b/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.ts
@@ -49,7 +49,7 @@ export class NodeProjectScannerAdapter implements ProjectScannerPort {
 	async detectFramework(
 		cwd = process.cwd(),
 		tsConfig?: ParsedTsConfig | null,
-	): Promise<"vite" | "bun" | "node"> {
+	): Promise<"vite" | "bun-fullstack" | "vanilla"> {
 		return detectFramework(cwd, tsConfig);
 	}
 

--- a/packages/cli/src/adapters/node-project-scanner/utils/detector.ts
+++ b/packages/cli/src/adapters/node-project-scanner/utils/detector.ts
@@ -37,15 +37,8 @@ export async function detectFramework(
 	}
 
 	// Bun Detection
-	const isBun =
-		tsConfig?.compilerOptions?.types?.includes("bun") ||
-		tsConfig?.compilerOptions?.types?.includes("@types/bun") ||
-		"bun" in process.versions;
-
-	if (isBun) {
-		const features = await detectBunFeatures(cwd, tsConfig);
-		if (features.length > 0) return "bun-fullstack";
-	}
+	const features = await detectBunFeatures(cwd, tsConfig);
+	if (features.length > 0) return "bun-fullstack";
 
 	return "vanilla";
 }
@@ -87,7 +80,7 @@ export async function detectBunFeatures(
 				(content.includes("Bun.serve") || content.includes("serve("))
 			) {
 				// Crude check for serve import from bun
-				if (content.includes('from "bun"') || content.includes("Bun.serve")) {
+				if (/from\s+['"]bun['"]/.test(content) || content.includes("Bun.serve")) {
 					foundServe = true;
 					features.push("serve");
 				}
@@ -96,7 +89,7 @@ export async function detectBunFeatures(
 				!foundBuild &&
 				(content.includes("Bun.build") || content.includes("build("))
 			) {
-				if (content.includes('from "bun"') || content.includes("Bun.build")) {
+				if (/from\s+['"]bun['"]/.test(content) || content.includes("Bun.build")) {
 					foundBuild = true;
 					features.push("build");
 				}

--- a/packages/cli/src/adapters/node-project-scanner/utils/detector.ts
+++ b/packages/cli/src/adapters/node-project-scanner/utils/detector.ts
@@ -80,7 +80,10 @@ export async function detectBunFeatures(
 				(content.includes("Bun.serve") || content.includes("serve("))
 			) {
 				// Crude check for serve import from bun
-				if (/from\s+['"]bun['"]/.test(content) || content.includes("Bun.serve")) {
+				if (
+					/from\s+['"]bun['"]/.test(content) ||
+					content.includes("Bun.serve")
+				) {
 					foundServe = true;
 					features.push("serve");
 				}
@@ -89,7 +92,10 @@ export async function detectBunFeatures(
 				!foundBuild &&
 				(content.includes("Bun.build") || content.includes("build("))
 			) {
-				if (/from\s+['"]bun['"]/.test(content) || content.includes("Bun.build")) {
+				if (
+					/from\s+['"]bun['"]/.test(content) ||
+					content.includes("Bun.build")
+				) {
 					foundBuild = true;
 					features.push("build");
 				}

--- a/packages/cli/src/adapters/node-project-scanner/utils/detector.ts
+++ b/packages/cli/src/adapters/node-project-scanner/utils/detector.ts
@@ -5,11 +5,10 @@ import type { ParsedTsConfig } from "@/shared/ports";
 export async function detectFramework(
 	cwd = process.cwd(),
 	tsConfig?: ParsedTsConfig | null,
-): Promise<"vite" | "bun" | "node"> {
+): Promise<"vite" | "bun-fullstack" | "vanilla"> {
 	if (tsConfig?.compilerOptions?.types) {
 		const types = tsConfig.compilerOptions.types;
 		if (types.includes("vite") || types.includes("vite/client")) return "vite";
-		if (types.includes("bun") || types.includes("@types/bun")) return "bun";
 	}
 
 	try {
@@ -19,7 +18,6 @@ export async function detectFramework(
 		const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
 
 		if (allDeps.vite) return "vite";
-		if (allDeps["@types/bun"] || allDeps.bun) return "bun";
 	} catch {
 		// ignore missing or invalid package.json
 	}
@@ -38,10 +36,18 @@ export async function detectFramework(
 		// vite.config.js not found
 	}
 
-	// Check for bun runtime
-	if ("bun" in process.versions) return "bun";
+	// Bun Detection
+	const isBun =
+		tsConfig?.compilerOptions?.types?.includes("bun") ||
+		tsConfig?.compilerOptions?.types?.includes("@types/bun") ||
+		"bun" in process.versions;
 
-	return "node";
+	if (isBun) {
+		const features = await detectBunFeatures(cwd, tsConfig);
+		if (features.length > 0) return "bun-fullstack";
+	}
+
+	return "vanilla";
 }
 
 export async function detectBunFeatures(
@@ -49,11 +55,29 @@ export async function detectBunFeatures(
 	_tsConfig?: ParsedTsConfig | null,
 ): Promise<("serve" | "build")[]> {
 	const features: ("serve" | "build")[] = [];
-	const { walk } = await import("./env-scanner");
 
+	// Check bunfig.toml first as it's a high-signal indicator
+	try {
+		const bunfigPath = path.join(cwd, "bunfig.toml");
+		const content = await fsp.readFile(bunfigPath, "utf-8");
+		if (content.includes("[serve]") || content.includes("[serve.static]")) {
+			features.push("serve");
+		}
+		// Bun doesn't have a standard [build] section in bunfig.toml yet,
+		// but checking for it doesn't hurt.
+		if (content.includes("[build]")) {
+			features.push("build");
+		}
+	} catch {
+		// ignore missing or unreadable bunfig.toml
+	}
+
+	if (features.includes("serve") && features.includes("build")) return features;
+
+	const { walk } = await import("./env-scanner");
 	const files = await walk(cwd);
-	let foundServe = false;
-	let foundBuild = false;
+	let foundServe = features.includes("serve");
+	let foundBuild = features.includes("build");
 
 	for (const file of files) {
 		try {

--- a/packages/cli/src/adapters/node-project-scanner/utils/detector.ts
+++ b/packages/cli/src/adapters/node-project-scanner/utils/detector.ts
@@ -44,6 +44,48 @@ export async function detectFramework(
 	return "node";
 }
 
+export async function detectBunFeatures(
+	cwd = process.cwd(),
+	_tsConfig?: ParsedTsConfig | null,
+): Promise<("serve" | "build")[]> {
+	const features: ("serve" | "build")[] = [];
+	const { walk } = await import("./env-scanner");
+
+	const files = await walk(cwd);
+	let foundServe = false;
+	let foundBuild = false;
+
+	for (const file of files) {
+		try {
+			const content = await fsp.readFile(file, "utf-8");
+			if (
+				!foundServe &&
+				(content.includes("Bun.serve") || content.includes("serve("))
+			) {
+				// Crude check for serve import from bun
+				if (content.includes('from "bun"') || content.includes("Bun.serve")) {
+					foundServe = true;
+					features.push("serve");
+				}
+			}
+			if (
+				!foundBuild &&
+				(content.includes("Bun.build") || content.includes("build("))
+			) {
+				if (content.includes('from "bun"') || content.includes("Bun.build")) {
+					foundBuild = true;
+					features.push("build");
+				}
+			}
+			if (foundServe && foundBuild) break;
+		} catch {
+			// ignore unreadable files
+		}
+	}
+
+	return features;
+}
+
 export async function detectPackageManager(
 	cwd = process.cwd(),
 	tsConfig?: ParsedTsConfig | null,

--- a/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
+++ b/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
@@ -3,7 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import dedent from "dedent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { NodeProjectScannerAdapter } from "../node-project-scanner";
+import { NodeProjectScannerAdapter } from "@/adapters";
+import { stripAnsi } from "@/test/utils";
 import { NodeWorkspace } from ".";
 
 describe("NodeWorkspace", () => {
@@ -122,13 +123,12 @@ describe("NodeWorkspace", () => {
 		const result = await workspace.bootstrapBunConfig(null, ["serve", "build"]);
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.instructions).toContain(
-				"Bun Fullstack (Bun.serve) Integration",
-			);
-			expect(result.instructions).toContain(
+			const stripped = stripAnsi(result.instructions);
+			expect(stripped).toContain("Bun Fullstack (Bun.serve) Integration");
+			expect(stripped).toContain(
 				"Bun Fullstack programmatic bundling (Bun.build)",
 			);
-			expect(result.instructions).toContain("inline environment variables");
+			expect(stripped).toContain("inline environment variables");
 		}
 	});
 
@@ -136,7 +136,9 @@ describe("NodeWorkspace", () => {
 		const result = await workspace.bootstrapBunConfig(null, []);
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.instructions).toContain("Vanilla Bun runtime integration");
+			expect(stripAnsi(result.instructions)).toContain(
+				"Vanilla Bun runtime integration",
+			);
 		}
 	});
 

--- a/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
+++ b/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
@@ -128,7 +128,7 @@ describe("NodeWorkspace", () => {
 			expect(result.instructions).toContain(
 				"Programmatic Bundler (Bun.build) Integration",
 			);
-			expect(result.instructions).toContain("inline PUBLIC_* variables");
+			expect(result.instructions).toContain("inline environment variables");
 		}
 	});
 

--- a/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
+++ b/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
@@ -132,12 +132,12 @@ describe("NodeWorkspace", () => {
 		}
 	});
 
-	it("returns instructions for standard bun integration", async () => {
+	it("returns instructions for vanilla bun integration", async () => {
 		const result = await workspace.bootstrapBunConfig(null, []);
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.instructions).toContain("standard Bun runtime integration");
-			expect(result.instructions).toContain("process.env");
+			expect(result.instructions).toContain("Vanilla Bun runtime integration");
+			expect(result.instructions).toContain("env");
 		}
 	});
 

--- a/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
+++ b/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
@@ -123,9 +123,21 @@ describe("NodeWorkspace", () => {
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.instructions).toContain(
-				"Bun.serve (Fullstack dev server) Integration",
+				"Fullstack dev server (Bun.serve) Integration",
 			);
-			expect(result.instructions).toContain("Bun.build (Bundler) Integration");
+			expect(result.instructions).toContain(
+				"Programmatic Bundler (Bun.build) Integration",
+			);
+			expect(result.instructions).toContain("inline PUBLIC_* variables");
+		}
+	});
+
+	it("returns instructions for standard bun integration", async () => {
+		const result = await workspace.bootstrapBunConfig(null, []);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.instructions).toContain("standard Bun runtime integration");
+			expect(result.instructions).toContain("process.env");
 		}
 	});
 

--- a/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
+++ b/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
@@ -122,7 +122,9 @@ describe("NodeWorkspace", () => {
 		const result = await workspace.bootstrapBunConfig(null, ["serve", "build"]);
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.instructions).toContain("Bun.serve (Server) Integration");
+			expect(result.instructions).toContain(
+				"Bun.serve (Fullstack dev server) Integration",
+			);
 			expect(result.instructions).toContain("Bun.build (Bundler) Integration");
 		}
 	});

--- a/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
+++ b/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
@@ -126,7 +126,7 @@ describe("NodeWorkspace", () => {
 				"Fullstack dev server (Bun.serve) Integration",
 			);
 			expect(result.instructions).toContain(
-				"Programmatic Bundler (Bun.build) Integration",
+				"Fullstack programmatic bundler (Bun.build) Integration",
 			);
 			expect(result.instructions).toContain("inline environment variables");
 		}

--- a/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
+++ b/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
@@ -118,11 +118,12 @@ describe("NodeWorkspace", () => {
 		expect(result.updated).toBe(false);
 	});
 
-	it("returns instructions for bunfig.toml", async () => {
-		const result = await workspace.bootstrapBunConfig("bunfig.toml");
+	it("returns instructions for bun features", async () => {
+		const result = await workspace.bootstrapBunConfig(null, ["serve", "build"]);
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.instructions).toContain("[preload]");
+			expect(result.instructions).toContain("Bun.serve (Server) Integration");
+			expect(result.instructions).toContain("Bun.build (Bundler) Integration");
 		}
 	});
 

--- a/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
+++ b/packages/cli/src/adapters/node-workspace/node-workspace.test.ts
@@ -123,10 +123,10 @@ describe("NodeWorkspace", () => {
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.instructions).toContain(
-				"Fullstack dev server (Bun.serve) Integration",
+				"Bun Fullstack (Bun.serve) Integration",
 			);
 			expect(result.instructions).toContain(
-				"Fullstack programmatic bundler (Bun.build) Integration",
+				"Bun Fullstack programmatic bundling (Bun.build)",
 			);
 			expect(result.instructions).toContain("inline environment variables");
 		}
@@ -137,7 +137,6 @@ describe("NodeWorkspace", () => {
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.instructions).toContain("Vanilla Bun runtime integration");
-			expect(result.instructions).toContain("env");
 		}
 	});
 

--- a/packages/cli/src/adapters/node-workspace/node-workspace.ts
+++ b/packages/cli/src/adapters/node-workspace/node-workspace.ts
@@ -105,8 +105,9 @@ export class NodeWorkspace implements WorkspacePort {
 
 	async bootstrapBunConfig(
 		configPath?: string | null,
+		features?: ("serve" | "build")[],
 	): Promise<BootstrapResult> {
-		return bootstrapBunConfig(configPath);
+		return bootstrapBunConfig(configPath, features);
 	}
 
 	async safeAppend(

--- a/packages/cli/src/adapters/node-workspace/node-workspace.ts
+++ b/packages/cli/src/adapters/node-workspace/node-workspace.ts
@@ -113,7 +113,7 @@ export class NodeWorkspace implements WorkspacePort {
 	async safeAppend(
 		filePath: string,
 		schemaPath: string,
-		framework: "vite" | "bun",
+		framework: "vite" | "bun-fullstack",
 	) {
 		const { safeAppend } = await import("../injection");
 		return safeAppend(filePath, schemaPath, framework);

--- a/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
+++ b/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
@@ -117,7 +117,7 @@ export async function bootstrapBunConfig(
 			await Bun.build({
 			  entrypoints: ["./index.ts"],
 			  outdir: "./dist",
-			  ${pc.green('plugins: [arkenv]')}
+			  ${pc.green("plugins: [arkenv]")}
 			});
 		`;
 	}

--- a/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
+++ b/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
@@ -76,49 +76,50 @@ export async function bootstrapViteConfig(
 }
 
 export async function bootstrapBunConfig(
-	configPath?: string | null,
+	_configPath?: string | null,
+	features?: ("serve" | "build")[],
 ): Promise<BootstrapResult> {
-	if (configPath?.endsWith("bunfig.toml")) {
+	if (!features || features.length === 0) {
 		return {
 			success: true,
 			instructions: dedent`
-					To complete Bun integration, ensure your ${code("bunfig.toml")} includes a preload file:
-
-					[preload]
-					preload = ["./bun.setup.ts"]
-
-					Then, in your setup file, import the ArkEnv plugin.
-				`,
+				No specific Bun APIs (Server/Bundler) selected. 
+				ArkEnv will run as a standard Node/Vanilla integration.
+			`,
 		};
 	}
 
-	if (
-		configPath?.endsWith("bun.setup.ts") ||
-		configPath?.endsWith("bun.setup.js")
-	) {
-		return {
-			success: true,
-			instructions: dedent`
-					To complete Bun integration, add the ArkEnv plugin to your setup file:
+	const hasServe = features.includes("serve");
+	const hasBuild = features.includes("build");
 
-					import arkenv from "@arkenv/bun-plugin";
+	let instructions = "";
 
-					// If using Bun.build or similar:
-					// plugins: [arkenv]
-				`,
-		};
+	if (hasServe) {
+		instructions += dedent`
+			${pc.bold("Bun.serve (Server) Integration:")}
+			To enable ArkEnv in your Bun server, add the plugin to your ${code("bunfig.toml")}:
+
+			[serve.static]
+			plugins = ["@arkenv/bun-plugin"]
+
+		`;
 	}
 
-	const instructions = dedent`
-			To complete Bun integration, we recommend creating a ${code("bun.setup.ts")} file and adding it to your ${code("bunfig.toml")}:
-
-			${pc.dim("[preload]")}
-			${pc.dim('preload = ["./bun.setup.ts"]')}
-
-			In your setup file, import the ArkEnv plugin:
+	if (hasBuild) {
+		if (instructions) instructions += "\n";
+		instructions += dedent`
+			${pc.bold("Bun.build (Bundler) Integration:")}
+			To enable ArkEnv in your programmatic build, add the plugin to your ${code("Bun.build")} call:
 
 			${code('import arkenv from "@arkenv/bun-plugin";')}
-		`;
 
-	return { success: true, instructions };
+			await Bun.build({
+			  entrypoints: ["./index.ts"],
+			  outdir: "./dist",
+			  ${pc.green("plugins: [arkenv]")}
+			});
+		`;
+	}
+
+	return { success: true, instructions: instructions.trim() };
 }

--- a/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
+++ b/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
@@ -83,7 +83,7 @@ export async function bootstrapBunConfig(
 		return {
 			success: true,
 			instructions: dedent`
-				No specific Bun APIs (Server/Bundler) selected. 
+				No specific Bun APIs (dev server/Bundler) selected. 
 				ArkEnv will run as a standard Node/Vanilla integration.
 			`,
 		};
@@ -96,7 +96,7 @@ export async function bootstrapBunConfig(
 
 	if (hasServe) {
 		instructions += dedent`
-			${pc.bold("Bun.serve (Server) Integration:")}
+			${pc.bold("Bun.serve (Fullstack dev server) Integration:")}
 			To enable ArkEnv in your Bun server, add the plugin to your ${code("bunfig.toml")}:
 
 			[serve.static]

--- a/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
+++ b/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
@@ -83,9 +83,10 @@ export async function bootstrapBunConfig(
 		return {
 			success: true,
 			instructions: dedent`
-				${pc.green("✔")} Use Vanilla Bun runtime integration.
-				Access validated variables via your ${code("env")} object for type safety.
-				No plugins are required for runtime-only usage.
+				${pc.green("✔")} Use ${pc.bold("Vanilla")} Bun runtime integration.
+				Access validated variables via your ${code("env")} object for typesafety.
+				Primarily used for ${pc.cyan("server-side")} or runtime-only validation.
+				No plugins are required.
 			`,
 		};
 	}
@@ -97,8 +98,8 @@ export async function bootstrapBunConfig(
 
 	if (hasServe) {
 		instructions += dedent`
-			${pc.bold("Fullstack dev server (Bun.serve) Integration:")}
-			To inline environment variables (e.g. ${code("PUBLIC_*")}) in your frontend code, add the plugin to ${code("bunfig.toml")}:
+			${pc.bold("Bun Fullstack (Bun.serve) Integration:")}
+			To inline environment variables (e.g. ${code("PUBLIC_*")}) in your ${pc.cyan("client-side")} code, add the plugin to ${code("bunfig.toml")}:
 
 			[serve.static]
 			plugins = ["@arkenv/bun-plugin"]
@@ -109,8 +110,8 @@ export async function bootstrapBunConfig(
 	if (hasBuild) {
 		if (instructions) instructions += "\n";
 		instructions += dedent`
-			${pc.bold("Fullstack programmatic bundler (Bun.build) Integration:")}
-			To inline environment variables (e.g. ${code("PUBLIC_*")}) in your custom build script, add the plugin to your ${code("Bun.build")} call:
+			${pc.bold("Bun Fullstack programmatic bundling (Bun.build):")}
+			To inline environment variables (e.g. ${code("PUBLIC_*")}) in your custom ${pc.cyan("client-side")} build script, add the plugin to your ${code("Bun.build")} call:
 
 			${code('import arkenv from "@arkenv/bun-plugin";')}
 

--- a/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
+++ b/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
@@ -109,7 +109,7 @@ export async function bootstrapBunConfig(
 	if (hasBuild) {
 		if (instructions) instructions += "\n";
 		instructions += dedent`
-			${pc.bold("Programmatic Bundler (Bun.build) Integration:")}
+			${pc.bold("Fullstack programmatic bundler (Bun.build) Integration:")}
 			To inline environment variables (e.g. ${code("PUBLIC_*")}) in your custom build script, add the plugin to your ${code("Bun.build")} call:
 
 			${code('import arkenv from "@arkenv/bun-plugin";')}

--- a/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
+++ b/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
@@ -85,7 +85,7 @@ export async function bootstrapBunConfig(
 			instructions: dedent`
 				${pc.green("✔")} Use Vanilla Bun runtime integration.
 				Access validated variables via your ${code("env")} object for type safety.
-				No build-time plugins are required for runtime-only usage.
+				No plugins are required for runtime-only usage.
 			`,
 		};
 	}

--- a/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
+++ b/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
@@ -83,8 +83,9 @@ export async function bootstrapBunConfig(
 		return {
 			success: true,
 			instructions: dedent`
-				No specific Bun APIs (dev server/Bundler) selected. 
-				ArkEnv will run as a standard Node/Vanilla integration.
+				${pc.green("✔")} Use standard Bun runtime integration.
+				Access validated variables directly via ${code("process.env")} in your server-side code.
+				No build-time plugins are required for standard runtime usage.
 			`,
 		};
 	}
@@ -96,8 +97,8 @@ export async function bootstrapBunConfig(
 
 	if (hasServe) {
 		instructions += dedent`
-			${pc.bold("Bun.serve (Fullstack dev server) Integration:")}
-			To enable ArkEnv in your Bun server, add the plugin to your ${code("bunfig.toml")}:
+			${pc.bold("Fullstack dev server (Bun.serve) Integration:")}
+			To inline ${code("PUBLIC_*")} variables in your frontend code, add the plugin to ${code("bunfig.toml")}:
 
 			[serve.static]
 			plugins = ["@arkenv/bun-plugin"]
@@ -108,15 +109,15 @@ export async function bootstrapBunConfig(
 	if (hasBuild) {
 		if (instructions) instructions += "\n";
 		instructions += dedent`
-			${pc.bold("Bun.build (Bundler) Integration:")}
-			To enable ArkEnv in your programmatic build, add the plugin to your ${code("Bun.build")} call:
+			${pc.bold("Programmatic Bundler (Bun.build) Integration:")}
+			To inline ${code("PUBLIC_*")} variables in your custom build script, add the plugin to your ${code("Bun.build")} call:
 
 			${code('import arkenv from "@arkenv/bun-plugin";')}
 
 			await Bun.build({
 			  entrypoints: ["./index.ts"],
 			  outdir: "./dist",
-			  ${pc.green("plugins: [arkenv]")}
+			  ${pc.green('plugins: [arkenv]')}
 			});
 		`;
 	}

--- a/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
+++ b/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
@@ -98,7 +98,7 @@ export async function bootstrapBunConfig(
 	if (hasServe) {
 		instructions += dedent`
 			${pc.bold("Fullstack dev server (Bun.serve) Integration:")}
-			To inline ${code("PUBLIC_*")} variables in your frontend code, add the plugin to ${code("bunfig.toml")}:
+			To inline environment variables (e.g. ${code("PUBLIC_*")}) in your frontend code, add the plugin to ${code("bunfig.toml")}:
 
 			[serve.static]
 			plugins = ["@arkenv/bun-plugin"]
@@ -110,14 +110,14 @@ export async function bootstrapBunConfig(
 		if (instructions) instructions += "\n";
 		instructions += dedent`
 			${pc.bold("Programmatic Bundler (Bun.build) Integration:")}
-			To inline ${code("PUBLIC_*")} variables in your custom build script, add the plugin to your ${code("Bun.build")} call:
+			To inline environment variables (e.g. ${code("PUBLIC_*")}) in your custom build script, add the plugin to your ${code("Bun.build")} call:
 
 			${code('import arkenv from "@arkenv/bun-plugin";')}
 
 			await Bun.build({
 			  entrypoints: ["./index.ts"],
 			  outdir: "./dist",
-			  ${pc.green("plugins: [arkenv]")}
+			  ${pc.green('plugins: [arkenv]')}
 			});
 		`;
 	}

--- a/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
+++ b/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
@@ -83,9 +83,9 @@ export async function bootstrapBunConfig(
 		return {
 			success: true,
 			instructions: dedent`
-				${pc.green("✔")} Use standard Bun runtime integration.
-				Access validated variables directly via ${code("process.env")} in your server-side code.
-				No build-time plugins are required for standard runtime usage.
+				${pc.green("✔")} Use Vanilla Bun runtime integration.
+				Access validated variables via your ${code("env")} object for type safety.
+				No build-time plugins are required for runtime-only usage.
 			`,
 		};
 	}

--- a/packages/cli/src/adapters/node-workspace/workspace.ts
+++ b/packages/cli/src/adapters/node-workspace/workspace.ts
@@ -5,7 +5,7 @@ import { applyEdits, modify } from "jsonc-parser";
 /**
  * Supported build/runtime frameworks.
  */
-export type Framework = "vite" | "bun" | "node";
+export type Framework = "vite" | "bun-fullstack" | "vanilla";
 
 /**
  * Options for configuring a Workspace.

--- a/packages/cli/src/adapters/node-workspace/workspace.ts
+++ b/packages/cli/src/adapters/node-workspace/workspace.ts
@@ -54,7 +54,9 @@ export class Workspace {
 			const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
 
 			if (allDeps.vite) return "vite";
-			if (allDeps["@types/bun"] || allDeps.bun) return "bun-fullstack";
+
+			const hasBunDep = allDeps["@types/bun"] || allDeps.bun;
+			if (hasBunDep && (await this.hasBunFeatures())) return "bun-fullstack";
 		} catch {
 			// ignore missing or invalid package.json
 		}
@@ -70,9 +72,41 @@ export class Workspace {
 		}
 
 		// Check for bun runtime
-		if ("bun" in process.versions) return "bun-fullstack";
+		if ("bun" in process.versions && (await this.hasBunFeatures())) {
+			return "bun-fullstack";
+		}
 
 		return "vanilla";
+	}
+
+	private async hasBunFeatures(): Promise<boolean> {
+		if (await this.exists("bunfig.toml")) {
+			const content = await this.readFile("bunfig.toml");
+			if (
+				content.includes("[serve]") ||
+				content.includes("[serve.static]") ||
+				content.includes("[build]")
+			) {
+				return true;
+			}
+		}
+
+		// Common entry points
+		const entryPoints = ["src/index.ts", "src/main.ts", "index.ts", "main.ts"];
+		for (const entry of entryPoints) {
+			if (await this.exists(entry)) {
+				const content = await this.readFile(entry);
+				if (
+					content.includes("Bun.serve") ||
+					content.includes("Bun.build") ||
+					/from\s+['"]bun['"]/.test(content)
+				) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	async setTsConfigProperty(propertyPath: string[], value: unknown) {

--- a/packages/cli/src/adapters/node-workspace/workspace.ts
+++ b/packages/cli/src/adapters/node-workspace/workspace.ts
@@ -55,8 +55,7 @@ export class Workspace {
 
 			if (allDeps.vite) return "vite";
 
-			const hasBunDep = allDeps["@types/bun"] || allDeps.bun;
-			if (hasBunDep && (await this.hasBunFeatures())) return "bun-fullstack";
+			if (await this.hasBunFeatures()) return "bun-fullstack";
 		} catch {
 			// ignore missing or invalid package.json
 		}
@@ -71,8 +70,8 @@ export class Workspace {
 			return "vite";
 		}
 
-		// Check for bun runtime
-		if ("bun" in process.versions && (await this.hasBunFeatures())) {
+		// Check for bun features
+		if (await this.hasBunFeatures()) {
 			return "bun-fullstack";
 		}
 

--- a/packages/cli/src/adapters/node-workspace/workspace.ts
+++ b/packages/cli/src/adapters/node-workspace/workspace.ts
@@ -54,7 +54,7 @@ export class Workspace {
 			const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
 
 			if (allDeps.vite) return "vite";
-			if (allDeps["@types/bun"] || allDeps.bun) return "bun";
+			if (allDeps["@types/bun"] || allDeps.bun) return "bun-fullstack";
 		} catch {
 			// ignore missing or invalid package.json
 		}
@@ -70,9 +70,9 @@ export class Workspace {
 		}
 
 		// Check for bun runtime
-		if ("bun" in process.versions) return "bun";
+		if ("bun" in process.versions) return "bun-fullstack";
 
-		return "node";
+		return "vanilla";
 	}
 
 	async setTsConfigProperty(propertyPath: string[], value: unknown) {

--- a/packages/cli/src/adapters/prompt.adapter.ts
+++ b/packages/cli/src/adapters/prompt.adapter.ts
@@ -23,8 +23,8 @@ export class ClackPromptAdapter implements PromptPort {
 			bunFeatures?: ProjectOptions["bunFeatures"];
 			defaultEnvPath?: string;
 			tsConfig?: ParsedTsConfig | null;
-			envKeys?: string[] | undefined;
-			envKeysSource?: ".env.example" | "project" | undefined;
+			envKeys?: string[];
+			envKeysSource?: ".env.example" | "project";
 			hasTypeFile?: boolean;
 		},
 		isYes = false,

--- a/packages/cli/src/adapters/prompt.adapter.ts
+++ b/packages/cli/src/adapters/prompt.adapter.ts
@@ -19,6 +19,7 @@ export class ClackPromptAdapter implements PromptPort {
 	async runWizard(
 		defaults?: {
 			framework?: ProjectOptions["framework"];
+			bunFeatures?: ProjectOptions["bunFeatures"];
 			defaultEnvPath?: string;
 			tsConfig?: ParsedTsConfig | null;
 			envKeys?: string[] | undefined;

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -80,7 +80,7 @@ export class InitUseCase {
 				tsConfig.parsed,
 			);
 			const detectedBunFeatures =
-				detectedFramework === "bun"
+				detectedFramework === "bun-fullstack"
 					? await this.scanner.detectBunFeatures(process.cwd(), tsConfig.parsed)
 					: undefined;
 			const defaultEnvPath = await this.scanner.suggestDefaultEnvPath(
@@ -96,7 +96,7 @@ export class InitUseCase {
 			);
 
 			let hasTypeFile = false;
-			if (detectedFramework === "vite" || detectedFramework === "bun") {
+			if (detectedFramework === "vite" || detectedFramework === "bun-fullstack") {
 				const typeFile =
 					detectedFramework === "vite" ? "vite-env.d.ts" : "bun-env.d.ts";
 				const targetDir = path.dirname(targetPath);
@@ -171,7 +171,7 @@ export class InitUseCase {
 			let typeFileName: string | undefined;
 			if (options.framework === "vite") {
 				typeFileName = "vite-env.d.ts";
-			} else if (options.framework === "bun") {
+			} else if (options.framework === "bun-fullstack") {
 				typeFileName = "bun-env.d.ts";
 			}
 

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -96,7 +96,10 @@ export class InitUseCase {
 			);
 
 			let hasTypeFile = false;
-			if (detectedFramework === "vite" || detectedFramework === "bun-fullstack") {
+			if (
+				detectedFramework === "vite" ||
+				detectedFramework === "bun-fullstack"
+			) {
 				const typeFile =
 					detectedFramework === "vite" ? "vite-env.d.ts" : "bun-env.d.ts";
 				const targetDir = path.dirname(targetPath);

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -79,6 +79,10 @@ export class InitUseCase {
 				process.cwd(),
 				tsConfig.parsed,
 			);
+			const detectedBunFeatures =
+				detectedFramework === "bun"
+					? await this.scanner.detectBunFeatures(process.cwd(), tsConfig.parsed)
+					: undefined;
 			const defaultEnvPath = await this.scanner.suggestDefaultEnvPath(
 				process.cwd(),
 				tsConfig.parsed,
@@ -103,6 +107,7 @@ export class InitUseCase {
 			const options = await this.prompt.runWizard(
 				{
 					framework: detectedFramework,
+					bunFeatures: detectedBunFeatures,
 					defaultEnvPath,
 					tsConfig: tsConfig.parsed ?? null,
 					envKeys: envRes?.keys,
@@ -181,6 +186,7 @@ export class InitUseCase {
 				cwd: process.cwd(),
 				options,
 				detectedFramework,
+				detectedBunFeatures,
 				packageManager,
 				tsConfig,
 				shouldUpdateTsConfig,

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import pc from "picocolors";
+import { shake } from "radashi";
 import { code } from "@/cli/ui";
 import { type CollectedState, createPlan, Executor } from "@/features/scaffold";
 import type {
@@ -112,7 +113,7 @@ export class InitUseCase {
 			}
 
 			const options = await this.prompt.runWizard(
-				{
+				shake({
 					framework: detectedFramework,
 					bunFeatures: detectedBunFeatures,
 					defaultEnvPath,
@@ -120,7 +121,7 @@ export class InitUseCase {
 					envKeys: envRes?.keys,
 					envKeysSource: envRes?.source,
 					hasTypeFile,
-				},
+				}),
 				isYes,
 			);
 
@@ -191,7 +192,7 @@ export class InitUseCase {
 					existingFiles.push(typeFilePath);
 			}
 
-			return {
+			return shake({
 				cwd: process.cwd(),
 				options,
 				detectedFramework,
@@ -201,7 +202,7 @@ export class InitUseCase {
 				shouldUpdateTsConfig,
 				existingFiles,
 				isYes,
-			};
+			});
 		} finally {
 			// Restore stdout
 			this.logger.interactiveStdout(false);

--- a/packages/cli/src/cli/ui/prompts.test.ts
+++ b/packages/cli/src/cli/ui/prompts.test.ts
@@ -39,34 +39,34 @@ describe("runPromptWizard", () => {
 
 	it("should include bunFeatures in isYes mode if detected", async () => {
 		const result = await runPromptWizard(
-			{ framework: "bun", bunFeatures: ["serve"] },
+			{ framework: "bun-fullstack", bunFeatures: ["serve"] },
 			true,
 		);
 
-		expect(result?.framework).toBe("bun");
+		expect(result?.framework).toBe("bun-fullstack");
 		expect(result?.bunFeatures).toEqual(["serve"]);
 	});
 
 	it("should include bunFeatures if user selects them in wizard", async () => {
 		vi.mocked(prompts.group).mockResolvedValue({
 			overwrite: true,
-			framework: "bun",
-			bunFeatures: ["serve", "build"],
+			framework: "bun-fullstack",
+			bunBuild: true,
 			validator: "arktype",
 			useEnvExample: true,
 			useDefaultPath: true,
 		});
 
-		const result = await runPromptWizard({ framework: "bun" });
+		const result = await runPromptWizard({ framework: "bun-fullstack" });
 
-		expect(result?.framework).toBe("bun");
+		expect(result?.framework).toBe("bun-fullstack");
 		expect(result?.bunFeatures).toEqual(["serve", "build"]);
 	});
 
 	it("should include envKeys if user accepts prompt", async () => {
 		vi.mocked(prompts.group).mockResolvedValue({
 			overwrite: true,
-			framework: "node",
+			framework: "vanilla",
 			validator: "arktype",
 			useEnvExample: true,
 			useDefaultPath: true,
@@ -80,7 +80,7 @@ describe("runPromptWizard", () => {
 	it("should NOT include envKeys if user declines prompt", async () => {
 		vi.mocked(prompts.group).mockResolvedValue({
 			overwrite: true,
-			framework: "node",
+			framework: "vanilla",
 			validator: "arktype",
 			useEnvExample: false,
 			useDefaultPath: true,

--- a/packages/cli/src/cli/ui/prompts.test.ts
+++ b/packages/cli/src/cli/ui/prompts.test.ts
@@ -37,6 +37,32 @@ describe("runPromptWizard", () => {
 		expect(result?.envKeys).toEqual(["API_KEY"]);
 	});
 
+	it("should include bunFeatures in isYes mode if detected", async () => {
+		const result = await runPromptWizard(
+			{ framework: "bun", bunFeatures: ["serve"] },
+			true,
+		);
+
+		expect(result?.framework).toBe("bun");
+		expect(result?.bunFeatures).toEqual(["serve"]);
+	});
+
+	it("should include bunFeatures if user selects them in wizard", async () => {
+		vi.mocked(prompts.group).mockResolvedValue({
+			overwrite: true,
+			framework: "bun",
+			bunFeatures: ["serve", "build"],
+			validator: "arktype",
+			useEnvExample: true,
+			useDefaultPath: true,
+		});
+
+		const result = await runPromptWizard({ framework: "bun" });
+
+		expect(result?.framework).toBe("bun");
+		expect(result?.bunFeatures).toEqual(["serve", "build"]);
+	});
+
 	it("should include envKeys if user accepts prompt", async () => {
 		vi.mocked(prompts.group).mockResolvedValue({
 			overwrite: true,

--- a/packages/cli/src/cli/ui/prompts/steps.ts
+++ b/packages/cli/src/cli/ui/prompts/steps.ts
@@ -7,7 +7,7 @@ import {
 	installTypeDefinitionsStep,
 } from "./steps/env-types";
 import {
-	bunFeaturesStep,
+	bunBuildStep,
 	frameworkStep,
 	validatorStep,
 } from "./steps/framework";
@@ -19,7 +19,7 @@ import { pathStep, useDefaultPathStep } from "./steps/path";
 export const steps = {
 	overwriteEnvSchemaFile: overwriteEnvSchemaFileStep,
 	framework: frameworkStep,
-	bunFeatures: bunFeaturesStep,
+	bunBuild: bunBuildStep,
 	useDefaultPath: useDefaultPathStep,
 	path: pathStep,
 	installTypeDefinitions: installTypeDefinitionsStep,

--- a/packages/cli/src/cli/ui/prompts/steps.ts
+++ b/packages/cli/src/cli/ui/prompts/steps.ts
@@ -6,11 +6,7 @@ import {
 	envDtsHandlingStep,
 	installTypeDefinitionsStep,
 } from "./steps/env-types";
-import {
-	bunBuildStep,
-	frameworkStep,
-	validatorStep,
-} from "./steps/framework";
+import { bunBuildStep, frameworkStep, validatorStep } from "./steps/framework";
 import { pathStep, useDefaultPathStep } from "./steps/path";
 
 /**

--- a/packages/cli/src/cli/ui/prompts/steps.ts
+++ b/packages/cli/src/cli/ui/prompts/steps.ts
@@ -6,7 +6,11 @@ import {
 	envDtsHandlingStep,
 	installTypeDefinitionsStep,
 } from "./steps/env-types";
-import { frameworkStep, validatorStep } from "./steps/framework";
+import {
+	bunFeaturesStep,
+	frameworkStep,
+	validatorStep,
+} from "./steps/framework";
 import { pathStep, useDefaultPathStep } from "./steps/path";
 
 /**
@@ -15,6 +19,7 @@ import { pathStep, useDefaultPathStep } from "./steps/path";
 export const steps = {
 	overwriteEnvSchemaFile: overwriteEnvSchemaFileStep,
 	framework: frameworkStep,
+	bunFeatures: bunFeaturesStep,
 	useDefaultPath: useDefaultPathStep,
 	path: pathStep,
 	installTypeDefinitions: installTypeDefinitionsStep,

--- a/packages/cli/src/cli/ui/prompts/steps/framework.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/framework.ts
@@ -27,17 +27,17 @@ export const frameworkStep =
 export const bunFeaturesStep =
 	(defaults?: { bunFeatures?: ProjectOptions["bunFeatures"] }) => async () => {
 		const answer = await multiselect({
-			message: "Which Bun-specific APIs would you like to integrate?",
+			message: "Optional: Select Bun features for frontend/fullstack bundling:",
 			options: [
 				{
 					value: "serve",
-					label: "Bun.serve (Fullstack dev server)",
-					hint: "Add plugin to bunfig.toml",
+					label: "Fullstack dev server (Bun.serve)",
+					hint: "Inline PUBLIC_ variables in frontend assets via bunfig.toml",
 				},
 				{
 					value: "build",
-					label: "Bun.build (Programmatic Bundler)",
-					hint: "Provide snippet for your build script",
+					label: "Programmatic Bundler (Bun.build)",
+					hint: "Inline PUBLIC_ variables in custom build scripts",
 				},
 			],
 			initialValues: defaults?.bunFeatures ?? [],

--- a/packages/cli/src/cli/ui/prompts/steps/framework.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/framework.ts
@@ -32,12 +32,12 @@ export const bunFeaturesStep =
 				{
 					value: "serve",
 					label: "Fullstack dev server (Bun.serve)",
-					hint: "Inline PUBLIC_ variables in frontend assets via bunfig.toml",
+					hint: "Inline env variables (e.g. PUBLIC_) in frontend assets via bunfig.toml",
 				},
 				{
 					value: "build",
 					label: "Programmatic Bundler (Bun.build)",
-					hint: "Inline PUBLIC_ variables in custom build scripts",
+					hint: "Inline env variables (e.g. PUBLIC_) in custom build scripts",
 				},
 			],
 			initialValues: defaults?.bunFeatures ?? [],

--- a/packages/cli/src/cli/ui/prompts/steps/framework.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/framework.ts
@@ -15,7 +15,7 @@ export const frameworkStep =
 				{
 					value: "vite",
 					label: `Vite${defaults?.framework === "vite" ? " (Detected)" : ""}`,
-					hint: "Client-side and build-time validation",
+					hint: "Client-side and static inlining validation",
 				},
 				{
 					value: "bun-fullstack",
@@ -27,11 +27,11 @@ export const frameworkStep =
 		return isCancel(answer) ? null : (answer as ProjectOptions["framework"]);
 	};
 
-export const bunBuildStep = async () => {
+export const bunBuildStep = (initialValue = false) => async () => {
 	const answer = await confirm({
 		message:
 			"Optional: Would you also like to bootstrap a custom Bun.build script for programmatic bundling?",
-		initialValue: false,
+		initialValue,
 	});
 	return isCancel(answer) ? null : answer;
 };

--- a/packages/cli/src/cli/ui/prompts/steps/framework.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/framework.ts
@@ -31,13 +31,13 @@ export const bunFeaturesStep =
 			options: [
 				{
 					value: "serve",
-					label: "Bun.serve (Fullstack Web Server)",
-					hint: "Adds plugin to bunfig.toml",
+					label: "Bun.serve (Fullstack dev server)",
+					hint: "Add plugin to bunfig.toml",
 				},
 				{
 					value: "build",
 					label: "Bun.build (Programmatic Bundler)",
-					hint: "Provides snippet for your build script",
+					hint: "Provide snippet for your build script",
 				},
 			],
 			initialValues: defaults?.bunFeatures ?? [],

--- a/packages/cli/src/cli/ui/prompts/steps/framework.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/framework.ts
@@ -27,14 +27,16 @@ export const frameworkStep =
 		return isCancel(answer) ? null : (answer as ProjectOptions["framework"]);
 	};
 
-export const bunBuildStep = (initialValue = false) => async () => {
-	const answer = await confirm({
-		message:
-			"Optional: Would you also like to bootstrap a custom Bun.build script for programmatic bundling?",
-		initialValue,
-	});
-	return isCancel(answer) ? null : answer;
-};
+export const bunBuildStep =
+	(initialValue = false) =>
+	async () => {
+		const answer = await confirm({
+			message:
+				"Optional: Would you also like to bootstrap a custom Bun.build script for programmatic bundling?",
+			initialValue,
+		});
+		return isCancel(answer) ? null : answer;
+	};
 
 export const validatorStep = async () => {
 	const answer = await select({

--- a/packages/cli/src/cli/ui/prompts/steps/framework.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/framework.ts
@@ -36,7 +36,7 @@ export const bunFeaturesStep =
 				},
 				{
 					value: "build",
-					label: "Programmatic Bundler (Bun.build)",
+					label: "Fullstack programmatic bundler (Bun.build)",
 					hint: "Inline env variables (e.g. PUBLIC_) in custom build scripts",
 				},
 			],

--- a/packages/cli/src/cli/ui/prompts/steps/framework.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/framework.ts
@@ -1,50 +1,40 @@
-import { isCancel, multiselect, select } from "@clack/prompts";
+import { confirm, isCancel, select } from "@clack/prompts";
 import type { ProjectOptions } from "@/features/scaffold";
 
 export const frameworkStep =
 	(defaults?: { framework?: ProjectOptions["framework"] }) => async () => {
 		const answer = await select({
-			message: "Select your framework or runtime:",
+			message: "Select your framework or build tool:",
 			initialValue: defaults?.framework,
 			options: [
 				{
+					value: "vanilla",
+					label: `Vanilla${defaults?.framework === "vanilla" ? " (Detected)" : ""}`,
+					hint: "Node.js, Bun, server-side or runtime-only validation",
+				},
+				{
 					value: "vite",
 					label: `Vite${defaults?.framework === "vite" ? " (Detected)" : ""}`,
+					hint: "Client-side and build-time validation",
 				},
 				{
-					value: "bun",
-					label: `Bun${defaults?.framework === "bun" ? " (Detected)" : ""}`,
-				},
-				{
-					value: "node",
-					label: `Node.js${defaults?.framework === "node" ? " (Detected)" : ""}`,
+					value: "bun-fullstack",
+					label: `Bun fullstack dev server${defaults?.framework === "bun-fullstack" ? " (Detected)" : ""}`,
+					hint: "Client-side bundling and Bun.serve integration",
 				},
 			],
 		});
 		return isCancel(answer) ? null : (answer as ProjectOptions["framework"]);
 	};
 
-export const bunFeaturesStep =
-	(defaults?: { bunFeatures?: ProjectOptions["bunFeatures"] }) => async () => {
-		const answer = await multiselect({
-			message: "Optional: Select Bun features for frontend/fullstack bundling:",
-			options: [
-				{
-					value: "serve",
-					label: "Fullstack dev server (Bun.serve)",
-					hint: "Inline env variables (e.g. PUBLIC_) in frontend assets via bunfig.toml",
-				},
-				{
-					value: "build",
-					label: "Fullstack programmatic bundler (Bun.build)",
-					hint: "Inline env variables (e.g. PUBLIC_) in custom build scripts",
-				},
-			],
-			initialValues: defaults?.bunFeatures ?? [],
-			required: false,
-		});
-		return isCancel(answer) ? null : (answer as ProjectOptions["bunFeatures"]);
-	};
+export const bunBuildStep = async () => {
+	const answer = await confirm({
+		message:
+			"Optional: Would you also like to bootstrap a custom Bun.build script for programmatic bundling?",
+		initialValue: false,
+	});
+	return isCancel(answer) ? null : answer;
+};
 
 export const validatorStep = async () => {
 	const answer = await select({

--- a/packages/cli/src/cli/ui/prompts/steps/framework.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/framework.ts
@@ -1,4 +1,4 @@
-import { isCancel, select } from "@clack/prompts";
+import { isCancel, multiselect, select } from "@clack/prompts";
 import type { ProjectOptions } from "@/features/scaffold";
 
 export const frameworkStep =
@@ -22,6 +22,28 @@ export const frameworkStep =
 			],
 		});
 		return isCancel(answer) ? null : (answer as ProjectOptions["framework"]);
+	};
+
+export const bunFeaturesStep =
+	(defaults?: { bunFeatures?: ProjectOptions["bunFeatures"] }) => async () => {
+		const answer = await multiselect({
+			message: "Which Bun-specific APIs would you like to integrate?",
+			options: [
+				{
+					value: "serve",
+					label: "Bun.serve (Fullstack Web Server)",
+					hint: "Adds plugin to bunfig.toml",
+				},
+				{
+					value: "build",
+					label: "Bun.build (Programmatic Bundler)",
+					hint: "Provides snippet for your build script",
+				},
+			],
+			initialValues: defaults?.bunFeatures ?? [],
+			required: false,
+		});
+		return isCancel(answer) ? null : (answer as ProjectOptions["bunFeatures"]);
 	};
 
 export const validatorStep = async () => {

--- a/packages/cli/src/cli/ui/prompts/utils.ts
+++ b/packages/cli/src/cli/ui/prompts/utils.ts
@@ -5,6 +5,6 @@ import { isCancel } from "@clack/prompts";
  */
 export function isSuccess<T extends Record<string, any>>(
 	result: T | symbol,
-): result is { [K in keyof T]: T[K] extends null ? never : T[K] } {
+): result is { [K in keyof T]: Exclude<T[K], null> } {
 	return !isCancel(result) && Object.values(result).every((v) => v !== null);
 }

--- a/packages/cli/src/cli/ui/prompts/utils.ts
+++ b/packages/cli/src/cli/ui/prompts/utils.ts
@@ -5,9 +5,6 @@ import { isCancel } from "@clack/prompts";
  */
 export function isSuccess<T extends Record<string, any>>(
 	result: T | symbol,
-): result is { [K in keyof T]: NonNullable<T[K]> } {
-	return (
-		!isCancel(result) &&
-		Object.values(result).every((v) => v !== null && v !== undefined)
-	);
+): result is { [K in keyof T]: T[K] extends null ? never : T[K] } {
+	return !isCancel(result) && Object.values(result).every((v) => v !== null);
 }

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -50,7 +50,12 @@ export async function runPromptWizard(
 			framework: steps.framework(defaults),
 			bunBuild: ({ results }) =>
 				results.framework === "bun-fullstack"
-					? steps.bunBuild()
+					? steps.bunBuild(
+							defaults?.bunFeatures?.includes("build") ||
+								(results.framework === "bun-fullstack" &&
+									defaults?.framework === "bun-fullstack" &&
+									defaults?.bunFeatures?.includes("build")),
+						)
 					: Promise.resolve(undefined),
 			useDefaultPath: steps.useDefaultPath(defaultEnvPath),
 			path: steps.path(defaultEnvPath),

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -34,7 +34,9 @@ export async function runPromptWizard(
 			validator: "arktype",
 			framework,
 			bunFeatures:
-				framework === "bun-fullstack" ? defaults?.bunFeatures : undefined,
+				framework === "bun-fullstack"
+					? (defaults?.bunFeatures ?? ["serve"])
+					: undefined,
 			language: "ts",
 			overwriteEnvSchemaFile: true,
 			installTypeDefinitions: framework !== "vanilla",

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -11,8 +11,8 @@ export async function runPromptWizard(
 		bunFeatures?: ProjectOptions["bunFeatures"];
 		defaultEnvPath?: string;
 		tsConfig?: ParsedTsConfig | null;
-		envKeys?: string[] | undefined;
-		envKeysSource?: ".env.example" | "project" | undefined;
+		envKeys?: string[];
+		envKeysSource?: ".env.example" | "project";
 		hasTypeFile?: boolean;
 	},
 	isYes = false,

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -22,10 +22,10 @@ export async function runPromptWizard(
 	const keysSource = defaults?.envKeysSource || ".env.example";
 
 	if (isYes) {
-		const framework = defaults?.framework || "node";
+		const framework = defaults?.framework || "vanilla";
 		let envDtsHandling: ProjectOptions["envDtsHandling"];
 
-		if (framework === "vite" || framework === "bun") {
+		if (framework === "vite" || framework === "bun-fullstack") {
 			envDtsHandling = defaults?.hasTypeFile ? "append" : "overwrite";
 		}
 
@@ -33,10 +33,11 @@ export async function runPromptWizard(
 			path: defaultEnvPath,
 			validator: "arktype",
 			framework,
-			bunFeatures: framework === "bun" ? defaults?.bunFeatures : undefined,
+			bunFeatures:
+				framework === "bun-fullstack" ? defaults?.bunFeatures : undefined,
 			language: "ts",
 			overwriteEnvSchemaFile: true,
-			installTypeDefinitions: framework !== "node",
+			installTypeDefinitions: framework !== "vanilla",
 			installSkill: false,
 			envDtsHandling,
 			envKeys: detectedKeys ?? undefined,
@@ -47,9 +48,9 @@ export async function runPromptWizard(
 		{
 			overwriteEnvSchemaFile: steps.overwriteEnvSchemaFile(defaultEnvPath),
 			framework: steps.framework(defaults),
-			bunFeatures: ({ results }) =>
-				results.framework === "bun"
-					? steps.bunFeatures(defaults)()
+			bunBuild: ({ results }) =>
+				results.framework === "bun-fullstack"
+					? steps.bunBuild()
 					: Promise.resolve(undefined),
 			useDefaultPath: steps.useDefaultPath(defaultEnvPath),
 			path: steps.path(defaultEnvPath),
@@ -69,8 +70,16 @@ export async function runPromptWizard(
 		return null;
 	}
 
+	const bunFeatures: ProjectOptions["bunFeatures"] =
+		result.framework === "bun-fullstack"
+			? result.bunBuild
+				? ["serve", "build"]
+				: ["serve"]
+			: undefined;
+
 	return shake({
 		...result,
+		bunFeatures,
 		language: "ts",
 		installSkill: false, // Defaulting to false, will be overridden by orchestrator if needed
 		envKeys: result.useEnvExample ? (detectedKeys ?? undefined) : undefined,

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { group } from "@clack/prompts";
 import { shake } from "radashi";
 import type { ProjectOptions } from "@/features/scaffold";
@@ -9,6 +8,7 @@ import { isSuccess } from "./utils";
 export async function runPromptWizard(
 	defaults?: {
 		framework?: ProjectOptions["framework"];
+		bunFeatures?: ProjectOptions["bunFeatures"];
 		defaultEnvPath?: string;
 		tsConfig?: ParsedTsConfig | null;
 		envKeys?: string[] | undefined;
@@ -33,6 +33,7 @@ export async function runPromptWizard(
 			path: defaultEnvPath,
 			validator: "arktype",
 			framework,
+			bunFeatures: framework === "bun" ? defaults?.bunFeatures : undefined,
 			language: "ts",
 			overwriteEnvSchemaFile: true,
 			installTypeDefinitions: framework !== "node",
@@ -46,6 +47,10 @@ export async function runPromptWizard(
 		{
 			overwriteEnvSchemaFile: steps.overwriteEnvSchemaFile(defaultEnvPath),
 			framework: steps.framework(defaults),
+			bunFeatures: ({ results }) =>
+				results.framework === "bun"
+					? steps.bunFeatures(defaults)()
+					: Promise.resolve(undefined),
 			useDefaultPath: steps.useDefaultPath(defaultEnvPath),
 			path: steps.path(defaultEnvPath),
 			installTypeDefinitions: steps.installTypeDefinitions,

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -55,7 +55,7 @@ export async function runPromptWizard(
 								(results.framework === "bun-fullstack" &&
 									defaults?.framework === "bun-fullstack" &&
 									defaults?.bunFeatures?.includes("build")),
-						)
+						)()
 					: Promise.resolve(undefined),
 			useDefaultPath: steps.useDefaultPath(defaultEnvPath),
 			path: steps.path(defaultEnvPath),

--- a/packages/cli/src/features/scaffold/env-template.test.ts
+++ b/packages/cli/src/features/scaffold/env-template.test.ts
@@ -6,7 +6,7 @@ describe("env-template", () => {
 		it("returns arktype template when validator is arktype", () => {
 			const options = {
 				validator: "arktype" as any,
-				framework: "node" as any,
+				framework: "vanilla" as any,
 				path: ".env.config.ts",
 				language: "ts" as const,
 				shouldUpdateTsConfig: false,
@@ -24,7 +24,7 @@ describe("env-template", () => {
 		it("returns arktype template with envKeys and defaults", () => {
 			const options = {
 				validator: "arktype" as any,
-				framework: "node" as any,
+				framework: "vanilla" as any,
 				path: "env.ts",
 				language: "ts" as const,
 				shouldUpdateTsConfig: false,
@@ -59,10 +59,10 @@ describe("env-template", () => {
 			);
 		});
 
-		it("returns arktype template for bun when validator is arktype", () => {
+		it("returns arktype template for bun-fullstack when validator is arktype", () => {
 			const options = {
 				validator: "arktype" as any,
-				framework: "bun" as any,
+				framework: "bun-fullstack" as any,
 				path: ".env.config.ts",
 				language: "ts" as const,
 				shouldUpdateTsConfig: false,
@@ -77,7 +77,7 @@ describe("env-template", () => {
 			expect(template).not.toContain("export const env = arkenv(Env)");
 			expect(template).toContain("export const Env = type({");
 			expect(template).toContain(
-				"In Bun, use \\`@arkenv/bun-plugin\\`".replace(/\\/g, ""),
+				"In Bun Fullstack, use \\`@arkenv/bun-plugin\\`".replace(/\\/g, ""),
 			);
 			expect(template).toContain("validate these at build-time");
 			expect(template).toContain(
@@ -88,7 +88,7 @@ describe("env-template", () => {
 		it("returns zod template when validator is zod", () => {
 			const options = {
 				validator: "zod" as any,
-				framework: "node" as any,
+				framework: "vanilla" as any,
 				path: ".env.config.ts",
 				language: "ts" as const,
 				shouldUpdateTsConfig: false,
@@ -103,7 +103,7 @@ describe("env-template", () => {
 		it("returns zod template with envKeys and defaults", () => {
 			const options = {
 				validator: "zod" as any,
-				framework: "node" as any,
+				framework: "vanilla" as any,
 				path: "env.ts",
 				language: "ts" as const,
 				shouldUpdateTsConfig: false,
@@ -117,7 +117,7 @@ describe("env-template", () => {
 		it("returns valibot template when validator is valibot", () => {
 			const options = {
 				validator: "valibot" as any,
-				framework: "node" as any,
+				framework: "vanilla" as any,
 				path: ".env.config.ts",
 				language: "ts" as const,
 				shouldUpdateTsConfig: false,
@@ -137,7 +137,7 @@ describe("env-template", () => {
 		it("returns valibot template with envKeys and defaults", () => {
 			const options = {
 				validator: "valibot" as any,
-				framework: "node" as any,
+				framework: "vanilla" as any,
 				path: "env.ts",
 				language: "ts" as const,
 				shouldUpdateTsConfig: false,
@@ -151,7 +151,7 @@ describe("env-template", () => {
 		it("throws error for unsupported validator", () => {
 			const options = {
 				validator: "unknown" as any,
-				framework: "node" as any,
+				framework: "vanilla" as any,
 				path: ".env.config.ts",
 				language: "ts" as const,
 				shouldUpdateTsConfig: false,

--- a/packages/cli/src/features/scaffold/executor.test.ts
+++ b/packages/cli/src/features/scaffold/executor.test.ts
@@ -61,7 +61,7 @@ describe("Executor", () => {
 		install: { packageManager: "pnpm", dependencies: ["arkenv"] },
 		metadata: {
 			displayPath: "env.ts",
-			framework: "node",
+			framework: "vanilla",
 			validator: "arktype",
 			packageManager: "pnpm",
 			importPath: "./env",

--- a/packages/cli/src/features/scaffold/executor.ts
+++ b/packages/cli/src/features/scaffold/executor.ts
@@ -125,20 +125,14 @@ export class Executor {
 					}
 				} else if (plan.bootstrap.framework === "bun-fullstack") {
 					const bunConfigPath = await this.workspace.findBunConfig();
-					if (bunConfigPath || plan.bootstrap.bunFeatures?.length) {
-						const result = await this.workspace.bootstrapBunConfig(
-							bunConfigPath,
-							plan.bootstrap.bunFeatures,
-						);
-						if (result.success && result.instructions) {
-							this.reporter.info(result.instructions);
-						} else if (!result.success) {
-							this.reporter.error(result.error || "Bun bootstrap failed");
-						}
-					} else {
-						this.reporter.info(
-							`No Bun config found — create a ${code("bun.config.ts")} or run ${code("bun init")} to bootstrap manually.`,
-						);
+					const result = await this.workspace.bootstrapBunConfig(
+						bunConfigPath,
+						plan.bootstrap.bunFeatures,
+					);
+					if (result.success && result.instructions) {
+						this.reporter.info(result.instructions);
+					} else if (!result.success) {
+						this.reporter.error(result.error || "Bun bootstrap failed");
 					}
 				}
 			}

--- a/packages/cli/src/features/scaffold/executor.ts
+++ b/packages/cli/src/features/scaffold/executor.ts
@@ -125,9 +125,11 @@ export class Executor {
 					}
 				} else if (plan.bootstrap.framework === "bun") {
 					const bunConfigPath = await this.workspace.findBunConfig();
-					if (bunConfigPath) {
-						const result =
-							await this.workspace.bootstrapBunConfig(bunConfigPath);
+					if (bunConfigPath || plan.bootstrap.bunFeatures?.length) {
+						const result = await this.workspace.bootstrapBunConfig(
+							bunConfigPath,
+							plan.bootstrap.bunFeatures,
+						);
 						if (result.success && result.instructions) {
 							this.reporter.info(result.instructions);
 						} else if (!result.success) {

--- a/packages/cli/src/features/scaffold/executor.ts
+++ b/packages/cli/src/features/scaffold/executor.ts
@@ -24,7 +24,7 @@ export class Executor {
 					if (
 						!plan.bootstrap ||
 						(plan.bootstrap.framework !== "vite" &&
-							plan.bootstrap.framework !== "bun")
+							plan.bootstrap.framework !== "bun-fullstack")
 					) {
 						this.reporter.warn(
 							`Skipping safe-append for ${code(path.basename(file.path))}: unsupported framework.`,
@@ -123,7 +123,7 @@ export class Executor {
 							`No Vite config found — please add ${code("@arkenv/vite-plugin")} to your Vite config manually.`,
 						);
 					}
-				} else if (plan.bootstrap.framework === "bun") {
+				} else if (plan.bootstrap.framework === "bun-fullstack") {
 					const bunConfigPath = await this.workspace.findBunConfig();
 					if (bunConfigPath || plan.bootstrap.bunFeatures?.length) {
 						const result = await this.workspace.bootstrapBunConfig(

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -10,12 +10,13 @@ export type ProjectOptions = {
 	path: string;
 	validator: "arktype" | "zod" | "valibot";
 	framework: "vite" | "bun" | "node";
+	bunFeatures?: ("serve" | "build")[] | undefined;
 	language: "ts"; // TODO: Support JS
-	overwriteEnvSchemaFile?: boolean;
-	envDtsHandling?: "overwrite" | "append" | "skip";
-	installTypeDefinitions?: boolean;
-	envKeys?: string[];
-	installSkill?: boolean;
+	overwriteEnvSchemaFile?: boolean | undefined;
+	envDtsHandling?: "overwrite" | "append" | "skip" | undefined;
+	installTypeDefinitions?: boolean | undefined;
+	envKeys?: string[] | undefined;
+	installSkill?: boolean | undefined;
 };
 
 /**
@@ -27,30 +28,39 @@ export type ScaffoldingPlan = {
 		path: string;
 		content: string;
 		action: "create" | "overwrite" | "append";
-		label?: string;
+		label?: string | undefined;
 	}[];
 	/** TypeScript configuration updates */
-	tsConfig?: {
-		path: string;
-		action: "strict";
-	};
+	tsConfig?:
+		| {
+				path: string;
+				action: "strict";
+		  }
+		| undefined;
 	/** Dependencies to install */
-	install?: {
-		packageManager: "pnpm" | "yarn" | "npm" | "bun";
-		dependencies: string[];
-	};
+	install?:
+		| {
+				packageManager: "pnpm" | "yarn" | "npm" | "bun";
+				dependencies: string[];
+		  }
+		| undefined;
 	/** Optional skill installation */
-	skill?: {
-		dlxCommand: string[];
-		packageName: string;
-		isYes: boolean;
-	};
+	skill?:
+		| {
+				dlxCommand: string[];
+				packageName: string;
+				isYes: boolean;
+		  }
+		| undefined;
 	/** Framework-specific bootstrapping */
-	bootstrap?: {
-		framework: "vite" | "bun";
-		path?: string;
-		importPath?: string;
-	};
+	bootstrap?:
+		| {
+				framework: "vite" | "bun";
+				path?: string | undefined;
+				importPath?: string | undefined;
+				bunFeatures?: ("serve" | "build")[] | undefined;
+		  }
+		| undefined;
 	/** Metadata for reporting */
 	metadata: {
 		displayPath: string;
@@ -68,10 +78,11 @@ export type CollectedState = {
 	cwd: string;
 	options: ProjectOptions;
 	detectedFramework: "vite" | "bun" | "node";
+	detectedBunFeatures?: ("serve" | "build")[] | undefined;
 	packageManager: "pnpm" | "yarn" | "npm" | "bun";
 	tsConfig: {
 		status: "strict" | "not_strict" | "not_found";
-		file?: string;
+		file?: string | undefined;
 	};
 	shouldUpdateTsConfig: boolean;
 	existingFiles: string[];

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -9,7 +9,7 @@ export type { Reporter, Workspace };
 export type ProjectOptions = {
 	path: string;
 	validator: "arktype" | "zod" | "valibot";
-	framework: "vite" | "bun" | "node";
+	framework: "vite" | "bun-fullstack" | "vanilla";
 	bunFeatures?: ("serve" | "build")[] | undefined;
 	language: "ts"; // TODO: Support JS
 	overwriteEnvSchemaFile?: boolean | undefined;
@@ -55,7 +55,7 @@ export type ScaffoldingPlan = {
 	/** Framework-specific bootstrapping */
 	bootstrap?:
 		| {
-				framework: "vite" | "bun";
+				framework: "vite" | "bun-fullstack";
 				path?: string | undefined;
 				importPath?: string | undefined;
 				bunFeatures?: ("serve" | "build")[] | undefined;
@@ -77,7 +77,7 @@ export type ScaffoldingPlan = {
 export type CollectedState = {
 	cwd: string;
 	options: ProjectOptions;
-	detectedFramework: "vite" | "bun" | "node";
+	detectedFramework: "vite" | "bun-fullstack" | "vanilla";
 	detectedBunFeatures?: ("serve" | "build")[] | undefined;
 	packageManager: "pnpm" | "yarn" | "npm" | "bun";
 	tsConfig: {

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -10,13 +10,13 @@ export type ProjectOptions = {
 	path: string;
 	validator: "arktype" | "zod" | "valibot";
 	framework: "vite" | "bun-fullstack" | "vanilla";
-	bunFeatures?: ("serve" | "build")[] | undefined;
+	bunFeatures?: ("serve" | "build")[];
 	language: "ts"; // TODO: Support JS
-	overwriteEnvSchemaFile?: boolean | undefined;
-	envDtsHandling?: "overwrite" | "append" | "skip" | undefined;
-	installTypeDefinitions?: boolean | undefined;
-	envKeys?: string[] | undefined;
-	installSkill?: boolean | undefined;
+	overwriteEnvSchemaFile?: boolean;
+	envDtsHandling?: "overwrite" | "append" | "skip";
+	installTypeDefinitions?: boolean;
+	envKeys?: string[];
+	installSkill?: boolean;
 };
 
 /**
@@ -28,39 +28,31 @@ export type ScaffoldingPlan = {
 		path: string;
 		content: string;
 		action: "create" | "overwrite" | "append";
-		label?: string | undefined;
+		label?: string;
 	}[];
 	/** TypeScript configuration updates */
-	tsConfig?:
-		| {
-				path: string;
-				action: "strict";
-		  }
-		| undefined;
+	tsConfig?: {
+		path: string;
+		action: "strict";
+	};
 	/** Dependencies to install */
-	install?:
-		| {
-				packageManager: "pnpm" | "yarn" | "npm" | "bun";
-				dependencies: string[];
-		  }
-		| undefined;
+	install?: {
+		packageManager: "pnpm" | "yarn" | "npm" | "bun";
+		dependencies: string[];
+	};
 	/** Optional skill installation */
-	skill?:
-		| {
-				dlxCommand: string[];
-				packageName: string;
-				isYes: boolean;
-		  }
-		| undefined;
+	skill?: {
+		dlxCommand: string[];
+		packageName: string;
+		isYes: boolean;
+	};
 	/** Framework-specific bootstrapping */
-	bootstrap?:
-		| {
-				framework: "vite" | "bun-fullstack";
-				path?: string | undefined;
-				importPath?: string | undefined;
-				bunFeatures?: ("serve" | "build")[] | undefined;
-		  }
-		| undefined;
+	bootstrap?: {
+		framework: "vite" | "bun-fullstack";
+		path?: string;
+		importPath?: string;
+		bunFeatures?: ("serve" | "build")[];
+	};
 	/** Metadata for reporting */
 	metadata: {
 		displayPath: string;
@@ -78,11 +70,11 @@ export type CollectedState = {
 	cwd: string;
 	options: ProjectOptions;
 	detectedFramework: "vite" | "bun-fullstack" | "vanilla";
-	detectedBunFeatures?: ("serve" | "build")[] | undefined;
+	detectedBunFeatures?: ("serve" | "build")[];
 	packageManager: "pnpm" | "yarn" | "npm" | "bun";
 	tsConfig: {
 		status: "strict" | "not_strict" | "not_found";
-		file?: string | undefined;
+		file?: string;
 	};
 	shouldUpdateTsConfig: boolean;
 	existingFiles: string[];

--- a/packages/cli/src/features/scaffold/planner.test.ts
+++ b/packages/cli/src/features/scaffold/planner.test.ts
@@ -8,12 +8,12 @@ describe("Planner", () => {
 		cwd: "/test",
 		options: {
 			validator: "arktype",
-			framework: "node",
+			framework: "vanilla",
 			path: "env.ts",
 			language: "ts",
 			installTypeDefinitions: true,
 		},
-		detectedFramework: "node",
+		detectedFramework: "vanilla",
 		packageManager: "pnpm",
 		tsConfig: { status: "strict", file: "tsconfig.json" },
 		shouldUpdateTsConfig: false,
@@ -44,37 +44,37 @@ describe("Planner", () => {
 		expect(plan.bootstrap?.framework).toBe("vite");
 	});
 
-	it("plans for bun framework with features", () => {
+	it("plans for bun-fullstack framework with features", () => {
 		const state: CollectedState = {
 			...defaultState,
 			options: {
 				...defaultState.options,
-				framework: "bun",
+				framework: "bun-fullstack",
 				bunFeatures: ["serve"],
 			},
-			detectedFramework: "bun",
+			detectedFramework: "bun-fullstack",
 		};
 		const plan = createPlan(state);
 		expect(plan.install?.dependencies).toContain("@arkenv/bun-plugin");
 		expect(plan.files.some((f) => f.path.endsWith("bun-env.d.ts"))).toBe(true);
-		expect(plan.bootstrap?.framework).toBe("bun");
+		expect(plan.bootstrap?.framework).toBe("bun-fullstack");
 		expect(plan.bootstrap?.bunFeatures).toContain("serve");
 	});
 
-	it("plans for bun framework without features", () => {
+	it("plans for bun-fullstack framework without features", () => {
 		const state: CollectedState = {
 			...defaultState,
 			options: {
 				...defaultState.options,
-				framework: "bun",
+				framework: "bun-fullstack",
 				bunFeatures: [],
 			},
-			detectedFramework: "bun",
+			detectedFramework: "bun-fullstack",
 		};
 		const plan = createPlan(state);
 		expect(plan.install?.dependencies).not.toContain("@arkenv/bun-plugin");
 		expect(plan.files.some((f) => f.path.endsWith("bun-env.d.ts"))).toBe(false);
-		expect(plan.bootstrap?.framework).toBe("bun");
+		expect(plan.bootstrap?.framework).toBe("bun-fullstack");
 		expect(plan.bootstrap?.bunFeatures).toEqual([]);
 	});
 

--- a/packages/cli/src/features/scaffold/planner.test.ts
+++ b/packages/cli/src/features/scaffold/planner.test.ts
@@ -44,16 +44,38 @@ describe("Planner", () => {
 		expect(plan.bootstrap?.framework).toBe("vite");
 	});
 
-	it("plans for bun framework", () => {
+	it("plans for bun framework with features", () => {
 		const state: CollectedState = {
 			...defaultState,
-			options: { ...defaultState.options, framework: "bun" },
+			options: {
+				...defaultState.options,
+				framework: "bun",
+				bunFeatures: ["serve"],
+			},
 			detectedFramework: "bun",
 		};
 		const plan = createPlan(state);
 		expect(plan.install?.dependencies).toContain("@arkenv/bun-plugin");
 		expect(plan.files.some((f) => f.path.endsWith("bun-env.d.ts"))).toBe(true);
 		expect(plan.bootstrap?.framework).toBe("bun");
+		expect(plan.bootstrap?.bunFeatures).toContain("serve");
+	});
+
+	it("plans for bun framework without features", () => {
+		const state: CollectedState = {
+			...defaultState,
+			options: {
+				...defaultState.options,
+				framework: "bun",
+				bunFeatures: [],
+			},
+			detectedFramework: "bun",
+		};
+		const plan = createPlan(state);
+		expect(plan.install?.dependencies).not.toContain("@arkenv/bun-plugin");
+		expect(plan.files.some((f) => f.path.endsWith("bun-env.d.ts"))).toBe(false);
+		expect(plan.bootstrap?.framework).toBe("bun");
+		expect(plan.bootstrap?.bunFeatures).toEqual([]);
 	});
 
 	it("plans tsconfig update when requested", () => {

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -5,7 +5,7 @@ import { getDlxCommand } from "./scaffold";
 import { bunTypesTemplate, viteTypesTemplate } from "./templates";
 
 /**
- * Creates a ScaffoldingPlan based on the collected workspace state.
+ * Create a ScaffoldingPlan based on the collected workspace state.
  *
  * @param state The collected state of the workspace.
  * @returns The resulting scaffolding plan.

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -49,7 +49,7 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 	// 2. dependencies
 	const deps = ["arkenv", options.validator];
 	if (options.framework === "vite") deps.push("@arkenv/vite-plugin");
-	if (options.framework === "bun" && options.bunFeatures?.length) {
+	if (options.framework === "bun-fullstack" && options.bunFeatures?.length) {
 		deps.push("@arkenv/bun-plugin");
 	}
 
@@ -69,7 +69,8 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 	// 4. Type Definitions
 	if (
 		(options.framework === "vite" ||
-			(options.framework === "bun" && options.bunFeatures?.length)) &&
+			(options.framework === "bun-fullstack" &&
+				options.bunFeatures?.length)) &&
 		options.installTypeDefinitions !== false
 	) {
 		const typeFileName =
@@ -104,11 +105,11 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 	}
 
 	// 5. Framework-specific bootstrapping
-	if (options.framework === "vite" || options.framework === "bun") {
+	if (options.framework === "vite" || options.framework === "bun-fullstack") {
 		plan.bootstrap = {
 			framework: options.framework,
 			bunFeatures:
-				options.framework === "bun" ? options.bunFeatures : undefined,
+				options.framework === "bun-fullstack" ? options.bunFeatures : undefined,
 		};
 	}
 

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -49,7 +49,9 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 	// 2. dependencies
 	const deps = ["arkenv", options.validator];
 	if (options.framework === "vite") deps.push("@arkenv/vite-plugin");
-	if (options.framework === "bun") deps.push("@arkenv/bun-plugin");
+	if (options.framework === "bun" && options.bunFeatures?.length) {
+		deps.push("@arkenv/bun-plugin");
+	}
 
 	plan.install = {
 		packageManager,
@@ -66,7 +68,8 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 
 	// 4. Type Definitions
 	if (
-		(options.framework === "vite" || options.framework === "bun") &&
+		(options.framework === "vite" ||
+			(options.framework === "bun" && options.bunFeatures?.length)) &&
 		options.installTypeDefinitions !== false
 	) {
 		const typeFileName =
@@ -104,6 +107,8 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 	if (options.framework === "vite" || options.framework === "bun") {
 		plan.bootstrap = {
 			framework: options.framework,
+			bunFeatures:
+				options.framework === "bun" ? options.bunFeatures : undefined,
 		};
 	}
 

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { shake } from "radashi";
 import { getEnvTemplate } from "./env-template";
 import type { CollectedState, ScaffoldingPlan } from "./plan";
 import { getDlxCommand } from "./scaffold";
@@ -105,11 +106,11 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 
 	// 5. Framework-specific bootstrapping
 	if (options.framework === "vite" || options.framework === "bun-fullstack") {
-		plan.bootstrap = {
+		plan.bootstrap = shake({
 			framework: options.framework,
 			bunFeatures:
 				options.framework === "bun-fullstack" ? options.bunFeatures : undefined,
-		};
+		});
 	}
 
 	// 6. Skill

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -69,8 +69,7 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 	// 4. Type Definitions
 	if (
 		(options.framework === "vite" ||
-			(options.framework === "bun-fullstack" &&
-				options.bunFeatures?.length)) &&
+			(options.framework === "bun-fullstack" && options.bunFeatures?.length)) &&
 		options.installTypeDefinitions !== false
 	) {
 		const typeFileName =

--- a/packages/cli/src/features/scaffold/templates/arktype.ts
+++ b/packages/cli/src/features/scaffold/templates/arktype.ts
@@ -4,7 +4,7 @@ import dedent from "dedent";
  * Generates a TypeScript template string for an ArkType environment configuration.
  *
  * @param envKeys - Optional array of environment variable keys to include in the schema.
- * @param framework - The framework being used (vite, bun, or node).
+ * @param framework - The framework being used (vite, bun-fullstack, or vanilla).
  * @returns The generated TypeScript template string.
  */
 export const arktypeTemplate = (envKeys?: string[], framework?: string) => {
@@ -20,7 +20,7 @@ export const arktypeTemplate = (envKeys?: string[], framework?: string) => {
 	/**
 	 * Environment variable schema.
 	 * In Vite, use \`@arkenv/vite-plugin\` to validate these at build-time
-	 * and provide typesafety for \`import.meta.env\`.
+	 * and provide typesafety for \`import.meta.env\` on the client-side.
 	 */
 	export const Env = type({
 ${schemaFields}
@@ -28,14 +28,14 @@ ${schemaFields}
 	`;
 	}
 
-	if (framework === "bun") {
+	if (framework === "bun-fullstack") {
 		return dedent /* ts */`
 	import { type } from "arkenv";
 
 	/**
 	 * Environment variable schema.
-	 * In Bun, use \`@arkenv/bun-plugin\` to validate these at build-time
-	 * and provide typesafety for \`process.env\`.
+	 * In Bun Fullstack, use \`@arkenv/bun-plugin\` to validate these at build-time
+	 * and provide typesafety for \`process.env\` on the client-side.
 	 */
 	export const Env = type({
 ${schemaFields}
@@ -46,6 +46,9 @@ ${schemaFields}
 	return dedent /* ts */`
 	import arkenv, { type } from "arkenv";
 
+	/**
+	 * Environment variable schema for server-side or runtime-only validation.
+	 */
 	export const Env = type({
 ${schemaFields}
 	});

--- a/packages/cli/src/features/scaffold/templates/valibot.ts
+++ b/packages/cli/src/features/scaffold/templates/valibot.ts
@@ -4,7 +4,7 @@ import dedent from "dedent";
  * Generates a TypeScript template string for a Valibot environment configuration.
  *
  * @param envKeys - Optional array of environment variable keys to include in the schema.
- * @param framework - The framework being used (vite, bun, or node).
+ * @param framework - The framework being used (vite, bun-fullstack, or vanilla).
  * @returns The generated TypeScript template string.
  */
 export const valibotTemplate = (envKeys?: string[], framework?: string) => {
@@ -20,7 +20,7 @@ export const valibotTemplate = (envKeys?: string[], framework?: string) => {
 	/**
 	 * Environment variable schema.
 	 * In Vite, use \`@arkenv/vite-plugin\` to validate these at build-time
-	 * and provide typesafety for \`import.meta.env\`.
+	 * and provide typesafety for \`import.meta.env\` on the client-side.
 	 */
 	export const Env = v.object({
 ${schemaFields}
@@ -28,14 +28,14 @@ ${schemaFields}
 	`;
 	}
 
-	if (framework === "bun") {
+	if (framework === "bun-fullstack") {
 		return dedent /* ts */`
 	import * as v from "valibot";
 
 	/**
 	 * Environment variable schema.
-	 * In Bun, use \`@arkenv/bun-plugin\` to validate these at build-time
-	 * and provide typesafety for \`process.env\`.
+	 * In Bun Fullstack, use \`@arkenv/bun-plugin\` to validate these at build-time
+	 * and provide typesafety for \`process.env\` on the client-side.
 	 */
 	export const Env = v.object({
 ${schemaFields}
@@ -47,6 +47,9 @@ ${schemaFields}
 	import arkenv from "arkenv/standard";
 	import * as v from "valibot";
 
+	/**
+	 * Environment variable schema for server-side or runtime-only validation.
+	 */
 	export const Env = v.object({
 ${schemaFields}
 	});

--- a/packages/cli/src/features/scaffold/templates/zod.ts
+++ b/packages/cli/src/features/scaffold/templates/zod.ts
@@ -4,7 +4,7 @@ import dedent from "dedent";
  * Generates a TypeScript template string for a Zod environment configuration.
  *
  * @param envKeys - Optional array of environment variable keys to include in the schema.
- * @param framework - The framework being used (vite, bun, or node).
+ * @param framework - The framework being used (vite, bun-fullstack, or vanilla).
  * @returns The generated TypeScript template string.
  */
 export const zodTemplate = (envKeys?: string[], framework?: string) => {
@@ -20,7 +20,7 @@ export const zodTemplate = (envKeys?: string[], framework?: string) => {
 	/**
 	 * Environment variable schema.
 	 * In Vite, use \`@arkenv/vite-plugin\` to validate these at build-time
-	 * and provide typesafety for \`import.meta.env\`.
+	 * and provide typesafety for \`import.meta.env\` on the client-side.
 	 */
 	export const Env = z.object({
 ${schemaFields}
@@ -28,14 +28,14 @@ ${schemaFields}
 	`;
 	}
 
-	if (framework === "bun") {
+	if (framework === "bun-fullstack") {
 		return dedent /* ts */`
 	import { z } from "zod";
 
 	/**
 	 * Environment variable schema.
-	 * In Bun, use \`@arkenv/bun-plugin\` to validate these at build-time
-	 * and provide typesafety for \`process.env\`.
+	 * In Bun Fullstack, use \`@arkenv/bun-plugin\` to validate these at build-time
+	 * and provide typesafety for \`process.env\` on the client-side.
 	 */
 	export const Env = z.object({
 ${schemaFields}
@@ -47,6 +47,9 @@ ${schemaFields}
 	import arkenv from "arkenv/standard";
 	import { z } from "zod";
 
+	/**
+	 * Environment variable schema for server-side or runtime-only validation.
+	 */
 	export const Env = z.object({
 ${schemaFields}
 	});

--- a/packages/cli/src/shared/ports/project-scanner.port.ts
+++ b/packages/cli/src/shared/ports/project-scanner.port.ts
@@ -30,7 +30,7 @@ export type ProjectScannerPort = {
 	detectFramework(
 		cwd?: string,
 		tsConfig?: ParsedTsConfig | null,
-	): Promise<"vite" | "bun" | "node">;
+	): Promise<"vite" | "bun-fullstack" | "vanilla">;
 	detectBunFeatures(
 		cwd?: string,
 		tsConfig?: ParsedTsConfig | null,

--- a/packages/cli/src/shared/ports/project-scanner.port.ts
+++ b/packages/cli/src/shared/ports/project-scanner.port.ts
@@ -31,6 +31,10 @@ export type ProjectScannerPort = {
 		cwd?: string,
 		tsConfig?: ParsedTsConfig | null,
 	): Promise<"vite" | "bun" | "node">;
+	detectBunFeatures(
+		cwd?: string,
+		tsConfig?: ParsedTsConfig | null,
+	): Promise<("serve" | "build")[]>;
 	detectPackageManager(
 		cwd?: string,
 		tsConfig?: ParsedTsConfig | null,

--- a/packages/cli/src/shared/ports/prompt.port.ts
+++ b/packages/cli/src/shared/ports/prompt.port.ts
@@ -12,8 +12,8 @@ export type PromptPort = {
 			bunFeatures?: ProjectOptions["bunFeatures"];
 			defaultEnvPath?: string;
 			tsConfig?: ParsedTsConfig | null;
-			envKeys?: string[] | undefined;
-			envKeysSource?: ".env.example" | "project" | undefined;
+			envKeys?: string[];
+			envKeysSource?: ".env.example" | "project";
 			hasTypeFile?: boolean;
 		},
 		isYes?: boolean,

--- a/packages/cli/src/shared/ports/prompt.port.ts
+++ b/packages/cli/src/shared/ports/prompt.port.ts
@@ -9,6 +9,7 @@ export type PromptPort = {
 	runWizard(
 		defaults?: {
 			framework?: ProjectOptions["framework"];
+			bunFeatures?: ProjectOptions["bunFeatures"];
 			defaultEnvPath?: string;
 			tsConfig?: ParsedTsConfig | null;
 			envKeys?: string[] | undefined;

--- a/packages/cli/src/shared/ports/workspace.port.ts
+++ b/packages/cli/src/shared/ports/workspace.port.ts
@@ -43,7 +43,10 @@ export type ConfigPort = {
 		path: string,
 		importPath: string,
 	): Promise<BootstrapResult>;
-	bootstrapBunConfig(path: string | null | undefined): Promise<BootstrapResult>;
+	bootstrapBunConfig(
+		path: string | null | undefined,
+		features?: ("serve" | "build")[],
+	): Promise<BootstrapResult>;
 	safeAppend(
 		path: string,
 		schemaPath: string,

--- a/packages/cli/src/shared/ports/workspace.port.ts
+++ b/packages/cli/src/shared/ports/workspace.port.ts
@@ -50,7 +50,7 @@ export type ConfigPort = {
 	safeAppend(
 		path: string,
 		schemaPath: string,
-		framework: "vite" | "bun",
+		framework: "vite" | "bun-fullstack",
 	): Promise<boolean>;
 };
 

--- a/packages/cli/src/test/utils.ts
+++ b/packages/cli/src/test/utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Strips ANSI escape codes from a string.
+ * Useful for testing terminal output without formatting.
+ */
+export function stripAnsi(str: string | undefined): string {
+	if (!str) return "";
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: Standard ANSI escape code stripping
+	return str.replace(/\x1B\[[0-9;]*[JKmsu]/g, "");
+}

--- a/skills/tackle-issue/SKILL.md
+++ b/skills/tackle-issue/SKILL.md
@@ -2,7 +2,7 @@
 name: tackle-issue
 description: Automates the process of working on GitHub issues, including branch creation, issue linking, label management, validation, changesets, and PR creation. Triggered by the command "/tackle-issue ISSUE_NUMBER".
 metadata:
-  internal: true
+   internal: true
 ---
 
 # Tackle Issue
@@ -59,15 +59,10 @@ Once implementation is complete, you MUST run the following validation suite in 
    ```
 3. **Lint & Format Check**:
    ```bash
-   pnpm run check
+   pnpm run fix
    ```
-   - If `pnpm run check` fails, attempt to auto-fix:
-     ```bash
-     pnpm run fix
-     ```
-   - After running `pnpm run fix`, run `pnpm run check` again to ensure all issues are resolved.
 
-If any of these steps fail (and cannot be auto-fixed), you MUST diagnose and fix the errors before proceeding.
+If this step fails (some lint/formatting issues cannot be auto-fixed), you MUST diagnose and fix the errors before proceeding.
 
 ### 5. Changeset Creation
 


### PR DESCRIPTION
Fixes #1015

This PR enhances the `arkenv init` command to support both **Vanilla Bun runtime** usage and full-stack/frontend bundling via Bun's dev server (`Bun.serve`) or programmatic Bundler (`Bun.build`).

### Changes:
- **Pivot to Vanilla Default**: Optimized the workflow for the majority of Bun users. **Vanilla** integration is now the default, emphasizing type-safe usage via the `env` object without needing build-time plugins.
- **Bun Full-Stack Application Grouping**: Grouped **Fullstack dev server (Bun.serve)** and **Fullstack programmatic bundler (Bun.build)** under a single category for better clarity on when they are needed (specifically for static inlining of environment variables).
- **Refined Detection**: Automatically detect usage of `Bun.serve` or `Bun.build` to suggest optional inlining integration.
- **Terminology Refinement**: Removed confusing "build-time" grammar from Bun Fullstack descriptions, replacing it with **"Static Inlining"** and **"static replacement during bundling"**.
- **Vocabulary Alignment**: Updated `CONTEXT.md` and CLI strings to use "Vanilla" terminology, "Fullstack" specific grammars, and imperative verbs.
- **Improved Type Safety**: Updated `ProjectOptions` and `ScaffoldingPlan` to handle optional properties more strictly (`exactOptionalPropertyTypes`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `arkenv init` flow with smarter architecture detection and explicit framework choices: Vite, Bun Fullstack, or Vanilla
  * Added Bun Fullstack handling (serve/build options) and a prompt to bootstrap Bun build integration

* **Documentation**
  * Updated integration guides and generated templates with clearer client vs server environment validation guidance and framework-specific instructions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yamcodes/arkenv/pull/1016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->