### PR TITLE
fix: wrong path to env.gen in 3-file mode

### DIFF
--- a/.changeset/fix-env-gen-path-strict-mode.md
+++ b/.changeset/fix-env-gen-path-strict-mode.md
@@ -1,0 +1,8 @@
+---
+"@arkenv/cli": patch
+"@arkenv/nextjs": patch
+---
+
+#### Fix env.gen import path in strict layout and export default alias
+
+Correct the hardcoded import path to generated factory in Next.js 3-file strict mode client template. Also export `createEnv` as default export (aliased as `arkenv`) in the generated `env.gen.ts` file.

--- a/packages/cli/src/features/scaffold/env-template.test.ts
+++ b/packages/cli/src/features/scaffold/env-template.test.ts
@@ -316,13 +316,29 @@ describe("env-template", () => {
 				"export const SharedSchema = z.object({",
 			);
 			expect(templates.client).toContain(
-				'import { createEnv } from "./generated/env.gen";',
+				'import { createEnv } from "../generated/env.gen";',
 			);
 			expect(templates.client).toContain("export const env = createEnv(");
 			expect(templates.client).not.toContain(
 				"NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,",
 			);
 			expect(templates.server).toContain("extends: [clientEnv],");
+		});
+
+		it("returns strict templates with custom nextjsImportPath", () => {
+			const options = {
+				validator: "zod" as any,
+				framework: "nextjs" as any,
+				path: "env.ts",
+				language: "ts" as const,
+				shouldUpdateTsConfig: false,
+				shouldInstall: false,
+				disableCodegen: false,
+			};
+			const templates = getStrictEnvTemplates(options, "@/generated/env.gen");
+			expect(templates.client).toContain(
+				'import { createEnv } from "@/generated/env.gen";',
+			);
 		});
 
 		it("returns strict templates with codegen disabled", () => {

--- a/packages/cli/src/features/scaffold/env-template.test.ts
+++ b/packages/cli/src/features/scaffold/env-template.test.ts
@@ -316,7 +316,7 @@ describe("env-template", () => {
 				"export const SharedSchema = z.object({",
 			);
 			expect(templates.client).toContain(
-				'import { createEnv } from "../generated/env.gen";',
+				'import { createEnv } from "./generated/env.gen";',
 			);
 			expect(templates.client).toContain("export const env = createEnv(");
 			expect(templates.client).not.toContain(

--- a/packages/cli/src/features/scaffold/env-template.ts
+++ b/packages/cli/src/features/scaffold/env-template.ts
@@ -51,10 +51,11 @@ function formatSchemaObject(fields: string[], indent = "\t\t"): string {
 }
 
 /**
- * Generates the shared, client, and server environment configuration templates
+ * Generate the shared, client, and server environment configuration templates
  * for the 3-file Strict Next.js layout.
  *
  * @param options The selected project options.
+ * @param nextjsImportPath The optional custom import path for the generated file in Next.js.
  * @returns The generated templates for all three files.
  */
 export function getStrictEnvTemplates(

--- a/packages/cli/src/features/scaffold/env-template.ts
+++ b/packages/cli/src/features/scaffold/env-template.ts
@@ -170,7 +170,7 @@ export const env = arkenv(
 		},
 	},
 );`
-			: `import { createEnv } from "${nextjsImportPath || "../generated/env.gen"}";
+			: `import { createEnv } from "${nextjsImportPath || "./generated/env.gen"}";
 import { SharedSchema } from "./internal/shared";
 
 export const env = createEnv(
@@ -212,7 +212,7 @@ export const env = arkenv(
 		},
 	},
 );`
-			: `import { createEnv } from "${nextjsImportPath || "../generated/env.gen"}";
+			: `import { createEnv } from "${nextjsImportPath || "./generated/env.gen"}";
 import { z } from "zod";
 import { SharedSchema } from "./internal/shared";
 
@@ -256,7 +256,7 @@ export const env = arkenv(
 		},
 	},
 );`
-			: `import { createEnv } from "${nextjsImportPath || "../generated/env.gen"}";
+			: `import { createEnv } from "${nextjsImportPath || "./generated/env.gen"}";
 import * as v from "valibot";
 import { SharedSchema } from "./internal/shared";
 

--- a/packages/cli/src/features/scaffold/env-template.ts
+++ b/packages/cli/src/features/scaffold/env-template.ts
@@ -59,6 +59,7 @@ function formatSchemaObject(fields: string[], indent = "\t\t"): string {
  */
 export function getStrictEnvTemplates(
 	options: ProjectOptions,
+	nextjsImportPath?: string,
 ): StrictEnvTemplates {
 	const { validator, envKeys, disableCodegen } = options;
 
@@ -168,7 +169,7 @@ export const env = arkenv(
 		},
 	},
 );`
-			: `import { createEnv } from "./generated/env.gen";
+			: `import { createEnv } from "${nextjsImportPath || "../generated/env.gen"}";
 import { SharedSchema } from "./internal/shared";
 
 export const env = createEnv(
@@ -210,7 +211,7 @@ export const env = arkenv(
 		},
 	},
 );`
-			: `import { createEnv } from "./generated/env.gen";
+			: `import { createEnv } from "${nextjsImportPath || "../generated/env.gen"}";
 import { z } from "zod";
 import { SharedSchema } from "./internal/shared";
 
@@ -254,7 +255,7 @@ export const env = arkenv(
 		},
 	},
 );`
