### PR TITLE
feat: Support POSIX-style short-flag bundling in CLI parser

### DIFF
--- a/.changeset/posix-flag-bundling.md
+++ b/.changeset/posix-flag-bundling.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/cli": minor
+---
+
+#### Support POSIX-style short-flag bundling in CLI parser
+
+Enables combining multiple short flags (e.g. `-yq` instead of `-y -q` or `-yfq` instead of `-y -f -q`) in CLI commands. Flag values starting with `-` (e.g. `init -e -abc`) are preserved without expansion.

--- a/.changeset/posix-flag-bundling.md
+++ b/.changeset/posix-flag-bundling.md
@@ -1,5 +1,5 @@
 ---
-"@arkenv/cli": minor
+"@arkenv/cli": patch
 ---
 
 #### Support POSIX-style short-flag bundling in CLI parser

--- a/packages/cli/src/cli/cli.test.ts
+++ b/packages/cli/src/cli/cli.test.ts
@@ -129,6 +129,15 @@ describe("CLI parser", () => {
 			expect(cli.validationError).toBeUndefined();
 		});
 
+		it("should not expand dash-prefixed values after bundled value-taking flags", () => {
+			const cli = new CLI(["node", "arkenv", "init", "-yqe", "-abc"]);
+			expect(cli.args).toEqual(["init", "-y", "-q", "-e", "-abc"]);
+			expect(cli.isYes).toBe(true);
+			expect(cli.isQuiet).toBe(true);
+			expect(cli.isAgent).toBe(false);
+			expect(cli.validationError).toBe("Unknown argument: -abc");
+		});
+
 		it("should ignore single-letter flags with dash or long flags", () => {
 			const cli1 = new CLI(["node", "arkenv", "init", "-y"]);
 			expect(cli1.isYes).toBe(true);

--- a/packages/cli/src/cli/cli.test.ts
+++ b/packages/cli/src/cli/cli.test.ts
@@ -71,4 +71,72 @@ describe("CLI parser", () => {
 		const cli = new CLI(["node", "arkenv", "init", "--foo"]);
 		expect(cli.validationError).toBe("Unknown argument: --foo");
 	});
+
+	describe("POSIX-style short-flag bundling", () => {
+		it("should expand a simple bundle of short flags", () => {
+			const cli = new CLI(["node", "arkenv", "init", "-yq"]);
+			expect(cli.isYes).toBe(true);
+			expect(cli.isQuiet).toBe(true);
+			expect(cli.validationError).toBeUndefined();
+		});
+
+		it("should expand a bundle of multiple short flags including force", () => {
+			const cli = new CLI(["node", "arkenv", "init", "-yfq"]);
+			expect(cli.isYes).toBe(true);
+			expect(cli.isForce).toBe(true);
+			expect(cli.isQuiet).toBe(true);
+			expect(cli.validationError).toBeUndefined();
+		});
+
+		it("should preserve positional arguments alongside expanded bundles", () => {
+			const cli = new CLI(["node", "arkenv", "init", "-yq", "my-project"]);
+			expect(cli.isYes).toBe(true);
+			expect(cli.isQuiet).toBe(true);
+			expect(cli.name).toBe("my-project");
+			expect(cli.validationError).toBeUndefined();
+		});
+
+		it("should not expand flag values immediately following value-taking flags (e.g. -e / --example)", () => {
+			const cli1 = new CLI(["node", "arkenv", "init", "-e", "-yq"]);
+			expect(cli1.args).toEqual(["init", "-e", "-yq"]);
+			expect(cli1.isYes).toBe(false);
+			expect(cli1.isQuiet).toBe(false);
+			expect(cli1.validationError).toBe("Unknown argument: -yq");
+
+			const cli2 = new CLI(["node", "arkenv", "init", "--example", "-abc"]);
+			expect(cli2.args).toEqual(["init", "--example", "-abc"]);
+			expect(cli2.isAgent).toBe(false);
+			expect(cli2.validationError).toBe("Unknown argument: -abc");
+		});
+
+		it("should not expand flag values immediately following name flags (e.g. -n / --name)", () => {
+			const cli1 = new CLI(["node", "arkenv", "init", "-n", "-yq"]);
+			expect(cli1.isYes).toBe(false);
+			expect(cli1.isQuiet).toBe(false);
+			// -n itself is not a known flag, so we expect a validation error on -n, but no expansion of -yq.
+			expect(cli1.validationError).toBe("Unknown argument: -n");
+
+			const cli2 = new CLI(["node", "arkenv", "init", "--name", "-abc"]);
+			expect(cli2.isAgent).toBe(false);
+			expect(cli2.validationError).toBe("Unknown argument: --name");
+		});
+
+		it("should expand a bundle ending in a value-taking flag and parse its value correctly", () => {
+			const cli = new CLI(["node", "arkenv", "init", "-yqe", "my-example"]);
+			expect(cli.isYes).toBe(true);
+			expect(cli.isQuiet).toBe(true);
+			expect(cli.example).toBe("my-example");
+			expect(cli.validationError).toBeUndefined();
+		});
+
+		it("should ignore single-letter flags with dash or long flags", () => {
+			const cli1 = new CLI(["node", "arkenv", "init", "-y"]);
+			expect(cli1.isYes).toBe(true);
+			expect(cli1.args).toEqual(["init", "-y"]);
+
+			const cli2 = new CLI(["node", "arkenv", "init", "--yes"]);
+			expect(cli2.isYes).toBe(true);
+			expect(cli2.args).toEqual(["init", "--yes"]);
+		});
+	});
 });

