### PR TITLE
fix: use the default import arkenv wherever possible

### DIFF
--- a/.changeset/default-import-arkenv.md
+++ b/.changeset/default-import-arkenv.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Update Next.js scaffold templates to use default import `arkenv`
+
+Change the generated `env.ts` templates to import the default `arkenv` factory from the generated config helper instead of the named `createEnv` import, ensuring compatibility with the ArkType IDE extension.

--- a/apps/www/content/docs/nextjs/index.mdx
+++ b/apps/www/content/docs/nextjs/index.mdx
@@ -19,7 +19,7 @@ ArkEnv features a runtime proxy that prevents server-side secrets from leaking t
   <Step>
     ### Configure environment
 
-    Create an `env.ts` file (typically in `src/env.ts` or at the root of your project) to define your schemas. Import `createEnv` from the auto-generated `./generated/env.gen.ts` helper file (rather than importing directly from `@arkenv/nextjs`):
+    Create an `env.ts` file (typically in `src/env.ts` or at the root of your project) to define your schemas. Import `arkenv` from the auto-generated `./generated/env.gen.ts` helper file (rather than importing directly from `@arkenv/nextjs`):
 
     ```ts title="src/env.ts" twoslash
     // @filename: generated/env.gen.ts
@@ -27,7 +27,7 @@ ArkEnv features a runtime proxy that prevents server-side secrets from leaking t
     import type { type as at, distill } from "arktype";
     export { type } from "@arkenv/nextjs";
 
-    export function createEnv<
+    export default function arkenv<
     	const TServer = {},
     	const TClient = {},
     	const TShared = {},
@@ -41,9 +41,9 @@ ArkEnv features a runtime proxy that prevents server-side secrets from leaking t
 
     // @filename: env.ts
     // ---cut---
-    import { createEnv } from "./generated/env.gen";
+    import arkenv from "./generated/env.gen";
 
-    export const env = createEnv({
+    export const env = arkenv({
     	server: {
     		DATABASE_URL: "string",
     	},
@@ -99,7 +99,7 @@ ArkEnv features a runtime proxy that prevents server-side secrets from leaking t
     import { createEnv as coreCreateEnv } from "@arkenv/nextjs";
     import type { type as at, distill } from "arktype";
     export { type } from "@arkenv/nextjs";
-    export function createEnv<
+    export default function arkenv<
     	const TServer = {},
     	const TClient = {},
     	const TShared = {},
@@ -112,8 +112,8 @@ ArkEnv features a runtime proxy that prevents server-side secrets from leaking t
     }
 
     // @filename: env.ts
-    import { createEnv } from "./generated/env.gen";
-    export const env = createEnv({
+    import arkenv from "./generated/env.gen";
+    export const env = arkenv({
     	server: { DATABASE_URL: "string" },
     	client: { NEXT_PUBLIC_API_URL: "string" },
     });
@@ -134,7 +134,7 @@ ArkEnv features a runtime proxy that prevents server-side secrets from leaking t
     import { createEnv as coreCreateEnv } from "@arkenv/nextjs";
     import type { type as at, distill } from "arktype";
     export { type } from "@arkenv/nextjs";
-    export function createEnv<
+    export default function arkenv<
     	const TServer = {},
     	const TClient = {},
     	const TShared = {},
@@ -147,8 +147,8 @@ ArkEnv features a runtime proxy that prevents server-side secrets from leaking t
     }
 
     // @filename: env.ts
-    import { createEnv } from "./generated/env.gen";
-    export const env = createEnv({
+    import arkenv from "./generated/env.gen";
+    export const env = arkenv({
     	server: { DATABASE_URL: "string" },
     	client: { NEXT_PUBLIC_API_URL: "string" },
     });
@@ -394,7 +394,7 @@ Here is an example using Zod with the 1-file codegen layout:
 import { createEnv as coreCreateEnv } from "@arkenv/nextjs";
 import type { type as at, distill } from "arktype";
 export { type } from "@arkenv/nextjs";
-export function createEnv<
+export default function arkenv<
 	const TServer = {},
 	const TClient = {},
 	const TShared = {},
@@ -408,10 +408,10 @@ export function createEnv<
 
 // @filename: env.ts
 // ---cut---
-import { createEnv } from "./generated/env.gen";
+import arkenv from "./generated/env.gen";
 import { z } from "zod";
 
-export const env = createEnv({
+export const env = arkenv({
 	server: {
 		DATABASE_URL: z.string().url(),
 	},

--- a/packages/arkenv/ARCHITECTURE.md
+++ b/packages/arkenv/ARCHITECTURE.md
@@ -6,7 +6,7 @@ ArkEnv ships three public entry points from a single npm package:
 
 | Entry    | Import                                      | ArkType required? | Purpose                                            |
 | -------- | ------------------------------------------- | ----------------- | -------------------------------------------------- |
-| Main     | `import { createEnv } from "arkenv"`        | Yes (static)      | ArkType-first `createEnv` + `type` helper          |
+| Main     | `import arkenv from "arkenv"`               | Yes (static)      | ArkType-first `createEnv` + `type` helper          |
 | Standard | `import arkenv from "arkenv/standard"`      | No                | ArkType-free `createEnv` for Standard Schema users |
 | Core     | `import { ArkEnvError } from "arkenv/core"` | No                | Entry-agnostic primitives (errors, types)          |
 

--- a/packages/cli/src/features/scaffold/env-template.test.ts
+++ b/packages/cli/src/features/scaffold/env-template.test.ts
@@ -46,9 +46,7 @@ describe("env-template", () => {
 				shouldInstall: false,
 			};
 			const template = getEnvTemplate(options);
-			expect(template).toContain(
-				'import { createEnv } from "./generated/env.gen"',
-			);
+			expect(template).toContain('import arkenv from "./generated/env.gen"');
 			expect(template).toContain("server: {");
 			expect(template).toContain("DATABASE_URL:");
 			expect(template).toContain("client: {");
@@ -68,9 +66,7 @@ describe("env-template", () => {
 				shouldInstall: false,
 			};
 			const template = getEnvTemplate(options, "@/generated/env.gen");
-			expect(template).toContain(
-				'import { createEnv } from "@/generated/env.gen"',
-			);
+			expect(template).toContain('import arkenv from "@/generated/env.gen"');
 		});
 
 		it("returns nextjs template with custom envKeys split correctly", () => {
@@ -90,9 +86,7 @@ describe("env-template", () => {
 				],
 			};
 			const template = getEnvTemplate(options);
-			expect(template).toContain(
-				'import { createEnv } from "./generated/env.gen"',
-			);
+			expect(template).toContain('import arkenv from "./generated/env.gen"');
 			expect(template).toContain("DATABASE_URL:");
 			expect(template).toContain("CUSTOM_VAR:");
 			expect(template).toContain("NEXT_PUBLIC_API_KEY:");
@@ -111,9 +105,7 @@ describe("env-template", () => {
 				shouldInstall: false,
 			};
 			const template = getEnvTemplate(options);
-			expect(template).toContain(
-				'import { createEnv } from "./generated/env.gen"',
-			);
+			expect(template).toContain('import arkenv from "./generated/env.gen"');
 			expect(template).toContain('import { z } from "zod"');
 			expect(template).toContain("DATABASE_URL: z.string().url().default(");
 		});
@@ -128,9 +120,7 @@ describe("env-template", () => {
 				shouldInstall: false,
 			};
 			const template = getEnvTemplate(options);
-			expect(template).toContain(
-				'import { createEnv } from "./generated/env.gen"',
-			);
+			expect(template).toContain('import arkenv from "./generated/env.gen"');
 			expect(template).toContain('import * as v from "valibot"');
 			expect(template).toContain(
 				"DATABASE_URL: v.optional(v.pipe(v.string(), v.url())",
@@ -316,9 +306,9 @@ describe("env-template", () => {
 				"export const SharedSchema = z.object({",
 			);
 			expect(templates.client).toContain(
-				'import { createEnv } from "./generated/env.gen";',
+				'import arkenv from "./generated/env.gen";',
 			);
-			expect(templates.client).toContain("export const env = createEnv(");
+			expect(templates.client).toContain("export const env = arkenv(");
 			expect(templates.client).not.toContain(
 				"NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,",
 			);
@@ -337,7 +327,7 @@ describe("env-template", () => {
 			};
 			const templates = getStrictEnvTemplates(options, "@/generated/env.gen");
 			expect(templates.client).toContain(
-				'import { createEnv } from "@/generated/env.gen";',
+				'import arkenv from "@/generated/env.gen";',
 			);
 		});
 
@@ -378,7 +368,7 @@ describe("env-template", () => {
 			};
 			const templates = getStrictEnvTemplates(options);
 			expect(templates.client).toContain(
-				"createEnv(\n\t{},\n\t{\n\t\textends: [SharedSchema],",
+				"arkenv(\n\t{},\n\t{\n\t\textends: [SharedSchema],",
 			);
 			expect(templates.shared).toContain(
 				"export const SharedSchema = z.object({});",

--- a/packages/cli/src/features/scaffold/env-template.ts
+++ b/packages/cli/src/features/scaffold/env-template.ts
@@ -170,10 +170,10 @@ export const env = arkenv(
 		},
 	},
 );`
