### PR TITLE
feat: force new project flow if --example is passed

### DIFF
--- a/.changeset/example-forces-new-project-flow.md
+++ b/.changeset/example-forces-new-project-flow.md
@@ -1,0 +1,19 @@
+---
+"@arkenv/cli": minor
+---
+
+#### `--example` now forces the new-project wizard regardless of the current directory
+
+Previously, passing `--example` in a non-empty directory (or one that already has a
+`package.json`) would silently fall through to the existing-project flow, ignoring the
+flag entirely. The flag now always triggers the new-project wizard:
+
+```sh
+# Works even in a non-empty directory or one with package.json
+arkenv init --example basic
+```
+
+**Special case – `--name .`**: If you explicitly pass `.` as the project name (or type it
+at the prompt) and the current directory is **not empty**, the CLI aborts with a clear
+error instead of scaffolding into the dirty directory. When the directory **is** empty,
+`.` is normalized to the current directory's basename as before.

--- a/.changeset/example-forces-new-project-flow.md
+++ b/.changeset/example-forces-new-project-flow.md
@@ -1,5 +1,5 @@
 ---
-"@arkenv/cli": minor
+"@arkenv/cli": patch
 ---
 
 #### `--example` now forces the new-project wizard regardless of the current directory

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -46,13 +46,37 @@ The `@arkenv/cli` is the fastest way to get started with ArkEnv. It provides an 
 
 ### `init`
 
-The `init` command is the primary entry point for the CLI. It will:
+The `init` command is the primary entry point for the CLI. It supports two flows:
+
+### Existing project
+
+When run in a directory that already has a `package.json`, the CLI will:
 
 1. **Detect Environment**: Check your package manager and project framework (Vite, Bun, Node.js).
 2. **Scan for Keys**: Detect if a `.env.example` exists and extract its keys to pre-populate your schema.
 3. **Enforce Best Practices**: Detect if `tsconfig.json` has `strict` mode enabled, and prompt to enable it if not.
 4. **Select Validator**: Ask you which validation library you'd prefer to use.
 5. **Generate Code**: Scaffold an `env.ts` file with a working schema and automatically install the required dependencies.
+
+### New project (`--example`)
+
+Passing `--example` always forces the new-project wizard, even if the current directory is non-empty or already has a `package.json`. The wizard will:
+
+1. **Prompt for a project name** (or use `--name` to skip the prompt).
+2. **Clone the selected example** from the ArkEnv repository into a new `<name>/` subdirectory.
+3. **Install dependencies** using your current package manager.
+
+```bash
+# Scaffold the "basic" example into ./my-app/
+npx @arkenv/cli@latest init --example basic --name my-app
+
+# Use an interactive example picker, prompt for name
+npx @arkenv/cli@latest init --example basic
+```
+
+<Callout type="info">
+  **Using `--name .`** scaffolds into the current directory instead of a subdirectory. If the current directory is not empty, the CLI will abort with an error to prevent overwriting existing files.
+</Callout>
 
 ## Options
 
@@ -64,7 +88,7 @@ The CLI supports the following flags to customize the behavior:
 | `--quiet`   | `-q`  | Quiet mode. Suppresses output unless a command fails, in which case buffered logs are shown for debugging.     |
 | `--json`    | `-j`  | Emit a structured JSON summary to `stdout` upon completion (all other output is sent to `stderr`).             |
 | `--agent`   | `-a`  | For agents. Macro for `--quiet --json --yes`, also skip the agent install step.                                |
-| `--example` | `-e`  | Specify an example ID to scaffold from (when creating a new project).                                          |
-| `--name`    | `-n`  | Specify the project name (when creating a new project).                                                        |
+| `--example` | `-e`  | Scaffold from a named example (e.g. `basic`). Always triggers the new-project flow, even in non-empty or existing-package directories. |
+| `--name`    | `-n`  | Project name for new-project scaffolding. Defaults to the current directory name. Use `.` to scaffold into the current directory (aborts if non-empty). |
 | `--force`   | `-f`  | Force scaffolding a new project in non-empty directories, and bypass technical requirement checks.             |
 | `--help`    | `-h`  | Show the help message.                                                                                         |

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -82,12 +82,12 @@ npx @arkenv/cli@latest init --example basic
 
 The CLI supports the following flags to customize the behavior:
 
