### PR TITLE
fix: Option to treat empty envs as undefined

### DIFF
--- a/.changeset/de4cfa57.md
+++ b/.changeset/de4cfa57.md
@@ -1,0 +1,35 @@
+---
+"arkenv": patch
+---
+
+#### Add `emptyAsUndefined` option to treat empty env values as missing
+
+Add a new `emptyAsUndefined` configuration option to both `createEnv` (ArkType mode) and `arkenv/standard` (Standard Schema mode). When enabled, environment variables set to empty strings (e.g., `PORT=` in a `.env` file) are treated as if they were missing, allowing defaults to apply and preventing unnecessary validation errors for numeric, boolean, or array types.
+
+**Usage:**
+
+```ts
+import arkenv from "arkenv";
+
+const env = arkenv(
+  { PORT: "number = 3000", DEBUG: "boolean = false" },
+  { emptyAsUndefined: true }
+);
+
+// Given PORT= and DEBUG= in the environment:
+// env.PORT  → 3000
+// env.DEBUG → false
+```
+
+```ts
+import arkenv from "arkenv/standard";
+import { z } from "zod";
+
+const env = arkenv(
+  { PORT: z.coerce.number().default(3000) },
+  { emptyAsUndefined: true }
+);
+```
+
+- The default behavior remains unchanged (`emptyAsUndefined: false`).
+- Keys with empty values are removed from the input record before validation so that ArkType defaults and optional types work correctly.

