### PR TITLE
fix(cli): ensure init wizard aborts immediately on cancel or 'No (abort)'

### DIFF
--- a/.changeset/quiet-wizards-quit.md
+++ b/.changeset/quiet-wizards-quit.md
@@ -2,4 +2,7 @@
 "@arkenv/cli": patch
 ---
 
-Fix the init wizard to abort immediately when prompts are cancelled or overwrite is declined.
+#### Fix init wizard for Ctrl+C
+
+Fix the init wizard to abort immediately when prompts are canceled or overwrite is declined.
+

--- a/.changeset/quiet-wizards-quit.md
+++ b/.changeset/quiet-wizards-quit.md
@@ -1,0 +1,5 @@
+---
+"@arkenv/cli": patch
+---
+
+Fix the init wizard to abort immediately when prompts are cancelled or overwrite is declined.

--- a/packages/cli/src/cli/ui/prompts.test.ts
+++ b/packages/cli/src/cli/ui/prompts.test.ts
@@ -96,25 +96,28 @@ describe("runPromptWizard", () => {
 
 		expect(result?.envKeys).toBeUndefined();
 	});
+it("should abort immediately if user selects No (abort) on overwrite prompt", async () => {
+	mockExistsSync.mockReturnValue(true);
+	vi.mocked(prompts.confirm).mockResolvedValueOnce(false);
 
-	it("should abort immediately if user selects No (abort) on overwrite prompt", async () => {
-		mockExistsSync.mockReturnValue(true);
-		vi.mocked(prompts.confirm).mockResolvedValueOnce(false);
+	const result = await runPromptWizard();
 
-		const result = await runPromptWizard();
-
-		expect(result).toBeNull();
-		expect(prompts.select).not.toHaveBeenCalled();
-	});
-
-	it("should abort immediately if user cancels a prompt (Ctrl+C)", async () => {
-		const cancelSymbol = Symbol("clack-cancel");
-		vi.mocked(prompts.isCancel).mockImplementation((v) => v === cancelSymbol);
-		vi.mocked(prompts.select).mockResolvedValueOnce(cancelSymbol); // framework
-
-		const result = await runPromptWizard();
-
-		expect(result).toBeNull();
-		expect(prompts.confirm).not.toHaveBeenCalled();
-	});
+	expect(result).toBeNull();
+	expect(prompts.select).not.toHaveBeenCalled();
+	expect(prompts.cancel).toHaveBeenCalledWith("Operation cancelled.");
 });
+
+it("should abort immediately if user cancels a prompt (Ctrl+C)", async () => {
+	const cancelSymbol = Symbol("clack-cancel");
+	vi.mocked(prompts.isCancel).mockImplementation((v) => v === cancelSymbol);
+	mockExistsSync.mockReturnValue(false);
+	vi.mocked(prompts.select).mockResolvedValueOnce(cancelSymbol); // framework
+
+	const result = await runPromptWizard();
+
+	expect(result).toBeNull();
+	expect(prompts.confirm).not.toHaveBeenCalled();
+	expect(prompts.cancel).toHaveBeenCalledWith("Operation cancelled.");
+});
+});
+

