### PR TITLE
feat(cli): add local interactive CLI testing playground utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,5 @@ gha-creds-*.json
 
 # CLI test playgrounds
 apps/playgrounds/tmp-cli-*
+apps/playgrounds/.tmp-cli-*
+/.tmp-cli-*

--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,6 @@ fabric.properties
 gha-creds-*.json
 
 # CLI test playgrounds
-apps/playgrounds/tmp-cli-*
-apps/playgrounds/.tmp-cli-*
-/.tmp-cli-*
+/tmp/
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ fabric.properties
 # So (say it with me) I'm going to ignore that for now
 
 gha-creds-*.json
+
+# CLI test playgrounds
+apps/playgrounds/tmp-cli-*

--- a/apps/playgrounds/arkenv-cli/README.md
+++ b/apps/playgrounds/arkenv-cli/README.md
@@ -16,7 +16,7 @@ From the root of the monorepo, run one of the following commands:
   pnpm test:cli --new
   ```
 
-These commands will automatically rebuild the CLI, configure a temporary playground directory under `apps/playgrounds/tmp-cli-*` (which is git-ignored and automatically cleaned up on every run), and launch the local CLI binary interactively inside it.
+These commands will automatically rebuild the CLI, create a temporary playground directory under the repo root at `tmp/new-*` or `tmp/existing-*` (which is git-ignored), and launch the local CLI binary interactively inside it.
 
 ---
 

--- a/apps/playgrounds/arkenv-cli/README.md
+++ b/apps/playgrounds/arkenv-cli/README.md
@@ -1,3 +1,24 @@
+# CLI Testing Playground
+
+This playground is configured for testing the `@arkenv/cli` package locally.
+
+## Testing the CLI
+
+To test the CLI's `init` wizard in this playground:
+
+1. **Run the CLI**: From the root of the monorepo, run:
+   ```bash
+   pnpm --filter=arkenv-cli-playground arkenv
+   ```
+   This will automatically rebuild the `@arkenv/cli` package and run the interactive initializer (`arkenv init`) in the context of this playground directory.
+
+2. **Clean / Reset changes**: After running the CLI and verifying the changes (such as updates to `tsconfig.json`, `vite.config.ts`, `package.json`, or the creation of `src/vite-env.d.ts`), you can discard all changes and reset the playground to a clean state by running:
+   ```bash
+   pnpm --filter=arkenv-cli-playground arkenv:clean
+   ```
+
+---
+
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.

--- a/apps/playgrounds/arkenv-cli/README.md
+++ b/apps/playgrounds/arkenv-cli/README.md
@@ -1,21 +1,22 @@
 # CLI Testing Playground
 
-This playground is configured for testing the `@arkenv/cli` package locally.
+This playground folder is the reference directory for the `@arkenv/cli` package, but to test the CLI's interactive wizard in a clean sandboxed environment, you should use the global testing utility.
 
 ## Testing the CLI
 
-To test the CLI's `init` wizard in this playground:
+From the root of the monorepo, run one of the following commands:
 
-1. **Run the CLI**: From the root of the monorepo, run:
-   ```bash
-   pnpm --filter=arkenv-cli-playground arkenv
-   ```
-   This will automatically rebuild the `@arkenv/cli` package and run the interactive initializer (`arkenv init`) in the context of this playground directory.
+- **Test in an ArkEnv-less existing project** (creates a folder with `package.json` + `tsconfig.json` + `.env.example` but no ArkEnv setup):
+  ```bash
+  pnpm test:cli --existing
+  ```
 
-2. **Clean / Reset changes**: After running the CLI and verifying the changes (such as updates to `tsconfig.json`, `vite.config.ts`, `package.json`, or the creation of `src/vite-env.d.ts`), you can discard all changes and reset the playground to a clean state by running:
-   ```bash
-   pnpm --filter=arkenv-cli-playground arkenv:clean
-   ```
+- **Test in a completely new/empty directory** (creates a completely blank directory and runs `init`):
+  ```bash
+  pnpm test:cli --new
+  ```
+
+These commands will automatically rebuild the CLI, configure a temporary playground directory under `apps/playgrounds/tmp-cli-*` (which is git-ignored and automatically cleaned up on every run), and launch the local CLI binary interactively inside it.
 
 ---
 

--- a/arkenv.code-workspace
+++ b/arkenv.code-workspace
@@ -48,6 +48,10 @@
 			"name": "🛠️ playwright"
 		},
 		{
+			"path": "tmp",
+			"name": "🕒 temporary"
+		},
+		{
 			"path": "apps/www",
 			"name": "🚀 www"
 		},

--- a/bin/test-cli.js
+++ b/bin/test-cli.js
@@ -46,10 +46,8 @@ if (mode !== "--new" && mode !== "--existing") {
 
 const isNew = mode === "--new";
 const suffix = crypto.randomBytes(2).toString("hex");
-const tempDirName = isNew
-	? `.tmp-cli-new-${suffix}`
-	: `.tmp-cli-existing-${suffix}`;
-const tempDir = path.resolve(rootDir, tempDirName);
+const tempDirName = isNew ? `new-${suffix}` : `existing-${suffix}`;
+const tempDir = path.resolve(rootDir, "tmp", tempDirName);
 
 // 1. Build the CLI
 console.log("Building @arkenv/cli...");

--- a/bin/test-cli.js
+++ b/bin/test-cli.js
@@ -82,7 +82,7 @@ if (!isNew) {
 			target: "ESNext",
 			module: "ESNext",
 			moduleResolution: "bundler",
-			strict: false,
+			strict: true,
 		},
 	};
 	fs.writeFileSync(

--- a/bin/test-cli.js
+++ b/bin/test-cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import crypto from "node:crypto";
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -41,7 +42,10 @@ if (mode !== "--new" && mode !== "--existing") {
 }
 
 const isNew = mode === "--new";
-const tempDirName = isNew ? "tmp-cli-new" : "tmp-cli-existing";
+const suffix = crypto.randomBytes(2).toString("hex");
+const tempDirName = isNew
+	? `tmp-cli-new-${suffix}`
+	: `tmp-cli-existing-${suffix}`;
 const tempDir = path.resolve(rootDir, "apps", "playgrounds", tempDirName);
 
 // 1. Build the CLI

--- a/bin/test-cli.js
+++ b/bin/test-cli.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, "..");
+
+const mode = process.argv[2];
+
+if (mode !== "--new" && mode !== "--existing") {
+	console.error("Usage: node bin/test-cli.js [--new | --existing]");
+	process.exit(1);
+}
+
+const isNew = mode === "--new";
+const tempDirName = isNew ? "tmp-cli-new" : "tmp-cli-existing";
+const tempDir = path.resolve(rootDir, "apps", "playgrounds", tempDirName);
+
+// 1. Build the CLI
+console.log("Building @arkenv/cli...");
+execSync("pnpm --filter=@arkenv/cli build", { cwd: rootDir, stdio: "inherit" });
+
+// 2. Prepare the directory
+console.log(`Preparing temporary directory: ${tempDir}`);
+if (fs.existsSync(tempDir)) {
+	fs.rmSync(tempDir, { recursive: true, force: true });
+}
+fs.mkdirSync(tempDir, { recursive: true });
+
+if (!isNew) {
+	// Setup existing project without ArkEnv
+	console.log(
+		"Setting up existing project files (package.json, tsconfig.json, .env.example)...",
+	);
+
+	const packageJson = {
+		name: "test-existing-project",
+		version: "1.0.0",
+		private: true,
+		dependencies: {
+			react: "^19.0.0",
+		},
+		devDependencies: {
+			typescript: "^5.0.0",
+		},
+	};
+	fs.writeFileSync(
+		path.join(tempDir, "package.json"),
+		JSON.stringify(packageJson, null, 2),
+	);
+
+	const tsconfigJson = {
+		compilerOptions: {
+			target: "ESNext",
+			module: "ESNext",
+			moduleResolution: "bundler",
+			strict: false,
+		},
+	};
+	fs.writeFileSync(
+		path.join(tempDir, "tsconfig.json"),
+		JSON.stringify(tsconfigJson, null, 2),
+	);
+
+	// Add an example .env.example file to test key detection
+	const envExampleContent =
+		"PORT=8000\nDATABASE_URL=postgresql://localhost:5432/mydb\n";
+	fs.writeFileSync(path.join(tempDir, ".env.example"), envExampleContent);
+}
+
+// 3. Run the CLI
+console.log(`Running arkenv init inside ${tempDir}...\n`);
+try {
+	execSync(
+		`node ${path.resolve(rootDir, "packages/cli/dist/index.cjs")} init`,
+		{
+			cwd: tempDir,
+			stdio: "inherit",
+		},
+	);
+	console.log(
+		"\nCLI execution completed. You can inspect the generated files at:",
+	);
+	console.log(tempDir);
+} catch (error) {
+	console.error("\nCLI execution failed:", error.message);
+	process.exit(1);
+}

--- a/bin/test-cli.js
+++ b/bin/test-cli.js
@@ -47,9 +47,9 @@ if (mode !== "--new" && mode !== "--existing") {
 const isNew = mode === "--new";
 const suffix = crypto.randomBytes(2).toString("hex");
 const tempDirName = isNew
-	? `tmp-cli-new-${suffix}`
-	: `tmp-cli-existing-${suffix}`;
-const tempDir = path.resolve(rootDir, "apps", "playgrounds", tempDirName);
+	? `.tmp-cli-new-${suffix}`
+	: `.tmp-cli-existing-${suffix}`;
+const tempDir = path.resolve(rootDir, tempDirName);
 
 // 1. Build the CLI
 console.log("Building @arkenv/cli...");
@@ -68,10 +68,20 @@ fs.writeFileSync(
 	"ignore-workspace-root-check=true\n",
 );
 
+// Write a dummy pnpm-workspace.yaml to isolate the playground from the parent monorepo workspace
+fs.writeFileSync(path.join(tempDir, "pnpm-workspace.yaml"), "packages: []\n");
+
 // Change current working directory to the temporary directory
 process.chdir(tempDir);
 
-if (!isNew) {
+if (isNew) {
+	// Setup a minimal package.json to isolate package installation inside this playground
+	const packageJson = {
+		name: "test-new-project",
+		private: true,
+	};
+	fs.writeFileSync("package.json", JSON.stringify(packageJson, null, 2));
+} else {
 	// Setup existing project without ArkEnv
 	console.log(
 		"Setting up existing project files (package.json, tsconfig.json, .env.example)...",
@@ -106,19 +116,28 @@ if (!isNew) {
 	fs.writeFileSync(".env.example", envExampleContent);
 }
 
-// Clean up npm/pnpm lifecycle environment variables to prevent nested pnpm calls
-// from inheriting the workspace root context.
+// Clean up all npm/pnpm lifecycle environment variables to isolate nested calls
 for (const key of Object.keys(process.env)) {
-	if (key.startsWith("npm_") || key.startsWith("PNPM_") || key === "INIT_CWD") {
+	const lowerKey = key.toLowerCase();
+	if (
+		lowerKey.startsWith("npm_") ||
+		lowerKey.startsWith("pnpm_") ||
+		lowerKey === "init_cwd"
+	) {
 		delete process.env[key];
 	}
 }
 
+// Explicitly set the configuration bypass settings so that pnpm allows running inside the subfolder
+process.env.pnpm_config_ignore_workspace_root_check = "true";
+process.env.NPM_CONFIG_IGNORE_WORKSPACE_ROOT_CHECK = "true";
+
 // 3. Run the CLI
+const extraArgs = process.argv.slice(process.argv[2] === mode ? 3 : 2);
 console.log(`Running arkenv init inside ${tempDir}...\n`);
 try {
 	execSync(
-		`node ${path.resolve(rootDir, "packages/cli/dist/index.cjs")} init`,
+		`node ${path.resolve(rootDir, "packages/cli/dist/index.cjs")} init ${extraArgs.join(" ")}`,
 		{
 			cwd: tempDir,
 			stdio: "inherit",

--- a/bin/test-cli.js
+++ b/bin/test-cli.js
@@ -3,12 +3,37 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { cancel, intro, isCancel, select } from "@clack/prompts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, "..");
 
-const mode = process.argv[2];
+let mode = process.argv[2];
+
+if (!mode) {
+	intro("ArkEnv CLI Local Testing Utility");
+	const answer = await select({
+		message: "Which workflow would you like to test?",
+		options: [
+			{
+				value: "--existing",
+				label:
+					"Existing Project Flow (with package.json, tsconfig.json, .env.example)",
+			},
+			{
+				value: "--new",
+				label: "New Project Flow (completely empty directory)",
+			},
+		],
+	});
+
+	if (isCancel(answer)) {
+		cancel("Operation cancelled.");
+		process.exit(0);
+	}
+	mode = answer;
+}
 
 if (mode !== "--new" && mode !== "--existing") {
 	console.error("Usage: node bin/test-cli.js [--new | --existing]");

--- a/bin/test-cli.js
+++ b/bin/test-cli.js
@@ -10,6 +10,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, "..");
 
+// Force pnpm to allow installing packages in workspace subfolders when testing
+process.env.NPM_CONFIG_IGNORE_WORKSPACE_ROOT_CHECK = "true";
+
 let mode = process.argv[2];
 
 if (!mode) {

--- a/bin/test-cli.js
+++ b/bin/test-cli.js
@@ -106,6 +106,14 @@ if (!isNew) {
 	fs.writeFileSync(".env.example", envExampleContent);
 }
 
+// Clean up npm/pnpm lifecycle environment variables to prevent nested pnpm calls
+// from inheriting the workspace root context.
+for (const key of Object.keys(process.env)) {
+	if (key.startsWith("npm_") || key.startsWith("PNPM_") || key === "INIT_CWD") {
+		delete process.env[key];
+	}
+}
+
 // 3. Run the CLI
 console.log(`Running arkenv init inside ${tempDir}...\n`);
 try {

--- a/bin/test-cli.js
+++ b/bin/test-cli.js
@@ -59,6 +59,15 @@ if (fs.existsSync(tempDir)) {
 }
 fs.mkdirSync(tempDir, { recursive: true });
 
+// Write .npmrc to prevent pnpm from complaining about workspace root installation
+fs.writeFileSync(
+	path.join(tempDir, ".npmrc"),
+	"ignore-workspace-root-check=true\n",
+);
+
+// Change current working directory to the temporary directory
+process.chdir(tempDir);
+
 if (!isNew) {
 	// Setup existing project without ArkEnv
 	console.log(
@@ -76,10 +85,7 @@ if (!isNew) {
 			typescript: "^5.0.0",
 		},
 	};
-	fs.writeFileSync(
-		path.join(tempDir, "package.json"),
-		JSON.stringify(packageJson, null, 2),
-	);
+	fs.writeFileSync("package.json", JSON.stringify(packageJson, null, 2));
 
 	const tsconfigJson = {
 		compilerOptions: {
@@ -89,15 +95,12 @@ if (!isNew) {
 			strict: true,
 		},
 	};
-	fs.writeFileSync(
-		path.join(tempDir, "tsconfig.json"),
-		JSON.stringify(tsconfigJson, null, 2),
-	);
+	fs.writeFileSync("tsconfig.json", JSON.stringify(tsconfigJson, null, 2));
 
 	// Add an example .env.example file to test key detection
 	const envExampleContent =
 		"PORT=8000\nDATABASE_URL=postgresql://localhost:5432/mydb\n";
-	fs.writeFileSync(path.join(tempDir, ".env.example"), envExampleContent);
+	fs.writeFileSync(".env.example", envExampleContent);
 }
 
 // 3. Run the CLI

--- a/bin/test-cli.js
+++ b/bin/test-cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import crypto from "node:crypto";
 import { execSync } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.4.14",
 		"@changesets/cli": "2.31.0",
+		"@clack/prompts": "^1.3.0",
 		"@manypkg/cli": "0.25.1",
 		"@playwright/test": "",
 		"@types/node": "catalog:",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 		"sync:examples:check": "node bin/sync-examples.js --check",
 		"contributors:add": "all-contributors add",
 		"contributors:generate": "all-contributors generate",
-		"knip": "knip"
+		"knip": "knip",
+		"test:cli": "node bin/test-cli.js"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.14",

--- a/packages/cli/ARCHITECTURE.md
+++ b/packages/cli/ARCHITECTURE.md
@@ -57,3 +57,21 @@ The architecture is specifically designed to support AI agents and headless envi
 - **Domain Tests**: Features are tested with pure data and mock ports. These tests are fast and do not touch the disk.
 - **Adapter Tests**: Concrete implementations in `adapters/` are tested against the actual Node.js environment (e.g., using `fsp.mkdtemp`).
 - **Smoke Tests**: High-level integration tests in `src/smoke.test.ts` verify the final bundled CLI from the user's perspective.
+
+### Interactive Local Testing
+
+To test the interactive onboarding wizard in real-world scenarios, a helper script is provided at the monorepo root. You can run the CLI inside a clean, sandboxed testing directory without affecting any existing codebase.
+
+From the monorepo root:
+
+- **Test in an ArkEnv-less existing project** (creates a folder with `package.json` + `tsconfig.json` + `.env.example` but no ArkEnv setup):
+  ```bash
+  pnpm test:cli --existing
+  ```
+
+- **Test in a completely new/empty directory** (creates a completely blank directory and runs `init`):
+  ```bash
+  pnpm test:cli --new
+  ```
+
+These commands will automatically rebuild the CLI, configure the temporary directory under `apps/playgrounds/tmp-cli-*` (which is git-ignored), and launch the local CLI binary interactively inside it.

--- a/packages/cli/ARCHITECTURE.md
+++ b/packages/cli/ARCHITECTURE.md
@@ -74,4 +74,4 @@ From the monorepo root:
   pnpm test:cli --new
   ```
 
