### PR TITLE
fix(www): add dynamic and fallback OG image generation

### DIFF
--- a/apps/www/app/api/og/route.test.tsx
+++ b/apps/www/app/api/og/route.test.tsx
@@ -1,0 +1,54 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+
+const mockGenerateOGImage = vi.fn();
+
+vi.mock("fumadocs-ui/og", () => ({
+	generateOGImage: (options: any) => mockGenerateOGImage(options),
+}));
+
+describe("api/og route", () => {
+	beforeEach(() => {
+		mockGenerateOGImage.mockReset();
+		mockGenerateOGImage.mockReturnValue(
+			new Response("mocked image", {
+				status: 200,
+				headers: { "content-type": "image/png" },
+			}),
+		);
+	});
+
+	it("should parse query parameters and generate OG image", async () => {
+		const req = new NextRequest(
+			"https://arkenv.js.org/api/og?title=Custom%20Title&description=Custom%20Description",
+		);
+		const response = await GET(req);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toBe("image/png");
+
+		expect(mockGenerateOGImage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "Custom Title",
+				description: "Custom Description",
+				site: "ArkEnv Docs",
+				primaryTextColor: "rgb(59, 130, 246)",
+			}),
+		);
+	});
+
+	it("should use default parameters when query parameters are missing", async () => {
+		const req = new NextRequest("https://arkenv.js.org/api/og");
+		const response = await GET(req);
+
+		expect(response.status).toBe(200);
+		expect(mockGenerateOGImage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "ArkEnv",
+				description: "Environment variable validation from editor to runtime",
+				site: "ArkEnv Docs",
+			}),
+		);
+	});
+});

--- a/apps/www/app/api/og/route.tsx
+++ b/apps/www/app/api/og/route.tsx
@@ -1,0 +1,53 @@
+import { generateOGImage } from "fumadocs-ui/og";
+import type { NextRequest } from "next/server";
+
+export const runtime = "edge";
+
+export function GET(request: NextRequest) {
+	const { searchParams } = new URL(request.url);
+	const title = searchParams.get("title") || "ArkEnv";
+	const description =
+		searchParams.get("description") ||
+		"Environment variable validation from editor to runtime";
+
+	return generateOGImage({
+		title,
+		description,
+		site: "ArkEnv Docs",
+		primaryColor: "rgba(59, 130, 246, 0.3)",
+		primaryTextColor: "rgb(59, 130, 246)",
+		icon: (
+			<svg
+				width="64"
+				height="64"
+				viewBox="0 0 12 12"
+				xmlns="http://www.w3.org/2000/svg"
+				aria-hidden="true"
+			>
+				<path
+					stroke="#3b82f6"
+					style={{
+						fill: "none",
+						strokeWidth: 0.99975,
+						strokeLinecap: "round",
+						strokeLinejoin: "round",
+						strokeMiterlimit: 10,
+						strokeDasharray: "none",
+						strokeOpacity: 1,
+					}}
+					d="M8.5 6c0-1.379-1.121-2.5-2.5-2.5A2.502 2.502 0 0 0 3.5 6c0 1.379 1.121 2.5 2.5 2.5S8.5 7.379 8.5 6ZM6 11V8.5M1 6h2.5m5 0H11M6 3.5V1M2.464 2.464l1.768 1.768m3.536 3.536 1.768 1.768m-7.072 0 1.768-1.768m3.536-3.536 1.768-1.768"
+				/>
+				<path
+					fill="#3b82f6"
+					style={{
+						fillOpacity: 1,
+						fillRule: "nonzero",
+						stroke: "none",
+						strokeWidth: 1,
+					}}
+					d="M6 5.102a.899.899 0 1 0 0 1.797.899.899 0 0 0 0-1.797Z"
+				/>
+			</svg>
+		),
+	});
+}

