### PR TITLE
fix: Ctrl+C should terminate the ArkEnv CLI

### DIFF
--- a/.changeset/graceful-shutdown-fix.md
+++ b/.changeset/graceful-shutdown-fix.md
@@ -1,0 +1,11 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Improve Ctrl+C handling and implement graceful shutdown
+
+- The CLI now terminates immediately upon receiving a `SIGINT` (Ctrl+C).
+- Implemented a graceful shutdown mechanism that ensures all log output and JSON data are flushed before exiting.
+- Added a 2-second timeout and "double Ctrl+C" handler to force termination if a graceful shutdown hangs.
+- Proper exit code (130) is now returned on `SIGINT`.
+- Fixed a bug where the `init` wizard would continue to subsequent steps after a prompt was cancelled.

--- a/.changeset/graceful-shutdown-fix.md
+++ b/.changeset/graceful-shutdown-fix.md
@@ -4,8 +4,6 @@
 
 #### Improve Ctrl+C handling and implement graceful shutdown
 
-- The CLI now terminates immediately upon receiving a `SIGINT` (Ctrl+C).
-- Implemented a graceful shutdown mechanism that ensures all log output and JSON data are flushed before exiting.
-- Added a 2-second timeout and "double Ctrl+C" handler to force termination if a graceful shutdown hangs.
-- Proper exit code (130) is now returned on `SIGINT`.
-- Fixed a bug where the `init` wizard would continue to subsequent steps after a prompt was cancelled.
+- Implemented graceful shutdown for `SIGINT` (Ctrl+C) to flush logs and JSON data, with a 2-second safety timeout and support for immediate exit on a second Ctrl+C.
+- Corrected exit code (130) for `SIGINT` terminations.
+- Fixed a bug where the `init` wizard would continue after a prompt was cancelled.

--- a/packages/cli/src/adapters/logger.adapter.ts
+++ b/packages/cli/src/adapters/logger.adapter.ts
@@ -90,7 +90,7 @@ export class Logger implements LoggerPort {
 		this.reporter.cancel(message);
 	}
 
-	fatal(message: string, error?: unknown) {
+	fatal(message: string, error?: unknown): never {
 		this.reporter.fatal(message, error);
 	}
 

--- a/packages/cli/src/adapters/reporters.test.ts
+++ b/packages/cli/src/adapters/reporters.test.ts
@@ -72,22 +72,20 @@ describe("Reporters", () => {
 			);
 		});
 