-These commands will automatically rebuild the CLI, configure the temporary directory under `apps/playgrounds/tmp-cli-*` (which is git-ignored), and launch the local CLI binary interactively inside it.
+These commands will automatically rebuild the CLI, create a temporary directory under the repo root at `tmp/new-*` or `tmp/existing-*` (which is git-ignored), and launch the local CLI binary interactively inside it.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,9 +21,9 @@ npx @arkenv/cli@latest init
 - [ArkEnv](https://arkenv.js.org) - Core library and docs
 - [ArkType](https://arktype.io/) - Underlying validator / type system
 
-## Architecture
+## Architecture & Development
 
-This CLI is built with a port-and-adapter architecture to remain flexible and testable.
+This CLI is built with a port-and-adapter architecture to remain flexible and testable. See [ARCHITECTURE.md](./ARCHITECTURE.md) for details on the codebase design, architecture rules, and how to use the interactive testing scripts.
 
 ### Local Environment Adapters (`Node*`)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,22 +374,6 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
-  apps/playgrounds/tmp-cli-existing:
-    dependencies:
-      arkenv:
-        specifier: ^0.11.0
-        version: 0.11.0(arktype@2.2.0)
-      arktype:
-        specifier: 'catalog:'
-        version: 2.2.0
-      react:
-        specifier: ^19.0.0
-        version: 19.2.5
-    devDependencies:
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
-
   apps/playgrounds/vite:
     dependencies:
       '@arkenv/vite-plugin':
@@ -5245,14 +5229,6 @@ packages:
   arkdark@5.4.2:
     resolution: {integrity: sha512-AMk8Jmrgo4X9TJtjwIa7K1zQqHh1OBzSU129IhB5jetFh6mMAhqT0QqyYQshB+4XEvtDeNjtfry+1XiXAoLYNg==}
     engines: {vscode: ^1.0.0}
-
-  arkenv@0.11.0:
-    resolution: {integrity: sha512-XLVk3uiNRwlaqJiRWqVGz5y75P30DczxuupzVz3EEbs2j539ftwusvlK+5y/MOIerUbskSpsm6c6B61YMr/UPA==}
-    peerDependencies:
-      arktype: ^2.1.22
-    peerDependenciesMeta:
-      arktype:
-        optional: true
 
   arkregex@0.0.4:
     resolution: {integrity: sha512-biS/FkvSwQq59TZ453piUp8bxMui11pgOMV9WHAnli1F8o0ayNCZzUwQadL/bGIUic5TkS/QlPcyMuI8ZIwedQ==}
@@ -14184,10 +14160,6 @@ snapshots:
   aria-query@5.3.2: {}
 
   arkdark@5.4.2: {}
-
-  arkenv@0.11.0(arktype@2.2.0):
-    optionalDependencies:
-      arktype: 2.2.0
 
   arkregex@0.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       '@changesets/cli':
         specifier: 2.31.0
         version: 2.31.0(@types/node@24.12.2)
+      '@clack/prompts':
+        specifier: ^1.3.0
+        version: 1.3.0
       '@manypkg/cli':
         specifier: 0.25.1
         version: 0.25.1
@@ -370,6 +373,22 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+
+  apps/playgrounds/tmp-cli-existing:
+    dependencies:
+      arkenv:
+        specifier: ^0.11.0
+        version: 0.11.0(arktype@2.2.0)
+      arktype:
+        specifier: 'catalog:'
+        version: 2.2.0
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+    devDependencies:
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   apps/playgrounds/vite:
     dependencies:
@@ -5226,6 +5245,14 @@ packages:
   arkdark@5.4.2:
     resolution: {integrity: sha512-AMk8Jmrgo4X9TJtjwIa7K1zQqHh1OBzSU129IhB5jetFh6mMAhqT0QqyYQshB+4XEvtDeNjtfry+1XiXAoLYNg==}
     engines: {vscode: ^1.0.0}
+
+  arkenv@0.11.0:
+    resolution: {integrity: sha512-XLVk3uiNRwlaqJiRWqVGz5y75P30DczxuupzVz3EEbs2j539ftwusvlK+5y/MOIerUbskSpsm6c6B61YMr/UPA==}
+    peerDependencies:
+      arktype: ^2.1.22
+    peerDependenciesMeta:
+      arktype:
+        optional: true
 
   arkregex@0.0.4:
     resolution: {integrity: sha512-biS/FkvSwQq59TZ453piUp8bxMui11pgOMV9WHAnli1F8o0ayNCZzUwQadL/bGIUic5TkS/QlPcyMuI8ZIwedQ==}
@@ -14157,6 +14184,10 @@ snapshots:
   aria-query@5.3.2: {}
 
   arkdark@5.4.2: {}
+
+  arkenv@0.11.0(arktype@2.2.0):
+    optionalDependencies:
+      arktype: 2.2.0
 
   arkregex@0.0.4:
     dependencies:


### PR DESCRIPTION
This PR introduces a convenient, robust way to locally test the `@arkenv/cli` initialization flows in the monorepo.

### What's Changed
- **New Testing Script**: Added `bin/test-cli.js` that compiles the CLI, prepares a clean testing environment (under `apps/playgrounds/tmp-cli-*`), and runs the built CLI interactively.
- **Root Package Script**: Added `pnpm test:cli` with two options:
  - `pnpm test:cli --existing` to test inside an ArkEnv-less existing project environment.
  - `pnpm test:cli --new` to test inside a completely new/empty directory environment.
- **Documentation**: Updated `packages/cli/README.md` and `packages/cli/ARCHITECTURE.md` to document this testing flow.
- **Git Ignore**: Ignored the temporary test directories (`apps/playgrounds/tmp-cli-*`).