### PR TITLE
fix: restrict shared variables in Next.js to NODE_ENV

### DIFF
--- a/.changeset/restrict-shared-variables-nextjs.md
+++ b/.changeset/restrict-shared-variables-nextjs.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Restrict Next.js shared scaffold templates to NODE_ENV
+
+Treat `PORT` as a server-only variable instead of a shared variable in scaffold templates and strict layout generators. This ensures that custom variables or variables like `PORT` are not placed in `shared` sections, avoiding potential client-side hydration mismatches in Next.js applications.

--- a/apps/www/content/docs/nextjs/index.mdx
+++ b/apps/www/content/docs/nextjs/index.mdx
@@ -457,3 +457,20 @@ You can freely mix Zod or Valibot schemas with the 3-file layout:
     ```
   </Tab>
 </Tabs>
+
+---
+
+## The Danger of Shared Variables
+
+> [!WARNING]
+> Restrict the `shared` block only to `NODE_ENV`. Avoid placing custom variables (like `PORT` or other custom configuration) in the `shared` block.
+
+### The Undefined Fallback Bug
+
+Next.js statically strips `process.env` references from client-side bundles unless they are prefixed with `NEXT_PUBLIC_`.
+If you define a custom variable in `shared` with a default value (e.g., `PORT` defaulting to `3000` or `THEME` defaulting to `'dark'`), the environment behaves asymmetrically:
+
+- On the **server**, ArkEnv reads the actual value from the environment (e.g. `PORT = 8080`).
+- On the **client**, Next.js strips `process.env.PORT` to `undefined`, causing ArkEnv to fall back to the default value (`3000`).
+
+This asymmetry causes React hydration mismatches and corrupts client-side state. Always place non-prefixed variables under `server` so they are strictly server-only.

--- a/packages/cli/src/features/scaffold/env-template.ts
+++ b/packages/cli/src/features/scaffold/env-template.ts
@@ -80,28 +80,42 @@ export function getStrictEnvTemplates(
 					clientFields.push(`${key}: v.optional(v.string()),`);
 				}
 				runtimeEnvFields.push(`${key}: process.env.${key},`);
-			} else if (key === "NODE_ENV" || key === "PORT") {
+			} else if (key === "NODE_ENV") {
 				if (validator === "arktype") {
 					sharedFields.push(
-						`${key}: "${key === "PORT" ? "number.port = 3000" : "'development' | 'production' | 'test' = 'development'"}",`,
+						`${key}: "'development' | 'production' | 'test' = 'development'",`,
 					);
 				} else if (validator === "zod") {
 					sharedFields.push(
-						`${key}: ${key === "PORT" ? "z.coerce.number().int().min(1).max(65535).default(3000)" : 'z.enum(["development", "production", "test"]).default("development")'},`,
+						`${key}: z.enum(["development", "production", "test"]).default("development"),`,
 					);
 				} else if (validator === "valibot") {
 					sharedFields.push(
-						`${key}: ${key === "PORT" ? "v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000)" : 'v.optional(v.picklist(["development", "production", "test"]), "development")'},`,
+						`${key}: v.optional(v.picklist(["development", "production", "test"]), "development"),`,
 					);
 				}
 				runtimeEnvFields.push(`${key}: process.env.${key},`);
 			} else {
-				if (validator === "arktype") {
-					serverFields.push(`${key}: "string?",`);
-				} else if (validator === "zod") {
-					serverFields.push(`${key}: z.string().optional(),`);
-				} else if (validator === "valibot") {
-					serverFields.push(`${key}: v.optional(v.string()),`);
+				if (key === "PORT") {
+					if (validator === "arktype") {
+						serverFields.push(`PORT: "number.port = 3000",`);
+					} else if (validator === "zod") {
+						serverFields.push(
+							"PORT: z.coerce.number().int().min(1).max(65535).default(3000),",
+						);
+					} else if (validator === "valibot") {
+						serverFields.push(
+							"PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),",
+						);
+					}
+				} else {
+					if (validator === "arktype") {
+						serverFields.push(`${key}: "string?",`);
+					} else if (validator === "zod") {
+						serverFields.push(`${key}: z.string().optional(),`);
+					} else if (validator === "valibot") {
+						serverFields.push(`${key}: v.optional(v.string()),`);
+					}
 				}
 			}
 		}

--- a/packages/cli/src/features/scaffold/templates/arktype.ts
+++ b/packages/cli/src/features/scaffold/templates/arktype.ts
@@ -56,8 +56,8 @@ export const arktypeTemplate = (
 			{
 				serverField: (key) => `\t\t${key}: "string?",`,
 				clientField: (key) => `\t\t${key}: "string?",`,
-				sharedField: (key, isPort) =>
-					`\t\t${key}: "${isPort ? "number.port = 3000" : "'development' | 'production' | 'test' = 'development'"}",`,
+				sharedField: (key) =>
+					`\t\t${key}: "'development' | 'production' | 'test' = 'development'",`,
 				defaultServerFields: [
 					`\t\tDATABASE_URL: "string = 'postgres://localhost:5432/mydb'",`,
 				],

--- a/packages/cli/src/features/scaffold/templates/nextjs-template.ts
+++ b/packages/cli/src/features/scaffold/templates/nextjs-template.ts
@@ -23,11 +23,10 @@ export type NextjsFieldBuilders = {
 	/**
 	 * Format a schema field line for a shared env var.
 	 *
-	 * @param key The env var name (e.g. `NODE_ENV` or `PORT`)
-	 * @param isPort `true` when the key is `PORT`; `false` for `NODE_ENV`
+	 * @param key The env var name (e.g. `NODE_ENV`)
 	 * @returns A formatted schema field string
 	 */
-	sharedField(key: string, isPort: boolean): string;
+	sharedField(key: string): string;
 	/** Default `server` section lines used when no `envKeys` are provided. */
 	defaultServerFields: string[];
 	/** Default `client` section lines used when no `envKeys` are provided. */
@@ -44,7 +43,7 @@ export type NextjsFieldBuilders = {
  * - Produce the `import` header and JSDoc comment
  * - Join sections and emit the final `export const env = arkenv({…})`
  *
- * @param envKeys Optional array of env var keys scanned from the project
+ * @param envKeys Optional array of env keys scanned from the project
  * @param builders Validator-specific field formatters and default field values
  * @param nextjsImportPath The optional custom import path for the generated file
  * @returns The generated TypeScript source string
@@ -73,8 +72,8 @@ export function buildNextjsTemplate(
 		for (const key of envKeys) {
 			if (key.startsWith("NEXT_PUBLIC_")) {
 				clientFields.push(clientField(key));
-			} else if (key === "NODE_ENV" || key === "PORT") {
-				sharedFields.push(sharedField(key, key === "PORT"));
+			} else if (key === "NODE_ENV") {
+				sharedFields.push(sharedField(key));
 			} else {
 				serverFields.push(serverField(key));
 			}
@@ -100,11 +99,7 @@ export function buildNextjsTemplate(
 		const runtimeEnvFields: string[] = [];
 		if (envKeys && envKeys.length > 0) {
 			for (const key of envKeys) {
-				if (
-					key.startsWith("NEXT_PUBLIC_") ||
-					key === "NODE_ENV" ||
-					key === "PORT"
-				) {
+				if (key.startsWith("NEXT_PUBLIC_") || key === "NODE_ENV") {
 					runtimeEnvFields.push(`\t\t${key}: process.env.${key},`);
 				}
 			}

--- a/packages/cli/src/features/scaffold/templates/valibot.ts
+++ b/packages/cli/src/features/scaffold/templates/valibot.ts
@@ -59,8 +59,8 @@ export const valibotTemplate = (
 				extraImports: `import * as v from "valibot";`,
 				serverField: (key) => `\t\t${key}: v.optional(v.string()),`,
 				clientField: (key) => `\t\t${key}: v.optional(v.string()),`,
-				sharedField: (key, isPort) =>
-					`\t\t${key}: ${isPort ? "v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000)" : 'v.optional(v.picklist(["development", "production", "test"]), "development")'},`,
+				sharedField: (key) =>
+					`\t\t${key}: v.optional(v.picklist(["development", "production", "test"]), "development"),`,
 				defaultServerFields: [
 					`\t\tDATABASE_URL: v.optional(v.pipe(v.string(), v.url()), "postgres://localhost:5432/mydb"),`,
 				],

--- a/packages/cli/src/features/scaffold/templates/zod.ts
+++ b/packages/cli/src/features/scaffold/templates/zod.ts
@@ -59,8 +59,8 @@ export const zodTemplate = (
 				extraImports: `import { z } from "zod";`,
 				serverField: (key) => `\t\t${key}: z.string().optional(),`,
 				clientField: (key) => `\t\t${key}: z.string().optional(),`,
-				sharedField: (key, isPort) =>
-					`\t\t${key}: ${isPort ? "z.coerce.number().int().min(1).max(65535).default(3000)" : 'z.enum(["development", "production", "test"]).default("development")'},`,
+				sharedField: (key) =>
+					`\t\t${key}: z.enum(["development", "production", "test"]).default("development"),`,
 				defaultServerFields: [
 					`\t\tDATABASE_URL: z.string().url().default("postgres://localhost:5432/mydb"),`,
 				],

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -87,3 +87,20 @@ export const env = createEnv({
   }
 });
 ```