-| Flag        | Alias | Description                                                                                                    |
-| ----------- | ----- | -------------------------------------------------------------------------------------------------------------- |
-| `--yes`     | `-y`  | Skip all prompts and use defaults. Also passes the `--yes` flag to underlying processes (like skill installs). |
-| `--quiet`   | `-q`  | Quiet mode. Suppresses output unless a command fails, in which case buffered logs are shown for debugging.     |
-| `--json`    | `-j`  | Emit a structured JSON summary to `stdout` upon completion (all other output is sent to `stderr`).             |
-| `--agent`   | `-a`  | For agents. Macro for `--quiet --json --yes`, also skip the agent install step.                                |
+| Flag        | Alias | Description                                                                                                                            |
+| ----------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `--yes`     | `-y`  | Skip all prompts and use defaults. Also passes the `--yes` flag to underlying processes (like skill installs).                         |
+| `--quiet`   | `-q`  | Quiet mode. Suppresses output unless a command fails, in which case buffered logs are shown for debugging.                             |
+| `--json`    | `-j`  | Emit a structured JSON summary to `stdout` upon completion (all other output is sent to `stderr`).                                     |
+| `--agent`   | `-a`  | For agents. Macro for `--quiet --json --yes`, also skip the agent install step.                                                        |
 | `--example` | `-e`  | Scaffold from a named example (e.g. `basic`). Always triggers the new-project flow, even in non-empty or existing-package directories. |
-| `--force`   | `-f`  | Force scaffolding a new project in non-empty directories, and bypass technical requirement checks.             |
-| `--help`    | `-h`  | Show the help message.                                                                                         |
+| `--force`   | `-f`  | Force scaffolding a new project in non-empty directories, and bypass technical requirement checks.                                     |
+| `--help`    | `-h`  | Show the help message.                                                                                                                 |

--- a/packages/cli/src/adapters/node-workspace/node-workspace.ts
+++ b/packages/cli/src/adapters/node-workspace/node-workspace.ts
@@ -44,9 +44,14 @@ export class NodeWorkspace implements WorkspacePort {
 		await fsp.mkdir(dirPath, { recursive });
 	}
 
