### PR TITLE
fix(example): replace z.string().hostname() with z.hostname() in with-zod example

### DIFF
--- a/examples/with-zod/src/index.ts
+++ b/examples/with-zod/src/index.ts
@@ -4,7 +4,7 @@ import z from "zod";
 const env = arkenv({
 	TEST_VALUE: z.url(),
 	PORT: z.coerce.number(),
-	HOST: z.literal("localhost").or(z.string().hostname()),
+	HOST: z.literal("localhost").or(z.hostname()),
 });
 
 console.log(`Value: ${String(env.TEST_VALUE)}`);


### PR DESCRIPTION
Fixes #1037

Replaces the invalid `z.string().hostname()` method chain with the correct Zod v4 top-level `z.hostname()` API in the `with-zod` example.

### Changes
- `examples/with-zod/src/index.ts`: Updated `HOST` schema from `z.literal("localhost").or(z.string().hostname())` to `z.literal("localhost").or(z.hostname())`