### PR TITLE
infra: add force_override option to deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,6 +2,12 @@ name: deploy-docs
 
 on:
   workflow_dispatch:
+    inputs:
+      force_override:
+        description: '⚠️ ADMIN ONLY: Bypass doc-only safety check'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -26,34 +32,38 @@ jobs:
 
       - name: Verify Doc-Only Changes
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-          # Fetch main to compare
-          git fetch origin main:main
-          
-          # Get list of changed files between main and dev
-          CHANGED_FILES=$(git diff --name-only main...dev)
-          
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No changes between dev and main. Nothing to sync."
-            exit 0
+          if [ "${{ github.event.inputs.force_override }}" = "true" ]; then
+            echo "⚠️ Admin override enabled. Bypassing safety checks."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            
+            # Fetch main to compare
+            git fetch origin main:main
+            
+            # Get list of changed files between main and dev
+            CHANGED_FILES=$(git diff --name-only main...dev)
+            
+            if [ -z "$CHANGED_FILES" ]; then
+              echo "No changes between dev and main. Nothing to sync."
+              exit 0
+            fi
+            
+            echo "Files changed between main and dev:"
+            echo "$CHANGED_FILES"
+            
+            # Filter out files that are allowed for doc-only deploys:
+            # docs/**, www/**, and markdown files in the root
+            NON_DOCS=$(echo "$CHANGED_FILES" | grep -vE "^(docs/|www/|[^/]+\.md)$")
+            
+            if [ -n "$NON_DOCS" ]; then
+              echo "::error::Cannot sync dev to main. The following files contain unreleased code changes:"
+              echo "$NON_DOCS"
+              exit 1
+            fi
+            
+            echo "✅ All changes are doc-only. Safe to fast-forward."
           fi
-          
-          echo "Files changed between main and dev:"
-          echo "$CHANGED_FILES"
-          
-          # Filter out files that are allowed for doc-only deploys:
-          # docs/**, www/**, and markdown files in the root
-          NON_DOCS=$(echo "$CHANGED_FILES" | grep -vE "^(docs/|www/|[^/]+\.md)$")
-          
-          if [ -n "$NON_DOCS" ]; then
-            echo "::error::Cannot sync dev to main. The following files contain unreleased code changes:"
-            echo "$NON_DOCS"
-            exit 1
-          fi
-          
-          echo "✅ All changes are doc-only. Safe to fast-forward."
 
       - name: Sync main branch
         run: |

--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -1,4 +1,4 @@
-name: Sync Main
+name: Sync main
 
 on:
   workflow_dispatch:

--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -1,4 +1,4 @@
-name: deploy-docs
+name: Sync Main
 
 on:
   workflow_dispatch:
@@ -13,8 +13,8 @@ permissions:
   contents: write
 
 jobs:
-  deploy-docs:
-    name: Deploy Doc-Only Changes
+  sync-main:
+    name: Sync main branch with dev
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App Token
@@ -32,15 +32,14 @@ jobs:
 
       - name: Verify Doc-Only Changes
         run: |
+          # ALWAYS configure git and fetch main first so git knows about it
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main:main
+          
           if [ "${{ github.event.inputs.force_override }}" = "true" ]; then
             echo "⚠️ Admin override enabled. Bypassing safety checks."
           else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            
-            # Fetch main to compare
-            git fetch origin main:main
-            
             # Get list of changed files between main and dev
             CHANGED_FILES=$(git diff --name-only main...dev)
             

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -83,7 +83,7 @@ If you make documentation updates (e.g., fixing a typo) and want to push them to
 If `dev` is currently clean (meaning there are no unreleased features merged into it):
 
 1. Merge your doc changes into `dev`.
-2. Manually trigger the **`deploy-docs`** GitHub Workflow.
+2. Manually trigger the **`Sync Main`** GitHub Workflow.
 3. This workflow verifies that the diff is strictly doc-only, fast-forwards `main` to `dev`, and pushes it to deploy.
 
 #### Scenario B: `dev` has unreleased code

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -83,7 +83,7 @@ If you make documentation updates (e.g., fixing a typo) and want to push them to
 If `dev` is currently clean (meaning there are no unreleased features merged into it):
 
 1. Merge your doc changes into `dev`.
-2. Manually trigger the **`Sync Main`** GitHub Workflow.
+2. Manually trigger the **`Sync main`** GitHub Workflow.
 3. This workflow verifies that the diff is strictly doc-only, fast-forwards `main` to `dev`, and pushes it to deploy.
 
 #### Scenario B: `dev` has unreleased code


### PR DESCRIPTION
Adds a manual force_override parameter to the deploy-docs workflow so repository admins can bypass safety checks and force a dev->main fast-forward sync.