### PR TITLE
fix: remove deprecation from createEnv export in @arkenv/nextjs

### DIFF
--- a/.changeset/remove-deprecation-nextjs-createenv.md
+++ b/.changeset/remove-deprecation-nextjs-createenv.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/nextjs": patch
+---
+
+#### Remove `@deprecated` JSDoc tag from `createEnv` and `arkenv` in the main and react-server entries
+
+Avoid warning users when they call `createEnv` manually without using the codegen workflow.

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -9,7 +9,6 @@ import { createEnvInternal } from "./create-env";
  * @returns A validated, readonly environment variables object wrapped in a security proxy
  * @throws An error if any client-side variable is not prefixed with `NEXT_PUBLIC_`
  * @throws An error if any client or shared variable is missing from `runtimeEnv`
- * @deprecated Use the codegen workflow by wrapping your config with `withArkEnv` from `@arkenv/nextjs/config` and importing `createEnv` from `./env.gen.ts`.
  */
 export function createEnv<
 	const TServer extends SchemaShape = {},
@@ -35,8 +34,6 @@ export { type } from "arkenv";
  * ArkEnv's Next.js integration export, an alias for {@link createEnv}
  *
  * {@link https://arkenv.js.org | ArkEnv} is a typesafe environment variables validator from editor to runtime.
- *
- * @deprecated Use the codegen workflow by wrapping your config with `withArkEnv` from `@arkenv/nextjs/config` and importing `createEnv` from `./env.gen.ts`.
  */
 const arkenv = createEnv;
 export default arkenv;

--- a/packages/nextjs/src/react-server.ts
+++ b/packages/nextjs/src/react-server.ts
@@ -9,7 +9,6 @@ import { createEnvInternal } from "./create-env";
  * @returns A validated, readonly environment variables object wrapped in a security proxy
  * @throws An error if any client-side variable is not prefixed with `NEXT_PUBLIC_`
  * @throws An error if any client or shared variable is missing from `runtimeEnv`
- * @deprecated Use the codegen workflow by wrapping your config with `withArkEnv` from `@arkenv/nextjs/config` and importing `createEnv` from `./env.gen.ts`.
  */
 export function createEnv<
 	const TServer extends SchemaShape = {},
@@ -35,8 +34,6 @@ export { type } from "arkenv";
  * ArkEnv's Next.js integration export, an alias for {@link createEnv}
  *
  * {@link https://arkenv.js.org | ArkEnv} is a typesafe environment variables validator from editor to runtime.
- *
- * @deprecated Use the codegen workflow by wrapping your config with `withArkEnv` from `@arkenv/nextjs/config` and importing `createEnv` from `./env.gen.ts`.
  */
 const arkenv = createEnv;
 export default arkenv;


### PR DESCRIPTION
Fixes #1128

Remove the incorrect @deprecated JSDoc tag from createEnv and arkenv in the main and react-server entry points of @arkenv/nextjs.