### PR TITLE
ci: split preview-www workflow to fix concurrency race

### DIFF
--- a/.github/workflows/preview-www-default.yml
+++ b/.github/workflows/preview-www-default.yml
@@ -1,0 +1,26 @@
+name: Preview www (Default Events)
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    paths:
+      - "apps/www/**"
+      - "packages/arkenv/**"
+      - "packages/vite-plugin/**"
+      - "packages/bun-plugin/**"
+      - "packages/fumadocs-ui/**"
+      - "packages/internal/**"
+      - ".github/workflows/preview-www-reusable.yml"
+      - ".github/workflows/preview-www-default.yml"
+      - ".github/workflows/preview-www-labeled.yml"
+      - "pnpm-lock.yaml"
+
+concurrency:
+  group: preview-www-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  Deploy-Preview:
+    if: github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'preview')
+    uses: ./.github/workflows/preview-www-reusable.yml
+    secrets: inherit

--- a/.github/workflows/preview-www-labeled.yml
+++ b/.github/workflows/preview-www-labeled.yml
@@ -1,0 +1,26 @@
+name: Preview www (Label Triggered)
+
+on:
+  pull_request:
+    types: [labeled]
+    paths:
+      - "apps/www/**"
+      - "packages/arkenv/**"
+      - "packages/vite-plugin/**"
+      - "packages/bun-plugin/**"
+      - "packages/fumadocs-ui/**"
+      - "packages/internal/**"
+      - ".github/workflows/preview-www-reusable.yml"
+      - ".github/workflows/preview-www-default.yml"
+      - ".github/workflows/preview-www-labeled.yml"
+      - "pnpm-lock.yaml"
+
+concurrency:
+  group: preview-www-labeled-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  Deploy-Preview:
+    if: github.event.label.name == 'preview'
+    uses: ./.github/workflows/preview-www-reusable.yml
+    secrets: inherit

--- a/.github/workflows/preview-www-reusable.yml
+++ b/.github/workflows/preview-www-reusable.yml
@@ -1,4 +1,8 @@
-name: Preview www (arkenv.js.org)
+name: Preview www Reusable
+
+on:
+  workflow_call:
+
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -6,27 +10,9 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
   TZ: ${{ vars.TIMEZONE || 'Asia/Almaty' }}
-on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, labeled]
-    paths:
-      - "apps/www/**"
-      - "packages/arkenv/**"
-      - "packages/vite-plugin/**"
-      - "packages/bun-plugin/**"
-      - "packages/fumadocs-ui/**"
-      - "packages/internal/**"
-      - ".github/workflows/preview-www.yml"
-      - "pnpm-lock.yaml"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Deploy-Preview:
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'preview') ||
-      (github.event.action != 'labeled' && (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'preview')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Splits the unified `preview-www` workflow into separate default triggers (`opened`, `synchronize`, `ready_for_review`) and label-triggered caller workflows, sharing a central reusable workflow. This resolves the concurrency race condition where automated PR labeling would cancel the active commit preview deployments.