### PR TITLE
feat(cli)!: replace --name flag with [project-name] positional argument on init

### DIFF
--- a/.changeset/replace-name-flag-with-positional.md
+++ b/.changeset/replace-name-flag-with-positional.md
@@ -1,0 +1,11 @@
+---
+"@arkenv/cli": minor
+---
+
+#### Replace `--name`/`-n` flag with `[project-name]` positional argument on `init` command
+
+The `init` command now accepts an optional `[project-name]` positional argument (e.g., `arkenv init my-new-project` or `arkenv init .`).
+
+The `--name` and `-n` flags have been removed.
+
+**BREAKING CHANGE**: The `--name` / `-n` flags are no longer supported and will result in a parsing error. Use the positional `[project-name]` argument instead.

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -44,9 +44,14 @@ The `@arkenv/cli` is the fastest way to get started with ArkEnv. It provides an 
 
 ## Commands
 
-### `init`
+### `init [project-name]`
 
-The `init` command is the primary entry point for the CLI. It will:
+The `init` command is the primary entry point for the CLI. It accepts an optional `[project-name]` positional argument (which defaults to the current directory `.`).
+
+- **Inside an existing project**: Running `init` will scaffold ArkEnv in that directory. If you specify a directory name, e.g., `init my-sub-project`, the CLI will perform all operations inside that subdirectory.
+- **Outside a project (New Project Flow)**: If the target directory does not have a `package.json` and is empty, the CLI will guide you through creating a new project from an example. The name and directory of the new project will be `[project-name]`.
+
+During initialization, the CLI will:
 
 1. **Detect Environment**: Check your package manager and project framework (Vite, Bun, Node.js).
 2. **Scan for Keys**: Detect if a `.env.example` exists and extract its keys to pre-populate your schema.
@@ -65,6 +70,5 @@ The CLI supports the following flags to customize the behavior:
 | `--json`    | `-j`  | Emit a structured JSON summary to `stdout` upon completion (all other output is sent to `stderr`).             |
 | `--agent`   | `-a`  | For agents. Macro for `--quiet --json --yes`, also skip the agent install step.                                |
 | `--example` | `-e`  | Specify an example ID to scaffold from (when creating a new project).                                          |
-| `--name`    | `-n`  | Specify the project name (when creating a new project).                                                        |
 | `--force`   | `-f`  | Force scaffolding a new project in non-empty directories, and bypass technical requirement checks.             |
 | `--help`    | `-h`  | Show the help message.                                                                                         |

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -11,25 +11,25 @@ The `@arkenv/cli` is the fastest way to get started with ArkEnv. It provides an 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab value="npm">
     ```bash
-    npx @arkenv/cli@latest init
+    npx @arkenv/cli@latest init [project-name] [options]
     ```
   </Tab>
 
   <Tab value="pnpm">
     ```bash
-    pnx @arkenv/cli@latest init
+    pnx @arkenv/cli@latest init [project-name] [options]
     ```
   </Tab>
 
   <Tab value="yarn">
     ```bash
-    yarn dlx @arkenv/cli@latest init
+    yarn dlx @arkenv/cli@latest init [project-name] [options]
     ```
   </Tab>
 
   <Tab value="bun">
     ```bash
-    bunx @arkenv/cli@latest init
+    bunx @arkenv/cli@latest init [project-name] [options]
     ```
   </Tab>
 </Tabs>
@@ -44,7 +44,7 @@ The `@arkenv/cli` is the fastest way to get started with ArkEnv. It provides an 
 
 ## Commands
 
-### `init [project-name]`
+### `init`
 
 The `init` command is the primary entry point for the CLI. It accepts an optional `[project-name]` positional argument (which defaults to the current directory `.`).
 

