### PR TITLE
fix: “Open on GitHub” button should take us to “dev”

### DIFF
--- a/apps/www/lib/utils/github.test.ts
+++ b/apps/www/lib/utils/github.test.ts
@@ -13,7 +13,7 @@ describe("github utilities", () => {
 			expect(result).toEqual({
 				owner: "yamcodes",
 				repo: "arkenv",
-				defaultBranch: "main",
+				defaultBranch: "dev",
 			});
 		});
 
@@ -23,7 +23,7 @@ describe("github utilities", () => {
 			expect(result).toEqual({
 				owner: "yamcodes",
 				repo: "arkenv",
-				defaultBranch: "main",
+				defaultBranch: "dev",
 			});
 		});
 
@@ -35,7 +35,7 @@ describe("github utilities", () => {
 			expect(result).toEqual({
 				owner: "example",
 				repo: "repo",
-				defaultBranch: "main",
+				defaultBranch: "dev",
 			});
 		});
 
@@ -61,7 +61,7 @@ describe("github utilities", () => {
 			expect(result).toEqual({
 				owner: "yamcodes",
 				repo: "arkenv",
-				defaultBranch: "main",
+				defaultBranch: "dev",
 			});
 		});
 
@@ -87,7 +87,7 @@ describe("github utilities", () => {
 			expect(result).toEqual({
 				owner: "tree",
 				repo: "main",
-				defaultBranch: "main",
+				defaultBranch: "dev",
 			});
 		});
 	});
@@ -100,8 +100,8 @@ describe("github utilities", () => {
 			);
 
 			expect(result).toEqual({
-				title: "Editing arkenv/README.md at main · yamcodes/arkenv",
-				href: "https://github.com/yamcodes/arkenv/edit/main/README.md",
+				title: "Editing arkenv/README.md at dev · yamcodes/arkenv",
+				href: "https://github.com/yamcodes/arkenv/edit/dev/README.md",
 			});
 		});
 
@@ -113,8 +113,8 @@ describe("github utilities", () => {
 
 			expect(result).toEqual({
 				title:
-					"Editing arkenv/docs/getting-started.md at main · yamcodes/arkenv",
-				href: "https://github.com/yamcodes/arkenv/edit/main/docs/getting-started.md",
+					"Editing arkenv/docs/getting-started.md at dev · yamcodes/arkenv",
+				href: "https://github.com/yamcodes/arkenv/edit/dev/docs/getting-started.md",
 			});
 		});
 
@@ -124,8 +124,8 @@ describe("github utilities", () => {
 			const result = getLinkTitleAndHref("test.md");
 
 			expect(result).toEqual({
-				title: "Editing repo/test.md at main · example/repo",
-				href: "https://github.com/example/repo/edit/main/test.md",
+				title: "Editing repo/test.md at dev · example/repo",
+				href: "https://github.com/example/repo/edit/dev/test.md",
 			});
 		});
 
@@ -148,8 +148,8 @@ describe("github utilities", () => {
 			const result = getLinkTitleAndHref("test.md");
 
 			expect(result).toEqual({
-				title: "Editing arkenv/test.md at main · yamcodes/arkenv",
-				href: "https://github.com/yamcodes/arkenv/edit/main/test.md",
+				title: "Editing arkenv/test.md at dev · yamcodes/arkenv",
+				href: "https://github.com/yamcodes/arkenv/edit/dev/test.md",
 			});
 		});
 
@@ -160,8 +160,8 @@ describe("github utilities", () => {
 			);
 
 			expect(result).toEqual({
-				title: "Editing arkenv/src/index.ts at main · yamcodes/arkenv",
-				href: "https://github.com/yamcodes/arkenv//edit/main/src/index.ts",
+				title: "Editing arkenv/src/index.ts at dev · yamcodes/arkenv",
+				href: "https://github.com/yamcodes/arkenv//edit/dev/src/index.ts",
 			});
 		});
 	});

--- a/apps/www/lib/utils/github.ts
+++ b/apps/www/lib/utils/github.ts
@@ -10,7 +10,7 @@ export const breakDownGithubUrl = (githubUrl?: string) => {
 		process.env.NEXT_PUBLIC_GITHUB_URL ??
 		"https://github.com/yamcodes/arkenv";
 
-	const defaultBranch = process.env.NEXT_PUBLIC_GITHUB_BRANCH ?? "main";
+	const defaultBranch = process.env.NEXT_PUBLIC_GITHUB_BRANCH ?? "dev";
 	const cleanUrl = url.replace(/\/$/, "");
 	const urlObj = new URL(cleanUrl);
 	const [owner, repo] = urlObj.pathname.split("/").filter(Boolean).slice(-2);


### PR DESCRIPTION
Fixes #1181\n\nUpdated the fallback default branch in GitHub utility functions from "main" to "dev" and updated the corresponding unit tests.