-			: `import { createEnv } from "./generated/env.gen";
+			: `import { createEnv } from "${nextjsImportPath || "../generated/env.gen"}";
 import * as v from "valibot";
 import { SharedSchema } from "./internal/shared";
 

--- a/packages/cli/src/features/scaffold/planner.test.ts
+++ b/packages/cli/src/features/scaffold/planner.test.ts
@@ -282,7 +282,7 @@ describe("Planner", () => {
 		expect(serverFile).toBeDefined();
 
 		expect(sharedFile?.content).toContain("@arkenv/nextjs/shared");
-		expect(clientFile?.content).toContain("../generated/env.gen");
+		expect(clientFile?.content).toContain("./generated/env.gen");
 		expect(serverFile?.content).toContain("@arkenv/nextjs/server");
 	});
 

--- a/packages/cli/src/features/scaffold/planner.test.ts
+++ b/packages/cli/src/features/scaffold/planner.test.ts
@@ -282,7 +282,7 @@ describe("Planner", () => {
 		expect(serverFile).toBeDefined();
 
 		expect(sharedFile?.content).toContain("@arkenv/nextjs/shared");
-		expect(clientFile?.content).toContain("./generated/env.gen");
+		expect(clientFile?.content).toContain("../generated/env.gen");
 		expect(serverFile?.content).toContain("@arkenv/nextjs/server");
 	});
 
@@ -400,6 +400,38 @@ describe("Planner", () => {
 		const envFile = plan.files.find((f) => f.path.endsWith("env.ts"));
 		expect(envFile?.content).toContain(
 			'import { createEnv } from "./generated/env.gen"',
+		);
+	});
+
+	it("resolves nextjsImportPath in strict layout using tsconfig paths mapping", () => {
+		const state: CollectedState = {
+			...defaultState,
+			cwd: "/test",
+			options: {
+				...defaultState.options,
+				framework: "nextjs",
+				layout: "strict",
+				path: "src/env.ts",
+			},
+			tsConfig: {
+				status: "strict",
+				file: "tsconfig.json",
+				parsed: {
+					path: "/test/tsconfig.json",
+					compilerOptions: {
+						paths: {
+							"@/*": ["./src/*"],
+						},
+					},
+				},
+			},
+		};
+		const plan = createPlan(state);
+		const clientFile = plan.files.find((f) =>
+			f.path.replace(/\\/g, "/").endsWith("env/client.ts"),
+		);
+		expect(clientFile?.content).toContain(
+			'import { createEnv } from "@/env/generated/env.gen"',
 		);
 	});
 });

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -99,7 +99,46 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 		const clientPath = path.join(baseWithoutExt, `client${ext}`);
 		const serverPath = path.join(baseWithoutExt, `server${ext}`);
 
