### PR TITLE
fix: ArkEnv skill should be detected by the CLI

### DIFF
--- a/.changeset/detect-existing-skill.md
+++ b/.changeset/detect-existing-skill.md
@@ -1,5 +1,5 @@
 ---
-"@arkenv/cli": minor
+"@arkenv/cli": patch
 ---
 
 #### Automatically detect installed arkenv AI skill

--- a/.changeset/detect-existing-skill.md
+++ b/.changeset/detect-existing-skill.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/cli": minor
+---
+
+#### Automatically detect installed arkenv AI skill
+
+During initialization, check if the `arkenv` agent skill is already present in the workspace. If detected, the installation prompt and setup are bypassed, defaulting to `false`, and an informational message confirming the detection is logged.

--- a/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.test.ts
+++ b/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.test.ts
@@ -295,4 +295,60 @@ API_KEY=
 			expect(result).toBe("./env.ts");
 		});
 	});
+
+	describe("hasSkill", () => {
+		it("returns true if skills-lock.json contains arkenv skill", async () => {
+			await fsp.writeFile(
+				path.join(tempDir, "skills-lock.json"),
+				JSON.stringify({
+					skills: {
+						arkenv: {
+							version: "1.0.0",
+						},
+					},
+				}),
+			);
+			const result = await scanner.hasSkill(tempDir);
+			expect(result).toBe(true);
+		});
+
+		it("returns false if skills-lock.json does not contain arkenv skill", async () => {
+			await fsp.writeFile(
+				path.join(tempDir, "skills-lock.json"),
+				JSON.stringify({
+					skills: {
+						other: {},
+					},
+				}),
+			);
+			const result = await scanner.hasSkill(tempDir);
+			expect(result).toBe(false);
+		});
+
+		it("returns true if skills/arkenv/SKILL.md exists", async () => {
+			await fsp.mkdir(path.join(tempDir, "skills", "arkenv"), { recursive: true });
+			await fsp.writeFile(path.join(tempDir, "skills", "arkenv", "SKILL.md"), "hello");
+			const result = await scanner.hasSkill(tempDir);
+			expect(result).toBe(true);
+		});
+
+		it("returns true if .agent/skills/arkenv/SKILL.md exists", async () => {
+			await fsp.mkdir(path.join(tempDir, ".agent", "skills", "arkenv"), { recursive: true });
+			await fsp.writeFile(path.join(tempDir, ".agent", "skills", "arkenv", "SKILL.md"), "hello");
+			const result = await scanner.hasSkill(tempDir);
+			expect(result).toBe(true);
+		});
+
+		it("returns true if .agents/skills/arkenv/SKILL.md exists", async () => {
+			await fsp.mkdir(path.join(tempDir, ".agents", "skills", "arkenv"), { recursive: true });
+			await fsp.writeFile(path.join(tempDir, ".agents", "skills", "arkenv", "SKILL.md"), "hello");
+			const result = await scanner.hasSkill(tempDir);
+			expect(result).toBe(true);
+		});
+
+		it("returns false if no skill indicators exist", async () => {
+			const result = await scanner.hasSkill(tempDir);
+			expect(result).toBe(false);
+		});
+	});
 });