--- a/packages/cli/src/adapters/node-workspace/node-workspace.ts
+++ b/packages/cli/src/adapters/node-workspace/node-workspace.ts
@@ -44,11 +44,16 @@ export class NodeWorkspace implements WorkspacePort {
 		await fsp.mkdir(dirPath, { recursive });
 	}
 
-	async execute(command: string, args: string[] = []): Promise<void> {
+	async execute(
+		command: string,
+		args: string[] = [],
+		cwd?: string,
+	): Promise<void> {
 		return new Promise<void>((resolve, reject) => {
 			const child = spawn(command, args, {
 				stdio: (this.isQuiet ? "pipe" : this.stdio) as StdioOptions,
 				shell: false,
+				cwd,
 			});
 
 			let stdout = "";
@@ -88,12 +93,12 @@ export class NodeWorkspace implements WorkspacePort {
 		return updateTsConfigToStrict(this, filePath);
 	}
 
-	async findViteConfig(): Promise<string | null> {
-		return findViteConfig();
+	async findViteConfig(cwd?: string): Promise<string | null> {
+		return findViteConfig(cwd);
 	}
 
-	async findBunConfig(): Promise<string | null> {
-		return findBunConfig();
+	async findBunConfig(cwd?: string): Promise<string | null> {
+		return findBunConfig(cwd);
 	}
 
 	async bootstrapViteConfig(

--- a/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
+++ b/packages/cli/src/adapters/node-workspace/utils/bootstrappers.ts
@@ -6,7 +6,9 @@ import { code } from "@/cli/ui/visuals";
 import { transformViteConfig } from "@/features/config-mutation";
 import type { BootstrapResult } from "@/shared/ports";
 
-export async function findViteConfig(): Promise<string | null> {
+export async function findViteConfig(
+	cwd = process.cwd(),
+): Promise<string | null> {
 	const filenames = [
 		"vite.config.ts",
 		"vite.config.js",
@@ -14,7 +16,7 @@ export async function findViteConfig(): Promise<string | null> {
 		"vite.config.mjs",
 	];
 	for (const file of filenames) {
-		const fullPath = path.resolve(process.cwd(), file);
+		const fullPath = path.resolve(cwd, file);
 		try {
 			await fsp.access(fullPath);
 			return fullPath;
@@ -25,10 +27,12 @@ export async function findViteConfig(): Promise<string | null> {
 	return null;
 }
 
-export async function findBunConfig(): Promise<string | null> {
+export async function findBunConfig(
+	cwd = process.cwd(),
+): Promise<string | null> {
 	const filenames = ["bunfig.toml", "bun.setup.ts", "bun.setup.js"];
 	for (const file of filenames) {
-		const fullPath = path.resolve(process.cwd(), file);
+		const fullPath = path.resolve(cwd, file);
 		try {
 			await fsp.access(fullPath);
 			return fullPath;

--- a/packages/cli/src/cli/cli.test.ts
+++ b/packages/cli/src/cli/cli.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { CLI } from "./cli";
+
+describe("CLI parser", () => {
+	it("should parse project name from positional argument", () => {
+		const cli = new CLI(["node", "arkenv", "init", "my-project"]);
+		expect(cli.command).toBe("init");
+		expect(cli.name).toBe("my-project");
+		expect(cli.validationError).toBeUndefined();
+	});
+
+	it("should parse project name with other boolean flags", () => {
+		const cli = new CLI([
+			"node",
+			"arkenv",
+			"init",
+			"my-project",
+			"--yes",
+			"--force",
+		]);
+		expect(cli.command).toBe("init");
+		expect(cli.name).toBe("my-project");
+		expect(cli.isYes).toBe(true);
+		expect(cli.isForce).toBe(true);
+		expect(cli.validationError).toBeUndefined();
+	});
+
+	it("should parse project name with valued example flag", () => {
+		const cli = new CLI([
+			"node",
+			"arkenv",
+			"init",
+			"--example",
+			"with-vite-react",
+			"my-project",
+		]);
+		expect(cli.command).toBe("init");
+		expect(cli.example).toBe("with-vite-react");
+		expect(cli.name).toBe("my-project");
+		expect(cli.validationError).toBeUndefined();
+	});
+
+	it("should parse dot as project name", () => {
+		const cli = new CLI(["node", "arkenv", "init", "."]);
+		expect(cli.command).toBe("init");
+		expect(cli.name).toBe(".");
+		expect(cli.validationError).toBeUndefined();
+	});
+
+	it("should set name to undefined if no positional argument is provided", () => {
+		const cli = new CLI(["node", "arkenv", "init", "--yes"]);
+		expect(cli.command).toBe("init");
+		expect(cli.name).toBeUndefined();
+		expect(cli.validationError).toBeUndefined();
+	});
+
+	it("should reject multiple positional arguments", () => {
+		const cli = new CLI(["node", "arkenv", "init", "project1", "project2"]);
+		expect(cli.validationError).toBe("Unknown argument: project2");
+	});
+
+	it("should reject --name / -n flags as unknown arguments", () => {
+		const cli1 = new CLI(["node", "arkenv", "init", "--name", "foo"]);
+		expect(cli1.validationError).toBe("Unknown argument: --name");
+
+		const cli2 = new CLI(["node", "arkenv", "init", "-n", "foo"]);
+		expect(cli2.validationError).toBe("Unknown argument: -n");
+	});
+
+	it("should reject any other unknown flags", () => {
+		const cli = new CLI(["node", "arkenv", "init", "--foo"]);
+		expect(cli.validationError).toBe("Unknown argument: --foo");
+	});
+});

--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -15,6 +15,7 @@ export class CLI {
 	public helpRequested: boolean;
 	public example: string | undefined;
 	public name: string | undefined;
+	public validationError: string | undefined;
 	public logger: Logger;
 
 	/**
@@ -32,7 +33,59 @@ export class CLI {
 			this.args.includes("--help") || this.args.includes("-h");
 
 		this.example = this.getFlagValue("--example", "-e");
-		this.name = this.getFlagValue("--name", "-n");
+
+		const knownFlags = new Set([
+			"--yes",
+			"-y",
+			"--force",
+			"-f",
+			"--quiet",
+			"-q",
+			"--json",
+			"-j",
+			"--agent",
+			"-a",
+			"--help",
+			"-h",
+			"--example",
+			"-e",
+		]);
+
+		const valuedFlags = new Set(["--example", "-e"]);
+
+		let i = 1;
+		const positionalArgs: string[] = [];
+		this.validationError = undefined;
+
+		while (i < this.args.length) {
+			const arg = this.args[i];
+			if (arg.startsWith("-")) {
+				if (!knownFlags.has(arg)) {
+					this.validationError = `Unknown argument: ${arg}`;
+					break;
+				}
+				if (valuedFlags.has(arg)) {
+					if (i + 1 < this.args.length && !this.args[i + 1].startsWith("-")) {
+						i += 2;
+					} else {
+						i += 1;
+					}
+				} else {
+					i += 1;
+				}
+			} else {
+				positionalArgs.push(arg);
+				i += 1;
+			}
+		}
+
+		if (!this.validationError) {
+			if (positionalArgs.length > 1) {
+				this.validationError = `Unknown argument: ${positionalArgs[1]}`;
+			} else {
+				this.name = positionalArgs[0];
+			}
+		}
 
 		if (this.isAgent) {
 			this.isYes = true;

--- a/packages/cli/src/cli/commands/help.ts
+++ b/packages/cli/src/cli/commands/help.ts
@@ -17,7 +17,9 @@ export class HelpUseCase {
 	async execute() {
 		this.logger.log(`ArkEnv CLI v${version}`);
 		this.logger.log(`\n${pc.bold("Usage:")}`);
-		this.logger.log("  arkenv init    Set up ArkEnv in your project");
+		this.logger.log(
+			"  arkenv init [project-name]    Set up ArkEnv in your project",
+		);
 		this.logger.log(`\n${pc.bold("Options:")}`);
 		this.logger.log(
 			"  --yes, -y      Skip prompts and use defaults (also passed to skill processes)",
@@ -28,9 +30,6 @@ export class HelpUseCase {
 		this.logger.log("  --agent, -a    Agent mode: --yes --quiet --json");
 		this.logger.log(
 			"  --example, -e Specify an example ID to scaffold from (when creating a new project)",
-		);
-		this.logger.log(
-			"  --name, -n     Specify the project name (when creating a new project)",
 		);
 		this.logger.log(
 			"  --quiet, -q    Quiet mode: Suppress output, capture logs on failure",

--- a/packages/cli/src/cli/commands/init.test.ts
+++ b/packages/cli/src/cli/commands/init.test.ts
@@ -33,7 +33,12 @@ describe("InitUseCase", () => {
 		} as unknown as LoggerPort;
 
 		workspace = {
-			exists: vi.fn(),
+			exists: vi.fn().mockImplementation(async (p: string) => {
+				if (p.endsWith(".ts") || p.endsWith(".json") || p.endsWith(".yaml")) {
+					return false;
+				}
+				return true;
+			}),
 			readFile: vi.fn(),
 			writeFile: vi.fn(),
 			mkdir: vi.fn(),
@@ -209,5 +214,52 @@ describe("InitUseCase", () => {
 		expect(logger.warn).toHaveBeenCalledWith(
 			"package.json: package.json not found",
 		);
+	});
+
+	it("should resolve target directory to subdirectory when project-name positional argument is provided", async () => {
+		vi.mocked(scanner.hasPackageJson).mockResolvedValue(true);
+		vi.mocked(prompt.runWizard).mockResolvedValue({
+			path: "./env.ts",
+			validator: "arktype",
+			framework: "vanilla",
+			language: "ts",
+		});
+
+		const result = await (useCase as any).collect({
+			name: "my-project",
+			isYes: false,
+			isForce: false,
+			isQuiet: false,
+			isAgent: false,
+		});
+
+		expect(result.cwd).toContain("my-project");
+		expect(scanner.hasPackageJson).toHaveBeenCalledWith(
+			expect.stringContaining("my-project"),
+		);
+		expect(scanner.checkTsConfig).toHaveBeenCalledWith(
+			expect.stringContaining("my-project"),
+		);
+	});
+
+	it("should resolve target directory to process.cwd() when project-name is '.'", async () => {
+		vi.mocked(scanner.hasPackageJson).mockResolvedValue(true);
+		vi.mocked(prompt.runWizard).mockResolvedValue({
+			path: "./env.ts",
+			validator: "arktype",
+			framework: "vanilla",
+			language: "ts",
+		});
+
+		const result = await (useCase as any).collect({
+			name: ".",
+			isYes: false,
+			isForce: false,
+			isQuiet: false,
+			isAgent: false,
+		});
+
+		expect(result.cwd).toBe(process.cwd());
+		expect(scanner.hasPackageJson).toHaveBeenCalledWith(process.cwd());
 	});
 });

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -63,15 +63,25 @@ export class InitUseCase {
 		this.logger.interactiveStdout(true);
 
 		try {
-			const hasPackageJson = await this.scanner.hasPackageJson();
-			const isEmpty = await this.scanner.isEmptyDirectory();
+			const targetDir =
+				input.name && input.name !== "."
+					? path.resolve(process.cwd(), input.name)
+					: process.cwd();
+
+			const dirExists = await this.workspace.exists(targetDir);
+			const hasPackageJson = dirExists
+				? await this.scanner.hasPackageJson(targetDir)
+				: false;
+			const isEmpty = dirExists
+				? await this.scanner.isEmptyDirectory(targetDir)
+				: true;
 
 			if (hasPackageJson) {
-				return await this.collectExistingProject(input);
+				return await this.collectExistingProject(input, targetDir);
 			}
 
 			if (isEmpty || input.isForce) {
-				return await this.collectNewProject(input);
+				return await this.collectNewProject(input, targetDir);
 			}
 
 			this.logger.error(
@@ -91,10 +101,11 @@ export class InitUseCase {
 	 */
 	private async collectExistingProject(
 		input: InitInput,
+		targetDir: string,
 	): Promise<CollectedState | null> {
 		const { isYes, isForce, isAgent } = input;
 
-		const requirements = await this.scanner.checkRequirements(process.cwd());
+		const requirements = await this.scanner.checkRequirements(targetDir);
 		const failures = requirements.filter((r) => r.status === "fail");
 		const warnings = requirements.filter((r) => r.status === "warn");
 
@@ -123,7 +134,7 @@ export class InitUseCase {
 		}
 
 		let shouldUpdateTsConfig = false;
-		const tsConfig = await this.scanner.checkTsConfig();
+		const tsConfig = await this.scanner.checkTsConfig(targetDir);
 
 		if (tsConfig.status === "not_strict") {
 			if (isYes) {
@@ -153,21 +164,21 @@ export class InitUseCase {
 		}
 
 		const detectedFramework = await this.scanner.detectFramework(
-			process.cwd(),
+			targetDir,
 			tsConfig.parsed,
 		);
 		const detectedBunFeatures =
 			detectedFramework === "bun-fullstack"
-				? await this.scanner.detectBunFeatures(process.cwd(), tsConfig.parsed)
+				? await this.scanner.detectBunFeatures(targetDir, tsConfig.parsed)
 				: undefined;
 		const defaultEnvPath = await this.scanner.suggestDefaultEnvPath(
-			process.cwd(),
+			targetDir,
 			tsConfig.parsed,
 		);
 
-		const targetPath = path.resolve(process.cwd(), defaultEnvPath);
+		const targetPath = path.resolve(targetDir, defaultEnvPath);
 		const envRes = await this.scanner.getEnvExampleKeys(
-			process.cwd(),
+			targetDir,
 			tsConfig.parsed,
 			targetPath,
 		);
@@ -176,8 +187,8 @@ export class InitUseCase {
 		if (detectedFramework === "vite" || detectedFramework === "bun-fullstack") {
 			const typeFile =
 				detectedFramework === "vite" ? "vite-env.d.ts" : "bun-env.d.ts";
-			const targetDir = path.dirname(targetPath);
-			const typeFilePath = path.join(targetDir, typeFile);
+			const targetDirOfSchema = path.dirname(targetPath);
+			const typeFilePath = path.join(targetDirOfSchema, typeFile);
 			hasTypeFile = await this.workspace.exists(typeFilePath);
 		}
 
@@ -217,7 +228,7 @@ export class InitUseCase {
 		}
 
 		// Handle existing env file prompt
-		const finalTargetPath = path.resolve(process.cwd(), options.path);
+		const finalTargetPath = path.resolve(targetDir, options.path);
 
 		if (
 			(await this.workspace.exists(finalTargetPath)) &&
@@ -241,7 +252,7 @@ export class InitUseCase {
 		}
 
 		const packageManager = await this.scanner.detectPackageManager(
-			process.cwd(),
+			targetDir,
 			tsConfig.parsed,
 		);
 
@@ -257,15 +268,15 @@ export class InitUseCase {
 		}
 
 		if (typeFileName) {
-			const targetDir = path.dirname(finalTargetPath);
-			const typeFilePath = path.join(targetDir, typeFileName);
+			const targetDirOfSchema = path.dirname(finalTargetPath);
+			const typeFilePath = path.join(targetDirOfSchema, typeFileName);
 			if (await this.workspace.exists(typeFilePath))
 				existingFiles.push(typeFilePath);
 		}
 
 		return shake({
 			mode: "existing" as const,
-			cwd: process.cwd(),
+			cwd: targetDir,
 			options,
 			detectedFramework,
 			detectedBunFeatures,
@@ -282,6 +293,7 @@ export class InitUseCase {
 	 */
 	private async collectNewProject(
 		input: InitInput,
+		targetDir: string,
 	): Promise<CollectedState | null> {
 		const { isYes, isAgent, example, name } = input;
 
@@ -303,9 +315,20 @@ export class InitUseCase {
 
 		const packageManager = this.detectPackageManager();
 
+		let finalTargetDir = targetDir;
+		if (!input.name) {
+			if (
+				options.name &&
+				options.name !== path.basename(process.cwd()) &&
+				options.name !== "."
+			) {
+				finalTargetDir = path.resolve(process.cwd(), options.name);
+			}
+		}
+
 		return shake({
 			mode: "new" as const,
-			cwd: process.cwd(),
+			cwd: finalTargetDir,
 			options,
 			detectedFramework: options.framework,
 			packageManager,

--- a/packages/cli/src/features/scaffold/cloner.ts
+++ b/packages/cli/src/features/scaffold/cloner.ts
@@ -11,9 +11,10 @@ export async function cloneExample(
 		repository: string;
 		example: string;
 		targetName: string;
+		targetDir: string;
 	},
 ): Promise<void> {
-	const tempDir = path.join(process.cwd(), ".arkenv-temp");
+	const tempDir = path.join(cloneInfo.targetDir, ".arkenv-temp");
 	await workspace.mkdir(tempDir, true);
 
 	try {
@@ -36,9 +37,9 @@ export async function cloneExample(
 			examplePath,
 		]);
 
-		// Move files to current directory
+		// Move files to target directory
 		const fullExamplePath = path.join(tempDir, examplePath);
-		await copyDirectoryContents(fullExamplePath, process.cwd());
+		await copyDirectoryContents(fullExamplePath, cloneInfo.targetDir);
 
 		// Remove any copied lockfiles to ensure clean install with target package manager
 		const lockfiles = [
@@ -49,11 +50,11 @@ export async function cloneExample(
 			"bun.lock",
 		];
 		for (const lockfile of lockfiles) {
-			await fsp.rm(path.join(process.cwd(), lockfile), { force: true });
+			await fsp.rm(path.join(cloneInfo.targetDir, lockfile), { force: true });
 		}
 
 		// Update package.json name
-		const pkgPath = path.join(process.cwd(), "package.json");
+		const pkgPath = path.join(cloneInfo.targetDir, "package.json");
 		if (await workspace.exists(pkgPath)) {
 			const pkgContent = await workspace.readFile(pkgPath);
 			const pkg = JSON.parse(pkgContent);

--- a/packages/cli/src/features/scaffold/executor.test.ts
+++ b/packages/cli/src/features/scaffold/executor.test.ts
@@ -61,6 +61,7 @@ describe("Executor", () => {
 	});
 
 	const defaultPlan: ScaffoldingPlan = {
+		cwd: ".",
 		files: [
 			{
 				path: "env.ts",
@@ -85,10 +86,11 @@ describe("Executor", () => {
 
 		expect(mockWorkspace.mkdir).toHaveBeenCalled();
 		expect(mockWorkspace.writeFile).toHaveBeenCalledWith("env.ts", "env");
-		expect(mockWorkspace.execute).toHaveBeenCalledWith("pnpm", [
-			"add",
-			"arkenv",
-		]);
+		expect(mockWorkspace.execute).toHaveBeenCalledWith(
+			"pnpm",
+			["add", "arkenv"],
+			defaultPlan.cwd,
+		);
 		expect(mockReporter.finish).toHaveBeenCalled();
 	});
 
@@ -109,6 +111,7 @@ describe("Executor", () => {
 				repository: "https://github.com/yamcodes/arkenv.git",
 				example: "basic",
 				targetName: "my-project",
+				targetDir: ".",
 			},
 		};
 		await executor.execute(newProjectPlan);
@@ -151,7 +154,11 @@ describe("Executor", () => {
 		);
 
 		// Assert dependency installation
-		expect(mockWorkspace.execute).toHaveBeenCalledWith("bun", ["install"]);
+		expect(mockWorkspace.execute).toHaveBeenCalledWith(
+			"bun",
+			["install"],
+			newProjectPlan.cwd,
+		);
 	});
 
 	it("updates tsconfig when planned", async () => {
@@ -203,12 +210,10 @@ describe("Executor", () => {
 			},
 		};
 		await executor.execute(plan);
-		expect(mockWorkspace.execute).toHaveBeenCalledWith("pnpm", [
-			"dlx",
-			"skills",
-			"add",
-			"yamcodes/arkenv",
-			"--yes",
-		]);
+		expect(mockWorkspace.execute).toHaveBeenCalledWith(
+			"pnpm",
+			["dlx", "skills", "add", "yamcodes/arkenv", "--yes"],
+			plan.cwd,
+		);
 	});
 });

--- a/packages/cli/src/features/scaffold/executor.ts
+++ b/packages/cli/src/features/scaffold/executor.ts
@@ -90,7 +90,7 @@ export class Executor {
 					plan.install.packageManager,
 					plan.install.dependencies,
 				);
-				await this.workspace.execute(cmd, args);
+				await this.workspace.execute(cmd, args, plan.cwd);
 			}
 
 			// 3. TS Config
@@ -114,7 +114,7 @@ export class Executor {
 			// 4. Framework bootstrapping
 			if (plan.bootstrap) {
 				if (plan.bootstrap.framework === "vite") {
-					const viteConfigPath = await this.workspace.findViteConfig();
+					const viteConfigPath = await this.workspace.findViteConfig(plan.cwd);
 					if (viteConfigPath) {
 						this.reporter.step("Bootstrapping Vite plugin...");
 						const result = await this.workspace.bootstrapViteConfig(
@@ -141,7 +141,7 @@ export class Executor {
 						);
 					}
 				} else if (plan.bootstrap.framework === "bun-fullstack") {
-					const bunConfigPath = await this.workspace.findBunConfig();
+					const bunConfigPath = await this.workspace.findBunConfig(plan.cwd);
 					const result = await this.workspace.bootstrapBunConfig(
 						bunConfigPath,
 						plan.bootstrap.bunFeatures,
@@ -164,7 +164,7 @@ export class Executor {
 					if (plan.skill.isYes) {
 						args.push("--yes");
 					}
-					await this.workspace.execute(cmd, args);
+					await this.workspace.execute(cmd, args, plan.cwd);
 					skillInstalled = true;
 				} catch (err: unknown) {
 					const message = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -30,6 +30,8 @@ export type ProjectOptions = {
  * Represents the complete plan of actions to scaffold ArkEnv.
  */
 export type ScaffoldingPlan = {
+	/** The target project root directory */
+	cwd: string;
 	/** Files to be created or modified */
 	files: {
 		path: string;
@@ -76,6 +78,7 @@ export type ScaffoldingPlan = {
 		repository: string;
 		example: string;
 		targetName: string;
+		targetDir: string;
 	};
 };
 

--- a/packages/cli/src/features/scaffold/planner.test.ts
+++ b/packages/cli/src/features/scaffold/planner.test.ts
@@ -139,4 +139,29 @@ describe("Planner", () => {
 		expect(plan.metadata.displayPath).toBe("./src/env.ts");
 		expect(plan.metadata.importPath).toBe("./src/env");
 	});
+
+	it("extracts basename for targetName in new project mode", () => {
+		const state: CollectedState = {
+			mode: "new",
+			cwd: "/test/yo/my-project",
+			options: {
+				mode: "new",
+				example: "basic",
+				name: "yo/my-project",
+				framework: "vanilla",
+				path: "./src/env.ts",
+				validator: "arktype",
+				language: "ts",
+				installSkill: false,
+			},
+			detectedFramework: "vanilla",
+			packageManager: "pnpm",
+			tsConfig: { status: "not_found" },
+			shouldUpdateTsConfig: false,
+			existingFiles: [],
+			isYes: false,
+		};
+		const plan = createPlan(state);
+		expect(plan.clone?.targetName).toBe("my-project");
+	});
 });

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -24,6 +24,7 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 
 	const plan: ScaffoldingPlan = {
 		files: [],
+		cwd,
 		metadata: shake({
 			displayPath: "",
 			framework: options.framework,
@@ -41,6 +42,7 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 			repository: "https://github.com/yamcodes/arkenv.git",
 			example: options.example!,
 			targetName: options.name!,
+			targetDir: cwd,
 		};
 
 		plan.install = {

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -22,6 +22,8 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 		existingFiles,
 	} = state;
 
+	const projectName = options.name ? path.basename(options.name) : undefined;
+
 	const plan: ScaffoldingPlan = {
 		files: [],
 		cwd,
@@ -33,7 +35,7 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 			importPath: "",
 			mode,
 			example: options.example,
-			name: options.name,
+			name: projectName,
 		}) as ScaffoldingPlan["metadata"],
 	};
 
@@ -41,7 +43,7 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 		plan.clone = {
 			repository: "https://github.com/yamcodes/arkenv.git",
 			example: options.example!,
-			targetName: options.name!,
+			targetName: projectName!,
 			targetDir: cwd,
 		};
 

--- a/packages/cli/src/features/scaffold/utils.test.ts
+++ b/packages/cli/src/features/scaffold/utils.test.ts
@@ -5,6 +5,7 @@ import { getUsageInstructions } from "./utils";
 describe("scaffold utils", () => {
 	describe("getUsageInstructions", () => {
 		const basePlan: ScaffoldingPlan = {
+			cwd: ".",
 			files: [],
 			metadata: {
 				displayPath: "./src/env.ts",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,13 @@ async function main() {
 
 	setupGracefulShutdown(logger);
 
+	if (cli.validationError) {
+		logger.error(cli.validationError);
+		await helpUseCase.execute();
+		await logger.flush();
+		process.exit(1);
+	}
+
 	if (cli.helpRequested) {
 		await helpUseCase.execute();
 		await logger.flush();

--- a/packages/cli/src/shared/ports/workspace.port.ts
+++ b/packages/cli/src/shared/ports/workspace.port.ts
@@ -26,7 +26,7 @@ export type FileSystemPort = {
 	 * For this reason, `command` MUST be strictly the executable name (e.g., "pnpm", not "pnpm dlx")
 	 * and any subsequent arguments must be passed in the `args` array.
 	 */
-	execute(command: string, args?: string[]): Promise<void>;
+	execute(command: string, args?: string[], cwd?: string): Promise<void>;
 };
 
 /**
@@ -37,8 +37,8 @@ export type ConfigPort = {
 		status: "updated" | "already_strict" | "not_found" | "error";
 		file?: string;
 	}>;
-	findViteConfig(): Promise<string | null>;
-	findBunConfig(): Promise<string | null>;
+	findViteConfig(cwd?: string): Promise<string | null>;
+	findBunConfig(cwd?: string): Promise<string | null>;
 	bootstrapViteConfig(
 		path: string,
 		importPath: string,


### PR DESCRIPTION
Fixes #1035

This PR replaces the `--name` / `-n` flags with the optional positional `[project-name]` argument on the `init` command. It also refactors the scaffolding planning, cloner, executor, workspace port, and adapters to resolve and execute all commands in the resolved target directory.