--- a/packages/cli/src/cli/ui/prompts.test.ts
+++ b/packages/cli/src/cli/ui/prompts.test.ts
@@ -1,9 +1,18 @@
+import * as fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import * as prompts from "@clack/prompts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runPromptWizard } from "./prompts";
+
+const { mockExistsSync } = vi.hoisted(() => ({
+	mockExistsSync: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("node:fs", () => ({
+	existsSync: mockExistsSync,
+}));
 
 vi.mock("@clack/prompts", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@clack/prompts")>();
@@ -24,6 +33,9 @@ describe("runPromptWizard", () => {
 	beforeEach(async () => {
 		tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "prompts-test-"));
 		vi.spyOn(process, "cwd").mockReturnValue(tempDir);
+		vi.resetAllMocks();
+		mockExistsSync.mockReturnValue(false);
+		vi.mocked(prompts.isCancel).mockReturnValue(false);
 	});
 
 	afterEach(async () => {
@@ -48,14 +60,12 @@ describe("runPromptWizard", () => {
 	});
 
 	it("should include bunFeatures if user selects them in wizard", async () => {
-		vi.mocked(prompts.group).mockResolvedValue({
-			overwrite: true,
-			framework: "bun-fullstack",
-			bunBuild: true,
-			validator: "arktype",
-			useEnvExample: true,
-			useDefaultPath: true,
-		});
+		vi.mocked(prompts.select).mockResolvedValueOnce("bun-fullstack"); // framework
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // bunBuild
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // installTypeDefinitions
+		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
 
 		const result = await runPromptWizard({ framework: "bun-fullstack" });
 
@@ -64,13 +74,11 @@ describe("runPromptWizard", () => {
 	});
 
 	it("should include envKeys if user accepts prompt", async () => {
-		vi.mocked(prompts.group).mockResolvedValue({
-			overwrite: true,
-			framework: "vanilla",
-			validator: "arktype",
-			useEnvExample: true,
-			useDefaultPath: true,
-		});
+		vi.mocked(prompts.select).mockResolvedValueOnce("vanilla"); // framework
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // installTypeDefinitions
+		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
 
 		const result = await runPromptWizard({ envKeys: ["API_KEY"] });
 
@@ -78,16 +86,35 @@ describe("runPromptWizard", () => {
 	});
 
 	it("should NOT include envKeys if user declines prompt", async () => {
-		vi.mocked(prompts.group).mockResolvedValue({
-			overwrite: true,
-			framework: "vanilla",
-			validator: "arktype",
-			useEnvExample: false,
-			useDefaultPath: true,
-		});
+		mockExistsSync.mockReturnValue(false);
+		vi.mocked(prompts.select).mockResolvedValueOnce("vanilla"); // framework
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
+		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(false); // useEnvExample
 
 		const result = await runPromptWizard({ envKeys: ["API_KEY"] });
 
 		expect(result?.envKeys).toBeUndefined();
+	});
+
+	it("should abort immediately if user selects No (abort) on overwrite prompt", async () => {
+		mockExistsSync.mockReturnValue(true);
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(false);
+
+		const result = await runPromptWizard();
+
+		expect(result).toBeNull();
+		expect(prompts.select).not.toHaveBeenCalled();
+	});
+
+	it("should abort immediately if user cancels a prompt (Ctrl+C)", async () => {
+		const cancelSymbol = Symbol("clack-cancel");
+		vi.mocked(prompts.isCancel).mockImplementation((v) => v === cancelSymbol);
+		vi.mocked(prompts.select).mockResolvedValueOnce(cancelSymbol); // framework
+
+		const result = await runPromptWizard();
+
+		expect(result).toBeNull();
+		expect(prompts.confirm).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/cli/ui/prompts.test.ts
+++ b/packages/cli/src/cli/ui/prompts.test.ts
@@ -104,7 +104,7 @@ describe("runPromptWizard", () => {
 
 		expect(result).toBeNull();
 		expect(prompts.select).not.toHaveBeenCalled();
-		expect(prompts.cancel).toHaveBeenCalledWith("Operation cancelled.");
+		expect(prompts.cancel).toHaveBeenCalledWith("Operation cancelled");
 	});
 
 	it("should abort immediately if user cancels a prompt (Ctrl+C)", async () => {
@@ -117,6 +117,6 @@ describe("runPromptWizard", () => {
 
 		expect(result).toBeNull();
 		expect(prompts.confirm).not.toHaveBeenCalled();
-		expect(prompts.cancel).toHaveBeenCalledWith("Operation cancelled.");
+		expect(prompts.cancel).toHaveBeenCalledWith("Operation cancelled");
 	});
 });

--- a/packages/cli/src/cli/ui/prompts.test.ts
+++ b/packages/cli/src/cli/ui/prompts.test.ts
@@ -96,28 +96,27 @@ describe("runPromptWizard", () => {
 
 		expect(result?.envKeys).toBeUndefined();
 	});
-it("should abort immediately if user selects No (abort) on overwrite prompt", async () => {
-	mockExistsSync.mockReturnValue(true);
-	vi.mocked(prompts.confirm).mockResolvedValueOnce(false);
+	it("should abort immediately if user selects No (abort) on overwrite prompt", async () => {
+		mockExistsSync.mockReturnValue(true);
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(false);
 
-	const result = await runPromptWizard();
+		const result = await runPromptWizard();
 
-	expect(result).toBeNull();
-	expect(prompts.select).not.toHaveBeenCalled();
-	expect(prompts.cancel).toHaveBeenCalledWith("Operation cancelled.");
+		expect(result).toBeNull();
+		expect(prompts.select).not.toHaveBeenCalled();
+		expect(prompts.cancel).toHaveBeenCalledWith("Operation cancelled.");
+	});
+
+	it("should abort immediately if user cancels a prompt (Ctrl+C)", async () => {
+		const cancelSymbol = Symbol("clack-cancel");
+		vi.mocked(prompts.isCancel).mockImplementation((v) => v === cancelSymbol);
+		mockExistsSync.mockReturnValue(false);
+		vi.mocked(prompts.select).mockResolvedValueOnce(cancelSymbol); // framework
+
+		const result = await runPromptWizard();
+
+		expect(result).toBeNull();
+		expect(prompts.confirm).not.toHaveBeenCalled();
+		expect(prompts.cancel).toHaveBeenCalledWith("Operation cancelled.");
+	});
 });
-
-it("should abort immediately if user cancels a prompt (Ctrl+C)", async () => {
-	const cancelSymbol = Symbol("clack-cancel");
-	vi.mocked(prompts.isCancel).mockImplementation((v) => v === cancelSymbol);
-	mockExistsSync.mockReturnValue(false);
-	vi.mocked(prompts.select).mockResolvedValueOnce(cancelSymbol); // framework
-
-	const result = await runPromptWizard();
-
-	expect(result).toBeNull();
-	expect(prompts.confirm).not.toHaveBeenCalled();
-	expect(prompts.cancel).toHaveBeenCalledWith("Operation cancelled.");
-});
-});
-

--- a/packages/cli/src/cli/ui/prompts/steps/env-example.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/env-example.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { confirm, isCancel } from "@clack/prompts";
 import pc from "picocolors";
@@ -7,7 +7,7 @@ import { code } from "@/cli/ui/visuals";
 export const overwriteEnvSchemaFileStep =
 	(defaultPath = "./src/env.ts") =>
 	async () => {
-		if (fs.existsSync(path.resolve(process.cwd(), defaultPath))) {
+		if (existsSync(path.resolve(process.cwd(), defaultPath))) {
 			const answer = await confirm({
 				message: pc.yellow(
 					`An existing ArkEnv configuration was found at ${code(defaultPath)}. Do you want to overwrite it?`,

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -1,9 +1,8 @@
-import { group } from "@clack/prompts";
+import { isCancel } from "@clack/prompts";
 import { shake } from "radashi";
 import type { ProjectOptions } from "@/features/scaffold";
 import type { ParsedTsConfig } from "@/shared/ports";
 import { steps } from "./steps";
-import { isSuccess } from "./utils";
 
 export async function runPromptWizard(
 	defaults?: {

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -85,7 +85,7 @@ export async function runPromptWizard(
 	for (const { key, fn } of stepsToRun) {
 		const result = await fn({ results });
 		if (result === null || (typeof result === "symbol" && isCancel(result))) {
-			cancel("Operation cancelled.");
+			cancel("Operation cancelled");
 			return null;
 		}
 		results[key] = result;

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -1,4 +1,4 @@
-import { isCancel } from "@clack/prompts";
+import { cancel, isCancel } from "@clack/prompts";
 import { shake } from "radashi";
 import type { ProjectOptions } from "@/features/scaffold";
 import type { ParsedTsConfig } from "@/shared/ports";
@@ -85,6 +85,7 @@ export async function runPromptWizard(
 	for (const { key, fn } of stepsToRun) {
 		const result = await fn({ results });
 		if (result === null || (typeof result === "symbol" && isCancel(result))) {
+			cancel("Operation cancelled.");
 			return null;
 		}
 		results[key] = result;

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -46,11 +46,17 @@ export async function runPromptWizard(
 		});
 	}
 
-	const result = await group(
+	const results: any = {};
+
+	const stepsToRun: { key: string; fn: (ctx: { results: any }) => Promise<any> }[] = [
 		{
-			overwriteEnvSchemaFile: steps.overwriteEnvSchemaFile(defaultEnvPath),
-			framework: steps.framework(defaults),
-			bunBuild: ({ results }) =>
+			key: "overwriteEnvSchemaFile",
+			fn: () => steps.overwriteEnvSchemaFile(defaultEnvPath)(),
+		},
+		{ key: "framework", fn: () => steps.framework(defaults)() },
+		{
+			key: "bunBuild",
+			fn: ({ results }) =>
 				results.framework === "bun-fullstack"
 					? steps.bunBuild(
 							defaults?.bunFeatures?.includes("build") ||
@@ -59,36 +65,41 @@ export async function runPromptWizard(
 									defaults?.bunFeatures?.includes("build")),
 						)()
 					: Promise.resolve(undefined),
-			useDefaultPath: steps.useDefaultPath(defaultEnvPath),
-			path: steps.path(defaultEnvPath),
-			installTypeDefinitions: steps.installTypeDefinitions,
-			envDtsHandling: steps.envDtsHandling,
-			validator: steps.validator,
-			useEnvExample: steps.useEnvExample(detectedKeys, keysSource),
 		},
+		{ key: "useDefaultPath", fn: () => steps.useDefaultPath(defaultEnvPath)() },
+		{ key: "path", fn: (ctx) => steps.path(defaultEnvPath)(ctx) },
 		{
-			onCancel: () => {
-				// We don't exit here, we let the group return a canceled state or null
-			},
+			key: "installTypeDefinitions",
+			fn: (ctx) => steps.installTypeDefinitions(ctx as any),
 		},
-	);
+		{ key: "envDtsHandling", fn: (ctx) => steps.envDtsHandling(ctx as any) },
+		{ key: "validator", fn: () => steps.validator() },
+		{
+			key: "useEnvExample",
+			fn: () => steps.useEnvExample(detectedKeys, keysSource)(),
+		},
+	];
 
-	if (!isSuccess(result)) {
-		return null;
+	for (const { key, fn } of stepsToRun) {
+		const result = await fn({ results });
+		if (result === null || (typeof result === "symbol" && isCancel(result))) {
+			return null;
+		}
+		results[key] = result;
 	}
 
 	const bunFeatures: ProjectOptions["bunFeatures"] =
-		result.framework === "bun-fullstack"
-			? result.bunBuild
+		results.framework === "bun-fullstack"
+			? results.bunBuild
 				? ["serve", "build"]
 				: ["serve"]
 			: undefined;
 
 	return shake({
-		...result,
+		...results,
 		bunFeatures,
 		language: "ts",
 		installSkill: false, // Defaulting to false, will be overridden by orchestrator if needed
-		envKeys: result.useEnvExample ? (detectedKeys ?? undefined) : undefined,
+		envKeys: results.useEnvExample ? (detectedKeys ?? undefined) : undefined,
 	} as Partial<ProjectOptions>) as ProjectOptions;
 }

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -48,7 +48,10 @@ export async function runPromptWizard(
 
 	const results: any = {};
 
-	const stepsToRun: { key: string; fn: (ctx: { results: any }) => Promise<any> }[] = [
+	const stepsToRun: {
+		key: string;
+		fn: (ctx: { results: any }) => Promise<any>;
+	}[] = [
 		{
 			key: "overwriteEnvSchemaFile",
 			fn: () => steps.overwriteEnvSchemaFile(defaultEnvPath)(),


### PR DESCRIPTION
Refactors `runPromptWizard` to execute steps sequentially instead of using `group()`, ensuring the process halts immediately when a prompt is cancelled or the user explicitly aborts.

Closes #1022
Closes #1023