### PR TITLE
fix: Cannot scaffold into a non-empty directory despite using --force

### DIFF
--- a/.changeset/allow-force-scaffold-dot.md
+++ b/.changeset/allow-force-scaffold-dot.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Allow scaffolding into non-empty directory when `--force` is used
+
+Ensure `--force` permits new-project scaffolding into a non-empty directory (e.g. `.`) while preventing silent overwrites of user files via a preflight collision check.

--- a/packages/cli/src/cli/commands/init.test.ts
+++ b/packages/cli/src/cli/commands/init.test.ts
@@ -109,6 +109,9 @@ describe("InitUseCase", () => {
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.stringContaining("Directory is not empty and no"),
 		);
+		expect(logger.info).toHaveBeenCalledWith(
+			expect.stringContaining("--force"),
+		);
 	});
 
 	it("should bypass empty check and enter new project flow if no package.json, not empty directory, and isForce is true", async () => {
@@ -216,6 +219,33 @@ describe("InitUseCase", () => {
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.stringContaining("Cannot scaffold into"),
 		);
+	});
+
+	it("should allow scaffolding when --example, project-name '.', and --force are used in a non-empty directory", async () => {
+		vi.mocked(scanner.hasPackageJson).mockResolvedValue(false);
+		vi.mocked(scanner.isEmptyDirectory).mockResolvedValue(false);
+		vi.mocked(prompt.runWizard).mockResolvedValue({
+			mode: "new",
+			example: "basic",
+			name: ".",
+			path: "./src/env.ts",
+			validator: "arktype",
+			framework: "vanilla",
+			language: "ts",
+		});
+
+		const result = await (useCase as any).collect({
+			isYes: true,
+			isForce: true,
+			isQuiet: false,
+			isAgent: false,
+			example: "basic",
+			name: ".",
+		});
+
+		expect(result).not.toBeNull();
+		expect(result.mode).toBe("new");
+		expect(logger.error).not.toHaveBeenCalled();
 	});
 
 	it("should exit early if requirements fail", async () => {

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -313,7 +313,7 @@ export class InitUseCase {
 		input: InitInput,
 		isEmpty = true,
 	): Promise<CollectedState | null> {
-		const { isYes, example, name } = input;
+		const { isYes, example, name, isForce } = input;
 
 		const registry = await this.registry.fetchRegistry();
 
@@ -333,7 +333,7 @@ export class InitUseCase {
 
 		// When the resolved project name is "." (current dir) and the directory is
 		// not empty, abort to avoid clobbering the existing contents.
-		if (options.name === "." && !isEmpty) {
+		if (options.name === "." && !isEmpty && !isForce) {
 			this.logger.error(
 				`Cannot scaffold into ${code(".")} because the current directory is not empty.`,
 			);

--- a/packages/cli/src/features/scaffold/cloner.ts
+++ b/packages/cli/src/features/scaffold/cloner.ts
@@ -47,6 +47,22 @@ export async function cloneExample(
 
 		// Move files to destination directory
 		const fullExamplePath = path.join(tempDir, examplePath);
+
+		// Preflight check: check if any files/directories from the example collide with existing ones in the destination
+		const entries = await fsp.readdir(fullExamplePath);
+		const collisions: string[] = [];
+		for (const entry of entries) {
+			const destPath = path.join(destDir, entry);
+			if (await workspace.exists(destPath)) {
+				collisions.push(entry);
+			}
+		}
+		if (collisions.length > 0) {
+			throw new Error(
+				`Scaffolding into a non-empty directory failed. The following paths already exist: ${collisions.join(", ")}`,
+			);
+		}
+
 		await copyDirectoryContents(fullExamplePath, destDir);
 
 		// Remove any copied lockfiles to ensure clean install with target package manager

--- a/packages/cli/src/features/scaffold/executor.test.ts
+++ b/packages/cli/src/features/scaffold/executor.test.ts
@@ -3,17 +3,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Executor } from "./executor";
 import type { Reporter, ScaffoldingPlan, Workspace } from "./plan";
 
+const mockExistingFiles = new Set<string>();
+
 vi.mock("node:fs/promises", () => ({
 	default: {
 		readdir: vi.fn().mockResolvedValue(["package.json"]),
-		cp: vi.fn().mockResolvedValue(undefined),
+		cp: vi.fn().mockImplementation(async (src, dest) => {
+			mockExistingFiles.add(dest);
+		}),
 		rm: vi.fn().mockResolvedValue(undefined),
 	},
 }));
 
 describe("Executor", () => {
 	const mockWorkspace: Workspace = {
-		exists: vi.fn().mockResolvedValue(true),
+		exists: vi.fn().mockImplementation(async (p) => mockExistingFiles.has(p)),
 		readFile: vi.fn().mockResolvedValue(""),
 		writeFile: vi.fn(),
 		mkdir: vi.fn(),
@@ -57,6 +61,7 @@ describe("Executor", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		delete process.env.SKIP_INSTALL;
+		mockExistingFiles.clear();
 		executor = new Executor(mockWorkspace, mockReporter);
 	});
 
@@ -268,5 +273,37 @@ describe("Executor", () => {
 			["dlx", "skills", "add", "yamcodes/arkenv", "--yes"],
 			plan.cwd,
 		);
+	});
+
+	it("fails scaffolding when example files collide with existing files in destination", async () => {
+		const newProjectPlan: ScaffoldingPlan = {
+			...defaultPlan,
+			install: {
+				packageManager: "bun",
+				dependencies: [],
+				cwd: "/some/parent/my-project",
+			},
+			metadata: {
+				...defaultPlan.metadata,
+				mode: "new",
+				packageManager: "bun",
+			},
+			clone: {
+				repository: "https://github.com/yamcodes/arkenv.git",
+				example: "basic",
+				targetName: "my-project",
+				targetDir: "/some/parent/my-project",
+			},
+		};
+
+		// Seed a file collision
+		mockExistingFiles.add("/some/parent/my-project/package.json");
+
+		await expect(executor.execute(newProjectPlan)).rejects.toThrow(
+			"Scaffolding into a non-empty directory failed. The following paths already exist: package.json",
+		);
+
+		// Verify fsp.cp was NOT called
+		expect(fsp.cp).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Fixes #1053

Allows scaffolding a new project into a non-empty directory (such as '.') when the '--force' flag is specified. Implements a preflight copy check to ensure that no existing user files or directories are silently overwritten.