### PR TITLE
feat: twoslash dev server optimizations - filesystem cache, reuse compiler instances, memory tuning

### DIFF
--- a/apps/www/bin/twoslash-mdx.ts
+++ b/apps/www/bin/twoslash-mdx.ts
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/suspicious/noConsole: This is a CLI debugging script
 import fs from "node:fs";
-import { twoslasher } from "twoslash";
+import { createTwoslasher } from "twoslash";
 import { arktypeTwoslashOptions } from "../lib/twoslash-options";
 
 const mdxPath = process.argv[2];
@@ -14,6 +14,7 @@ const content = fs.readFileSync(mdxPath, "utf8");
 // Use the shared options, but we need the inner twoslashOptions property
 // which contains compilerOptions, extraFiles, etc.
 const options = arktypeTwoslashOptions.twoslashOptions;
+const twoslasher = createTwoslasher(options);
 
 const codeBlockRegex =
 	/```(ts|tsx|js|jsx)(?:[ \t]+[^\n]*?)?[ \t]+twoslash(?:[ \t]+[^\n]*?)?\r?\n([\s\S]*?)\r?\n[ \t]*```/g;
@@ -25,7 +26,7 @@ for (const match of content.matchAll(codeBlockRegex)) {
 	if (code === undefined) continue;
 	console.log(`\n--- Block ${blockIndex++} ---`);
 	try {
-		const result = twoslasher(code, lang, options);
+		const result = twoslasher(code, lang);
 
 		console.log("Hovers:");
 		for (const h of result.hovers) {

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -23,6 +23,11 @@ const config = {
 		// We check typesafety on ci
 		ignoreBuildErrors: true,
 	},
+	experimental: {
+		// Aggressively reclaim memory during Webpack builds in dev mode.
+		// Can be reverted if any instability is observed in Next.js 16.
+		webpackMemoryOptimizations: true,
+	},
 	// Redirect /docs to /docs/arkenv
 	async redirects() {
 		return [

--- a/apps/www/source.config.ts
+++ b/apps/www/source.config.ts
@@ -5,6 +5,7 @@ import {
 } from "fumadocs-core/mdx-plugins";
 import { defineConfig, defineDocs } from "fumadocs-mdx/config";
 import { transformerTwoslash } from "fumadocs-twoslash";
+import { createFileSystemTypesCache } from "fumadocs-twoslash/cache-fs";
 import remarkDirective from "remark-directive";
 import remarkGemoji from "remark-gemoji";
 import { rehypeOptimizeInternalLinks } from "./lib/plugins/rehype-optimize-internal-links";
@@ -147,7 +148,10 @@ export default defineConfig({
 				dark: "github-dark-high-contrast",
 			},
 			transformers: [
-				transformerTwoslash(arktypeTwoslashOptions),
+				transformerTwoslash({
+					...arktypeTwoslashOptions,
+					typesCache: createFileSystemTypesCache(),
+				}),
 				...(rehypeCodeDefaultOptions.transformers ?? []),
 			],
 		},


### PR DESCRIPTION
Fixes #1183

This PR applies three targeted optimizations to reduce memory usage and improve dev server responsiveness during MDX page compilation:

- **Filesystem types cache:**
  - `transformerTwoslash()` is now configured with `typesCache: createFileSystemTypesCache()` from `fumadocs-twoslash/cache-fs`
  - Caches type-checking results to `.next/cache/twoslash/` (already gitignored, cleaned by `pnpm run clear-cache`)
  - Avoids redundant TypeScript compiler invocations for unchanged code blocks

- **Reuse compiler in CLI script:**
  - `twoslash-mdx.ts` now uses `createTwoslasher(options)` once before the loop
  - Reuses the TypeScript VFS and compiler instance across all code blocks in a file

- **Webpack memory optimizations:**
  - Added `experimental.webpackMemoryOptimizations: true` to `next.config.ts`
  - Instructs Webpack to aggressively reclaim memory during dev mode
  - Includes a comment noting it can be reverted if instability is observed in Next.js 16
