### PR TITLE
feat: Integrate 'start with an example' flow into the CLI

### DIFF
--- a/.changeset/warm-taxis-relate.md
+++ b/.changeset/warm-taxis-relate.md
@@ -1,0 +1,12 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Add interactive "Select Example" step to `arkenv init` wizard
+
+During `arkenv init`, you can now choose to start with a pre-configured example:
+- **Vite + Zod**: Full-stack validation with Zod and Vite.
+- **Next.js + ArkType**: Optimized for Next.js and ArkType.
+- **Basic + Valibot**: Lightweight validation with Valibot.
+
+Selecting an example will automatically populate your `env.ts` and `.env` files with template content.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -203,6 +203,9 @@ pnpm run test:e2e                     # E2E tests
     }
   }
   ```
+- **CLI Flag Aliases**:
+  - \`-t\`, \`--template\`: For selecting an example (must use the full template ID from the registry).
+  - \`-n\`, \`--name\`: For specifying the project name.
 - Only examples listed here are displayed in the CLI.
 
 **ArkType Integration:**

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -179,6 +179,32 @@ pnpm run test:e2e                     # E2E tests
 - Validation happens at both build-time (via Vite plugin) and runtime
 - Missing or invalid variables throw `ArkEnvError` with clear error messages
 
+**Initialization Flows:**
+
+- **Existing Project Flow**: Triggered when a `package.json` is detected. Focuses on adding ArkEnv to the current project. "Start with an example" is not offered.
+- **New Project Flow**: Triggered in strictly empty directories.
+  - Offers a list of templates from `examples/registry.json` (fetched from GitHub).
+  - Templates are scaffolded using `git sparse-checkout` from the `yamcodes/arkenv` repository.
+  - Prompts for project name (defaults to directory name if "." is provided).
+  - Automatically renames the `name` field in `package.json`.
+  - Package manager is auto-detected via `process.env.npm_config_user_agent`.
+  - Automatically runs the install command after scaffolding.
+
+**Template Registry:**
+
+- A central JSON file (`examples/registry.json`) in the monorepo root.
+- Maps example directory names to metadata:
+  ```json
+  {
+    "with-vite-react": {
+      "label": "Vite",
+      "description": "React + Vite + ArkType",
+      "framework": "vite"
+    }
+  }
+  ```
+- Only examples listed here are displayed in the CLI.
+
 **ArkType Integration:**
 
 - Uses ArkType's `scope` system to extend base types

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -1,0 +1,27 @@
+{
+	"basic": {
+		"label": "Basic",
+		"description": "Minimal Node.js project with ArkType (Recommended)",
+		"framework": "vanilla"
+	},
+	"with-vite-react": {
+		"label": "Vite",
+		"description": "React + Vite + ArkType (Client-side inlining)",
+		"framework": "vite"
+	},
+	"with-bun": {
+		"label": "Bun (Vanilla)",
+		"description": "Minimal Bun project with ArkType",
+		"framework": "vanilla"
+	},
+	"with-bun-react": {
+		"label": "Bun Fullstack",
+		"description": "React + Bun.serve + ArkType",
+		"framework": "bun-fullstack"
+	},
+	"with-zod": {
+		"label": "Zod (Vanilla)",
+		"description": "Minimal Node.js project using Zod instead of ArkType",
+		"framework": "vanilla"
+	}
+}

--- a/packages/cli/src/cli/ui/prompts.test.ts
+++ b/packages/cli/src/cli/ui/prompts.test.ts
@@ -11,6 +11,9 @@ const { mockExistsSync } = vi.hoisted(() => ({
 }));
 
 vi.mock("node:fs", () => ({
+	default: {
+		existsSync: mockExistsSync,
+	},
 	existsSync: mockExistsSync,
 }));
 
@@ -60,6 +63,7 @@ describe("runPromptWizard", () => {
 	});
 
 	it("should include bunFeatures if user selects them in wizard", async () => {
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // example
 		vi.mocked(prompts.select).mockResolvedValueOnce("bun-fullstack"); // framework
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // bunBuild
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
@@ -74,6 +78,7 @@ describe("runPromptWizard", () => {
 	});
 
 	it("should include envKeys if user accepts prompt", async () => {
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // example
 		vi.mocked(prompts.select).mockResolvedValueOnce("vanilla"); // framework
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // installTypeDefinitions
@@ -87,6 +92,7 @@ describe("runPromptWizard", () => {
 
 	it("should NOT include envKeys if user declines prompt", async () => {
 		mockExistsSync.mockReturnValue(false);
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // example
 		vi.mocked(prompts.select).mockResolvedValueOnce("vanilla"); // framework
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
@@ -96,6 +102,21 @@ describe("runPromptWizard", () => {
 
 		expect(result?.envKeys).toBeUndefined();
 	});
+
+	it("should handle example selection and skip related prompts", async () => {
+		vi.mocked(prompts.select).mockResolvedValueOnce("vite-zod"); // example
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // installTypeDefinitions
+		vi.mocked(prompts.select).mockResolvedValueOnce("skip"); // envDtsHandling
+
+		const result = await runPromptWizard();
+
+		expect(result?.example).toBe("vite-zod");
+		expect(result?.framework).toBe("vite");
+		expect(result?.validator).toBe("zod");
+		expect(result?.envKeys).toBeUndefined();
+	});
+
 	it("should abort immediately if user selects No (abort) on overwrite prompt", async () => {
 		mockExistsSync.mockReturnValue(true);
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(false);
@@ -111,7 +132,7 @@ describe("runPromptWizard", () => {
 		const cancelSymbol = Symbol("clack-cancel");
 		vi.mocked(prompts.isCancel).mockImplementation((v) => v === cancelSymbol);
 		mockExistsSync.mockReturnValue(false);
-		vi.mocked(prompts.select).mockResolvedValueOnce(cancelSymbol); // framework
+		vi.mocked(prompts.select).mockResolvedValueOnce(cancelSymbol); // example
 
 		const result = await runPromptWizard();
 

--- a/packages/cli/src/cli/ui/prompts/steps.ts
+++ b/packages/cli/src/cli/ui/prompts/steps.ts
@@ -6,6 +6,7 @@ import {
 	envDtsHandlingStep,
 	installTypeDefinitionsStep,
 } from "./steps/env-types";
+import { exampleStep } from "./steps/example";
 import { bunBuildStep, frameworkStep, validatorStep } from "./steps/framework";
 import { pathStep, useDefaultPathStep } from "./steps/path";
 
@@ -14,6 +15,7 @@ import { pathStep, useDefaultPathStep } from "./steps/path";
  */
 export const steps = {
 	overwriteEnvSchemaFile: overwriteEnvSchemaFileStep,
+	example: exampleStep,
 	framework: frameworkStep,
 	bunBuild: bunBuildStep,
 	useDefaultPath: useDefaultPathStep,

--- a/packages/cli/src/cli/ui/prompts/steps/example.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/example.ts
@@ -1,0 +1,32 @@
+import { select } from "@clack/prompts";
+import type { ProjectOptions } from "@/features/scaffold";
+
+/**
+ * Prompt to ask the user if they want to start with an example template.
+ */
+export const exampleStep = () => {
+	return async () => {
+		return select({
+			message: "Would you like to start with an example?",
+			options: [
+				{ value: "none", label: "None (Blank config)", hint: "recommended" },
+				{
+					value: "vite-zod",
+					label: "Vite + Zod",
+					hint: "Full-stack validation with Zod",
+				},
+				{
+					value: "next-arktype",
+					label: "Next.js + ArkType",
+					hint: "Optimized for Next.js and ArkType",
+				},
+				{
+					value: "basic-valibot",
+					label: "Basic + Valibot",
+					hint: "Lightweight validation with Valibot",
+				},
+			],
+			initialValue: "none",
+		});
+	};
+};

--- a/packages/cli/src/cli/ui/prompts/steps/example.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/example.ts
@@ -16,11 +16,6 @@ export const exampleStep = () => {
 					hint: "Full-stack validation with Zod",
 				},
 				{
-					value: "next-arktype",
-					label: "Next.js + ArkType",
-					hint: "Optimized for Next.js and ArkType",
-				},
-				{
 					value: "basic-valibot",
 					label: "Basic + Valibot",
 					hint: "Lightweight validation with Valibot",

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -60,13 +60,7 @@ export async function runPromptWizard(
 			key: "framework",
 			fn: ({ results }) =>
 				results.example !== "none"
-					? Promise.resolve(
-							results.example === "vite-zod"
-								? "vite"
-								: results.example === "next-arktype"
-									? "vanilla"
-									: "vanilla",
-						)
+					? Promise.resolve(results.example === "vite-zod" ? "vite" : "vanilla")
 					: steps.framework(defaults)(),
 		},
 		{
@@ -92,13 +86,7 @@ export async function runPromptWizard(
 			key: "validator",
 			fn: ({ results }) =>
 				results.example !== "none"
-					? Promise.resolve(
-							results.example === "vite-zod"
-								? "zod"
-								: results.example === "next-arktype"
-									? "arktype"
-									: "valibot",
-						)
+					? Promise.resolve(results.example === "vite-zod" ? "zod" : "valibot")
 					: steps.validator(),
 		},
 		{

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -55,7 +55,20 @@ export async function runPromptWizard(
 			key: "overwriteEnvSchemaFile",
 			fn: () => steps.overwriteEnvSchemaFile(defaultEnvPath)(),
 		},
-		{ key: "framework", fn: () => steps.framework(defaults)() },
+		{ key: "example", fn: () => steps.example()() },
+		{
+			key: "framework",
+			fn: ({ results }) =>
+				results.example !== "none"
+					? Promise.resolve(
+							results.example === "vite-zod"
+								? "vite"
+								: results.example === "next-arktype"
+									? "vanilla"
+									: "vanilla",
+						)
+					: steps.framework(defaults)(),
+		},
 		{
 			key: "bunBuild",
 			fn: ({ results }) =>
@@ -75,10 +88,25 @@ export async function runPromptWizard(
 			fn: (ctx) => steps.installTypeDefinitions(ctx as any),
 		},
 		{ key: "envDtsHandling", fn: (ctx) => steps.envDtsHandling(ctx as any) },
-		{ key: "validator", fn: () => steps.validator() },
+		{
+			key: "validator",
+			fn: ({ results }) =>
+				results.example !== "none"
+					? Promise.resolve(
+							results.example === "vite-zod"
+								? "zod"
+								: results.example === "next-arktype"
+									? "arktype"
+									: "valibot",
+						)
+					: steps.validator(),
+		},
 		{
 			key: "useEnvExample",
-			fn: () => steps.useEnvExample(detectedKeys, keysSource)(),
+			fn: ({ results }) =>
+				results.example !== "none"
+					? Promise.resolve(false)
+					: steps.useEnvExample(detectedKeys, keysSource)(),
 		},
 	];
 
@@ -100,6 +128,7 @@ export async function runPromptWizard(
 
 	return shake({
 		...results,
+		example: results.example === "none" ? undefined : results.example,
 		bunFeatures,
 		language: "ts",
 		installSkill: false, // Defaulting to false, will be overridden by orchestrator if needed

--- a/packages/cli/src/features/scaffold/env-template.ts
+++ b/packages/cli/src/features/scaffold/env-template.ts
@@ -1,5 +1,12 @@
 import type { ProjectOptions } from "./plan";
-import { arktypeTemplate, valibotTemplate, zodTemplate } from "./templates";
+import {
+	arktypeTemplate,
+	basicValibotExample,
+	nextArktypeExample,
+	valibotTemplate,
+	viteZodExample,
+	zodTemplate,
+} from "./templates";
 
 /**
  * Generates the complete environment configuration template
@@ -9,7 +16,11 @@ import { arktypeTemplate, valibotTemplate, zodTemplate } from "./templates";
  * @returns The generated template code.
  */
 export function getEnvTemplate(options: ProjectOptions): string {
-	const { validator, envKeys, framework } = options;
+	const { validator, envKeys, framework, example } = options;
+
+	if (example === "vite-zod") return `${viteZodExample()}\n`;
+	if (example === "next-arktype") return `${nextArktypeExample()}\n`;
+	if (example === "basic-valibot") return `${basicValibotExample()}\n`;
 
 	switch (validator) {
 		case "arktype":

--- a/packages/cli/src/features/scaffold/env-template.ts
+++ b/packages/cli/src/features/scaffold/env-template.ts
@@ -2,7 +2,6 @@ import type { ProjectOptions } from "./plan";
 import {
 	arktypeTemplate,
 	basicValibotExample,
-	nextArktypeExample,
 	valibotTemplate,
 	viteZodExample,
 	zodTemplate,
@@ -19,7 +18,6 @@ export function getEnvTemplate(options: ProjectOptions): string {
 	const { validator, envKeys, framework, example } = options;
 
 	if (example === "vite-zod") return `${viteZodExample()}\n`;
-	if (example === "next-arktype") return `${nextArktypeExample()}\n`;
 	if (example === "basic-valibot") return `${basicValibotExample()}\n`;
 
 	switch (validator) {

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -10,6 +10,7 @@ export type ProjectOptions = {
 	path: string;
 	validator: "arktype" | "zod" | "valibot";
 	framework: "vite" | "bun-fullstack" | "vanilla";
+	example?: "vite-zod" | "next-arktype" | "basic-valibot";
 	bunFeatures?: ("serve" | "build")[];
 	language: "ts"; // TODO: Support JS
 	overwriteEnvSchemaFile?: boolean;

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -10,7 +10,7 @@ export type ProjectOptions = {
 	path: string;
 	validator: "arktype" | "zod" | "valibot";
 	framework: "vite" | "bun-fullstack" | "vanilla";
-	example?: "vite-zod" | "next-arktype" | "basic-valibot";
+	example?: "vite-zod" | "basic-valibot";
 	bunFeatures?: ("serve" | "build")[];
 	language: "ts"; // TODO: Support JS
 	overwriteEnvSchemaFile?: boolean;

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -47,6 +47,30 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 		});
 	}
 
+	// 1b. .env file for examples
+	if (options.example) {
+		const dotEnvPath = path.resolve(cwd, ".env");
+		if (!state.existingFiles.includes(dotEnvPath)) {
+			let dotEnvContent = "";
+			if (options.example === "vite-zod") {
+				dotEnvContent =
+					"VITE_API_URL=https://api.example.com\nVITE_ENABLE_FEATURE_X=false\n";
+			} else if (options.example === "next-arktype") {
+				dotEnvContent =
+					"NEXT_PUBLIC_API_URL=https://api.example.com\nDATABASE_URL=postgresql://localhost:5432/mydb\n";
+			} else if (options.example === "basic-valibot") {
+				dotEnvContent = "PORT=3000\nHOST=localhost\n";
+			}
+
+			plan.files.push({
+				path: dotEnvPath,
+				content: dotEnvContent,
+				action: "create",
+				label: ".env file",
+			});
+		}
+	}
+
 	// 2. dependencies
 	const deps = ["arkenv", options.validator];
 	if (options.framework === "vite") deps.push("@arkenv/vite-plugin");

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -55,9 +55,6 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 			if (options.example === "vite-zod") {
 				dotEnvContent =
 					"VITE_API_URL=https://api.example.com\nVITE_ENABLE_FEATURE_X=false\n";
-			} else if (options.example === "next-arktype") {
-				dotEnvContent =
-					"NEXT_PUBLIC_API_URL=https://api.example.com\nDATABASE_URL=postgresql://localhost:5432/mydb\n";
 			} else if (options.example === "basic-valibot") {
 				dotEnvContent = "PORT=3000\nHOST=localhost\n";
 			}

--- a/packages/cli/src/features/scaffold/templates/examples.ts
+++ b/packages/cli/src/features/scaffold/templates/examples.ts
@@ -16,27 +16,9 @@ export const viteZodExample = () => {
   `;
 };
 