-		it("cancel logs to stderr and exits", () => {
+		it("cancel logs to stderr", () => {
 			reporter.cancel("canceled");
 			expect(stderrSpy).toHaveBeenCalledWith(
 				expect.stringContaining("✘ canceled"),
-				expect.any(Function),
 			);
-			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(exitSpy).not.toHaveBeenCalled();
 		});
 
-		it("fatal logs to stderr and exits", () => {
+		it("fatal logs to stderr", () => {
 			reporter.fatal("fatal error");
 			expect(stderrSpy).toHaveBeenCalledWith(
 				expect.stringContaining("✘ fatal error"),
-				expect.any(Function),
 			);
-			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(exitSpy).not.toHaveBeenCalled();
 		});
 	});
 
@@ -113,7 +111,7 @@ describe("Reporters", () => {
 			);
 		});
 
-		it("fatal logs json to stdout and exits", () => {
+		it("fatal logs json to stdout", () => {
 			reporter.fatal("fatal error");
 			expect(stdoutSpy).toHaveBeenCalledWith(
 				expect.stringContaining('"status": "error"'),
@@ -121,11 +119,10 @@ describe("Reporters", () => {
 			expect(stdoutSpy).toHaveBeenCalledWith(
 				expect.stringContaining('"message": "fatal error"'),
 			);
-			expect(stdoutSpy).toHaveBeenCalledWith("", expect.any(Function));
-			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(exitSpy).not.toHaveBeenCalled();
 		});
 
-		it("cancel logs json to stdout and exits", () => {
+		it("cancel logs json to stdout", () => {
 			reporter.cancel("cancelled");
 			expect(stdoutSpy).toHaveBeenCalledWith(
 				expect.stringContaining('"status": "cancelled"'),
@@ -133,8 +130,7 @@ describe("Reporters", () => {
 			expect(stdoutSpy).toHaveBeenCalledWith(
 				expect.stringContaining('"message": "cancelled"'),
 			);
-			expect(stdoutSpy).toHaveBeenCalledWith("", expect.any(Function));
-			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(exitSpy).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/adapters/reporters.test.ts
+++ b/packages/cli/src/adapters/reporters.test.ts
@@ -80,12 +80,11 @@ describe("Reporters", () => {
 			expect(exitSpy).not.toHaveBeenCalled();
 		});
 
-		it("fatal logs to stderr", () => {
-			reporter.fatal("fatal error");
+		it("fatal logs to stderr and throws", () => {
+			expect(() => reporter.fatal("fatal error")).toThrow("fatal error");
 			expect(stderrSpy).toHaveBeenCalledWith(
 				expect.stringContaining("✘ fatal error"),
 			);
-			expect(exitSpy).not.toHaveBeenCalled();
 		});
 	});
 
@@ -111,15 +110,14 @@ describe("Reporters", () => {
 			);
 		});
 
-		it("fatal logs json to stdout", () => {
-			reporter.fatal("fatal error");
+		it("fatal logs json to stdout and throws", () => {
+			expect(() => reporter.fatal("fatal error")).toThrow("fatal error");
 			expect(stdoutSpy).toHaveBeenCalledWith(
 				expect.stringContaining('"status": "error"'),
 			);
 			expect(stdoutSpy).toHaveBeenCalledWith(
 				expect.stringContaining('"message": "fatal error"'),
 			);
-			expect(exitSpy).not.toHaveBeenCalled();
 		});
 
 		it("cancel logs json to stdout", () => {

--- a/packages/cli/src/adapters/reporters/json.reporter.ts
+++ b/packages/cli/src/adapters/reporters/json.reporter.ts
@@ -57,7 +57,7 @@ export class JsonReporter implements Reporter {
 		});
 	}
 
-	fatal(message: string, error?: unknown) {
+	fatal(message: string, error?: unknown): never {
 		this.json({
 			status: "error",
 			details: {
@@ -70,6 +70,7 @@ export class JsonReporter implements Reporter {
 							: undefined,
 			},
 		});
+		throw error instanceof Error ? error : new Error(message);
 	}
 
 	finish(message: string, details?: Record<string, unknown>) {

--- a/packages/cli/src/adapters/reporters/json.reporter.ts
+++ b/packages/cli/src/adapters/reporters/json.reporter.ts
@@ -55,7 +55,6 @@ export class JsonReporter implements Reporter {
 			status: "cancelled",
 			message,
 		});
-		process.stdout.write("", () => process.exit(1));
 	}
 
 	fatal(message: string, error?: unknown) {
@@ -71,7 +70,6 @@ export class JsonReporter implements Reporter {
 							: undefined,
 			},
 		});
-		process.stdout.write("", () => process.exit(1));
 	}
 
 	finish(message: string, details?: Record<string, unknown>) {

--- a/packages/cli/src/adapters/reporters/memory.reporter.ts
+++ b/packages/cli/src/adapters/reporters/memory.reporter.ts
@@ -51,8 +51,9 @@ export class MemoryReporter implements Reporter {
 		this.logs.push({ type: "cancel", message });
 	}
 
-	fatal(message: string, error?: unknown) {
+	fatal(message: string, error?: unknown): never {
 		this.logs.push({ type: "fatal", message, data: error });
+		throw error instanceof Error ? error : new Error(message);
 	}
 
 	finish(message: string, details?: Record<string, unknown>) {

--- a/packages/cli/src/adapters/reporters/silent.reporter.ts
+++ b/packages/cli/src/adapters/reporters/silent.reporter.ts
@@ -36,13 +36,14 @@ export class SilentReporter implements Reporter {
 		process.stderr.write(`✘ Cancelled: ${message}\n`);
 	}
 
-	fatal(message: string, error?: unknown) {
+	fatal(message: string, error?: unknown): never {
 		process.stderr.write(`✘ Fatal: ${message}\n`);
 		if (error) {
 			process.stderr.write(
 				`${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
 			);
 		}
+		throw error instanceof Error ? error : new Error(message);
 	}
 
 	finish(_message: string, _details?: Record<string, unknown>) {}

--- a/packages/cli/src/adapters/reporters/silent.reporter.ts
+++ b/packages/cli/src/adapters/reporters/silent.reporter.ts
@@ -33,9 +33,7 @@ export class SilentReporter implements Reporter {
 	}
 
 	cancel(message: string) {
-		process.stderr.write(`✘ Cancelled: ${message}\n`, () => {
-			process.exit(1);
-		});
+		process.stderr.write(`✘ Cancelled: ${message}\n`);
 	}
 
 	fatal(message: string, error?: unknown) {
@@ -45,9 +43,6 @@ export class SilentReporter implements Reporter {
 				`${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
 			);
 		}
-		process.stderr.write("", () => {
-			process.exit(1);
-		});
 	}
 
 	finish(_message: string, _details?: Record<string, unknown>) {}

--- a/packages/cli/src/adapters/reporters/text.reporter.ts
+++ b/packages/cli/src/adapters/reporters/text.reporter.ts
@@ -47,12 +47,13 @@ export class TextReporter implements Reporter {
 		process.stderr.write(`${pc.red(`✘ ${message}`)}\n`);
 	}
 
-	fatal(message: string, error?: unknown) {
+	fatal(message: string, error?: unknown): never {
 		process.stderr.write(`${pc.red(`✘ ${message}`)}\n`);
 		if (error) {
 			const detail = `${pc.red(error instanceof Error ? (error.stack ?? String(error)) : String(error))}\n`;
 			process.stderr.write(detail);
 		}
+		throw error instanceof Error ? error : new Error(message);
 	}
 
 	finish(message: string, _details?: Record<string, unknown>) {

--- a/packages/cli/src/adapters/reporters/text.reporter.ts
+++ b/packages/cli/src/adapters/reporters/text.reporter.ts
@@ -44,18 +44,14 @@ export class TextReporter implements Reporter {
 	}
 
 	cancel(message: string) {
-		process.stderr.write(`${pc.red(`✘ ${message}`)}\n`, () => process.exit(1));
+		process.stderr.write(`${pc.red(`✘ ${message}`)}\n`);
 	}
 
 	fatal(message: string, error?: unknown) {
-		const msg = `${pc.red(`✘ ${message}`)}\n`;
+		process.stderr.write(`${pc.red(`✘ ${message}`)}\n`);
 		if (error) {
 			const detail = `${pc.red(error instanceof Error ? (error.stack ?? String(error)) : String(error))}\n`;
-			process.stderr.write(msg, () => {
-				process.stderr.write(detail, () => process.exit(1));
-			});
-		} else {
-			process.stderr.write(msg, () => process.exit(1));
+			process.stderr.write(detail);
 		}
 	}
 

--- a/packages/cli/src/adapters/reporters/types.ts
+++ b/packages/cli/src/adapters/reporters/types.ts
@@ -21,7 +21,7 @@ export type Reporter = {
 	spinner(): Spinner;
 	json(data: unknown): void;
 	cancel(message: string): void;
-	fatal(message: string, error?: unknown): void;
+	fatal(message: string, error?: unknown): never;
 	finish(message: string, details?: Record<string, unknown>): void;
 	flush(): Promise<void>;
 };

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -66,6 +66,10 @@ export class InitUseCase {
 						true,
 					);
 
+					if (confirmStrict === null) {
+						return null;
+					}
+
 					if (!confirmStrict) {
 						this.logger.cancel("Operation cancelled.");
 						return null;
@@ -112,8 +116,7 @@ export class InitUseCase {
 				isYes,
 			);
 
-			if (!options) {
-				this.logger.cancel("Operation cancelled.");
+			if (options === null) {
 				return null;
 			}
 
@@ -128,7 +131,6 @@ export class InitUseCase {
 					true,
 				);
 				if (confirmInstall === null) {
-					this.logger.cancel("Operation cancelled.");
 					return null;
 				}
 				options.installSkill = confirmInstall;
@@ -145,6 +147,10 @@ export class InitUseCase {
 					`File ${code(path.basename(finalTargetPath))} already exists. Overwrite?`,
 					false,
 				);
+
+				if (confirmOverwrite === null) {
+					return null;
+				}
 
 				if (!confirmOverwrite) {
 					this.logger.cancel("Operation cancelled.");

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { group } from "@clack/prompts";
 import { shake } from "radashi";
 import type { ProjectOptions } from "@/features/scaffold";
@@ -42,23 +41,16 @@ export async function runPromptWizard(
 		});
 	}
 
-	const result = await group(
-		{
-			overwriteEnvSchemaFile: steps.overwriteEnvSchemaFile(defaultEnvPath),
-			framework: steps.framework(defaults),
-			useDefaultPath: steps.useDefaultPath(defaultEnvPath),
-			path: steps.path(defaultEnvPath),
-			installTypeDefinitions: steps.installTypeDefinitions,
-			envDtsHandling: steps.envDtsHandling,
-			validator: steps.validator,
-			useEnvExample: steps.useEnvExample(detectedKeys, keysSource),
-		},
-		{
-			onCancel: () => {
-				// We don't exit here, we let the group return a canceled state or null
-			},
-		},
-	);
+	const result = await group({
+		overwriteEnvSchemaFile: steps.overwriteEnvSchemaFile(defaultEnvPath),
+		framework: steps.framework(defaults),
+		useDefaultPath: steps.useDefaultPath(defaultEnvPath),
+		path: steps.path(defaultEnvPath),
+		installTypeDefinitions: steps.installTypeDefinitions,
+		envDtsHandling: steps.envDtsHandling,
+		validator: steps.validator,
+		useEnvExample: steps.useEnvExample(detectedKeys, keysSource),
+	});
 
 	if (!isSuccess(result)) {
 		return null;

--- a/packages/cli/src/features/scaffold/executor.test.ts
+++ b/packages/cli/src/features/scaffold/executor.test.ts
@@ -36,7 +36,9 @@ describe("Executor", () => {
 		note: vi.fn(),
 		json: vi.fn(),
 		cancel: vi.fn(),
-		fatal: vi.fn(),
+		fatal: vi.fn(() => {
+			throw new Error("fatal");
+		}),
 		finish: vi.fn(),
 		flush: vi.fn().mockResolvedValue(undefined),
 	};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,7 +34,11 @@ async function main() {
 			isAgent: cli.isAgent,
 		});
 	} catch (error) {
-		logger.fatal("An unexpected error occurred", error);
+		try {
+			logger.fatal("An unexpected error occurred", error);
+		} catch {
+			// Ignore throw from fatal as we are already handling the error
+		}
 		await logger.flush();
 		process.exit(1);
 	}
@@ -56,9 +60,18 @@ function setupGracefulShutdown(logger: any) {
 		if (logger.interactiveStdout) {
 			logger.interactiveStdout(false);
 		}
-		logger.cancel("Operation cancelled.");
-		await logger.flush();
-		process.exit(code);
+
+		try {
+			logger.cancel("Operation cancelled.");
+			await logger.flush();
+		} catch (err) {
+			// Best-effort logging on shutdown failure
+			if (logger.error) {
+				logger.error("Logger failed during shutdown", err);
+			}
+		} finally {
+			process.exit(code);
+		}
 	};
 
 	process.on("SIGINT", () => shutdown(130));
@@ -70,7 +83,11 @@ main();
 // Defense-in-depth for unforeseen async rejections
 process.on("unhandledRejection", async (err) => {
 	if (globalLogger) {
-		globalLogger.fatal("Unhandled rejection", err);
+		try {
+			globalLogger.fatal("Unhandled rejection", err);
+		} catch {
+			// Already logged
+		}
 		await globalLogger.flush();
 	} else {
 		console.error("Unhandled rejection", err);
@@ -80,7 +97,11 @@ process.on("unhandledRejection", async (err) => {
 
 process.on("uncaughtException", async (err) => {
 	if (globalLogger) {
-		globalLogger.fatal("Uncaught exception", err);
+		try {
+			globalLogger.fatal("Uncaught exception", err);
+		} catch {
+			// Already logged
+		}
 		await globalLogger.flush();
 	} else {
 		console.error("Uncaught exception", err);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,10 +2,13 @@
 import { compose } from "./cli/composition";
 
 let globalLogger: any;
+let isShuttingDown = false;
 
 async function main() {
 	const { cli, logger, initUseCase, helpUseCase } = compose(process.argv);
 	globalLogger = logger;
+
+	setupGracefulShutdown(logger);
 
 	if (cli.helpRequested) {
 		await helpUseCase.execute();
@@ -35,6 +38,31 @@ async function main() {
 		await logger.flush();
 		process.exit(1);
 	}
+}
+
+function setupGracefulShutdown(logger: any) {
+	const shutdown = async (code: number) => {
+		if (isShuttingDown) {
+			process.exit(code);
+		}
+		isShuttingDown = true;
+
+		// Force exit after 2 seconds if graceful shutdown hangs
+		const timeout = setTimeout(() => {
+			process.exit(code);
+		}, 2000);
+		timeout.unref();
+
+		if (logger.interactiveStdout) {
+			logger.interactiveStdout(false);
+		}
+		logger.cancel("Operation cancelled.");
+		await logger.flush();
+		process.exit(code);
+	};
+
+	process.on("SIGINT", () => shutdown(130));
+	process.on("SIGTERM", () => shutdown(143));
 }
 
 main();

--- a/packages/cli/src/shared/ports/logger.port.ts
+++ b/packages/cli/src/shared/ports/logger.port.ts
@@ -21,7 +21,7 @@ export type LoggerPort = {
 	spinner(): Spinner;
 	json(data: unknown): void;
 	cancel(message: string): void;
-	fatal(message: string, error?: unknown): void;
+	fatal(message: string, error?: unknown): never;
 	finish(message: string, details?: Record<string, unknown>): void;
 	flush(): Promise<void>;
 	interactiveStdout(enable: boolean): void;


### PR DESCRIPTION
Fixes #1017. Implements graceful shutdown and improved SIGINT handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful shutdown handler with 2-second timeout; double Ctrl+C forces immediate exit.

* **Bug Fixes**
  * Init wizard no longer progresses after a cancelled prompt.
  * CLI now gracefully shuts down on Ctrl+C, flushing all logs and JSON output before exit.
  * Exit code 130 now returned when interrupted with SIGINT.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yamcodes/arkenv/pull/1019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->