--- a/packages/cli/src/cli/cli.test.ts
+++ b/packages/cli/src/cli/cli.test.ts
@@ -59,17 +59,37 @@ describe("CLI parser", () => {
 		expect(cli.validationError).toBe("Unknown argument: project2");
 	});
 
-	it("should reject --name / -n flags as unknown arguments", () => {
-		const cli1 = new CLI(["node", "arkenv", "init", "--name", "foo"]);
-		expect(cli1.validationError).toBe("Unknown argument: --name");
-
-		const cli2 = new CLI(["node", "arkenv", "init", "-n", "foo"]);
-		expect(cli2.validationError).toBe("Unknown argument: -n");
-	});
-
 	it("should reject any other unknown flags", () => {
 		const cli = new CLI(["node", "arkenv", "init", "--foo"]);
 		expect(cli.validationError).toBe("Unknown argument: --foo");
+	});
+
+	describe("Agent presets override", () => {
+		it("should set isYes, isQuiet, and isJson to true when --agent is passed", () => {
+			const cli = new CLI(["node", "arkenv", "init", "--agent"]);
+			expect(cli.isAgent).toBe(true);
+			expect(cli.isYes).toBe(true);
+			expect(cli.isQuiet).toBe(true);
+			expect(cli.isJson).toBe(true);
+			expect(cli.isForce).toBe(false);
+		});
+
+		it("should set isYes, isQuiet, and isJson to true when -a is passed", () => {
+			const cli = new CLI(["node", "arkenv", "init", "-a"]);
+			expect(cli.isAgent).toBe(true);
+			expect(cli.isYes).toBe(true);
+			expect(cli.isQuiet).toBe(true);
+			expect(cli.isJson).toBe(true);
+			expect(cli.isForce).toBe(false);
+		});
+
+		it("should evaluate isYes, isQuiet, and isJson normally when --agent is not passed", () => {
+			const cli = new CLI(["node", "arkenv", "init", "--json"]);
+			expect(cli.isAgent).toBe(false);
+			expect(cli.isYes).toBe(false);
+			expect(cli.isQuiet).toBe(false);
+			expect(cli.isJson).toBe(true);
+		});
 	});
 
 	describe("POSIX-style short-flag bundling", () => {
@@ -107,18 +127,6 @@ describe("CLI parser", () => {
 			expect(cli2.args).toEqual(["init", "--example", "-abc"]);
 			expect(cli2.isAgent).toBe(false);
 			expect(cli2.validationError).toBe("Unknown argument: -abc");
-		});
-
-		it("should not expand flag values immediately following name flags (e.g. -n / --name)", () => {
-			const cli1 = new CLI(["node", "arkenv", "init", "-n", "-yq"]);
-			expect(cli1.isYes).toBe(false);
-			expect(cli1.isQuiet).toBe(false);
-			// -n itself is not a known flag, so we expect a validation error on -n, but no expansion of -yq.
-			expect(cli1.validationError).toBe("Unknown argument: -n");
-
-			const cli2 = new CLI(["node", "arkenv", "init", "--name", "-abc"]);
-			expect(cli2.isAgent).toBe(false);
-			expect(cli2.validationError).toBe("Unknown argument: --name");
 		});
 
 		it("should expand a bundle ending in a value-taking flag and parse its value correctly", () => {

--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -57,7 +57,7 @@ export class CLI {
 				for (const char of chars) {
 					expandedArgs.push(`-${char}`);
 				}
-				if (expansionValuedFlags.has(`-${chars[chars.length - 1]}`)) {
+				if (valuedFlags.has(`-${chars[chars.length - 1]}`)) {
 					skipNext = true;
 				}
 			} else {

--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -45,6 +45,9 @@ export class CLI {
 				for (const char of chars) {
 					expandedArgs.push(`-${char}`);
 				}
+				if (expansionValuedFlags.has(`-${chars[chars.length - 1]}`)) {
+					skipNext = true;
+				}
 			} else {
 				expandedArgs.push(arg);
 			}

--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -1,19 +1,32 @@
 import { Logger } from "@/adapters";
 import type { InitInput } from "./commands/init";
 
+const FLAG_CONFIG = {
+	isYes: { long: "--yes", short: "-y", kind: "boolean" },
+	isForce: { long: "--force", short: "-f", kind: "boolean" },
+	isQuiet: { long: "--quiet", short: "-q", kind: "boolean" },
+	isJson: { long: "--json", short: "-j", kind: "boolean" },
+	isAgent: { long: "--agent", short: "-a", kind: "boolean" },
+	helpRequested: { long: "--help", short: "-h", kind: "boolean" },
+	example: { long: "--example", short: "-e", kind: "value" },
+} as const;
+
+const knownFlags = new Set<string>(
+	Object.values(FLAG_CONFIG).flatMap((f) => [f.long, f.short]),
+);
+
+const valuedFlags = new Set<string>(
+	Object.values(FLAG_CONFIG)
+		.filter((f) => f.kind === "value")
+		.flatMap((f) => [f.long, f.short]),
+);
+
 /**
  * Main CLI class that parses arguments and sets up the global execution context.
  */
 export class CLI {
 	public args: string[];
 	public command: string;
-	public isYes: boolean;
-	public isForce: boolean;
-	public isQuiet: boolean;
-	public isJson: boolean;
-	public isAgent: boolean;
-	public helpRequested: boolean;
-	public example: string | undefined;
 	public name: string | undefined;
 	public validationError: string | undefined;
 	public logger: Logger;
@@ -24,7 +37,6 @@ export class CLI {
 	constructor(argv: string[], options: { logger?: Logger } = {}) {
 		const rawArgs = argv.slice(2);
 		const expandedArgs: string[] = [];
-		const expansionValuedFlags = new Set(["--example", "-e", "--name", "-n"]);
 		let skipNext = false;
 
 		for (const arg of rawArgs) {
@@ -34,7 +46,7 @@ export class CLI {
 				continue;
 			}
 
-			if (expansionValuedFlags.has(arg)) {
+			if (valuedFlags.has(arg)) {
 				expandedArgs.push(arg);
 				skipNext = true;
 				continue;
@@ -55,34 +67,6 @@ export class CLI {
 
 		this.args = expandedArgs;
 		this.command = this.args[0];
-		this.isYes = this.args.includes("--yes") || this.args.includes("-y");
-		this.isForce = this.args.includes("--force") || this.args.includes("-f");
-		this.isQuiet = this.args.includes("--quiet") || this.args.includes("-q");
-		this.isJson = this.args.includes("--json") || this.args.includes("-j");
-		this.isAgent = this.args.includes("--agent") || this.args.includes("-a");
-		this.helpRequested =
-			this.args.includes("--help") || this.args.includes("-h");
-
-		this.example = this.getFlagValue("--example", "-e");
-
-		const knownFlags = new Set([
-			"--yes",
-			"-y",
-			"--force",
-			"-f",
-			"--quiet",
-			"-q",
-			"--json",
-			"-j",
-			"--agent",
-			"-a",
-			"--help",
-			"-h",
-			"--example",
-			"-e",
-		]);
-
-		const valuedFlags = new Set(["--example", "-e"]);
 
 		let i = 1;
 		const positionalArgs: string[] = [];
@@ -118,12 +102,6 @@ export class CLI {
 			}
 		}
 
-		if (this.isAgent) {
-			this.isYes = true;
-			this.isQuiet = true;
-			this.isJson = true;
-		}
-
 		this.logger =
 			options.logger ||
 			new Logger({
@@ -131,6 +109,40 @@ export class CLI {
 				isJson: this.isJson,
 				isYes: this.isYes,
 			});
+	}
+
+	get isAgent(): boolean {
+		return this.hasFlag("isAgent");
+	}
+
+	get isYes(): boolean {
+		return this.isAgent || this.hasFlag("isYes");
+	}
+
+	get isQuiet(): boolean {
+		return this.isAgent || this.hasFlag("isQuiet");
+	}
+
+	get isJson(): boolean {
+		return this.isAgent || this.hasFlag("isJson");
+	}
+
+	get isForce(): boolean {
+		return this.hasFlag("isForce");
+	}
+
+	get helpRequested(): boolean {
+		return this.hasFlag("helpRequested");
+	}
+
+	get example(): string | undefined {
+		const flag = FLAG_CONFIG.example;
+		return this.getFlagValue(flag.long, flag.short);
+	}
+
+	private hasFlag(prop: keyof typeof FLAG_CONFIG): boolean {
+		const flag = FLAG_CONFIG[prop];
+		return this.args.includes(flag.long) || this.args.includes(flag.short);
 	}
 
 	/**

--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -22,7 +22,35 @@ export class CLI {
 	 * Creates a CLI context from process arguments and optional adapters.
 	 */
 	constructor(argv: string[], options: { logger?: Logger } = {}) {
-		this.args = argv.slice(2);
+		const rawArgs = argv.slice(2);
+		const expandedArgs: string[] = [];
+		const expansionValuedFlags = new Set(["--example", "-e", "--name", "-n"]);
+		let skipNext = false;
+
+		for (const arg of rawArgs) {
+			if (skipNext) {
+				expandedArgs.push(arg);
+				skipNext = false;
+				continue;
+			}
+
+			if (expansionValuedFlags.has(arg)) {
+				expandedArgs.push(arg);
+				skipNext = true;
+				continue;
+			}
+
+			if (/^-[a-zA-Z]{2,}$/.test(arg)) {
+				const chars = arg.slice(1).split("");
+				for (const char of chars) {
+					expandedArgs.push(`-${char}`);
+				}
+			} else {
+				expandedArgs.push(arg);
+			}
+		}
+
+		this.args = expandedArgs;
 		this.command = this.args[0];
 		this.isYes = this.args.includes("--yes") || this.args.includes("-y");
 		this.isForce = this.args.includes("--force") || this.args.includes("-f");


### PR DESCRIPTION
Fixes #1032

Enables POSIX-style combined short-flags (e.g., `-yfq` -> `-y`, `-f`, `-q`) in CLI commands, and preserves values starting with `-` immediately following value-taking flags (like `-e`/`--example` and `-n`/`--name`).