-export const nextArktypeExample = () => {
-	return dedent /* ts */`
-    import arkenv, { type } from "arkenv";
-
-    /**
-     * Environment variable schema using ArkType.
-     * Optimized for Next.js with both server and client-side support.
-     */
-    export const Env = type({
-      NEXT_PUBLIC_API_URL: "string.url = 'https://api.example.com'",
-      DATABASE_URL: "string.url",
-      NODE_ENV: "'development' | 'production' | 'test' = 'development'",
-    });
-
-    export const env = arkenv(Env);
-  `;
-};
-
 export const basicValibotExample = () => {
 	return dedent /* ts */`
-    import arkenv from "arkenv";
+    import arkenv from "arkenv/standard";
     import * as v from "valibot";
 
     /**

--- a/packages/cli/src/features/scaffold/templates/examples.ts
+++ b/packages/cli/src/features/scaffold/templates/examples.ts
@@ -1,0 +1,52 @@
+import dedent from "dedent";
+
+export const viteZodExample = () => {
+	return dedent /* ts */`
+    import { z } from "zod";
+
+    /**
+     * Environment variable schema using Zod.
+     * In Vite, use \`@arkenv/vite-plugin\` to validate these at build-time.
+     */
+    export const Env = z.object({
+      VITE_API_URL: z.string().url().default("https://api.example.com"),
+      VITE_ENABLE_FEATURE_X: z.enum(["true", "false"]).default("false"),
+      NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+    });
+  `;
+};
+
+export const nextArktypeExample = () => {
+	return dedent /* ts */`
+    import arkenv, { type } from "arkenv";
+
+    /**
+     * Environment variable schema using ArkType.
+     * Optimized for Next.js with both server and client-side support.
+     */
+    export const Env = type({
+      NEXT_PUBLIC_API_URL: "string.url = 'https://api.example.com'",
+      DATABASE_URL: "string.url",
+      NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+    });
+
+    export const env = arkenv(Env);
+  `;
+};
+
+export const basicValibotExample = () => {
+	return dedent /* ts */`
+    import arkenv from "arkenv";
+    import * as v from "valibot";
+
+    /**
+     * Basic environment variable schema using Valibot.
+     */
+    export const Env = v.object({
+      PORT: v.optional(v.pipe(v.string(), v.transform(Number)), 3000),
+      HOST: v.optional(v.string(), "localhost"),
+    });
+
+    export const env = arkenv(Env);
+  `;
+};

--- a/packages/cli/src/features/scaffold/templates/index.ts
+++ b/packages/cli/src/features/scaffold/templates/index.ts
@@ -1,4 +1,5 @@
 export * from "./arktype";
+export * from "./examples";
 export * from "./types";
 export * from "./valibot";
 export * from "./zod";


### PR DESCRIPTION
Fixes #926

This PR adds an interactive "Select Example" step to the `arkenv init` wizard. Users can now choose from pre-configured templates (Vite + Zod, Next.js + ArkType, Basic + Valibot) which automatically scaffold both the `env.ts` schema and a corresponding `.env` file.

Changes:
- Added `example` prompt step to the `init` wizard.
- Added example templates and updated the scaffolding planner to handle them.
- Updated tests and verified that example selection skips redundant prompts.
- Included a changeset for `@arkenv/cli`.