### PR TITLE
feat: Support llms.txt in www

### DIFF
--- a/apps/www/app/docs/[package]/llms.txt/route.test.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/lib/source", () => ({
+	source: {
+		getPages: () => [],
+		getPageTree: () => ({
+			type: "root",
+			children: [
+				{
+					type: "folder",
+					$ref: "arkenv/meta.json",
+					children: [
+						{
+							type: "page",
+							url: "/docs/arkenv",
+							name: "ArkEnv",
+						},
+					],
+				},
+			],
+		}),
+	},
+}));
+
+vi.mock("fumadocs-core/source", () => ({
+	llms: () => ({
+		indexNode: (node: any) => `Mocked Folder Index Content: ${node.$ref || node.name}`,
+	}),
+}));
+
+import { GET } from "./route";
+
+describe("/docs/[package]/llms.txt route", () => {
+	it("should return the package-specific llms.txt content for arkenv", async () => {
+		const req = new Request("https://arkenv.js.org/docs/arkenv/llms.txt");
+		const params = Promise.resolve({ package: "arkenv" });
+		const response = await GET(req, { params });
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+
+		const body = await response.text();
+		expect(body).toBeTypeOf("string");
+		expect(body).toContain("arkenv");
+	});
+
+	it("should return 404 for a nonexistent package", async () => {
+		const req = new Request("https://arkenv.js.org/docs/nonexistent/llms.txt");
+		const params = Promise.resolve({ package: "nonexistent" });
+
+		await expect(GET(req, { params })).rejects.toThrow();
+	});
+});