-			: `import { createEnv } from "${nextjsImportPath || "./generated/env.gen"}";
+			: `import arkenv from "${nextjsImportPath || "./generated/env.gen"}";
 import { SharedSchema } from "./internal/shared";
 
-export const env = createEnv(
+export const env = arkenv(
 	${formatSchemaObject(clientFields, "\t\t")},
 	{
 		extends: [SharedSchema],
@@ -212,11 +212,11 @@ export const env = arkenv(
 		},
 	},
 );`
-			: `import { createEnv } from "${nextjsImportPath || "./generated/env.gen"}";
+			: `import arkenv from "${nextjsImportPath || "./generated/env.gen"}";
 import { z } from "zod";
 import { SharedSchema } from "./internal/shared";
 
-export const env = createEnv(
+export const env = arkenv(
 	${formatSchemaObject(clientFields, "\t\t")},
 	{
 		extends: [SharedSchema],
@@ -256,11 +256,11 @@ export const env = arkenv(
 		},
 	},
 );`
-			: `import { createEnv } from "${nextjsImportPath || "./generated/env.gen"}";
+			: `import arkenv from "${nextjsImportPath || "./generated/env.gen"}";
 import * as v from "valibot";
 import { SharedSchema } from "./internal/shared";
 
-export const env = createEnv(
+export const env = arkenv(
 	${formatSchemaObject(clientFields, "\t\t")},
 	{
 		extends: [SharedSchema],

--- a/packages/cli/src/features/scaffold/planner.test.ts
+++ b/packages/cli/src/features/scaffold/planner.test.ts
@@ -341,7 +341,7 @@ describe("Planner", () => {
 		const plan = createPlan(state);
 		const envFile = plan.files.find((f) => f.path.endsWith("env.ts"));
 		expect(envFile?.content).toContain(
-			'import { createEnv } from "@/generated/env.gen"',
+			'import arkenv from "@/generated/env.gen"',
 		);
 	});
 
@@ -370,7 +370,7 @@ describe("Planner", () => {
 		const plan = createPlan(state);
 		const envFile = plan.files.find((f) => f.path.endsWith("env.ts"));
 		expect(envFile?.content).toContain(
-			'import { createEnv } from "@/generated/env.gen"',
+			'import arkenv from "@/generated/env.gen"',
 		);
 	});
 
@@ -399,7 +399,7 @@ describe("Planner", () => {
 		const plan = createPlan(state);
 		const envFile = plan.files.find((f) => f.path.endsWith("env.ts"));
 		expect(envFile?.content).toContain(
-			'import { createEnv } from "./generated/env.gen"',
+			'import arkenv from "./generated/env.gen"',
 		);
 	});
 
@@ -431,7 +431,7 @@ describe("Planner", () => {
 			f.path.replace(/\\/g, "/").endsWith("env/client.ts"),
 		);
 		expect(clientFile?.content).toContain(
-			'import { createEnv } from "@/env/generated/env.gen"',
+			'import arkenv from "@/env/generated/env.gen"',
 		);
 	});
 });

--- a/packages/cli/src/features/scaffold/templates/nextjs-template.ts
+++ b/packages/cli/src/features/scaffold/templates/nextjs-template.ts
@@ -135,7 +135,7 @@ ${sections.join(",\n")},
 	}
 
 	const imports = [
-		`import { createEnv } from "${nextjsImportPath || "./generated/env.gen"}";`,
+		`import arkenv from "${nextjsImportPath || "./generated/env.gen"}";`,
 		...(extraImports ? [extraImports] : []),
 	].join("\n");
 
