### PR TITLE
fix: You can pass --example with no value after

### DIFF
--- a/.changeset/validate-valued-flags.md
+++ b/.changeset/validate-valued-flags.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Validate valued CLI flags and reject missing values
+
+Add parser-level validation to reject flags that require a value (e.g. `--example` or `-e`) when they are passed without one. A validation error message is set, and the CLI exits with status code 1.

--- a/packages/cli/src/cli/cli.test.ts
+++ b/packages/cli/src/cli/cli.test.ts
@@ -121,12 +121,12 @@ describe("CLI parser", () => {
 			expect(cli1.args).toEqual(["init", "-e", "-yq"]);
 			expect(cli1.isYes).toBe(false);
 			expect(cli1.isQuiet).toBe(false);
-			expect(cli1.validationError).toBe("Unknown argument: -yq");
+			expect(cli1.validationError).toBe("Missing value for option: -e");
 
 			const cli2 = new CLI(["node", "arkenv", "init", "--example", "-abc"]);
 			expect(cli2.args).toEqual(["init", "--example", "-abc"]);
 			expect(cli2.isAgent).toBe(false);
-			expect(cli2.validationError).toBe("Unknown argument: -abc");
+			expect(cli2.validationError).toBe("Missing value for option: --example");
 		});
 
 		it("should expand a bundle ending in a value-taking flag and parse its value correctly", () => {
@@ -143,7 +143,7 @@ describe("CLI parser", () => {
 			expect(cli.isYes).toBe(true);
 			expect(cli.isQuiet).toBe(true);
 			expect(cli.isAgent).toBe(false);
-			expect(cli.validationError).toBe("Unknown argument: -abc");
+			expect(cli.validationError).toBe("Missing value for option: -e");
 		});
 
 		it("should ignore single-letter flags with dash or long flags", () => {
@@ -154,6 +154,20 @@ describe("CLI parser", () => {
 			const cli2 = new CLI(["node", "arkenv", "init", "--yes"]);
 			expect(cli2.isYes).toBe(true);
 			expect(cli2.args).toEqual(["init", "--yes"]);
+		});
+
+		it("should reject valued flags passed without a value", () => {
+			const cli1 = new CLI(["node", "arkenv", "init", "--example"]);
+			expect(cli1.validationError).toBe("Missing value for option: --example");
+
+			const cli2 = new CLI(["node", "arkenv", "init", "-e"]);
+			expect(cli2.validationError).toBe("Missing value for option: -e");
+
+			const cli3 = new CLI(["node", "arkenv", "init", "--example", "--yes"]);
+			expect(cli3.validationError).toBe("Missing value for option: --example");
+
+			const cli4 = new CLI(["node", "arkenv", "init", "-yqe"]);
+			expect(cli4.validationError).toBe("Missing value for option: -e");
 		});
 	});
 });

--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -83,7 +83,8 @@ export class CLI {
 					if (i + 1 < this.args.length && !this.args[i + 1].startsWith("-")) {
 						i += 2;
 					} else {
-						i += 1;
+						this.validationError = `Missing value for option: ${arg}`;
+						break;
 					}
 				} else {
 					i += 1;


### PR DESCRIPTION
Fixes #1050

Reject valued flags (like `--example` or `-e`) when they are passed without any value (either at the end of the argument list or followed immediately by another flag).