--- a/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.test.ts
+++ b/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.test.ts
@@ -326,22 +326,37 @@ API_KEY=
 		});
 
 		it("returns true if skills/arkenv/SKILL.md exists", async () => {
-			await fsp.mkdir(path.join(tempDir, "skills", "arkenv"), { recursive: true });
-			await fsp.writeFile(path.join(tempDir, "skills", "arkenv", "SKILL.md"), "hello");
+			await fsp.mkdir(path.join(tempDir, "skills", "arkenv"), {
+				recursive: true,
+			});
+			await fsp.writeFile(
+				path.join(tempDir, "skills", "arkenv", "SKILL.md"),
+				"hello",
+			);
 			const result = await scanner.hasSkill(tempDir);
 			expect(result).toBe(true);
 		});
 
 		it("returns true if .agent/skills/arkenv/SKILL.md exists", async () => {
-			await fsp.mkdir(path.join(tempDir, ".agent", "skills", "arkenv"), { recursive: true });
-			await fsp.writeFile(path.join(tempDir, ".agent", "skills", "arkenv", "SKILL.md"), "hello");
+			await fsp.mkdir(path.join(tempDir, ".agent", "skills", "arkenv"), {
+				recursive: true,
+			});
+			await fsp.writeFile(
+				path.join(tempDir, ".agent", "skills", "arkenv", "SKILL.md"),
+				"hello",
+			);
 			const result = await scanner.hasSkill(tempDir);
 			expect(result).toBe(true);
 		});
 
 		it("returns true if .agents/skills/arkenv/SKILL.md exists", async () => {
-			await fsp.mkdir(path.join(tempDir, ".agents", "skills", "arkenv"), { recursive: true });
-			await fsp.writeFile(path.join(tempDir, ".agents", "skills", "arkenv", "SKILL.md"), "hello");
+			await fsp.mkdir(path.join(tempDir, ".agents", "skills", "arkenv"), {
+				recursive: true,
+			});
+			await fsp.writeFile(
+				path.join(tempDir, ".agents", "skills", "arkenv", "SKILL.md"),
+				"hello",
+			);
 			const result = await scanner.hasSkill(tempDir);
 			expect(result).toBe(true);
 		});

--- a/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.ts
+++ b/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.ts
@@ -130,4 +130,38 @@ export class NodeProjectScannerAdapter implements ProjectScannerPort {
 	): Promise<"pnpm" | "yarn" | "npm" | "bun"> {
 		return detectPackageManager(cwd, tsConfig);
 	}
+
+	/**
+	 * Detects whether the arkenv skill is already installed.
+	 */
+	async hasSkill(cwd = process.cwd()): Promise<boolean> {
+		try {
+			const skillsLockPath = path.join(cwd, "skills-lock.json");
+			const content = await fsp.readFile(skillsLockPath, "utf-8");
+			const parsed = JSON.parse(content);
+			if (parsed && typeof parsed === "object" && parsed.skills && typeof parsed.skills === "object") {
+				if ("arkenv" in parsed.skills) {
+					return true;
+				}
+			}
+		} catch {
+			// ignore missing or malformed skills-lock.json
+		}
+
+		const skillPaths = [
+			"skills/arkenv/SKILL.md",
+			".agent/skills/arkenv/SKILL.md",
+			".agents/skills/arkenv/SKILL.md",
+		];
+		for (const relativePath of skillPaths) {
+			try {
+				await fsp.access(path.join(cwd, relativePath));
+				return true;
+			} catch {
+				// ignore path not accessible
+			}
+		}
+
+		return false;
+	}
 }