--- a/apps/www/app/docs/[package]/llms.txt/route.test.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.test.ts
@@ -24,7 +24,8 @@ vi.mock("~/lib/source", () => ({
 
 vi.mock("fumadocs-core/source", () => ({
 	llms: () => ({
-		indexNode: (node: any) => `Mocked Folder Index Content: ${node.$ref || node.name}`,
+		indexNode: (node: any) =>
+			`Mocked Folder Index Content: ${node.$ref || node.name}`,
 	}),
 }));
 
@@ -37,7 +38,9 @@ describe("/docs/[package]/llms.txt route", () => {
 		const response = await GET(req, { params });
 
 		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+		expect(response.headers.get("Content-Type")).toBe(
+			"text/plain; charset=utf-8",
+		);
 
 		const body = await response.text();
 		expect(body).toBeTypeOf("string");

--- a/apps/www/app/docs/[package]/llms.txt/route.test.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.test.ts
@@ -29,7 +29,8 @@ vi.mock("fumadocs-core/source", () => ({
 	}),
 }));
 
-import { GET } from "./route";
+import { source } from "~/lib/source";
+import { GET, generateStaticParams } from "./route";
 
 describe("/docs/[package]/llms.txt route", () => {
 	it("should return the package-specific llms.txt content for arkenv", async () => {
@@ -52,5 +53,43 @@ describe("/docs/[package]/llms.txt route", () => {
 		const params = Promise.resolve({ package: "nonexistent" });
 
 		await expect(GET(req, { params })).rejects.toThrow();
+	});
+
+	it("should return static params for all expected packages", () => {
+		const spy = vi.spyOn(source, "getPages").mockReturnValue([
+			{
+				slugs: ["arkenv", "intro"],
+				url: "/docs/arkenv",
+				data: { title: "ArkEnv" },
+			},
+			{ slugs: ["cli", "intro"], url: "/docs/cli", data: { title: "CLI" } },
+			{
+				slugs: ["bun-plugin", "intro"],
+				url: "/docs/bun-plugin",
+				data: { title: "Bun Plugin" },
+			},
+			{
+				slugs: ["nextjs", "intro"],
+				url: "/docs/nextjs",
+				data: { title: "NextJS" },
+			},
+			{
+				slugs: ["vite-plugin", "intro"],
+				url: "/docs/vite-plugin",
+				data: { title: "Vite Plugin" },
+			},
+		] as any);
+
+		const params = generateStaticParams();
+
+		expect(params).toEqual([
+			{ package: "arkenv" },
+			{ package: "cli" },
+			{ package: "bun-plugin" },
+			{ package: "nextjs" },
+			{ package: "vite-plugin" },
+		]);
+
+		spy.mockRestore();
 	});
 });

--- a/apps/www/app/docs/[package]/llms.txt/route.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.ts
@@ -1,5 +1,5 @@
-import { notFound } from "next/navigation";
 import { llms } from "fumadocs-core/source";
+import { notFound } from "next/navigation";
 import { source } from "~/lib/source";
 
 export const revalidate = false;
@@ -7,7 +7,7 @@ export const revalidate = false;
 /**
  * Node definition for page tree traversal.
  */
-interface Node {
+type Node = {
 	type: "page" | "folder" | "separator";
 	$ref?: string;
 	url?: string;
@@ -15,7 +15,7 @@ interface Node {
 		url: string;
 	};
 	children?: Node[];
-}
+};
 
 /**
  * Traverses the page tree nodes to find the folder corresponding to the package slug.
@@ -32,7 +32,11 @@ function findFolder(nodes: Node[], packageSlug: string): Node | undefined {
 				return node;
 			}
 			// 2. Or, does its $ref contain the slug?
-			if (node.$ref && (node.$ref.includes(`${packageSlug}/meta.json`) || node.$ref.includes(`${packageSlug}/`))) {
+			if (
+				node.$ref &&
+				(node.$ref.includes(`${packageSlug}/meta.json`) ||
+					node.$ref.includes(`${packageSlug}/`))
+			) {
 				return node;
 			}
 			// 3. Or, do any of its child pages have a URL that starts with `/docs/${packageSlug}`?
@@ -40,7 +44,8 @@ function findFolder(nodes: Node[], packageSlug: string): Node | undefined {
 				(child) =>
 					child.type === "page" &&
 					child.url &&
-					(child.url === `/docs/${packageSlug}` || child.url.startsWith(`/docs/${packageSlug}/`))
+					(child.url === `/docs/${packageSlug}` ||
+						child.url.startsWith(`/docs/${packageSlug}/`)),
 			);
 			if (hasMatchingPage) {
 				return node;
@@ -62,12 +67,15 @@ function findFolder(nodes: Node[], packageSlug: string): Node | undefined {
  */
 export async function GET(
 	_req: Request,
-	{ params }: { params: Promise<{ package: string }> }
+	{ params }: { params: Promise<{ package: string }> },
 ) {
 	const { package: packageSlug } = await params;
-	
+
 	const tree = source.getPageTree();
-	const folderNode = findFolder(tree.children as unknown as Node[], packageSlug);
+	const folderNode = findFolder(
+		tree.children as unknown as Node[],
+		packageSlug,
+	);
 
 	if (!folderNode) {
 		notFound();

--- a/apps/www/app/docs/[package]/llms.txt/route.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.ts
@@ -1,0 +1,79 @@
+import { notFound } from "next/navigation";
+import { llms } from "fumadocs-core/source";
+import { source } from "~/lib/source";
+
+export const revalidate = false;
+
+interface Node {
+	type: "page" | "folder" | "separator";
+	$ref?: string;
+	url?: string;
+	index?: {
+		url: string;
+	};
+	children?: Node[];
+}
+
+function findFolder(nodes: Node[], packageSlug: string): Node | undefined {
+	for (const node of nodes) {
+		if (node.type === "folder") {
+			// 1. If it has an index, does its index.url match `/docs/${packageSlug}`?
+			if (node.index && node.index.url === `/docs/${packageSlug}`) {
+				return node;
+			}
+			// 2. Or, does its $ref contain the slug?
+			if (node.$ref && (node.$ref.includes(`${packageSlug}/meta.json`) || node.$ref.includes(`${packageSlug}/`))) {
+				return node;
+			}
+			// 3. Or, do any of its child pages have a URL that starts with `/docs/${packageSlug}`?
+			const hasMatchingPage = node.children?.some(
+				(child) =>
+					child.type === "page" &&
+					child.url &&
+					(child.url === `/docs/${packageSlug}` || child.url.startsWith(`/docs/${packageSlug}/`))
+			);
+			if (hasMatchingPage) {
+				return node;
+			}
+
+			// Recursively search children
+			if (node.children) {
+				const found = findFolder(node.children, packageSlug);
+				if (found) return found;
+			}
+		}
+	}
+	return undefined;
+}
+
+export async function GET(
+	_req: Request,
+	{ params }: { params: Promise<{ package: string }> }
+) {
+	const { package: packageSlug } = await params;
+	
+	const tree = source.getPageTree();
+	const folderNode = findFolder(tree.children as unknown as Node[], packageSlug);
+
+	if (!folderNode) {
+		notFound();
+	}
+
+	const indexContent = llms(source).indexNode(folderNode as any);
+
+	return new Response(indexContent, {
+		headers: {
+			"Content-Type": "text/plain; charset=utf-8",
+		},
+	});
+}
+
+export function generateStaticParams() {
+	return [
+		{ package: "arkenv" },
+		{ package: "cli" },
+		{ package: "bun-plugin" },
+		{ package: "nextjs" },
+		{ package: "vite-plugin" },
+	];
+}

--- a/apps/www/app/docs/[package]/llms.txt/route.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.ts
@@ -18,11 +18,11 @@ type Node = {
 };
 
 /**
- * Traverses the page tree nodes to find the folder corresponding to the package slug.
+ * Traverse the page tree nodes to find the folder corresponding to the package slug.
  *
- * @param nodes - The page tree nodes to search.
- * @param packageSlug - The package folder/slug name.
- * @returns The matching Folder node, or undefined if not found.
+ * @param nodes The page tree nodes to search
+ * @param packageSlug The package folder/slug name
+ * @returns The matching Folder node, or undefined if not found
  */
 function findFolder(nodes: Node[], packageSlug: string): Node | undefined {
 	for (const node of nodes) {
@@ -62,8 +62,11 @@ function findFolder(nodes: Node[], packageSlug: string): Node | undefined {
 }
 
 /**
- * GET route handler for package-specific llms.txt endpoints.
- * Serves plain-text indexes for a specific package subdirectory.
+ * Handle GET requests for package-specific llms.txt endpoints.
+ *
+ * @param _req The incoming HTTP request
+ * @param context The route parameters context
+ * @returns A Response containing the plain-text index of the package documentation
  */
 export async function GET(
 	_req: Request,
@@ -91,7 +94,9 @@ export async function GET(
 }
 
 /**
- * Dynamically generates static parameters for all packages present in the page collection slugs.
+ * Generate static parameters for all packages present in the page collection slugs.
+ *
+ * @returns The array of package slug parameters
  */
 export function generateStaticParams() {
 	const packages = new Set<string>();

--- a/apps/www/app/docs/[package]/llms.txt/route.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.ts
@@ -34,8 +34,8 @@ function findFolder(nodes: Node[], packageSlug: string): Node | undefined {
 			// 2. Or, does its $ref contain the slug?
 			if (
 				node.$ref &&
-				(node.$ref.includes(`${packageSlug}/meta.json`) ||
-					node.$ref.includes(`${packageSlug}/`))
+				(node.$ref === `${packageSlug}/meta.json` ||
+					node.$ref.startsWith(`${packageSlug}/`))
 			) {
 				return node;
 			}

--- a/apps/www/app/docs/[package]/llms.txt/route.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.ts
@@ -4,6 +4,9 @@ import { source } from "~/lib/source";
 
 export const revalidate = false;
 
+/**
+ * Node definition for page tree traversal.
+ */
 interface Node {
 	type: "page" | "folder" | "separator";
 	$ref?: string;
@@ -14,6 +17,13 @@ interface Node {
 	children?: Node[];
 }
 
+/**
+ * Traverses the page tree nodes to find the folder corresponding to the package slug.
+ *
+ * @param nodes - The page tree nodes to search.
+ * @param packageSlug - The package folder/slug name.
+ * @returns The matching Folder node, or undefined if not found.
+ */
 function findFolder(nodes: Node[], packageSlug: string): Node | undefined {
 	for (const node of nodes) {
 		if (node.type === "folder") {
@@ -46,6 +56,10 @@ function findFolder(nodes: Node[], packageSlug: string): Node | undefined {
 	return undefined;
 }
 
+/**
+ * GET route handler for package-specific llms.txt endpoints.
+ * Serves plain-text indexes for a specific package subdirectory.
+ */
 export async function GET(
 	_req: Request,
 	{ params }: { params: Promise<{ package: string }> }
@@ -68,12 +82,15 @@ export async function GET(
 	});
 }
 
+/**
+ * Dynamically generates static parameters for all packages present in the page collection slugs.
+ */
 export function generateStaticParams() {
-	return [
-		{ package: "arkenv" },
-		{ package: "cli" },
-		{ package: "bun-plugin" },
-		{ package: "nextjs" },
-		{ package: "vite-plugin" },
-	];
+	const packages = new Set<string>();
+	for (const page of source.getPages()) {
+		if (page.slugs[0]) {
+			packages.add(page.slugs[0]);
+		}
+	}
+	return Array.from(packages).map((pkg) => ({ package: pkg }));
 }

--- a/apps/www/app/llms.txt/route.test.ts
+++ b/apps/www/app/llms.txt/route.test.ts
@@ -30,7 +30,9 @@ describe("/llms.txt route", () => {
 		const response = await GET();
 
 		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+		expect(response.headers.get("Content-Type")).toBe(
+			"text/plain; charset=utf-8",
+		);
 
 		const body = await response.text();
 		expect(body).toBeTypeOf("string");

--- a/apps/www/app/llms.txt/route.test.ts
+++ b/apps/www/app/llms.txt/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/lib/source", () => ({
+	source: {
+		getPages: () => [
+			{
+				url: "/docs/arkenv",
+				data: {
+					title: "ArkEnv",
+				},
+			},
+		],
+		getPageTree: () => ({
+			type: "root",
+			children: [],
+		}),
+	},
+}));
+
+vi.mock("fumadocs-core/source", () => ({
+	llms: () => ({
+		index: () => "Mocked Root Index Content: ArkEnv",
+	}),
+}));
+
+import { GET } from "./route";
+
+describe("/llms.txt route", () => {
+	it("should return the llms.txt content", async () => {
+		const response = await GET();
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+
+		const body = await response.text();
+		expect(body).toBeTypeOf("string");
+		expect(body).toContain("ArkEnv");
+	});
+});

--- a/apps/www/app/llms.txt/route.ts
+++ b/apps/www/app/llms.txt/route.ts
@@ -4,8 +4,9 @@ import { source } from "~/lib/source";
 export const revalidate = false;
 
 /**
- * GET route handler for root llms.txt.
- * Generates a plain-text index of all documentation pages on the site.
+ * Handle GET requests for root llms.txt.
+ *
+ * @returns A Response containing the plain-text index of all documentation pages
  */
 export async function GET() {
 	const indexContent = llms(source).index();

--- a/apps/www/app/llms.txt/route.ts
+++ b/apps/www/app/llms.txt/route.ts
@@ -1,0 +1,14 @@
+import { llms } from "fumadocs-core/source";
+import { source } from "~/lib/source";
+
+export const revalidate = false;
+
+export async function GET() {
+	const indexContent = llms(source).index();
+
+	return new Response(indexContent, {
+		headers: {
+			"Content-Type": "text/plain; charset=utf-8",
+		},
+	});
+}

--- a/apps/www/app/llms.txt/route.ts
+++ b/apps/www/app/llms.txt/route.ts
@@ -3,6 +3,10 @@ import { source } from "~/lib/source";
 
 export const revalidate = false;
 
+/**
+ * GET route handler for root llms.txt.
+ * Generates a plain-text index of all documentation pages on the site.
+ */
 export async function GET() {
 	const indexContent = llms(source).index();
 

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -31,6 +31,11 @@ const config = {
 				destination: "/docs/arkenv",
 				permanent: true,
 			},
+			{
+				source: "/docs/llms.txt",
+				destination: "/llms.txt",
+				permanent: true,
+			},
 		];
 	},
 	async rewrites() {


### PR DESCRIPTION
Fixes #1091

Adds root `/llms.txt` and package-specific `/docs/[package]/llms.txt` route handlers to serve plain-text documentation indexes for AI agents, redirecting `/docs/llms.txt` permanently to `/llms.txt`, and including Vitest suites.