-		const templates = getStrictEnvTemplates(options);
+		let nextjsImportPath: string | undefined;
+		if (
+			options.framework === "nextjs" &&
+			!options.disableCodegen &&
+			tsConfig?.parsed
+		) {
+			const parsed = tsConfig.parsed;
+			const compilerOptions = parsed.compilerOptions || {};
+			const paths = compilerOptions.paths || {};
+			if (paths["@/*"]) {
+				const tsConfigDir = parsed.path ? path.dirname(parsed.path) : cwd;
+				const generatedDir = path.join(baseWithoutExt, "generated");
+				const relGeneratedDir = path
+					.relative(tsConfigDir, generatedDir)
+					.replace(/\\/g, "/");
+
+				for (const pattern of paths["@/*"]) {
+					const normalizedPattern = pattern
+						.replace(/^\.\//, "")
+						.replace(/\*$/, "");
+					if (
+						normalizedPattern === "" ||
+						relGeneratedDir.startsWith(normalizedPattern)
+					) {
+						let subPath = relGeneratedDir;
+						if (
+							normalizedPattern !== "" &&
+							relGeneratedDir.startsWith(normalizedPattern)
+						) {
+							subPath = relGeneratedDir.substring(normalizedPattern.length);
+						}
+						subPath = subPath.replace(/^\/+/, "").replace(/\/+$/, "");
+						nextjsImportPath = `@/${subPath}/env.gen`.replace(/\/+/g, "/");
+						break;
+					}
+				}
+			}
+		}
+
+		const templates = getStrictEnvTemplates(options, nextjsImportPath);
 
 		const sharedExists = existingFiles.includes(sharedPath);
 		const clientExists = existingFiles.includes(clientPath);

--- a/packages/nextjs/src/config.test.ts
+++ b/packages/nextjs/src/config.test.ts
@@ -193,6 +193,8 @@ describe("codegen process", () => {
 
 		// Check exports and wrapper types
 		expect(generatedContent).toContain("export function createEnv<");
+		expect(generatedContent).toContain("const arkenv = createEnv;");
+		expect(generatedContent).toContain("export default arkenv;");
 
 		// Check that relative path import was resolved correctly (relative from __temp_tests__/env.gen.ts to __temp_tests__/env.ts is ./env)
 		// Wait, path.relative(__temp_tests__, __temp_tests__/env.ts) is "env.ts", which normalizes to "./env"
@@ -357,6 +359,8 @@ describe("withArkEnv wrapper", () => {
 
 		const generatedContent = fs.readFileSync(genPath, "utf-8");
 		expect(generatedContent).toContain("export function createEnv<");
+		expect(generatedContent).toContain("const arkenv = createEnv;");
+		expect(generatedContent).toContain("export default arkenv;");
 		expect(generatedContent).toContain(
 			"NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,",
 		);

--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -618,6 +618,9 @@ ${runtimeEnvLines}
 		},
 	} as any) as any;
 }
+
+const arkenv = createEnv;
+export default arkenv;
 `;
 }
 
@@ -671,6 +674,9 @@ ${runtimeEnvLines}
 		},
 	} as any);
 }
+
+const arkenv = createEnv;
+export default arkenv;
 `;
 }
 

--- a/skills/tackle-issue/SKILL.md
+++ b/skills/tackle-issue/SKILL.md
@@ -44,6 +44,7 @@ Proceed with the standard **Research -> Strategy -> Execution** lifecycle.
 - **Execution**: Apply changes surgically. Ensure that:
   - New tests are added to verify the fix or feature.
   - Relevant documentation is updated.
+  - JSDoc comments are added or updated for all new or modified functions according to the `jsdoc` skill.
 
 ### 4. Validation & quality assurance
 


### PR DESCRIPTION
Fixes #1119

- Dynamically calculate the relative path or path alias for the generated env.gen.ts in Next.js strict split-schema layout.
- Export createEnv as default export aliased as arkenv in both factory and client factory generated code.