+
+---
+
+## The Danger of Shared Variables
+
+> [!WARNING]
+> Restrict the `shared` block only to `NODE_ENV`. Avoid placing custom variables (like `PORT` or other custom configuration) in the `shared` block.
+
+### The Undefined Fallback Bug
+
+Next.js statically strips `process.env` references from client-side bundles unless they are prefixed with `NEXT_PUBLIC_`.
+If you define a custom variable in `shared` with a default value (e.g., `PORT` defaulting to `3000` or `THEME` defaulting to `'dark'`), the environment behaves asymmetrically:
+
+- On the **server**, ArkEnv reads the actual value from the environment (e.g. `PORT = 8080`).
+- On the **client**, Next.js strips `process.env.PORT` to `undefined`, causing ArkEnv to fall back to the default value (`3000`).
+
+This asymmetry causes React hydration mismatches and corrupts client-side state. Always place non-prefixed variables under `server` so they are strictly server-only.

--- a/packages/nextjs/src/type-regression.test-d.ts
+++ b/packages/nextjs/src/type-regression.test-d.ts
@@ -37,16 +37,17 @@ describe("@arkenv/nextjs type regression", () => {
 		createEnv({
 			server: {
 				DATABASE_URL: "string.url",
+				PORT: "number.port = 3000",
 			},
 			client: {
 				NEXT_PUBLIC_API_URL: "string.url",
 			},
 			shared: {
-				PORT: "number.port = 3000",
+				NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 			},
 			runtimeEnv: {
 				NEXT_PUBLIC_API_URL: "https://api.example.com",
-				PORT: "3000",
+				NODE_ENV: "development",
 			},
 		});
 	});
@@ -56,6 +57,8 @@ describe("@arkenv/nextjs type regression", () => {
 			server: {
 				// @ts-expect-error invalid ArkType schema string
 				DATABASE_URL: "not-a-valid-type",
+				// @ts-expect-error invalid ArkType schema string
+				PORT: "not-a-valid-type",
 			},
 			client: {
 				// @ts-expect-error invalid ArkType schema string
@@ -63,11 +66,11 @@ describe("@arkenv/nextjs type regression", () => {
 			},
 			shared: {
 				// @ts-expect-error invalid ArkType schema string
-				PORT: "not-a-valid-type",
+				NODE_ENV: "not-a-valid-type",
 			},
 			runtimeEnv: {
 				NEXT_PUBLIC_API_URL: "https://api.example.com",
-				PORT: "3000",
+				NODE_ENV: "development",
 			},
 		});
 	});


### PR DESCRIPTION
Fixes #1131

Restrict Next.js environment configuration templates and scaffolding generated by the CLI so that custom variables (like `PORT`) are generated as server-only variables instead of shared variables. This prevents client-side hydration mismatches since Next.js strips non-prefixed variables on the client.