@@ -143,10 +143,10 @@ ${sections.join(",\n")},
 
 /**
  * Environment variable schema.
- * In Next.js, use the generated \`createEnv\` from \`env.gen.ts\` to validate variables.
+ * In Next.js, use the generated \`arkenv\` from \`env.gen.ts\` to validate variables.
  * Enforces client/server separation and prevents secret leaks.
  */
-export const env = createEnv({
+export const env = arkenv({
 ${sections.join(",\n")},
 });
 `;

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -32,13 +32,13 @@ export default withArkEnv(nextConfig);
 
 ### 2. Define your schema in `env.ts`
 
-Import `createEnv` from the generated `./generated/env.gen` file instead of the package:
+Import `arkenv` from the generated `./generated/env.gen` file instead of the package:
 
 ```typescript
 // src/env.ts
-import { createEnv } from "./generated/env.gen";
+import arkenv from "./generated/env.gen";
 
-export const env = createEnv({
+export const env = arkenv({
   server: {
     DATABASE_URL: "string",
     STRIPE_API_KEY: "string",
@@ -79,9 +79,9 @@ Then, import from the custom location:
 
 ```typescript
 // src/env.ts
-import { createEnv } from "./generated/env.gen";
+import arkenv from "./generated/env.gen";
 
-export const env = createEnv({
+export const env = arkenv({
   client: {
     NEXT_PUBLIC_API_URL: "string",
   }

--- a/packages/nextjs/src/config.test.ts
+++ b/packages/nextjs/src/config.test.ts
@@ -12,8 +12,8 @@ import {
 describe("config key extraction", () => {
 	it("should extract client and shared keys correctly", () => {
 		const source = `
-			import { createEnv } from "./env.gen";
-			export const env = createEnv({
+			import arkenv from "./env.gen";
+			export const env = arkenv({
 				server: {
 					DATABASE_URL: "string",
 				},
@@ -38,7 +38,7 @@ describe("config key extraction", () => {
 
 	it("should handle single-line comments", () => {
 		const source = `
-			export const env = createEnv({
+			export const env = arkenv({
 				client: {
 					// This is a comment
 					NEXT_PUBLIC_VAR_1: "string",
@@ -54,7 +54,7 @@ describe("config key extraction", () => {
 
 	it("should handle multi-line comments", () => {
 		const source = `
-			export const env = createEnv({
+			export const env = arkenv({
 				client: {
 					/*
 					* Multi-line comment:
@@ -70,7 +70,7 @@ describe("config key extraction", () => {
 
 	it("should ignore string values that contain colons", () => {
 		const source = `
-			export const env = createEnv({
+			export const env = arkenv({
 				client: {
 					NEXT_PUBLIC_API_URL: "string = 'http://localhost:3000'",
 					NEXT_PUBLIC_NESTED: 'string = "foo:bar"',
@@ -89,7 +89,7 @@ describe("config key extraction", () => {
 
 	it("should extract quoted keys correctly", () => {
 		const source = `
-			export const env = createEnv({
+			export const env = arkenv({
 				client: {
 					"NEXT_PUBLIC_VAR_1": "string",
 					'NEXT_PUBLIC_VAR_2': "string",
@@ -103,7 +103,7 @@ describe("config key extraction", () => {
 
 	it("should ignore braces inside string templates or comments in extractBlock", () => {
 		const source = `
-			export const env = createEnv({
+			export const env = arkenv({
 				client: {
 					NEXT_PUBLIC_VAR_1: "string = '{not-a-brace}'",
 					// {comment-brace}
@@ -118,7 +118,7 @@ describe("config key extraction", () => {
 
 	it("should ignore nested keys inside complex values in parseBlockKeys", () => {
 		const source = `
-			export const env = createEnv({
+			export const env = arkenv({
 				client: {
 					NEXT_PUBLIC_VAR_1: type("string", { description: "nested:key" }),
 					NEXT_PUBLIC_VAR_2: "string",
@@ -132,7 +132,7 @@ describe("config key extraction", () => {
 
 	it("should extract keys when using ArkType 'type({...})' wrapper", () => {
 		const source = `
-			export const env = createEnv({
+			export const env = arkenv({
 				client: type({
 					NEXT_PUBLIC_VAR_1: "string",
 					NEXT_PUBLIC_VAR_2: "string",
@@ -169,8 +169,8 @@ describe("codegen process", () => {
 		fs.writeFileSync(
 			schemaPath,
 			`
-			import { createEnv } from "./env.gen";
-			export const env = createEnv({
+			import arkenv from "./env.gen";
+			export const env = arkenv({
 				client: {
 					NEXT_PUBLIC_API_URL: "string",
 				},
@@ -220,7 +220,7 @@ describe("codegen process", () => {
 		fs.writeFileSync(
 			schemaPath,
 			`
-			export const env = createEnv({
+			export const env = arkenv({
 				client: {
 					NEXT_PUBLIC_API_URL: "string",
 				}
@@ -281,7 +281,7 @@ describe("withArkEnv wrapper", () => {
 		fs.writeFileSync(
 			schemaPath,
 			`
-			export const env = createEnv({
+			export const env = arkenv({
 				client: { NEXT_PUBLIC_API_URL: "string" }
 			});
 			`,
@@ -376,7 +376,7 @@ describe("withArkEnv wrapper", () => {
 		// Only create the schema file, not the strict layout files
 		fs.writeFileSync(
 			schemaPath,
-			`export const env = createEnv({ client: { NEXT_PUBLIC_VAR: "string" } });`,
+			`export const env = arkenv({ client: { NEXT_PUBLIC_VAR: "string" } });`,
 			"utf-8",
 		);
 

--- a/skills/create-changeset/SKILL.md
+++ b/skills/create-changeset/SKILL.md
@@ -93,15 +93,15 @@ Create a file in `.changeset/` with a random name:
 "arkenv": minor
 ---
 
-#### Add `createEnv` helper for improved type inference
+#### Add `arkenv` helper for improved type inference
 
 Usage:
 
 ```ts
-import { createEnv } from "arkenv"
+import arkenv from "arkenv"
 import { type } from "arktype"
 
-export const env = createEnv({
+export const env = arkenv({
   schema: {
     NODE_ENV: type("'development' | 'production' | 'test'"),
     PORT: type.number.parseable()

--- a/skills/create-changeset/references/scenarios.md
+++ b/skills/create-changeset/references/scenarios.md
@@ -19,17 +19,17 @@ Categories with parent slugs now correctly link to their parent categories durin
 "arkenv": minor
 ---
 
-#### Add `createEnv` for type-safe environment variables
+#### Add `arkenv` for type-safe environment variables
 
-The new `createEnv` function allows you to define your environment schema using ArkType.
+The new `arkenv` function allows you to define your environment schema using ArkType.
 
 Usage:
 
 ```ts
-import { createEnv } from "arkenv"
+import arkenv from "arkenv"
 import { type } from "arktype"
 
-const env = createEnv({
+const env = arkenv({
   schema: {
     PORT: type.number.parseable()
   }
@@ -48,19 +48,19 @@ console.log(env.PORT) // number
 
 #### Change configuration format for validators
 
-**BREAKING CHANGE**: Validator options are now passed as a second argument to `createEnv`.
+**BREAKING CHANGE**: Validator options are now passed as a second argument to `arkenv`.
 
 Before:
 ```ts
-createEnv({ schema, strict: true })
+arkenv({ schema, strict: true })
 ```
 
 After:
 ```ts
-createEnv({ schema }, { strict: true })
+arkenv({ schema }, { strict: true })
 ```
 
-Migration: Update your `createEnv` calls to separate the options from the schema configuration.
+Migration: Update your `arkenv` calls to separate the options from the schema configuration.
 ````
 
 ## Multiple related changes


### PR DESCRIPTION
Fixes #1129

Updates Next.js scaffold templates, documentation, examples, and agent skills to use the default import arkenv instead of the named createEnv import. This ensures compatibility with the ArkType IDE extension for syntax highlighting.