--- a/apps/www/content/docs/arkenv/coercion.mdx
+++ b/apps/www/content/docs/arkenv/coercion.mdx
@@ -11,7 +11,7 @@ Coercion in [arkenv/standard](/docs/arkenv/standard) only works with:
 - [Zod](https://zod.dev) (v4.2+)
 - [Valibot](https://valibot.dev) (v1.2+ via `@valibot/to-json-schema`)
 - [Zod Mini](https://zod.dev)
-- [stnl](https://github.com/re-utils/stnl)
+- [VineJS](https://vinejs.dev/) (v4.3.0+)
 - Any validator compliant with [Standard JSON Schema v1](https://standardschema.dev/json-schema#what-schema-libraries-support-this-spec)
   :::
 
@@ -105,33 +105,6 @@ ArkEnv introspects your schema to identify fields that should be numbers, boolea
 ## Performance
 
 Coercion is highly optimized: ArkEnv performs a one-time introspection of your schema to map out exactly which paths need conversion. At runtime, it only touches the variables that actually need coercion, keeping your startup time virtually identical to manually parsing `process.env`.
-
-## Empty values
-
-By default, an empty value in your environment (e.g., `PORT=` in a `.env` file) is treated as an empty string (`""`). This means defaults won't apply and validation may fail for non-string types.
-
-You can opt-in to treating empty values as missing by setting `emptyAsUndefined` to `true`:
-
-```ts twoslash
-import arkenv from "arkenv";
-// ---cut---
-const env = arkenv(
-  {
-    PORT: "number = 3000",
-    DEBUG: "boolean = false",
-  },
-  {
-    emptyAsUndefined: true,
-    env: {
-      PORT: "",
-      DEBUG: "",
-    },
-  }
-);
-
-// env.PORT  → 3000 (default applied)
-// env.DEBUG → false (default applied)
-```
 
 ## Disabling coercion
 

--- a/apps/www/content/docs/arkenv/coercion.mdx
+++ b/apps/www/content/docs/arkenv/coercion.mdx
@@ -106,6 +106,33 @@ ArkEnv introspects your schema to identify fields that should be numbers, boolea
 
 Coercion is highly optimized: ArkEnv performs a one-time introspection of your schema to map out exactly which paths need conversion. At runtime, it only touches the variables that actually need coercion, keeping your startup time virtually identical to manually parsing `process.env`.
 
+## Empty values
+
+By default, an empty value in your environment (e.g., `PORT=` in a `.env` file) is treated as an empty string (`""`). This means defaults won't apply and validation may fail for non-string types.
+
+You can opt-in to treating empty values as missing by setting `emptyAsUndefined` to `true`:
+
+```ts twoslash
+import arkenv from "arkenv";
+// ---cut---
+const env = arkenv(
+  {
+    PORT: "number = 3000",
+    DEBUG: "boolean = false",
+  },
+  {
+    emptyAsUndefined: true,
+    env: {
+      PORT: "",
+      DEBUG: "",
+    },
+  }
+);
+
+// env.PORT  → 3000 (default applied)
+// env.DEBUG → false (default applied)
+```
+
 ## Disabling coercion
 
 You can opt-out of this behavior by setting `coerce` to `false`.

--- a/apps/www/content/docs/arkenv/faq.mdx
+++ b/apps/www/content/docs/arkenv/faq.mdx
@@ -50,7 +50,7 @@ const env = arkenv(
 );
 ```
 
-See the [coercion docs](/docs/arkenv/coercion#empty-values) for more details.
+See the [options docs](/docs/arkenv/options) for more details.
 
 [//]: # "2. The Validator Story"
 

--- a/apps/www/content/docs/arkenv/faq.mdx
+++ b/apps/www/content/docs/arkenv/faq.mdx
@@ -37,6 +37,21 @@ Most modern frameworks load `.env` files automatically. For plain Node.js, we re
 
 ArkEnv intercepts the populated `process.env` or `import.meta.env` object, evaluates it against your schema, and applies **automatic type coercion**.
 
+## Why do empty values in my `.env` file cause validation errors?
+
+An empty value (e.g., `PORT=` in a `.env` file) is passed to ArkEnv as an empty string (`""`). By default, ArkEnv treats this as an actual value — it won't apply defaults and it will fail validation for non-string types like `number` or `boolean`.
+
+If you want empty values to be treated as missing (so defaults apply), enable the `emptyAsUndefined` option:
+
+```ts
+const env = arkenv(
+  { PORT: "number = 3000" },
+  { emptyAsUndefined: true }
+);
+```
+
+See the [coercion docs](/docs/arkenv/coercion#empty-values) for more details.
+
 [//]: # "2. The Validator Story"
 
 ## Do I have to use ArkType?

--- a/apps/www/content/docs/arkenv/meta.json
+++ b/apps/www/content/docs/arkenv/meta.json
@@ -15,6 +15,7 @@
 		"---API---",
 		"[arkenv/standard](/docs/arkenv/standard)",
 		"coercion",
+		"options",
 		"---How-to---",
 		"[Load environment variables](/docs/arkenv/how-to/load-environment-variables)",
 		"[Reuse your schema](/docs/arkenv/how-to/reuse-schemas)"

--- a/apps/www/content/docs/arkenv/options.mdx
+++ b/apps/www/content/docs/arkenv/options.mdx
@@ -1,0 +1,89 @@
+---
+title: Options
+description: Configuration options for the arkenv() function.
+---
+
+The second argument to `arkenv()` is an optional configuration object.
+
+:::note
+All options listed below apply to both `arkenv` (ArkType mode) and `arkenv/standard` (Standard Schema mode).
+:::
+
+## `env`
+
+The environment variables to parse. Defaults to `process.env`.
+
+```ts twoslash
+import arkenv from "arkenv";
+// ---cut---
+const env = arkenv(
+  { PORT: "number" },
+  { env: { PORT: "3000" } }
+);
+```
+
+## `coerce`
+
+Whether to coerce environment variables to their defined types. Defaults to `true`.
+
+```ts twoslash
+import arkenv from "arkenv";
+// ---cut---
+const env = arkenv(
+  { PORT: "number" },
+  { coerce: false }
+);
+```
+
+See the [coercion docs](/docs/arkenv/coercion) for more details.
+
+## `onUndeclaredKey`
+
+Control how ArkEnv handles environment variables that are not defined in your schema. Defaults to `"delete"`.
+
+- `"delete"` — Undeclared keys are allowed on input but stripped from the output.
+- `"ignore"` — Undeclared keys are allowed and preserved in the output.
+- `"reject"` — Undeclared keys will cause validation to fail.
+
+## `arrayFormat`
+
+The format to use for array parsing when coercion is enabled. Defaults to `"comma"`.
+
+- `"comma"` — Strings are split by comma and trimmed.
+- `"json"` — Strings are parsed as JSON.
+
+```ts twoslash
+import arkenv from "arkenv";
+// ---cut---
+const env = arkenv(
+  { TAGS: "string[]" },
+  { arrayFormat: "json", env: { TAGS: '["web", "app"]' } }
+);
+```
+
+## `emptyAsUndefined`
+
+Whether to treat empty strings (`""`) as `undefined` before validation. Defaults to `false`.
+
+When enabled, an environment variable set to an empty value (e.g., `PORT=` in a `.env` file) will be treated as if it were missing, allowing defaults to apply and preventing validation errors for numeric or boolean types.
+
+```ts twoslash
+import arkenv from "arkenv";
+// ---cut---
+const env = arkenv(
+  {
+    PORT: "number = 3000",
+    DEBUG: "boolean = false",
+  },
+  {
+    emptyAsUndefined: true,
+    env: {
+      PORT: "",
+      DEBUG: "",
+    },
+  }
+);
+
+// env.PORT  → 3000 (default applied)
+// env.DEBUG → false (default applied)
+```

--- a/packages/arkenv/src/arktype/create-env.test.ts
+++ b/packages/arkenv/src/arktype/create-env.test.ts
@@ -176,6 +176,41 @@ describe("createEnv", () => {
 			const env = createEnv({ VAL: "unknown" }, { env: { VAL: "" } });
 			expect(env.VAL).toBe("");
 		});
+
+		describe("emptyAsUndefined", () => {
+			it("should apply defaults to empty environment variables", () => {
+				const env = createEnv(
+					{ PORT: "number = 3000" },
+					{ env: { PORT: "" }, emptyAsUndefined: true },
+				);
+				expect(env.PORT).toBe(3000);
+			});
+
+			it("should allow optional keys to be undefined when empty", () => {
+				const env = createEnv(
+					{ VAL: "string?" },
+					{ env: { VAL: "" }, emptyAsUndefined: true },
+				);
+				expect(env.VAL).toBeUndefined();
+			});
+
+			it("should throw for required keys when empty", () => {
+				expect(() =>
+					createEnv(
+						{ VAL: "string" },
+						{ env: { VAL: "" }, emptyAsUndefined: true },
+					),
+				).toThrow();
+			});
+
+			it("should respect array defaults when empty", () => {
+				const env = createEnv(
+					{ TAGS: type("string[]").default(() => []) },
+					{ env: { TAGS: "" }, emptyAsUndefined: true },
+				);
+				expect(env.TAGS).toEqual([]);
+			});
+		});
 	});
 
 	describe("standard array syntax", () => {

--- a/packages/arkenv/src/arktype/create-env.test.ts
+++ b/packages/arkenv/src/arktype/create-env.test.ts
@@ -210,6 +210,14 @@ describe("createEnv", () => {
 				);
 				expect(env.TAGS).toEqual([]);
 			});
+
+			it("should still work when coercion is disabled", () => {
+				const env = createEnv(
+					{ VAL: "string = 'default'" },
+					{ env: { VAL: "" }, emptyAsUndefined: true, coerce: false },
+				);
+				expect(env.VAL).toBe("default");
+			});
 		});
 	});
 

--- a/packages/arkenv/src/arktype/index.ts
+++ b/packages/arkenv/src/arktype/index.ts
@@ -2,6 +2,7 @@ import { $ } from "@repo/scope";
 import type { SchemaShape } from "@repo/types";
 import type { distill } from "arktype";
 import { ArkErrors } from "arktype";
+import { stripEmptyStrings } from "@/coercion/shared";
 import { ArkEnvError, type ValidationIssue } from "@/core";
 import type { ArkEnvConfig, EnvSchema } from "@/create-env";
 import { styleText } from "@/utils/style-text";
@@ -84,6 +85,7 @@ export function parse<const T extends SchemaShape>(
 		coerce: shouldCoerce = true,
 		onUndeclaredKey = "delete",
 		arrayFormat = "comma",
+		emptyAsUndefined = false,
 	} = config;
 
 	// If def is a type definition (has assert method), use it directly
@@ -100,8 +102,13 @@ export function parse<const T extends SchemaShape>(
 		finalSchema = coerce($.type, schemaWithKeys, { arrayFormat });
 	}
 
+	// Optionally treat empty strings as undefined
+	const processedEnv = emptyAsUndefined
+		? stripEmptyStrings(env as Record<string, string | undefined>)
+		: env;
+
 	// Validate the environment variables
-	const validatedEnv = finalSchema(env);
+	const validatedEnv = finalSchema(processedEnv);
 
 	// In ArkType 2.x, calling a type as a function returns the validated data or ArkErrors
 	if (validatedEnv instanceof ArkErrors) {

--- a/packages/arkenv/src/coercion/shared.test.ts
+++ b/packages/arkenv/src/coercion/shared.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { stripEmptyStrings } from "./shared";
+
+describe("stripEmptyStrings", () => {
+	it("should remove keys with empty string values", () => {
+		const env = { A: "", B: "value", C: "" };
+		const result = stripEmptyStrings(env);
+		expect(result).toEqual({ B: "value" });
+	});
+
+	it("should preserve keys with undefined values", () => {
+		const env = { A: undefined, B: "value" };
+		const result = stripEmptyStrings(env);
+		expect(result).toEqual({ A: undefined, B: "value" });
+	});
+
+	it("should return a new object", () => {
+		const env = { A: "value" };
+		const result = stripEmptyStrings(env);
+		expect(result).not.toBe(env);
+	});
+});

--- a/packages/arkenv/src/coercion/shared.ts
+++ b/packages/arkenv/src/coercion/shared.ts
@@ -1,6 +1,28 @@
 import { coerceBoolean, coerceDate, coerceJson, coerceNumber } from "./morphs";
 
 /**
+ * Remove keys with empty string values from an environment record.
+ *
+ * When a key is set to `""` (e.g. `PORT=` in a `.env` file), deleting it
+ * allows the validator to treat it as missing so that defaults apply.
+ *
+ * @param env The environment variables record
+ * @returns A new record with empty string keys removed
+ */
+export const stripEmptyStrings = (
+	env: Record<string, string | undefined>,
+): Record<string, string | undefined> => {
+	const result: Record<string, string | undefined> = {};
+	for (const key in env) {
+		const value = env[key];
+		if (value !== "") {
+			result[key] = value;
+		}
+	}
+	return result;
+};
+
+/**
  * A marker used in the coercion path to indicate that the target
  * is the *elements* of an array, rather than the array property itself.
  */

--- a/packages/arkenv/src/create-env.ts
+++ b/packages/arkenv/src/create-env.ts
@@ -74,6 +74,17 @@ export type ArkEnvConfig = {
 	 * @default "comma"
 	 */
 	arrayFormat?: "comma" | "json";
+
+	/**
+	 * Whether to treat empty strings (`""`) as `undefined` before validation.
+	 *
+	 * When enabled, an environment variable set to an empty value (e.g. `PORT=`)
+	 * will be treated as if it were missing, allowing defaults to apply and
+	 * preventing validation errors for numeric or boolean types.
+	 *
+	 * @default false
+	 */
+	emptyAsUndefined?: boolean;
 };
 
 /**

--- a/packages/arkenv/src/parse-standard.ts
+++ b/packages/arkenv/src/parse-standard.ts
@@ -1,5 +1,9 @@
 import type { StandardSchemaV1 } from "@repo/types";
-import { applyCoercion, findCoercionPaths } from "./coercion/shared";
+import {
+	applyCoercion,
+	findCoercionPaths,
+	stripEmptyStrings,
+} from "./coercion/shared";
 import { ArkEnvError, type ValidationIssue } from "./core";
 
 /**
@@ -41,6 +45,17 @@ export type ParseStandardConfig = {
 	 * @default "comma"
 	 */
 	arrayFormat?: "comma" | "json";
+
+	/**
+	 * Whether to treat empty strings (`""`) as `undefined` before validation.
+	 *
+	 * When enabled, an environment variable set to an empty value (e.g. `PORT=`)
+	 * will be treated as if it were missing, allowing defaults to apply and
+	 * preventing validation errors for numeric or boolean types.
+	 *
+	 * @default false
+	 */
+	emptyAsUndefined?: boolean;
 };
 
 /**
@@ -156,12 +171,17 @@ export function parseStandard(
 		onUndeclaredKey = "delete",
 		coerce = true,
 		arrayFormat = "comma",
+		emptyAsUndefined = false,
 	} = config;
 	const output: Record<string, unknown> = {};
 	const errors: ValidationIssue[] = [];
-	const envKeys = new Set(Object.keys(env));
 
-	let coercedEnv: Record<string, unknown> = { ...env };
+	const processedEnv = emptyAsUndefined
+		? stripEmptyStrings(env as Record<string, string | undefined>)
+		: env;
+	const envKeys = new Set(Object.keys(processedEnv));
+
+	let coercedEnv: Record<string, unknown> = { ...processedEnv };
 	const missingJsonSchemaKeys: string[] = [];
 
 	if (coerce) {

--- a/packages/arkenv/src/standard-mode.test.ts
+++ b/packages/arkenv/src/standard-mode.test.ts
@@ -300,3 +300,31 @@ describe("Standard Mode Coercion", () => {
 		expect(env.STNL_VAR).toBe(true);
 	});
 });
+
+describe("Standard Mode emptyAsUndefined", () => {
+	it("should treat empty strings as undefined when enabled", () => {
+		vi.stubEnv("STRING_VAR", "");
+
+		const env = createEnv(
+			{
+				STRING_VAR: createMockStandardSchema("default-value"),
+			},
+			{ emptyAsUndefined: true },
+		);
+
+		expect(env.STRING_VAR).toBe("default-value");
+	});
+
+	it("should pass empty strings through when disabled", () => {
+		vi.stubEnv("STRING_VAR", "");
+
+		const env = createEnv(
+			{
+				STRING_VAR: createMockStandardSchema(""),
+			},
+			{ emptyAsUndefined: false },
+		);
+
+		expect(env.STRING_VAR).toBe("");
+	});
+});


### PR DESCRIPTION
Fixes #695

Add a new `emptyAsUndefined` configuration option to both ArkType and Standard Schema modes. When enabled, environment variables set to empty strings are treated as missing, allowing defaults to apply and preventing validation errors for numeric, boolean, or array types.