-	async execute(command: string, args: string[] = []): Promise<void> {
+	async execute(
+		command: string,
+		args: string[] = [],
+		cwd?: string,
+	): Promise<void> {
 		return new Promise<void>((resolve, reject) => {
 			const child = spawn(command, args, {
+				cwd,
 				stdio: (this.isQuiet ? "pipe" : this.stdio) as StdioOptions,
 				shell: false,
 			});

--- a/packages/cli/src/cli/commands/init.test.ts
+++ b/packages/cli/src/cli/commands/init.test.ts
@@ -129,6 +129,90 @@ describe("InitUseCase", () => {
 		expect(result.mode).toBe("new");
 	});
 
+	it("should force new project flow if --example is passed even in non-empty directory", async () => {
+		vi.mocked(scanner.hasPackageJson).mockResolvedValue(false);
+		vi.mocked(scanner.isEmptyDirectory).mockResolvedValue(false);
+		vi.mocked(prompt.runWizard).mockResolvedValue({
+			mode: "new",
+			example: "basic",
+			name: "my-project",
+			path: "./src/env.ts",
+			validator: "arktype",
+			framework: "vanilla",
+			language: "ts",
+		});
+
+		const result = await (useCase as any).collect({
+			isYes: false,
+			isForce: false,
+			isQuiet: false,
+			isAgent: false,
+			example: "basic",
+		});
+
+		expect(result).not.toBeNull();
+		expect(result.mode).toBe("new");
+		expect(prompt.runWizard).toHaveBeenCalledWith(
+			expect.objectContaining({ mode: "new", example: "basic" }),
+			false,
+		);
+	});
+
+	it("should force new project flow if --example is passed even when package.json exists", async () => {
+		vi.mocked(scanner.hasPackageJson).mockResolvedValue(true);
+		vi.mocked(scanner.isEmptyDirectory).mockResolvedValue(false);
+		vi.mocked(prompt.runWizard).mockResolvedValue({
+			mode: "new",
+			example: "basic",
+			name: "my-project",
+			path: "./src/env.ts",
+			validator: "arktype",
+			framework: "vanilla",
+			language: "ts",
+		});
+
+		const result = await (useCase as any).collect({
+			isYes: false,
+			isForce: false,
+			isQuiet: false,
+			isAgent: false,
+			example: "basic",
+		});
+
+		expect(result).not.toBeNull();
+		expect(result.mode).toBe("new");
+		// collectExistingProject should never have been called (no requirement checks)
+		expect(scanner.checkRequirements).not.toHaveBeenCalled();
+	});
+
+	it("should abort with non-empty error when --example --name . is used and directory is not empty", async () => {
+		vi.mocked(scanner.hasPackageJson).mockResolvedValue(false);
+		vi.mocked(scanner.isEmptyDirectory).mockResolvedValue(false);
+		vi.mocked(prompt.runWizard).mockResolvedValue({
+			mode: "new",
+			example: "basic",
+			name: ".",
+			path: "./src/env.ts",
+			validator: "arktype",
+			framework: "vanilla",
+			language: "ts",
+		});
+
+		const result = await (useCase as any).collect({
+			isYes: true,
+			isForce: false,
+			isQuiet: false,
+			isAgent: false,
+			example: "basic",
+			name: ".",
+		});
+
+		expect(result).toBeNull();
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.stringContaining("Cannot scaffold into"),
+		);
+	});
+
 	it("should exit early if requirements fail", async () => {
 		vi.mocked(scanner.checkRequirements).mockResolvedValue([
 			{

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -66,12 +66,18 @@ export class InitUseCase {
 			const hasPackageJson = await this.scanner.hasPackageJson();
 			const isEmpty = await this.scanner.isEmptyDirectory();
 
+			// --example always forces the new-project flow, even in non-empty or
+			// existing-project directories.
+			if (input.example !== undefined) {
+				return await this.collectNewProject(input, isEmpty);
+			}
+
 			if (hasPackageJson) {
 				return await this.collectExistingProject(input);
 			}
 
 			if (isEmpty || input.isForce) {
-				return await this.collectNewProject(input);
+				return await this.collectNewProject(input, isEmpty);
 			}
 
 			this.logger.error(
@@ -282,6 +288,7 @@ export class InitUseCase {
 	 */
 	private async collectNewProject(
 		input: InitInput,
+		isEmpty = true,
 	): Promise<CollectedState | null> {
 		const { isYes, isAgent, example, name } = input;
 
@@ -299,6 +306,23 @@ export class InitUseCase {
 
 		if (options === null) {
 			return null;
+		}
+
+		// When the resolved project name is "." (current dir) and the directory is
+		// not empty, abort to avoid clobbering the existing contents.
+		if (options.name === "." && !isEmpty) {
+			this.logger.error(
+				`Cannot scaffold into ${code(".")} because the current directory is not empty.`,
+			);
+			this.logger.info(
+				`Run ${code("arkenv init")} in an empty directory or choose a sub-directory name instead.`,
+			);
+			return null;
+		}
+
+		// Normalize "." to the current directory basename for package.json naming.
+		if (options.name === ".") {
+			options.name = path.basename(process.cwd());
 		}
 
 		const packageManager = this.detectPackageManager();

--- a/packages/cli/src/cli/ui/prompts.test.ts
+++ b/packages/cli/src/cli/ui/prompts.test.ts
@@ -174,4 +174,29 @@ describe("runPromptWizard", () => {
 			}),
 		);
 	});
+
+	it("should preserve '.' as the project name when the user explicitly types it", async () => {
+		const mockCwd = path.join(os.tmpdir(), "my-project");
+		vi.spyOn(process, "cwd").mockReturnValue(mockCwd);
+
+		const examples = [
+			{
+				id: "basic",
+				name: "Basic",
+				description: "A minimal ArkEnv setup in Node.js",
+				framework: "vanilla" as const,
+			},
+		];
+
+		vi.mocked(prompts.text).mockResolvedValueOnce("."); // User types "."
+		vi.mocked(prompts.select).mockResolvedValueOnce("basic");
+
+		const result = await runPromptWizard({
+			mode: "new",
+			examples,
+		});
+
+		// "." should be preserved; normalization is the caller's responsibility.
+		expect(result?.name).toBe(".");
+	});
 });

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -58,12 +58,10 @@ async function runNewProjectWizard(
 
 		const nameResult = handlePrompt(name);
 		if (nameResult === null) return null;
+		// Preserve "." so the caller (collectNewProject) can enforce the
+		// non-empty-directory guard before normalizing.
 		projectName = nameResult || defaultProjectName;
 	} else {
-		projectName = defaultProjectName;
-	}
-
-	if (projectName === ".") {
 		projectName = defaultProjectName;
 	}
 

--- a/packages/cli/src/features/scaffold/cloner.ts
+++ b/packages/cli/src/features/scaffold/cloner.ts
@@ -3,7 +3,9 @@ import path from "node:path";
 import type { Workspace } from "./plan";
 
 /**
- * Clones a example example into the current working directory and rewrites its package name.
+ * Clones a example example into the target directory and rewrites its package name.
+ * When `cloneInfo.targetDir` is set the files are placed there; otherwise they
+ * land in the current working directory (the `name: "."` case).
  */
 export async function cloneExample(
 	workspace: Workspace,
@@ -11,10 +13,17 @@ export async function cloneExample(
 		repository: string;
 		example: string;
 		targetName: string;
+		targetDir?: string;
 	},
 ): Promise<void> {
+	const destDir = cloneInfo.targetDir ?? process.cwd();
 	const tempDir = path.join(process.cwd(), ".arkenv-temp");
 	await workspace.mkdir(tempDir, true);
+
+	// Ensure destination directory exists (a no-op when targeting cwd).
+	if (cloneInfo.targetDir) {
+		await workspace.mkdir(destDir, true);
+	}
 
 	try {
 		// Clone sparsely
@@ -36,9 +45,9 @@ export async function cloneExample(
 			examplePath,
 		]);
 
-		// Move files to current directory
+		// Move files to destination directory
 		const fullExamplePath = path.join(tempDir, examplePath);
-		await copyDirectoryContents(fullExamplePath, process.cwd());
+		await copyDirectoryContents(fullExamplePath, destDir);
 
 		// Remove any copied lockfiles to ensure clean install with target package manager
 		const lockfiles = [
@@ -49,11 +58,11 @@ export async function cloneExample(
 			"bun.lock",
 		];
 		for (const lockfile of lockfiles) {
-			await fsp.rm(path.join(process.cwd(), lockfile), { force: true });
+			await fsp.rm(path.join(destDir, lockfile), { force: true });
 		}
 
 		// Update package.json name
-		const pkgPath = path.join(process.cwd(), "package.json");
+		const pkgPath = path.join(destDir, "package.json");
 		if (await workspace.exists(pkgPath)) {
 			const pkgContent = await workspace.readFile(pkgPath);
 			const pkg = JSON.parse(pkgContent);

--- a/packages/cli/src/features/scaffold/executor.test.ts
+++ b/packages/cli/src/features/scaffold/executor.test.ts
@@ -85,10 +85,11 @@ describe("Executor", () => {
 
 		expect(mockWorkspace.mkdir).toHaveBeenCalled();
 		expect(mockWorkspace.writeFile).toHaveBeenCalledWith("env.ts", "env");
-		expect(mockWorkspace.execute).toHaveBeenCalledWith("pnpm", [
-			"add",
-			"arkenv",
-		]);
+		expect(mockWorkspace.execute).toHaveBeenCalledWith(
+			"pnpm",
+			["add", "arkenv"],
+			undefined,
+		);
 		expect(mockReporter.finish).toHaveBeenCalled();
 	});
 
@@ -99,7 +100,11 @@ describe("Executor", () => {
 
 		const newProjectPlan: ScaffoldingPlan = {
 			...defaultPlan,
-			install: { packageManager: "bun", dependencies: [] },
+			install: {
+				packageManager: "bun",
+				dependencies: [],
+				cwd: "/some/parent/my-project",
+			},
 			metadata: {
 				...defaultPlan.metadata,
 				mode: "new",
@@ -158,7 +163,11 @@ describe("Executor", () => {
 		);
 
 		// Assert dependency installation
-		expect(mockWorkspace.execute).toHaveBeenCalledWith("bun", ["install"]);
+		expect(mockWorkspace.execute).toHaveBeenCalledWith(
+			"bun",
+			["install"],
+			"/some/parent/my-project",
+		);
 	});
 
 	it("executes a plan for a new project with name '.' (cloned into cwd)", async () => {
@@ -184,7 +193,9 @@ describe("Executor", () => {
 		// mkdir should NOT have been called with a new subdirectory path
 		// (only the temp dir mkdir matters here)
 		const mkdirCalls = vi.mocked(mockWorkspace.mkdir).mock.calls;
-		const subDirCall = mkdirCalls.find(([p]) => p === `${cwdBefore}/my-dir-name`);
+		const subDirCall = mkdirCalls.find(
+			([p]) => p === `${cwdBefore}/my-dir-name`,
+		);
 		expect(subDirCall).toBeUndefined();
 
 		// Copy goes into cwd, not a named subdir

--- a/packages/cli/src/features/scaffold/executor.test.ts
+++ b/packages/cli/src/features/scaffold/executor.test.ts
@@ -92,7 +92,7 @@ describe("Executor", () => {
 		expect(mockReporter.finish).toHaveBeenCalled();
 	});
 
-	it("executes a plan for a new project (cloned example)", async () => {
+	it("executes a plan for a new project (cloned example) into a named subdirectory", async () => {
 		vi.mocked(mockWorkspace.readFile).mockResolvedValue(
 			JSON.stringify({ name: "old-name" }),
 		);
@@ -109,6 +109,7 @@ describe("Executor", () => {
 				repository: "https://github.com/yamcodes/arkenv.git",
 				example: "basic",
 				targetName: "my-project",
+				targetDir: "/some/parent/my-project",
 			},
 		};
 		await executor.execute(newProjectPlan);
@@ -130,13 +131,19 @@ describe("Executor", () => {
 			"examples/basic",
 		]);
 
-		// Assert file copy and cleanup
+		// Assert the destination directory was created
+		expect(mockWorkspace.mkdir).toHaveBeenCalledWith(
+			"/some/parent/my-project",
+			true,
+		);
+
+		// Assert file copy lands in the named subdirectory, not cwd
 		expect(fsp.readdir).toHaveBeenCalledWith(
 			expect.stringContaining(".arkenv-temp/examples/basic"),
 		);
 		expect(fsp.cp).toHaveBeenCalledWith(
 			expect.stringContaining(".arkenv-temp/examples/basic/package.json"),
-			expect.stringContaining("package.json"),
+			expect.stringContaining("/some/parent/my-project/package.json"),
 			expect.any(Object),
 		);
 		expect(fsp.rm).toHaveBeenCalledWith(
@@ -144,14 +151,51 @@ describe("Executor", () => {
 			expect.any(Object),
 		);
 
-		// Assert package.json rewrite
+		// Assert package.json rewrite in the subdirectory
 		expect(mockWorkspace.writeFile).toHaveBeenCalledWith(
-			expect.stringContaining("package.json"),
+			"/some/parent/my-project/package.json",
 			expect.stringContaining('"name": "my-project"'),
 		);
 
 		// Assert dependency installation
 		expect(mockWorkspace.execute).toHaveBeenCalledWith("bun", ["install"]);
+	});
+
+	it("executes a plan for a new project with name '.' (cloned into cwd)", async () => {
+		vi.mocked(mockWorkspace.readFile).mockResolvedValue(
+			JSON.stringify({ name: "old-name" }),
+		);
+
+		const cwdBefore = process.cwd();
+
+		const dotPlan: ScaffoldingPlan = {
+			...defaultPlan,
+			install: { packageManager: "npm", dependencies: [] },
+			metadata: { ...defaultPlan.metadata, mode: "new", packageManager: "npm" },
+			clone: {
+				repository: "https://github.com/yamcodes/arkenv.git",
+				example: "basic",
+				targetName: "my-dir-name",
+				// No targetDir — "." case, scaffold into cwd
+			},
+		};
+		await executor.execute(dotPlan);
+
+		// mkdir should NOT have been called with a new subdirectory path
+		// (only the temp dir mkdir matters here)
+		const mkdirCalls = vi.mocked(mockWorkspace.mkdir).mock.calls;
+		const subDirCall = mkdirCalls.find(([p]) => p === `${cwdBefore}/my-dir-name`);
+		expect(subDirCall).toBeUndefined();
+
+		// Copy goes into cwd, not a named subdir
+		expect(fsp.cp).toHaveBeenCalledWith(
+			expect.stringContaining(".arkenv-temp/examples/basic/package.json"),
+			expect.stringContaining("package.json"),
+			expect.any(Object),
+		);
+		// The destination should NOT include a /my-dir-name/ path segment
+		const cpDest = vi.mocked(fsp.cp).mock.calls[0][1] as string;
+		expect(cpDest).not.toContain("/my-dir-name/");
 	});
 
 	it("updates tsconfig when planned", async () => {

--- a/packages/cli/src/features/scaffold/executor.ts
+++ b/packages/cli/src/features/scaffold/executor.ts
@@ -90,7 +90,7 @@ export class Executor {
 					plan.install.packageManager,
 					plan.install.dependencies,
 				);
-				await this.workspace.execute(cmd, args);
+				await this.workspace.execute(cmd, args, plan.install.cwd);
 			}
 
 			// 3. TS Config

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -76,6 +76,8 @@ export type ScaffoldingPlan = {
 		repository: string;
 		example: string;
 		targetName: string;
+		/** Absolute path to copy the example into. Defaults to process.cwd() when absent. */
+		targetDir?: string;
 	};
 };
 

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -46,6 +46,7 @@ export type ScaffoldingPlan = {
 	install?: {
 		packageManager: PackageManager;
 		dependencies: string[];
+		cwd?: string;
 	};
 	/** Optional skill installation */
 	skill?: {

--- a/packages/cli/src/features/scaffold/planner.test.ts
+++ b/packages/cli/src/features/scaffold/planner.test.ts
@@ -157,6 +157,7 @@ describe("Planner", () => {
 		expect(plan.clone).toBeDefined();
 		expect(plan.clone?.targetDir).toBe("/parent/my-app");
 		expect(plan.clone?.targetName).toBe("my-app");
+		expect(plan.install?.cwd).toBe("/parent/my-app");
 	});
 
 	it("omits targetDir when name is '.' so cloner falls back to cwd", () => {
@@ -176,5 +177,6 @@ describe("Planner", () => {
 		expect(plan.clone).toBeDefined();
 		expect(plan.clone?.targetDir).toBeUndefined();
 		expect(plan.clone?.targetName).toBe(".");
+		expect(plan.install?.cwd).toBeUndefined();
 	});
 });

--- a/packages/cli/src/features/scaffold/planner.test.ts
+++ b/packages/cli/src/features/scaffold/planner.test.ts
@@ -139,4 +139,42 @@ describe("Planner", () => {
 		expect(plan.metadata.displayPath).toBe("./src/env.ts");
 		expect(plan.metadata.importPath).toBe("./src/env");
 	});
+
+	it("sets targetDir to a named subdirectory when name is not '.'", () => {
+		const state: CollectedState = {
+			...defaultState,
+			mode: "new",
+			cwd: "/parent",
+			options: {
+				...defaultState.options,
+				mode: "new",
+				example: "basic",
+				name: "my-app",
+				path: "./src/env.ts",
+			},
+		};
+		const plan = createPlan(state);
+		expect(plan.clone).toBeDefined();
+		expect(plan.clone?.targetDir).toBe("/parent/my-app");
+		expect(plan.clone?.targetName).toBe("my-app");
+	});
+
+	it("omits targetDir when name is '.' so cloner falls back to cwd", () => {
+		const state: CollectedState = {
+			...defaultState,
+			mode: "new",
+			cwd: "/parent",
+			options: {
+				...defaultState.options,
+				mode: "new",
+				example: "basic",
+				name: ".",
+				path: "./src/env.ts",
+			},
+		};
+		const plan = createPlan(state);
+		expect(plan.clone).toBeDefined();
+		expect(plan.clone?.targetDir).toBeUndefined();
+		expect(plan.clone?.targetName).toBe(".");
+	});
 });

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -37,10 +37,16 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 	};
 
 	if (mode === "new") {
+		const targetDir =
+			options.name && options.name !== "."
+				? path.join(cwd, options.name)
+				: undefined;
+
 		plan.clone = {
 			repository: "https://github.com/yamcodes/arkenv.git",
 			example: options.example!,
 			targetName: options.name!,
+			...(targetDir !== undefined && { targetDir }),
 		};
 
 		plan.install = {

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -52,6 +52,7 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 		plan.install = {
 			packageManager,
 			dependencies: [], // Dependencies are already in the example's package.json
+			...(targetDir !== undefined && { cwd: targetDir }),
 		};
 
 		if (options.installSkill) {

--- a/packages/cli/src/shared/ports/workspace.port.ts
+++ b/packages/cli/src/shared/ports/workspace.port.ts
@@ -26,7 +26,7 @@ export type FileSystemPort = {
 	 * For this reason, `command` MUST be strictly the executable name (e.g., "pnpm", not "pnpm dlx")
 	 * and any subsequent arguments must be passed in the `args` array.
 	 */
-	execute(command: string, args?: string[]): Promise<void>;
+	execute(command: string, args?: string[], cwd?: string): Promise<void>;
 };
 
 /**


### PR DESCRIPTION
Fixes #1040

## Summary

When `--example` is passed, the CLI now always enters the new-project wizard, regardless of whether the directory is non-empty or already has a `package.json`. Previously the existing-project / non-empty-directory guards ran first, silently ignoring the flag.

## Changes

- **`InitUseCase.collect()`** (): Added an early guard — if `input.example !== undefined`, skip straight to `collectNewProject()` before the existing-project / empty-directory checks.
- **`InitUseCase.collectNewProject()`**: Accepts an `isEmpty` flag. After the wizard returns, aborts with a clear error if `options.name === "."` and the directory was not empty; normalizes `"."` to the directory basename only when the directory is empty.
- **`runNewProjectWizard()`** (`packages/cli/src/cli/ui/prompts/wizard.ts`): Removed the premature `"."` → `path.basename(cwd)` conversion so the raw value is preserved through to `collectNewProject()` where the guard lives.
- **Tests**: 3 new `InitUseCase` tests and 1 new `runPromptWizard` test covering all described scenarios.