### PR TITLE
fix: Memory and file descriptor leak in nextjs withArkEnv development watcher

### DIFF
--- a/.changeset/fix-nextjs-watcher-leak.md
+++ b/.changeset/fix-nextjs-watcher-leak.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/nextjs": patch
+---
+
+#### Fix development watcher memory and file descriptor leak
+
+Store the active `chokidar` watcher instance on `globalThis.__arkenv_watcher__` and close it when configuring a new watcher instance.

--- a/packages/nextjs/src/config.test.ts
+++ b/packages/nextjs/src/config.test.ts
@@ -1,16 +1,26 @@
 import fs from "node:fs";
 import path from "node:path";
-import { watch as chokidarWatch } from "chokidar";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("chokidar", () => {
+let useMockWatcher = false;
+const mockClose = vi.fn().mockResolvedValue(undefined);
+const mockWatch = vi.fn().mockImplementation(() => {
 	return {
-		watch: vi.fn().mockImplementation(() => {
-			return {
-				on: vi.fn().mockReturnThis(),
-				close: vi.fn().mockResolvedValue(undefined),
-			};
-		}),
+		on: vi.fn().mockReturnThis(),
+		close: mockClose,
+	};
+});
+
+vi.mock("chokidar", async (importOriginal) => {
+	const original = await importOriginal<typeof import("chokidar")>();
+	return {
+		...original,
+		watch: (schemaPath: any, options?: any) => {
+			if (useMockWatcher) {
+				return mockWatch(schemaPath, options);
+			}
+			return original.watch(schemaPath, options);
+		},
 	};
 });
 
@@ -399,6 +409,10 @@ describe("withArkEnv wrapper", () => {
 	});
 
 	it("should close the previous watcher when initialized multiple times in development", () => {
+		useMockWatcher = true;
+		mockWatch.mockClear();
+		mockClose.mockClear();
+
 		if (!fs.existsSync(tempDir)) {
 			fs.mkdirSync(tempDir, { recursive: true });
 		}
@@ -415,18 +429,17 @@ describe("withArkEnv wrapper", () => {
 		try {
 			// Call withArkEnv once
 			withArkEnv({ reactStrictMode: true }, { schemaPath });
-			expect(chokidarWatch).toHaveBeenCalledTimes(1);
+			expect(mockWatch).toHaveBeenCalledTimes(1);
 
 			// Call withArkEnv a second time
 			withArkEnv({ reactStrictMode: true }, { schemaPath });
-			expect(chokidarWatch).toHaveBeenCalledTimes(2);
+			expect(mockWatch).toHaveBeenCalledTimes(2);
 
-			const firstWatcherInstance =
-				vi.mocked(chokidarWatch).mock.results[0].value;
-			expect(firstWatcherInstance.close).toHaveBeenCalledTimes(1);
+			expect(mockClose).toHaveBeenCalledTimes(1);
 		} finally {
 			process.env.NODE_ENV = originalNodeEnv;
 			delete (globalThis as any).__arkenv_watcher__;
+			useMockWatcher = false;
 		}
 	});
 });

--- a/packages/nextjs/src/config.test.ts
+++ b/packages/nextjs/src/config.test.ts
@@ -1,6 +1,19 @@
 import fs from "node:fs";
 import path from "node:path";
+import { watch as chokidarWatch } from "chokidar";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("chokidar", () => {
+	return {
+		watch: vi.fn().mockImplementation(() => {
+			return {
+				on: vi.fn().mockReturnThis(),
+				close: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
+	};
+});
+
 import {
 	extractClientKeys,
 	extractKeys,
@@ -383,6 +396,38 @@ describe("withArkEnv wrapper", () => {
 		expect(() =>
 			withArkEnv({ reactStrictMode: true }, { schemaPath, layout: "strict" }),
 		).toThrow("[ArkEnv] Strict layout requires");
+	});
+
+	it("should close the previous watcher when initialized multiple times in development", () => {
+		if (!fs.existsSync(tempDir)) {
+			fs.mkdirSync(tempDir, { recursive: true });
+		}
+
+		fs.writeFileSync(
+			schemaPath,
+			`export const env = createEnv({ client: { NEXT_PUBLIC_API_URL: "string" } });`,
+			"utf-8",
+		);
+
+		const originalNodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = "development";
+
+		try {
+			// Call withArkEnv once
+			withArkEnv({ reactStrictMode: true }, { schemaPath });
+			expect(chokidarWatch).toHaveBeenCalledTimes(1);
+
+			// Call withArkEnv a second time
+			withArkEnv({ reactStrictMode: true }, { schemaPath });
+			expect(chokidarWatch).toHaveBeenCalledTimes(2);
+
+			const firstWatcherInstance =
+				vi.mocked(chokidarWatch).mock.results[0].value;
+			expect(firstWatcherInstance.close).toHaveBeenCalledTimes(1);
+		} finally {
+			process.env.NODE_ENV = originalNodeEnv;
+			delete (globalThis as any).__arkenv_watcher__;
+		}
 	});
 });
 

--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -2,6 +2,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { watch as chokidarWatch } from "chokidar";
 
+declare global {
+	// eslint-disable-next-line no-var
+	var __arkenv_watcher__: import("chokidar").FSWatcher | undefined;
+}
+
 /**
  * Configuration options for the ArkEnv Next.js integration.
  *
@@ -279,7 +284,7 @@ function watchSchema(
 	outputPath: string,
 	layout?: "simple" | "strict",
 ) {
-	const previousWatcher = (globalThis as any).__arkenv_watcher__;
+	const previousWatcher = globalThis.__arkenv_watcher__;
 	if (previousWatcher && typeof previousWatcher.close === "function") {
 		previousWatcher.close().catch((err: unknown) => {
 			const message = err instanceof Error ? err.message : String(err);
@@ -292,7 +297,7 @@ function watchSchema(
 
 	try {
 		const watcher = chokidarWatch(schemaPath, { ignoreInitial: true });
-		(globalThis as any).__arkenv_watcher__ = watcher;
+		globalThis.__arkenv_watcher__ = watcher;
 
 		watcher.on("change", () => {
 			try {

--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -55,8 +55,6 @@ export type ArkEnvConfigOptions = {
 	layout?: "simple" | "strict";
 };
 
-let watcherInitialized = false;
-
 /**
  * Wrap a Next.js configuration object to automatically generate the `runtimeEnv` block in `env.gen.ts`.
  *
@@ -281,11 +279,22 @@ function watchSchema(
 	outputPath: string,
 	layout?: "simple" | "strict",
 ) {
-	if (watcherInitialized) return;
-	watcherInitialized = true;
+	const previousWatcher = (globalThis as any).__arkenv_watcher__;
+	if (previousWatcher && typeof previousWatcher.close === "function") {
+		previousWatcher.close().catch((err: unknown) => {
+			const message = err instanceof Error ? err.message : String(err);
+			// biome-ignore lint/suspicious/noConsole: watcher errors must be logged
+			console.error(
+				`[ArkEnv Watcher] Failed to close previous watcher: ${message}`,
+			);
+		});
+	}
 
 	try {
-		chokidarWatch(schemaPath, { ignoreInitial: true }).on("change", () => {
+		const watcher = chokidarWatch(schemaPath, { ignoreInitial: true });
+		(globalThis as any).__arkenv_watcher__ = watcher;
+
+		watcher.on("change", () => {
 			try {
 				const mainSchemaPath = Array.isArray(schemaPath)
 					? schemaPath[0]


### PR DESCRIPTION
Fixes #1130

Store the active chokidar watcher instance on globalThis.__arkenv_watcher__ and close it before instantiating a new watcher during config reloads, preventing memory and file descriptor leaks.