--- a/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.ts
+++ b/packages/cli/src/adapters/node-project-scanner/node-project-scanner.adapter.ts
@@ -139,7 +139,12 @@ export class NodeProjectScannerAdapter implements ProjectScannerPort {
 			const skillsLockPath = path.join(cwd, "skills-lock.json");
 			const content = await fsp.readFile(skillsLockPath, "utf-8");
 			const parsed = JSON.parse(content);
-			if (parsed && typeof parsed === "object" && parsed.skills && typeof parsed.skills === "object") {
+			if (
+				parsed &&
+				typeof parsed === "object" &&
+				parsed.skills &&
+				typeof parsed.skills === "object"
+			) {
 				if ("arkenv" in parsed.skills) {
 					return true;
 				}

--- a/packages/cli/src/cli/commands/init.test.ts
+++ b/packages/cli/src/cli/commands/init.test.ts
@@ -59,6 +59,7 @@ describe("InitUseCase", () => {
 			suggestDefaultEnvPath: vi.fn().mockResolvedValue("./env.ts"),
 			getEnvExampleKeys: vi.fn().mockResolvedValue(null),
 			detectPackageManager: vi.fn().mockResolvedValue("pnpm"),
+			hasSkill: vi.fn().mockResolvedValue(false),
 		} as unknown as ProjectScannerPort;
 
 		useCase = new InitUseCase(logger, workspace, prompt, scanner);
@@ -406,5 +407,51 @@ describe("InitUseCase", () => {
 			}),
 			false,
 		);
+	});
+
+	it("should detect installed arkenv skill, log a message, and skip prompt setting installSkill to false", async () => {
+		vi.mocked(scanner.hasSkill).mockResolvedValue(true);
+		vi.mocked(prompt.runWizard).mockResolvedValue({
+			path: "./env.ts",
+			validator: "arktype",
+			framework: "vanilla",
+			language: "ts",
+		});
+
+		const result = await (useCase as any).collect({
+			isYes: false,
+			isForce: false,
+			isQuiet: false,
+			isAgent: false,
+		});
+
+		expect(result).not.toBeNull();
+		expect(result.options.installSkill).toBe(false);
+		expect(result.options.skillDetected).toBe(true);
+		expect(logger.info).toHaveBeenCalledWith(
+			expect.stringContaining("ArkEnv agent skill detected."),
+		);
+		expect(prompt.confirm).not.toHaveBeenCalled();
+	});
+
+	it("should detect installed arkenv skill and skip prompt setting installSkill to false even with isYes = true", async () => {
+		vi.mocked(scanner.hasSkill).mockResolvedValue(true);
+		vi.mocked(prompt.runWizard).mockResolvedValue({
+			path: "./env.ts",
+			validator: "arktype",
+			framework: "vanilla",
+			language: "ts",
+		});
+
+		const result = await (useCase as any).collect({
+			isYes: true,
+			isForce: false,
+			isQuiet: false,
+			isAgent: false,
+		});
+
+		expect(result).not.toBeNull();
+		expect(result.options.installSkill).toBe(false);
+		expect(result.options.skillDetected).toBe(true);
 	});
 });

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -126,7 +126,7 @@ export class InitUseCase {
 		input: InitInput,
 		targetDir: string,
 	): Promise<CollectedState | null> {
-		const { isYes, isForce, isAgent } = input;
+		const { isYes, isForce, isQuiet, isAgent } = input;
 
 		const requirements = await this.scanner.checkRequirements(targetDir);
 		const failures = requirements.filter((r) => r.status === "fail");
@@ -250,8 +250,18 @@ export class InitUseCase {
 			return null;
 		}
 
+		const hasSkill = await this.scanner.hasSkill(targetDir);
+		if (hasSkill) {
+			options.skillDetected = true;
+			if (!isQuiet && !isAgent) {
+				this.logger.info("ArkEnv agent skill detected.");
+			}
+		}
+
 		// Handle installSkill logic
-		if (isAgent) {
+		if (hasSkill) {
+			options.installSkill = false;
+		} else if (isAgent) {
 			options.installSkill = false;
 		} else if (isYes) {
 			options.installSkill = true;

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -24,6 +24,7 @@ export type ProjectOptions = {
 	installTypeDefinitions?: boolean;
 	envKeys?: string[];
 	installSkill?: boolean;
+	skillDetected?: boolean;
 };
 
 /**
@@ -73,6 +74,7 @@ export type ScaffoldingPlan = {
 		mode: "existing" | "new";
 		example?: string;
 		name?: string;
+		skillDetected?: boolean;
 	};
 	/** Git clone information for new project flow */
 	clone?: {

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -39,6 +39,7 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 			mode,
 			example: options.example,
 			name: projectName,
+			skillDetected: options.skillDetected,
 		}) as ScaffoldingPlan["metadata"],
 	};
 

--- a/packages/cli/src/features/scaffold/utils.ts
+++ b/packages/cli/src/features/scaffold/utils.ts
@@ -42,7 +42,7 @@ export function getNextStepsNote(
 	plan: ScaffoldingPlan,
 	skillInstalled: boolean,
 ): { message: string; title: string } {
-	if (skillInstalled) {
+	if (skillInstalled || plan.metadata.skillDetected) {
 		return {
 			message: dedent`
 					Inside your AI assistant (e.g. Claude Code), use:

--- a/packages/cli/src/shared/ports/project-scanner.port.ts
+++ b/packages/cli/src/shared/ports/project-scanner.port.ts
@@ -88,4 +88,8 @@ export type ProjectScannerPort = {
 		cwd?: string,
 		tsConfig?: ParsedTsConfig | null,
 	): Promise<"pnpm" | "yarn" | "npm" | "bun">;
+	/**
+	 * Detects whether the arkenv skill is already installed.
+	 */
+	hasSkill(cwd?: string): Promise<boolean>;
 };

--- a/skills/create-changeset/SKILL.md
+++ b/skills/create-changeset/SKILL.md
@@ -34,9 +34,9 @@ A changeset is a markdown file in the `.changeset/` directory that describes:
 
 | Type    | When to Use                                | v0 Version Change (Current) | v1+ Version Change |
 | ------- | ------------------------------------------ | --------------------------- | ------------------ |
-| `patch` | Bug fixes, refactoring, dependency updates | 0.0.1 → 0.0.2               | 1.0.0 → 1.0.1      |
-| `minor` | New features, **Breaking changes** (in v0) | 0.0.1 → 0.1.0               | 1.0.0 → 1.1.0      |
-| `major` | **Avoid in v0** (unless going to v1.0.0)   | 0.0.1 → 1.0.0               | 1.0.0 → 2.0.0      |
+| `patch` | Any non-breaking change (fixes, features)  | 0.0.1 → 0.0.2               | 1.0.0 → 1.0.1      |
+| `minor` | **Breaking changes**                       | 0.0.1 → 0.1.0               | 1.0.0 → 1.1.0      |
+| `major` | Switch to v1 (only when instructed)        | 0.0.1 → 1.0.0               | 1.0.0 → 2.0.0      |
 
 ## Decision guide (v0 rules)
 
@@ -44,26 +44,21 @@ Most packages in this repo are currently in **v0** (0.x.y). For these packages:
 
 ### Use `patch` for:
 
-- Bug fixes that don't change behavior
+- **Any non-breaking change** (including new features, new CLI commands, new configuration options, enhanced functionality, non-breaking API additions, etc.)
+- Bug fixes
 - Dependency updates (non-breaking)
 - Performance improvements
 - Code style/linting fixes
 
 **Note**: Purely internal refactorings (e.g., library switches, internal type cleanup) that offer no tangible benefit or change to the consumer should NOT be documented in a changeset. Do not clutter the changelog with changes that are meaningless to the end user.
 
-### Use `minor` for:
+### Use `minor` ONLY for:
 
 - **Breaking changes** (Required in v0 for any breaking modification. You MUST prefix the description with `**BREAKING CHANGE**:`).
-- New features
-- New CLI commands
-- New configuration options
-- Enhanced functionality
-- New entity types support
-- Non-breaking API additions
 
 ### Use `major` ONLY for:
 
-- Explicitly transitioning the project from v0.x.y to v1.0.0. **Do not use major for breaking changes in v0.**
+- Explicitly transitioning the project from v0.x.y to v1.0.0. **Only use major when explicitly instructed to switch/transition to v1.** Do not use major for breaking changes in v0.
 
 ## Creating a changeset
 

--- a/skills/create-changeset/SKILL.md
+++ b/skills/create-changeset/SKILL.md
@@ -32,11 +32,11 @@ A changeset is a markdown file in the `.changeset/` directory that describes:
 
 ## Changeset types
 
-| Type    | When to Use                                | v0 Version Change (Current) | v1+ Version Change |
-| ------- | ------------------------------------------ | --------------------------- | ------------------ |
-| `patch` | Any non-breaking change (fixes, features)  | 0.0.1 → 0.0.2               | 1.0.0 → 1.0.1      |
-| `minor` | **Breaking changes**                       | 0.0.1 → 0.1.0               | 1.0.0 → 1.1.0      |
-| `major` | Switch to v1 (only when instructed)        | 0.0.1 → 1.0.0               | 1.0.0 → 2.0.0      |
+| Type    | When to Use                               | v0 Version Change (Current) | v1+ Version Change |
+| ------- | ----------------------------------------- | --------------------------- | ------------------ |
+| `patch` | Any non-breaking change (fixes, features) | 0.0.1 → 0.0.2               | 1.0.0 → 1.0.1      |
+| `minor` | **Breaking changes**                      | 0.0.1 → 0.1.0               | 1.0.0 → 1.1.0      |
+| `major` | Switch to v1 (only when instructed)       | 0.0.1 → 1.0.0               | 1.0.0 → 2.0.0      |
 
 ## Decision guide (v0 rules)
 


### PR DESCRIPTION
Fixes #1089

Automatically detects if the arkenv AI skill is already installed (checks skills-lock.json and SKILL.md paths) and skips the installer prompts/installation steps during arkenv init.