### PR TITLE
fix: Support adding .md to url to view markdown

### DIFF
--- a/apps/www/app/llms.mdx/docs/[[...slug]]/route.test.ts
+++ b/apps/www/app/llms.mdx/docs/[[...slug]]/route.test.ts
@@ -1,0 +1,122 @@
+import { notFound } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET, generateStaticParams } from "./route";
+
+const mockGetLLMText = vi.fn();
+const mockGetPage = vi.fn();
+const mockGenerateParams = vi.fn();
+
+vi.mock("~/lib/get-llm-text", () => ({
+	getLLMText: (page: unknown) => mockGetLLMText(page),
+}));
+
+vi.mock("~/lib/source", () => ({
+	source: {
+		getPage: (slug: string[] | undefined) => mockGetPage(slug),
+		generateParams: () => mockGenerateParams(),
+	},
+}));
+
+vi.mock("next/navigation", () => ({
+	notFound: vi.fn(() => {
+		throw new Error("NEXT_NOT_FOUND");
+	}),
+}));
+
+const makeRequest = () => new Request("http://localhost/");
+
+const makeParams = (slug: string[] | undefined) =>
+	Promise.resolve({ slug });
+
+describe("GET /llms.mdx/docs/[[...slug]]", () => {
+	beforeEach(() => {
+		mockGetLLMText.mockReset();
+		mockGetPage.mockReset();
+		mockGenerateParams.mockReset();
+		vi.mocked(notFound).mockReset();
+		vi.mocked(notFound).mockImplementation(() => {
+			throw new Error("NEXT_NOT_FOUND");
+		});
+	});
+
+	it("returns 200 with text/markdown for a .mdx URL", async () => {
+		const fakePage = { data: { title: "Getting Started", getText: vi.fn() } };
+		mockGetPage.mockReturnValue(fakePage);
+		mockGetLLMText.mockResolvedValue("# Getting Started\n\nContent here.");
+
+		const response = await GET(makeRequest(), {
+			params: makeParams(["arkenv", "getting-started.mdx"]),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe("text/markdown");
+		expect(await response.text()).toBe("# Getting Started\n\nContent here.");
+		// Extension should be stripped before getPage lookup
+		expect(mockGetPage).toHaveBeenCalledWith(["arkenv", "getting-started"]);
+	});
+
+	it("returns 200 with text/markdown for a .md URL", async () => {
+		const fakePage = { data: { title: "Getting Started", getText: vi.fn() } };
+		mockGetPage.mockReturnValue(fakePage);
+		mockGetLLMText.mockResolvedValue("# Getting Started\n\nContent here.");
+
+		const response = await GET(makeRequest(), {
+			params: makeParams(["arkenv", "getting-started.md"]),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe("text/markdown");
+		expect(await response.text()).toBe("# Getting Started\n\nContent here.");
+		// Extension should be stripped before getPage lookup
+		expect(mockGetPage).toHaveBeenCalledWith(["arkenv", "getting-started"]);
+	});
+
+	it("calls notFound for a non-existent .md page", async () => {
+		mockGetPage.mockReturnValue(undefined);
+
+		await expect(
+			GET(makeRequest(), {
+				params: makeParams(["nonexistent", "page.md"]),
+			}),
+		).rejects.toThrow("NEXT_NOT_FOUND");
+
+		expect(notFound).toHaveBeenCalled();
+	});
+
+	it("calls notFound for a non-existent .mdx page", async () => {
+		mockGetPage.mockReturnValue(undefined);
+
+		await expect(
+			GET(makeRequest(), {
+				params: makeParams(["nonexistent", "page.mdx"]),
+			}),
+		).rejects.toThrow("NEXT_NOT_FOUND");
+
+		expect(notFound).toHaveBeenCalled();
+	});
+
+	it("works without any extension for bare slug", async () => {
+		const fakePage = { data: { title: "Intro", getText: vi.fn() } };
+		mockGetPage.mockReturnValue(fakePage);
+		mockGetLLMText.mockResolvedValue("# Intro");
+
+		const response = await GET(makeRequest(), {
+			params: makeParams(["arkenv", "intro"]),
+		});
+
+		expect(response.status).toBe(200);
+		expect(mockGetPage).toHaveBeenCalledWith(["arkenv", "intro"]);
+	});
+});
+
+describe("generateStaticParams", () => {
+	it("delegates to source.generateParams()", () => {
+		const fakeParams = [{ slug: ["arkenv", "getting-started"] }];
+		mockGenerateParams.mockReturnValue(fakeParams);
+
+		const result = generateStaticParams();
+
+		expect(result).toBe(fakeParams);
+		expect(mockGenerateParams).toHaveBeenCalledOnce();
+	});
+});

--- a/apps/www/app/llms.mdx/docs/[[...slug]]/route.ts
+++ b/apps/www/app/llms.mdx/docs/[[...slug]]/route.ts
@@ -9,7 +9,10 @@ export async function GET(
 	{ params }: { params: Promise<{ slug?: string[] }> },
 ) {
 	const { slug } = await params;
-	const page = source.getPage(slug);
+	const normalizedSlug = slug?.map((s, i) =>
+		i === slug.length - 1 ? s.replace(/\.(md|mdx)$/, "") : s,
+	);
+	const page = source.getPage(normalizedSlug);
 	if (!page) notFound();
 
 	return new Response(await getLLMText(page), {

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -44,6 +44,10 @@ const config = {
 				source: "/docs/:path*.mdx",
 				destination: "/llms.mdx/docs/:path*",
 			},
+			{
+				source: "/docs/:path*.md",
+				destination: "/llms.mdx/docs/:path*",
+			},
 			/**
 			 * PostHog rewrites to support analytics ingestion proxy
 			 */


### PR DESCRIPTION
Fixes #1095

## Changes

- ****: Added a rewrite rule for `/docs/:path*.md` → `/llms.mdx/docs/:path*`, mirroring the existing `.mdx` rule so AI agents can fetch docs pages using the Fumadocs-recommended `.md` extension.
- **`apps/www/app/llms.mdx/docs/[[...slug]]/route.ts`**: Added slug normalization to strip `.md` or `.mdx` extensions from the last slug segment before calling `source.getPage()`. This ensures the page lookup succeeds regardless of which extension was used.
- **`apps/www/app/llms.mdx/docs/[[...slug]]/route.test.ts`**: Added unit tests covering:
  - `GET` returns `200 OK` + `text/markdown` for a `.md` URL (happy path)
  - `GET` returns `200 OK` + `text/markdown` for a `.mdx` URL (no regression)
  - `GET` calls `notFound()` for a non-existent `.md` page (sad path)
  - `GET` calls `notFound()` for a non-existent `.mdx` page (sad path)
  - Bare slug (no extension) still works
  - `generateStaticParams` delegates to `source.generateParams()`