--- a/apps/www/app/docs/[[...slug]]/page.tsx
+++ b/apps/www/app/docs/[[...slug]]/page.tsx
@@ -66,8 +66,32 @@ export async function generateMetadata(props: {
 	const page = source.getPage(params.slug);
 	if (!page) notFound();
 
+	const ogUrl = new URL("https://arkenv.js.org/api/og");
+	ogUrl.searchParams.set("title", page.data.title);
+	if (page.data.description) {
+		ogUrl.searchParams.set("description", page.data.description);
+	}
+
 	return {
 		title: `${page.data.title} · ArkEnv`,
 		description: page.data.description,
+		openGraph: {
+			title: `${page.data.title} · ArkEnv`,
+			description: page.data.description,
+			images: [
+				{
+					url: ogUrl.toString(),
+					width: 1200,
+					height: 630,
+					alt: page.data.title,
+				},
+			],
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: `${page.data.title} · ArkEnv`,
+			description: page.data.description,
+			images: [ogUrl.toString()],
+		},
 	};
 }

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -17,6 +17,7 @@ const mono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
+	metadataBase: new URL("https://arkenv.js.org"),
 	icons: {
 		icon: [
 			{
@@ -24,6 +25,14 @@ export const metadata: Metadata = {
 				type: "image/svg+xml",
 			},
 		],
+	},
+	openGraph: {
+		siteName: "ArkEnv",
+		locale: "en_US",
+		type: "website",
+	},
+	twitter: {
+		card: "summary_large_image",
 	},
 };
 

--- a/apps/www/app/opengraph-image.test.tsx
+++ b/apps/www/app/opengraph-image.test.tsx
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Image, { alt, contentType, size } from "./opengraph-image";
+
+const mockGenerateOGImage = vi.fn();
+
+vi.mock("fumadocs-ui/og", () => ({
+	generateOGImage: (options: any) => mockGenerateOGImage(options),
+}));
+
+describe("homepage opengraph-image", () => {
+	beforeEach(() => {
+		mockGenerateOGImage.mockReset();
+		mockGenerateOGImage.mockReturnValue(
+			new Response("mocked image", {
+				status: 200,
+				headers: { "content-type": "image/png" },
+			}),
+		);
+	});
+
+	it("should export correct metadata", () => {
+		expect(alt).toBe("ArkEnv");
+		expect(contentType).toBe("image/png");
+		expect(size).toEqual({ width: 1200, height: 630 });
+	});
+
+	it("should generate OG image for homepage", async () => {
+		const response = await Image();
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toBe("image/png");
+
+		expect(mockGenerateOGImage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "ArkEnv",
+				description: "Environment variable validation from editor to runtime",
+				site: "arkenv.js.org",
+				primaryTextColor: "rgb(59, 130, 246)",
+			}),
+		);
+	});
+});

--- a/apps/www/app/opengraph-image.tsx
+++ b/apps/www/app/opengraph-image.tsx
@@ -1,0 +1,53 @@
+import { generateOGImage } from "fumadocs-ui/og";
+
+export const runtime = "edge";
+
+export const alt = "ArkEnv";
+export const size = {
+	width: 1200,
+	height: 630,
+};
+export const contentType = "image/png";
+
+export default function Image() {
+	return generateOGImage({
+		title: "ArkEnv",
+		description: "Environment variable validation from editor to runtime",
+		site: "arkenv.js.org",
+		primaryColor: "rgba(59, 130, 246, 0.3)",
+		primaryTextColor: "rgb(59, 130, 246)",
+		icon: (
+			<svg
+				width="64"
+				height="64"
+				viewBox="0 0 12 12"
+				xmlns="http://www.w3.org/2000/svg"
+				aria-hidden="true"
+			>
+				<path
+					stroke="#3b82f6"
+					style={{
+						fill: "none",
+						strokeWidth: 0.99975,
+						strokeLinecap: "round",
+						strokeLinejoin: "round",
+						strokeMiterlimit: 10,
+						strokeDasharray: "none",
+						strokeOpacity: 1,
+					}}
+					d="M8.5 6c0-1.379-1.121-2.5-2.5-2.5A2.502 2.502 0 0 0 3.5 6c0 1.379 1.121 2.5 2.5 2.5S8.5 7.379 8.5 6ZM6 11V8.5M1 6h2.5m5 0H11M6 3.5V1M2.464 2.464l1.768 1.768m3.536 3.536 1.768 1.768m-7.072 0 1.768-1.768m3.536-3.536 1.768-1.768"
+				/>
+				<path
+					fill="#3b82f6"
+					style={{
+						fillOpacity: 1,
+						fillRule: "nonzero",
+						stroke: "none",
+						strokeWidth: 1,
+					}}
+					d="M6 5.102a.899.899 0 1 0 0 1.797.899.899 0 0 0 0-1.797Z"
+				/>
+			</svg>
+		),
+	});
+}


### PR DESCRIPTION
This PR adds dynamic Open Graph (OG) image generation for the website's docs pages and a fallback/default OG image for the home page. It uses the `fumadocs-ui/og` package with the styled ArkEnv logo.