### PR TITLE
feat(nuxt): core API & flat layout support

### DIFF
--- a/.changeset/nuxt-flat-layout.md
+++ b/.changeset/nuxt-flat-layout.md
@@ -1,14 +1,12 @@
 ---
-"@arkenv/nuxt": minor
+"@arkenv/nuxt": patch
 "@arkenv/build": patch
 ---
 
-#### Add core API and flat layout support to `@arkenv/nuxt`
+#### Add flat layout support to `@arkenv/nuxt`
 
-Introduce flat layout schema support and signature overloads to `@arkenv/nuxt` mirroring Next.js parity.
+Introduce flat layout schema support and type-safe `createEnv` signature overloads to `@arkenv/nuxt`.
 
-- Add `"flat"` layout mode to `ModuleOptions` and auto-detect it for a single `env.ts` file.
+- Add `"flat"` layout mode to `ModuleOptions` and auto-detect it when a single `env.ts` file is configured.
 - Emit a deprecation warning in development when using the legacy `"simple"` layout option.
-- Parameterize `@arkenv/build`'s `extractKeys` helper to accept a framework public prefix (e.g. `"NUXT_PUBLIC_"` or `"NEXT_PUBLIC_"`), avoiding duplicate parser code.
-- Categorize flat layout keys in `createEnvInternal` using `NUXT_PUBLIC_`, `NODE_ENV`, and `exposeToClient`.
-- Expose flat `createEnv(schema, options)` signature overload from `@arkenv/nuxt` with proper TypeScript inference.
+- Expose flat `createEnv(schema, options)` overload with type inference for `NUXT_PUBLIC_` prefixes, `NODE_ENV`, and custom `exposeToClient` variables.

--- a/.changeset/nuxt-flat-layout.md
+++ b/.changeset/nuxt-flat-layout.md
@@ -5,7 +5,7 @@
 
 #### Add flat layout support to `@arkenv/nuxt`
 
-Introduce flat layout schema support and type-safe `createEnv` signature overloads to `@arkenv/nuxt`.
+Introduce flat layout schema support and typesafe `createEnv` signature overloads to `@arkenv/nuxt`.
 
 - Add `"flat"` layout mode to `ModuleOptions` and auto-detect it when a single `env.ts` file is configured.
 - Emit a deprecation warning in development when using the legacy `"simple"` layout option.

--- a/.changeset/nuxt-flat-layout.md
+++ b/.changeset/nuxt-flat-layout.md
@@ -1,0 +1,14 @@
+---
+"@arkenv/nuxt": patch
+"@arkenv/build": patch
+---
+
+#### Add core API and flat layout support to `@arkenv/nuxt`
+
+Introduce flat layout schema support and signature overloads to `@arkenv/nuxt` mirroring Next.js parity.
+
+- Add `"flat"` layout mode to `ModuleOptions` and auto-detect it for a single `env.ts` file.
+- Emit a deprecation warning in development when using the legacy `"simple"` layout option.
+- Parameterize `@arkenv/build`'s `extractKeys` helper to accept a framework public prefix (e.g. `"NUXT_PUBLIC_"` or `"NEXT_PUBLIC_"`), avoiding duplicate parser code.
+- Categorize flat layout keys in `createEnvInternal` using `NUXT_PUBLIC_`, `NODE_ENV`, and `exposeToClient`.
+- Expose flat `createEnv(schema, options)` signature overload from `@arkenv/nuxt` with proper TypeScript inference.

--- a/.changeset/nuxt-flat-layout.md
+++ b/.changeset/nuxt-flat-layout.md
@@ -1,5 +1,5 @@
 ---
-"@arkenv/nuxt": patch
+"@arkenv/nuxt": minor
 "@arkenv/build": patch
 ---
 

--- a/packages/build/src/index.test.ts
+++ b/packages/build/src/index.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+	extractArkenvBlock,
+	extractBlock,
+	extractKeys,
+	parseBlockKeys,
+} from "./index";
+
+describe("@arkenv/build extractors", () => {
+	describe("extractKeys", () => {
+		it("should extract keys from legacy nested layout schema", () => {
+			const content = `
+				export const env = createEnv({
+					server: {
+						DATABASE_URL: "string",
+						ADMIN_TOKEN: "string"
+					},
+					client: {
+						NEXT_PUBLIC_API_URL: "string",
+						NEXT_PUBLIC_APP_ENV: "string"
+					},
+					shared: {
+						NODE_ENV: "string"
+					}
+				});
+			`;
+			const res = extractKeys(content, "NEXT_PUBLIC_");
+			expect(res.isLegacy).toBe(true);
+			expect(res.serverKeys).toEqual(["DATABASE_URL", "ADMIN_TOKEN"]);
+			expect(res.clientKeys).toEqual([
+				"NEXT_PUBLIC_API_URL",
+				"NEXT_PUBLIC_APP_ENV",
+			]);
+			expect(res.sharedKeys).toEqual(["NODE_ENV"]);
+		});
+
+		it("should extract keys from flat layout schema with NEXT_PUBLIC_ prefix", () => {
+			const content = `
+				export const env = createEnv({
+					DATABASE_URL: "string",
+					NEXT_PUBLIC_API_URL: "string",
+					NODE_ENV: "string",
+					CUSTOM_VAR: "string"
+				}, {
+					exposeToClient: ["CUSTOM_VAR"]
+				});
+			`;
+			const res = extractKeys(content, "NEXT_PUBLIC_");
+			expect(res.isLegacy).toBe(false);
+			expect(res.serverKeys).toEqual(["DATABASE_URL"]);
+			expect(res.clientKeys).toEqual(["NEXT_PUBLIC_API_URL"]);
+			expect(res.sharedKeys).toEqual(["NODE_ENV", "CUSTOM_VAR"]);
+		});
+
+		it("should extract keys from flat layout schema with NUXT_PUBLIC_ prefix", () => {
+			const content = `
+				export const env = arkenv({
+					DATABASE_URL: "string",
+					NUXT_PUBLIC_API_URL: "string",
+					NODE_ENV: "string",
+					CUSTOM_VAR: "string"
+				}, {
+					exposeToClient: ["CUSTOM_VAR"]
+				});
+			`;
+			const res = extractKeys(content, "NUXT_PUBLIC_");
+			expect(res.isLegacy).toBe(false);
+			expect(res.serverKeys).toEqual(["DATABASE_URL"]);
+			expect(res.clientKeys).toEqual(["NUXT_PUBLIC_API_URL"]);
+			expect(res.sharedKeys).toEqual(["NODE_ENV", "CUSTOM_VAR"]);
+		});
+	});
+
+	describe("extractBlock", () => {
+		it("should extract a specified block body", () => {
+			const content = `
+				createEnv({
+					server: {
+						DB_URL: "string"
+					},
+					client: {
+						API_URL: "string"
+					}
+				})
+			`;
+			expect(extractBlock(content, "server")).toBe('DB_URL: "string"');
+			expect(extractBlock(content, "client")).toBe('API_URL: "string"');
+		});
+
+		it("should return null for non-existent block", () => {
+			const content = "createEnv({ server: {} })";
+			expect(extractBlock(content, "shared")).toBeNull();
+		});
+	});
+
+	describe("parseBlockKeys", () => {
+		it("should parse standard, quoted, and comment-wrapped keys", () => {
+			const content = `
+				DATABASE_URL: "string",
+				"NUXT_PUBLIC_API_URL": "string",
+				'SINGLE_QUOTED': "string",
+				// Ignored key: "value",
+				/* Multi-line ignored: "value" */
+				nested: {
+					INNER_KEY: "string"
+				},
+				PORT: 3000
+			`;
+			const keys = parseBlockKeys(content);
+			expect(keys).toEqual([
+				"DATABASE_URL",
+				"NUXT_PUBLIC_API_URL",
+				"SINGLE_QUOTED",
+				"nested",
+				"PORT",
+			]);
+		});
+	});
+
+	describe("extractArkenvBlock", () => {
+		it("should extract the arkenv block content", () => {
+			const content = `
+				import { arkenv } from "arkenv";
+				export const env = arkenv({
+					DATABASE_URL: "string",
+					PORT: "number"
+				});
+			`;
+			expect(extractArkenvBlock(content)).toBe(
+				'DATABASE_URL: "string",\n\t\t\t\t\tPORT: "number"',
+			);
+		});
+	});
+});

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -141,31 +141,192 @@ export function findSchemaPath(cwd = process.cwd()): string | null {
  * @param content The string content of the schema file
  * @returns An object containing arrays of server, client, and shared keys
  */
-export function extractKeys(content: string): {
+function extractCallArguments(
+	content: string,
+): { schemaArg: string; optionsArg: string | null } | null {
+	const regex = /\b(?:arkenv|createEnv)\s*\(/g;
+	while (regex.exec(content) !== null) {
+		let parenCount = 1;
+		let index = regex.lastIndex;
+		let inString: string | null = null;
+		let inComment: "single" | "multi" | null = null;
+		let braceCount = 0;
+		let bracketCount = 0;
+
+		const args: string[] = [];
+		let currentArg = "";
+
+		while (index < content.length && parenCount > 0) {
+			const char = content[index];
+			const nextChar = content[index + 1];
+
+			if (inComment === "single") {
+				if (char === "\n" || char === "\r") inComment = null;
+				currentArg += char;
+				index++;
+				continue;
+			}
+			if (inComment === "multi") {
+				if (char === "*" && nextChar === "/") {
+					inComment = null;
+					currentArg += "*/";
+					index += 2;
+					continue;
+				}
+				currentArg += char;
+				index++;
+				continue;
+			}
+
+			if (inString) {
+				if (char === inString && content[index - 1] !== "\\") {
+					inString = null;
+				}
+				currentArg += char;
+				index++;
+				continue;
+			}
+
+			if (char === "/" && nextChar === "/") {
+				inComment = "single";
+				currentArg += "//";
+				index += 2;
+				continue;
+			}
+			if (char === "/" && nextChar === "*") {
+				inComment = "multi";
+				currentArg += "/*";
+				index += 2;
+				continue;
+			}
+			if (char === "'" || char === '"' || char === "`") {
+				inString = char;
+				currentArg += char;
+				index++;
+				continue;
+			}
+
+			if (char === "(") {
+				parenCount++;
+			} else if (char === ")") {
+				parenCount--;
+			} else if (char === "{") {
+				braceCount++;
+			} else if (char === "}") {
+				braceCount--;
+			} else if (char === "[") {
+				bracketCount++;
+			} else if (char === "]") {
+				bracketCount--;
+			}
+
+			if (parenCount === 0) {
+				args.push(currentArg);
+				break;
+			}
+
+			if (
+				char === "," &&
+				parenCount === 1 &&
+				braceCount === 0 &&
+				bracketCount === 0
+			) {
+				args.push(currentArg);
+				currentArg = "";
+			} else {
+				currentArg += char;
+			}
+			index++;
+		}
+
+		if (parenCount === 0 && args.length > 0) {
+			return {
+				schemaArg: args[0].trim(),
+				optionsArg: args[1] ? args[1].trim() : null,
+			};
+		}
+	}
+	return null;
+}
+
+/**
+ * Statically extract client, shared, and server keys from the schema content.
+ * Supports both legacy nested layout and the flat layout with parameterizable public prefix.
+ *
+ * @param content The schema file string content
+ * @param publicPrefix An optional framework-specific public prefix (e.g. "NEXT_PUBLIC_" or "NUXT_PUBLIC_")
+ * @returns An object containing arrays of server, client, and shared keys
+ */
+export function extractKeys(
+	content: string,
+	publicPrefix?: string,
+): {
 	serverKeys: string[];
 	clientKeys: string[];
 	sharedKeys: string[];
+	isLegacy?: boolean;
 } {
 	const serverKeys: string[] = [];
 	const clientKeys: string[] = [];
 	const sharedKeys: string[] = [];
 
-	const serverBlock = extractBlock(content, "server");
-	if (serverBlock) {
-		serverKeys.push(...parseBlockKeys(serverBlock));
+	const args = extractCallArguments(content);
+	if (!args) {
+		return { serverKeys, clientKeys, sharedKeys, isLegacy: false };
 	}
 
-	const clientBlock = extractBlock(content, "client");
-	if (clientBlock) {
-		clientKeys.push(...parseBlockKeys(clientBlock));
+	// Strip outer braces if present
+	const trimmedSchema = args.schemaArg
+		.replace(/^\{/, "")
+		.replace(/\}$/, "")
+		.trim();
+	const topKeys = parseBlockKeys(trimmedSchema);
+	const isLegacy =
+		topKeys.includes("client") ||
+		topKeys.includes("server") ||
+		topKeys.includes("shared");
+
+	if (isLegacy) {
+		const clientBlock = extractBlock(args.schemaArg, "client");
+		if (clientBlock) {
+			clientKeys.push(...parseBlockKeys(clientBlock));
+		}
+		const sharedBlock = extractBlock(args.schemaArg, "shared");
+		if (sharedBlock) {
+			sharedKeys.push(...parseBlockKeys(sharedBlock));
+		}
+		const serverBlock = extractBlock(args.schemaArg, "server");
+		if (serverBlock) {
+			serverKeys.push(...parseBlockKeys(serverBlock));
+		}
+	} else {
+		// New flat layout
+		const optionExposedKeys: string[] = [];
+		if (args.optionsArg) {
+			const exposeMatch =
+				args.optionsArg.match(/exposeToClient\s*:\s*\[([\s\S]*?)\]/) ||
+				args.optionsArg.match(/expose\s*:\s*\[([\s\S]*?)\]/) ||
+				args.optionsArg.match(/shared\s*:\s*\[([\s\S]*?)\]/);
+			if (exposeMatch) {
+				const matches = exposeMatch[1].matchAll(/['"`](.*?)['"`]/g);
+				for (const match of matches) {
+					optionExposedKeys.push(match[1]);
+				}
+			}
+		}
+
+		for (const key of topKeys) {
+			if (optionExposedKeys.includes(key) || key === "NODE_ENV") {
+				sharedKeys.push(key);
+			} else if (publicPrefix && key.startsWith(publicPrefix)) {
+				clientKeys.push(key);
+			} else {
+				serverKeys.push(key);
+			}
+		}
 	}
 
-	const sharedBlock = extractBlock(content, "shared");
-	if (sharedBlock) {
-		sharedKeys.push(...parseBlockKeys(sharedBlock));
-	}
-
-	return { serverKeys, clientKeys, sharedKeys };
+	return { serverKeys, clientKeys, sharedKeys, isLegacy };
 }
 
 /**

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -144,105 +144,54 @@ export function findSchemaPath(cwd = process.cwd()): string | null {
 function extractCallArguments(
 	content: string,
 ): { schemaArg: string; optionsArg: string | null } | null {
-	const regex = /\b(?:arkenv|createEnv)\s*\(/g;
-	while (regex.exec(content) !== null) {
+	const callRegex = /\b(?:arkenv|createEnv)\s*\(/g;
+	let match: RegExpExecArray | null;
+
+	while ((match = callRegex.exec(content)) !== null) {
+		const start = callRegex.lastIndex;
 		let parenCount = 1;
-		let index = regex.lastIndex;
-		let inString: string | null = null;
-		let inComment: "single" | "multi" | null = null;
 		let braceCount = 0;
 		let bracketCount = 0;
-
 		const args: string[] = [];
-		let currentArg = "";
+		let lastIndex = start;
 
-		while (index < content.length && parenCount > 0) {
-			const char = content[index];
-			const nextChar = content[index + 1];
+		const tokenRegex =
+			/\/\/.*|\/\*[\s\S]*?\*\/|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\$]|\\[\s\S]|\${[\s\S]*?})*`|[(){}[\],]/g;
+		tokenRegex.lastIndex = start;
 
-			if (inComment === "single") {
-				if (char === "\n" || char === "\r") inComment = null;
-				currentArg += char;
-				index++;
-				continue;
-			}
-			if (inComment === "multi") {
-				if (char === "*" && nextChar === "/") {
-					inComment = null;
-					currentArg += "*/";
-					index += 2;
-					continue;
-				}
-				currentArg += char;
-				index++;
-				continue;
-			}
+		let tokenMatch: RegExpExecArray | null;
+		while (parenCount > 0 && (tokenMatch = tokenRegex.exec(content)) !== null) {
+			const token = tokenMatch[0];
+			const index = tokenMatch.index;
 
-			if (inString) {
-				if (char === inString && content[index - 1] !== "\\") {
-					inString = null;
-				}
-				currentArg += char;
-				index++;
-				continue;
-			}
-
-			if (char === "/" && nextChar === "/") {
-				inComment = "single";
-				currentArg += "//";
-				index += 2;
-				continue;
-			}
-			if (char === "/" && nextChar === "*") {
-				inComment = "multi";
-				currentArg += "/*";
-				index += 2;
-				continue;
-			}
-			if (char === "'" || char === '"' || char === "`") {
-				inString = char;
-				currentArg += char;
-				index++;
-				continue;
-			}
-
-			if (char === "(") {
+			if (token === "(") {
 				parenCount++;
-			} else if (char === ")") {
+			} else if (token === ")") {
 				parenCount--;
-			} else if (char === "{") {
+			} else if (token === "{") {
 				braceCount++;
-			} else if (char === "}") {
+			} else if (token === "}") {
 				braceCount--;
-			} else if (char === "[") {
+			} else if (token === "[") {
 				bracketCount++;
-			} else if (char === "]") {
+			} else if (token === "]") {
 				bracketCount--;
-			}
-
-			if (parenCount === 0) {
-				args.push(currentArg);
-				break;
-			}
-
-			if (
-				char === "," &&
+			} else if (
+				token === "," &&
 				parenCount === 1 &&
 				braceCount === 0 &&
 				bracketCount === 0
 			) {
-				args.push(currentArg);
-				currentArg = "";
-			} else {
-				currentArg += char;
+				args.push(content.slice(lastIndex, index).trim());
+				lastIndex = tokenRegex.lastIndex;
 			}
-			index++;
 		}
 
-		if (parenCount === 0 && args.length > 0) {
+		if (parenCount === 0) {
+			args.push(content.slice(lastIndex, tokenRegex.lastIndex - 1).trim());
 			return {
-				schemaArg: args[0].trim(),
-				optionsArg: args[1] ? args[1].trim() : null,
+				schemaArg: args[0] || "",
+				optionsArg: args[1] || null,
 			};
 		}
 	}
@@ -347,67 +296,26 @@ export function extractBlock(
 	const match = regex.exec(content);
 	if (!match) return null;
 
-	const startIndex = regex.lastIndex;
+	const start = regex.lastIndex;
 	let braceCount = 1;
-	let index = startIndex;
-	let inString: string | null = null;
-	let inComment: "single" | "multi" | null = null;
 
-	while (index < content.length && braceCount > 0) {
-		const char = content[index];
-		const nextChar = content[index + 1];
+	const tokenRegex =
+		/\/\/.*|\/\*[\s\S]*?\*\/|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\$]|\\[\s\S]|\${[\s\S]*?})*`|[{}]/g;
+	tokenRegex.lastIndex = start;
 
-		if (inComment === "single") {
-			if (char === "\n" || char === "\r") inComment = null;
-			index++;
-			continue;
-		}
-		if (inComment === "multi") {
-			if (char === "*" && nextChar === "/") {
-				inComment = null;
-				index += 2;
-				continue;
-			}
-			index++;
-			continue;
-		}
-
-		if (inString) {
-			if (char === inString && content[index - 1] !== "\\") {
-				inString = null;
-			}
-			index++;
-			continue;
-		}
-
-		if (char === "/" && nextChar === "/") {
-			inComment = "single";
-			index += 2;
-			continue;
-		}
-		if (char === "/" && nextChar === "*") {
-			inComment = "multi";
-			index += 2;
-			continue;
-		}
-		if (char === "'" || char === '"' || char === "`") {
-			inString = char;
-			index++;
-			continue;
-		}
-
-		if (char === "{") {
+	let tokenMatch: RegExpExecArray | null;
+	while (braceCount > 0 && (tokenMatch = tokenRegex.exec(content)) !== null) {
+		const token = tokenMatch[0];
+		if (token === "{") {
 			braceCount++;
-		} else if (char === "}") {
+		} else if (token === "}") {
 			braceCount--;
 		}
-		index++;
 	}
 
 	if (braceCount === 0) {
-		return content.slice(startIndex, index - 1);
+		return content.slice(start, tokenRegex.lastIndex - 1).trim();
 	}
-
 	return null;
 }
 
@@ -419,85 +327,56 @@ export function extractBlock(
  */
 export function parseBlockKeys(blockContent: string): string[] {
 	const keys: string[] = [];
-	let inString: string | null = null;
-	let inComment: "single" | "multi" | null = null;
-	let currentToken = "";
-	let lastStringContent = "";
+	const tokenRegex =
+		/\/\/.*|\/\*[\s\S]*?\*\/|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\$]|\\[\s\S]|\${[\s\S]*?})*`|[{}[\]:]|[a-zA-Z0-9_$]+/g;
+
+	let lastIdentifier = "";
+	let lastString = "";
 	let braceDepth = 0;
+	let bracketDepth = 0;
 
-	for (let i = 0; i < blockContent.length; i++) {
-		const char = blockContent[i];
-		const nextChar = blockContent[i + 1];
+	let match: RegExpExecArray | null;
+	while ((match = tokenRegex.exec(blockContent)) !== null) {
+		const token = match[0];
 
-		if (inComment === "single") {
-			if (char === "\n" || char === "\r") inComment = null;
-			continue;
-		}
-		if (inComment === "multi") {
-			if (char === "*" && nextChar === "/") {
-				inComment = null;
-				i++;
-			}
-			continue;
-		}
-
-		if (inString) {
-			if (char === inString && blockContent[i - 1] !== "\\") {
-				inString = null;
-				lastStringContent = currentToken;
-				currentToken = "";
-			} else {
-				currentToken += char;
-			}
-			continue;
-		}
-
-		if (char === "/" && nextChar === "/") {
-			inComment = "single";
-			i++;
-			continue;
-		}
-		if (char === "/" && nextChar === "*") {
-			inComment = "multi";
-			i++;
-			continue;
-		}
-		if (char === "'" || char === '"' || char === "`") {
-			inString = char;
-			currentToken = "";
-			continue;
-		}
-
-		if (char === "{") {
+		if (token === "{") {
 			braceDepth++;
-			currentToken = "";
-			lastStringContent = "";
-			continue;
-		}
-		if (char === "}") {
+			lastIdentifier = "";
+			lastString = "";
+		} else if (token === "}") {
 			braceDepth--;
-			currentToken = "";
-			lastStringContent = "";
-			continue;
-		}
-
-		if (char === ":") {
-			if (braceDepth === 0) {
-				const key = currentToken.trim() || lastStringContent.trim();
+			lastIdentifier = "";
+			lastString = "";
+		} else if (token === "[") {
+			bracketDepth++;
+			lastIdentifier = "";
+			lastString = "";
+		} else if (token === "]") {
+			bracketDepth--;
+			lastIdentifier = "";
+			lastString = "";
+		} else if (token === ":") {
+			if (braceDepth === 0 && bracketDepth === 0) {
+				const key = lastIdentifier || lastString;
 				if (key) {
 					keys.push(key);
 				}
 			}
-			currentToken = "";
-			lastStringContent = "";
-			continue;
-		}
-
-		if (/[a-zA-Z0-9_$]/.test(char)) {
-			currentToken += char;
-		} else if (char === "," || char === "\n" || char === "\r") {
-			currentToken = "";
-			lastStringContent = "";
+			lastIdentifier = "";
+			lastString = "";
+		} else if (
+			token.startsWith("'") ||
+			token.startsWith('"') ||
+			token.startsWith("`")
+		) {
+			lastString = token.slice(1, -1);
+			lastIdentifier = "";
+		} else if (/^[a-zA-Z0-9_$]+$/.test(token)) {
+			lastIdentifier = token;
+			lastString = "";
+		} else {
+			lastIdentifier = "";
+			lastString = "";
 		}
 	}
 
@@ -515,67 +394,26 @@ export function extractArkenvBlock(content: string): string | null {
 	const match = regex.exec(content);
 	if (!match) return null;
 
-	const startIndex = regex.lastIndex;
+	const start = regex.lastIndex;
 	let braceCount = 1;
-	let index = startIndex;
-	let inString: string | null = null;
-	let inComment: "single" | "multi" | null = null;
 
-	while (index < content.length && braceCount > 0) {
-		const char = content[index];
-		const nextChar = content[index + 1];
+	const tokenRegex =
+		/\/\/.*|\/\*[\s\S]*?\*\/|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\$]|\\[\s\S]|\${[\s\S]*?})*`|[{}]/g;
+	tokenRegex.lastIndex = start;
 
-		if (inComment === "single") {
-			if (char === "\n" || char === "\r") inComment = null;
-			index++;
-			continue;
-		}
-		if (inComment === "multi") {
-			if (char === "*" && nextChar === "/") {
-				inComment = null;
-				index += 2;
-				continue;
-			}
-			index++;
-			continue;
-		}
-
-		if (inString) {
-			if (char === inString && content[index - 1] !== "\\") {
-				inString = null;
-			}
-			index++;
-			continue;
-		}
-
-		if (char === "/" && nextChar === "/") {
-			inComment = "single";
-			index += 2;
-			continue;
-		}
-		if (char === "/" && nextChar === "*") {
-			inComment = "multi";
-			index += 2;
-			continue;
-		}
-		if (char === "'" || char === '"' || char === "`") {
-			inString = char;
-			index++;
-			continue;
-		}
-
-		if (char === "{") {
+	let tokenMatch: RegExpExecArray | null;
+	while (braceCount > 0 && (tokenMatch = tokenRegex.exec(content)) !== null) {
+		const token = tokenMatch[0];
+		if (token === "{") {
 			braceCount++;
-		} else if (char === "}") {
+		} else if (token === "}") {
 			braceCount--;
 		}
-		index++;
 	}
 
 	if (braceCount === 0) {
-		return content.slice(startIndex, index - 1);
+		return content.slice(start, tokenRegex.lastIndex - 1).trim();
 	}
-
 	return null;
 }
 

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -145,9 +145,9 @@ function extractCallArguments(
 	content: string,
 ): { schemaArg: string; optionsArg: string | null } | null {
 	const callRegex = /\b(?:arkenv|createEnv)\s*\(/g;
-	let match: RegExpExecArray | null;
+	let match = callRegex.exec(content);
 
-	while ((match = callRegex.exec(content)) !== null) {
+	while (match !== null) {
 		const start = callRegex.lastIndex;
 		let parenCount = 1;
 		let braceCount = 0;
@@ -159,8 +159,8 @@ function extractCallArguments(
 			/\/\/.*|\/\*[\s\S]*?\*\/|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\$]|\\[\s\S]|\${[\s\S]*?})*`|[(){}[\],]/g;
 		tokenRegex.lastIndex = start;
 
-		let tokenMatch: RegExpExecArray | null;
-		while (parenCount > 0 && (tokenMatch = tokenRegex.exec(content)) !== null) {
+		let tokenMatch = tokenRegex.exec(content);
+		while (parenCount > 0 && tokenMatch !== null) {
 			const token = tokenMatch[0];
 			const index = tokenMatch.index;
 
@@ -185,6 +185,7 @@ function extractCallArguments(
 				args.push(content.slice(lastIndex, index).trim());
 				lastIndex = tokenRegex.lastIndex;
 			}
+			tokenMatch = tokenRegex.exec(content);
 		}
 
 		if (parenCount === 0) {
@@ -194,6 +195,7 @@ function extractCallArguments(
 				optionsArg: args[1] || null,
 			};
 		}
+		match = callRegex.exec(content);
 	}
 	return null;
 }
@@ -303,14 +305,15 @@ export function extractBlock(
 		/\/\/.*|\/\*[\s\S]*?\*\/|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\$]|\\[\s\S]|\${[\s\S]*?})*`|[{}]/g;
 	tokenRegex.lastIndex = start;
 
-	let tokenMatch: RegExpExecArray | null;
-	while (braceCount > 0 && (tokenMatch = tokenRegex.exec(content)) !== null) {
+	let tokenMatch = tokenRegex.exec(content);
+	while (braceCount > 0 && tokenMatch !== null) {
 		const token = tokenMatch[0];
 		if (token === "{") {
 			braceCount++;
 		} else if (token === "}") {
 			braceCount--;
 		}
+		tokenMatch = tokenRegex.exec(content);
 	}
 
 	if (braceCount === 0) {
@@ -335,8 +338,8 @@ export function parseBlockKeys(blockContent: string): string[] {
 	let braceDepth = 0;
 	let bracketDepth = 0;
 
-	let match: RegExpExecArray | null;
-	while ((match = tokenRegex.exec(blockContent)) !== null) {
+	let match = tokenRegex.exec(blockContent);
+	while (match !== null) {
 		const token = match[0];
 
 		if (token === "{") {
@@ -378,6 +381,7 @@ export function parseBlockKeys(blockContent: string): string[] {
 			lastIdentifier = "";
 			lastString = "";
 		}
+		match = tokenRegex.exec(blockContent);
 	}
 
 	return keys;
@@ -401,14 +405,15 @@ export function extractArkenvBlock(content: string): string | null {
 		/\/\/.*|\/\*[\s\S]*?\*\/|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\$]|\\[\s\S]|\${[\s\S]*?})*`|[{}]/g;
 	tokenRegex.lastIndex = start;
 
-	let tokenMatch: RegExpExecArray | null;
-	while (braceCount > 0 && (tokenMatch = tokenRegex.exec(content)) !== null) {
+	let tokenMatch = tokenRegex.exec(content);
+	while (braceCount > 0 && tokenMatch !== null) {
 		const token = tokenMatch[0];
 		if (token === "{") {
 			braceCount++;
 		} else if (token === "}") {
 			braceCount--;
 		}
+		tokenMatch = tokenRegex.exec(content);
 	}
 
 	if (braceCount === 0) {

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -185,6 +185,9 @@ function extractCallArguments(
 				args.push(content.slice(lastIndex, index).trim());
 				lastIndex = tokenRegex.lastIndex;
 			}
+			if (parenCount === 0) {
+				break;
+			}
 			tokenMatch = tokenRegex.exec(content);
 		}
 
@@ -313,6 +316,9 @@ export function extractBlock(
 		} else if (token === "}") {
 			braceCount--;
 		}
+		if (braceCount === 0) {
+			break;
+		}
 		tokenMatch = tokenRegex.exec(content);
 	}
 
@@ -412,6 +418,9 @@ export function extractArkenvBlock(content: string): string | null {
 			braceCount++;
 		} else if (token === "}") {
 			braceCount--;
+		}
+		if (braceCount === 0) {
+			break;
 		}
 		tokenMatch = tokenRegex.exec(content);
 	}

--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -2,11 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-	extractBlock,
+	extractKeys as coreExtractKeys,
 	extractClientKeys,
 	extractSharedKeys,
 	findSchemaPath,
-	parseBlockKeys,
 	resolveLayout,
 	watchSchema,
 } from "@arkenv/build";
@@ -318,116 +317,8 @@ export function runCodegen(
 	}
 }
 
-function extractCallArguments(
-	content: string,
-): { schemaArg: string; optionsArg: string | null } | null {
-	const regex = /\b(?:arkenv|createEnv)\s*\(/g;
-	while (regex.exec(content) !== null) {
-		let parenCount = 1;
-		let index = regex.lastIndex;
-		let inString: string | null = null;
-		let inComment: "single" | "multi" | null = null;
-		let braceCount = 0;
-		let bracketCount = 0;
-
-		const args: string[] = [];
-		let currentArg = "";
-
-		while (index < content.length && parenCount > 0) {
-			const char = content[index];
-			const nextChar = content[index + 1];
-
-			if (inComment === "single") {
-				if (char === "\n" || char === "\r") inComment = null;
-				currentArg += char;
-				index++;
-				continue;
-			}
-			if (inComment === "multi") {
-				if (char === "*" && nextChar === "/") {
-					inComment = null;
-					currentArg += "*/";
-					index += 2;
-					continue;
-				}
-				currentArg += char;
-				index++;
-				continue;
-			}
-
-			if (inString) {
-				if (char === inString && content[index - 1] !== "\\") {
-					inString = null;
-				}
-				currentArg += char;
-				index++;
-				continue;
-			}
-
-			if (char === "/" && nextChar === "/") {
-				inComment = "single";
-				currentArg += "//";
-				index += 2;
-				continue;
-			}
-			if (char === "/" && nextChar === "*") {
-				inComment = "multi";
-				currentArg += "/*";
-				index += 2;
-				continue;
-			}
-			if (char === "'" || char === '"' || char === "`") {
-				inString = char;
-				currentArg += char;
-				index++;
-				continue;
-			}
-
-			if (char === "(") {
-				parenCount++;
-			} else if (char === ")") {
-				parenCount--;
-			} else if (char === "{") {
-				braceCount++;
-			} else if (char === "}") {
-				braceCount--;
-			} else if (char === "[") {
-				bracketCount++;
-			} else if (char === "]") {
-				bracketCount--;
-			}
-
-			if (parenCount === 0) {
-				args.push(currentArg);
-				break;
-			}
-
-			if (
-				char === "," &&
-				parenCount === 1 &&
-				braceCount === 0 &&
-				bracketCount === 0
-			) {
-				args.push(currentArg);
-				currentArg = "";
-			} else {
-				currentArg += char;
-			}
-			index++;
-		}
-
-		if (parenCount === 0 && args.length > 0) {
-			return {
-				schemaArg: args[0].trim(),
-				optionsArg: args[1] ? args[1].trim() : null,
-			};
-		}
-	}
-	return null;
-}
-
 /**
- * Statically extract client and shared keys from the schema content.
+ * Statically extract client and shared keys from the schema content using NEXT_PUBLIC_ prefix.
  *
  * @param content The schema file string content
  * @returns An object containing the extracted client and shared keys
@@ -435,64 +326,10 @@ function extractCallArguments(
 export function extractKeys(content: string): {
 	clientKeys: string[];
 	sharedKeys: string[];
+	serverKeys: string[];
 	isLegacy?: boolean;
 } {
-	const clientKeys: string[] = [];
-	const sharedKeys: string[] = [];
-
-	const args = extractCallArguments(content);
-	if (!args) {
-		return { clientKeys, sharedKeys, isLegacy: false };
-	}
-
-	// Strip outer braces if present
-	const trimmedSchema = args.schemaArg
-		.replace(/^\{/, "")
-		.replace(/\}$/, "")
-		.trim();
-	const topKeys = parseBlockKeys(trimmedSchema);
-	const isLegacy =
-		topKeys.includes("client") ||
-		topKeys.includes("server") ||
-		topKeys.includes("shared");
-
-	if (isLegacy) {
-		const clientBlock = extractBlock(args.schemaArg, "client");
-		if (clientBlock) {
-			clientKeys.push(...parseBlockKeys(clientBlock));
-		}
-		const sharedBlock = extractBlock(args.schemaArg, "shared");
-		if (sharedBlock) {
-			sharedKeys.push(...parseBlockKeys(sharedBlock));
-		}
-	} else {
-		// New flat layout
-		const optionExposedKeys: string[] = [];
-		if (args.optionsArg) {
-			const exposeMatch =
-				args.optionsArg.match(/exposeToClient\s*:\s*\[([\s\S]*?)\]/) ||
-				args.optionsArg.match(/expose\s*:\s*\[([\s\S]*?)\]/) ||
-				args.optionsArg.match(/shared\s*:\s*\[([\s\S]*?)\]/);
-			if (exposeMatch) {
-				const matches = exposeMatch[1].matchAll(/['"`](.*?)['"`]/g);
-				for (const match of matches) {
-					optionExposedKeys.push(match[1]);
-				}
-			}
-		}
-
-		for (const key of topKeys) {
-			// NODE_ENV is implicitly shared as Next.js automatically inlines and replaces references to process.env.NODE_ENV in browser bundles.
-			// See: https://nextjs.org/docs/app/guides/environment-variables
-			if (optionExposedKeys.includes(key) || key === "NODE_ENV") {
-				sharedKeys.push(key);
-			} else if (key.startsWith("NEXT_PUBLIC_")) {
-				clientKeys.push(key);
-			}
-		}
-	}
-
-	return { clientKeys, sharedKeys, isLegacy };
+	return coreExtractKeys(content, "NEXT_PUBLIC_");
 }
 
 /**

--- a/packages/nuxt/src/client.ts
+++ b/packages/nuxt/src/client.ts
@@ -57,6 +57,7 @@ export function createEnv(schemaOrOptions: any, optionsOrIsServer?: any): any {
 
 	return createEnvInternal(schemaOrOptions, optionsOrIsServer, {
 		isServer: false,
+		strictLayout: "client",
 	});
 }
 

--- a/packages/nuxt/src/client.ts
+++ b/packages/nuxt/src/client.ts
@@ -6,7 +6,7 @@ import { createEnvInternal } from "./create-env";
 import type { MergeExtends } from "./types";
 
 /**
- * Create a validated, type-safe environment configuration for Nuxt applications (Client entry point).
+ * Create a validated, typesafe environment configuration for Nuxt applications (Client entry point).
  *
  * @param schemaOrOptions The schema definition or configuration options containing client/shared schemas
  * @param optionsOrIsServer Optional configuration paths or a boolean indicating server status

--- a/packages/nuxt/src/config.test.ts
+++ b/packages/nuxt/src/config.test.ts
@@ -72,6 +72,24 @@ describe("Nuxt config parser & codegen", () => {
 		expect(res.sharedKeys).toEqual(["NODE_ENV"]);
 	});
 
+	it("should extract keys in flat layout", () => {
+		const content = `
+			export const env = arkenv({
+				DATABASE_URL: "string",
+				NUXT_PUBLIC_API_URL: "string",
+				NODE_ENV: "string",
+				CUSTOM_SHARED: "string",
+			}, {
+				exposeToClient: ["CUSTOM_SHARED"],
+			});
+		`;
+
+		const res = extractKeys(content);
+		expect(res.serverKeys).toEqual(["DATABASE_URL"]);
+		expect(res.clientKeys).toEqual(["NUXT_PUBLIC_API_URL"]);
+		expect(res.sharedKeys).toEqual(["NODE_ENV", "CUSTOM_SHARED"]);
+	});
+
 	it("should handle parser edge cases with comments, nested objects, and templates", () => {
 		const content = `
 			export const env = arkenv({

--- a/packages/nuxt/src/config.ts
+++ b/packages/nuxt/src/config.ts
@@ -1,10 +1,26 @@
+import { extractKeys as coreExtractKeys } from "@arkenv/build";
+
 export type { LayoutMode, Logger, ResolvedLayout } from "@arkenv/build";
 export {
 	extractArkenvBlock,
 	extractClientKeys,
-	extractKeys,
 	extractServerKeys,
 	extractSharedKeys,
 	findSchemaPath,
 	resolveLayout,
 } from "@arkenv/build";
+
+/**
+ * Extract keys from the schema content using the NUXT_PUBLIC_ prefix.
+ *
+ * @param content The schema file string content
+ * @returns An object containing arrays of server, client, and shared keys
+ */
+export function extractKeys(content: string): {
+	serverKeys: string[];
+	clientKeys: string[];
+	sharedKeys: string[];
+	isLegacy?: boolean;
+} {
+	return coreExtractKeys(content, "NUXT_PUBLIC_");
+}

--- a/packages/nuxt/src/create-env.ts
+++ b/packages/nuxt/src/create-env.ts
@@ -30,6 +30,7 @@ export function createEnvInternal(
 	let client: Record<string, unknown> = {};
 	let shared: SchemaShape = {};
 	let extendsList: unknown[] = [];
+	let runtimeEnv: Record<string, unknown> = {};
 	let isServer = false;
 
 	const globalConfig =
@@ -49,12 +50,14 @@ export function createEnvInternal(
 		client = schemaOrOptions.client || {};
 		shared = schemaOrOptions.shared || {};
 		extendsList = schemaOrOptions.extends || [];
+		runtimeEnv = schemaOrOptions.runtimeEnv || {};
 		isServer = optionsOrIsServer;
 	} else {
 		// New flat schema behavior
 		const flatSchema = schemaOrOptions || {};
 		const options = optionsOrIsServer || {};
 		extendsList = options.extends || [];
+		runtimeEnv = options.runtimeEnv || {};
 		isServer =
 			(globalThis as any).__arkenv_force_server__ === true ||
 			!!context?.isServer;
@@ -189,6 +192,15 @@ export function createEnvInternal(
 		}
 	}
 
+	// Check runtimeEnv does not have any keys not defined in the schema (allKeys)
+	for (const key of Object.keys(runtimeEnv)) {
+		if (!allKeys.has(key)) {
+			throw new Error(
+				`Environment variable '${key}' is passed to runtimeEnv but is not defined in the schema.`,
+			);
+		}
+	}
+
 	// Build final combinedEnv
 	for (const key of Object.keys(extendedEnvValues)) {
 		if (extendedEnvValues[key] !== undefined) {
@@ -199,6 +211,12 @@ export function createEnvInternal(
 	for (const key of Object.keys(sourceEnv)) {
 		if (sourceEnv[key] !== undefined) {
 			combinedEnv[key] = sourceEnv[key];
+		}
+	}
+
+	for (const key of Object.keys(runtimeEnv)) {
+		if (runtimeEnv[key] !== undefined) {
+			combinedEnv[key] = runtimeEnv[key];
 		}
 	}
 

--- a/packages/nuxt/src/create-env.ts
+++ b/packages/nuxt/src/create-env.ts
@@ -41,6 +41,7 @@ export function createEnvInternal(
 	if (typeof optionsOrIsServer === "boolean") {
 		if (process.env.NODE_ENV === "development" && !hasWarnedLegacy) {
 			hasWarnedLegacy = true;
+			// biome-ignore lint/suspicious/noConsole: deprecation warning
 			console.warn(
 				"⚠️ [arkenv] Deprecated: The nested layout structure (specifying 'server', 'client', or 'shared' keys in createEnv) is deprecated and will be removed in the next major version. Please migrate to the flat layout.",
 			);

--- a/packages/nuxt/src/create-env.ts
+++ b/packages/nuxt/src/create-env.ts
@@ -5,6 +5,8 @@ export const EXTENDED_ENV = Symbol.for("arkenv.extended_env");
 export const ENV_KEYS = Symbol.for("arkenv.keys");
 export const SERVER_ONLY_KEYS = Symbol.for("arkenv.server_only_keys");
 
+let hasWarnedLegacy = false;
+
 /**
  * Validate and wrap environment variables in a security proxy.
  *
@@ -18,7 +20,11 @@ export const SERVER_ONLY_KEYS = Symbol.for("arkenv.server_only_keys");
 export function createEnvInternal(
 	schemaOrOptions: any,
 	optionsOrIsServer: any,
-	context?: { isServer: boolean; isShared?: boolean },
+	context?: {
+		isServer: boolean;
+		isShared?: boolean;
+		strictLayout?: "client" | "server";
+	},
 ): unknown {
 	let server: SchemaShape = {};
 	let client: Record<string, unknown> = {};
@@ -32,6 +38,12 @@ export function createEnvInternal(
 			: undefined;
 
 	if (typeof optionsOrIsServer === "boolean") {
+		if (process.env.NODE_ENV === "development" && !hasWarnedLegacy) {
+			hasWarnedLegacy = true;
+			console.warn(
+				"⚠️ [arkenv] Deprecated: The nested layout structure (specifying 'server', 'client', or 'shared' keys in createEnv) is deprecated and will be removed in the next major version. Please migrate to the flat layout.",
+			);
+		}
 		// Old nested schema behavior (backward compatible)
 		server = schemaOrOptions.server || {};
 		client = schemaOrOptions.client || {};
@@ -43,14 +55,29 @@ export function createEnvInternal(
 		const flatSchema = schemaOrOptions || {};
 		const options = optionsOrIsServer || {};
 		extendsList = options.extends || [];
-		isServer = !!context?.isServer;
+		isServer =
+			(globalThis as any).__arkenv_force_server__ === true ||
+			!!context?.isServer;
 
 		if (context?.isShared) {
 			shared = flatSchema;
-		} else if (isServer) {
+		} else if (context?.strictLayout === "client") {
+			client = flatSchema;
+		} else if (context?.strictLayout === "server") {
 			server = flatSchema;
 		} else {
-			client = flatSchema;
+			const exposedKeys =
+				options.exposeToClient || options.expose || options.shared || [];
+			for (const key of Object.keys(flatSchema)) {
+				// NODE_ENV is implicitly shared as Nuxt automatically inlines and replaces references to process.env.NODE_ENV in browser bundles.
+				if (exposedKeys.includes(key) || key === "NODE_ENV") {
+					shared[key] = flatSchema[key];
+				} else if (key.startsWith("NUXT_PUBLIC_")) {
+					client[key] = flatSchema[key];
+				} else {
+					server[key] = flatSchema[key];
+				}
+			}
 		}
 	}
 

--- a/packages/nuxt/src/index.test.ts
+++ b/packages/nuxt/src/index.test.ts
@@ -215,4 +215,45 @@ describe("createEnv (Nuxt runtime)", () => {
 			delete process.env.CUSTOM_SHARED;
 		}
 	});
+
+	it("should support, validate and merge runtimeEnv correctly in flat layout", () => {
+		// Verify runtimeEnv merges and overrides process.env
+		process.env.DATABASE_URL = "original-db";
+		try {
+			const env = createEnv(
+				{
+					DATABASE_URL: "string",
+					NUXT_PUBLIC_API_URL: "string",
+				},
+				{
+					runtimeEnv: {
+						DATABASE_URL: "override-db",
+						NUXT_PUBLIC_API_URL: "https://override.api.com",
+					},
+				},
+			);
+
+			expect(env.DATABASE_URL).toBe("override-db");
+			expect(env.NUXT_PUBLIC_API_URL).toBe("https://override.api.com");
+
+			// Verify it throws if runtimeEnv has a key not defined in schema
+			expect(() => {
+				createEnv(
+					{
+						DATABASE_URL: "string",
+					},
+					{
+						runtimeEnv: {
+							DATABASE_URL: "db-val",
+							UNDEFINED_KEY: "invalid",
+						},
+					},
+				);
+			}).toThrow(
+				"Environment variable 'UNDEFINED_KEY' is passed to runtimeEnv but is not defined in the schema.",
+			);
+		} finally {
+			delete process.env.DATABASE_URL;
+		}
+	});
 });

--- a/packages/nuxt/src/index.test.ts
+++ b/packages/nuxt/src/index.test.ts
@@ -17,9 +17,9 @@ describe("createEnv (Nuxt runtime)", () => {
 
 	it("should enforce NUXT_PUBLIC_ prefix for client keys at compile-time and runtime", () => {
 		expect(() => {
+			// @ts-expect-error - Client keys must be prefixed with NUXT_PUBLIC_
 			createEnv({
 				client: {
-					// @ts-expect-error - Client keys must be prefixed with NUXT_PUBLIC_
 					API_URL: "string",
 				},
 			});
@@ -144,6 +144,75 @@ describe("createEnv (Nuxt runtime)", () => {
 			expect(envRecord.__v_raw).toBeUndefined();
 		} finally {
 			(globalThis as any).window = originalWindow;
+		}
+	});
+
+	it("should support flat layout at runtime on both client and server", () => {
+		process.env.DATABASE_URL = "postgres://localhost:5432/db";
+		process.env.NUXT_PUBLIC_API_URL = "https://api.example.com";
+		process.env.NODE_ENV = "test";
+		process.env.CUSTOM_SHARED = "shared-value";
+
+		// Server-side flat schema evaluation
+		const serverEnv = createEnv(
+			{
+				DATABASE_URL: "string",
+				NUXT_PUBLIC_API_URL: "string",
+				NODE_ENV: "string",
+				CUSTOM_SHARED: "string",
+			},
+			{
+				exposeToClient: ["CUSTOM_SHARED"],
+			},
+		);
+
+		expect(serverEnv.DATABASE_URL).toBe("postgres://localhost:5432/db");
+		expect(serverEnv.NUXT_PUBLIC_API_URL).toBe("https://api.example.com");
+		expect(serverEnv.NODE_ENV).toBe("test");
+		expect(serverEnv.CUSTOM_SHARED).toBe("shared-value");
+
+		// Client-side flat schema evaluation
+		const originalWindow = globalThis.window;
+		(globalThis as any).window = {
+			__NUXT__: {
+				config: {
+					public: {
+						NUXT_PUBLIC_API_URL: "https://api.example.com",
+						NODE_ENV: "test",
+						CUSTOM_SHARED: "shared-value",
+					},
+				},
+			},
+		};
+
+		try {
+			const clientEnv = createEnv(
+				{
+					DATABASE_URL: "string",
+					NUXT_PUBLIC_API_URL: "string",
+					NODE_ENV: "string",
+					CUSTOM_SHARED: "string",
+				},
+				{
+					exposeToClient: ["CUSTOM_SHARED"],
+				},
+			);
+
+			expect(clientEnv.NUXT_PUBLIC_API_URL).toBe("https://api.example.com");
+			expect(clientEnv.NODE_ENV).toBe("test");
+			expect(clientEnv.CUSTOM_SHARED).toBe("shared-value");
+
+			expect(() => {
+				clientEnv.DATABASE_URL;
+			}).toThrow(
+				"Accessing server-side environment variable 'DATABASE_URL' on the client is not allowed.",
+			);
+		} finally {
+			(globalThis as any).window = originalWindow;
+			delete process.env.DATABASE_URL;
+			delete process.env.NUXT_PUBLIC_API_URL;
+			delete process.env.NODE_ENV;
+			delete process.env.CUSTOM_SHARED;
 		}
 	});
 });

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -22,7 +22,7 @@ export function createEnv<
 }): Readonly<Infer<TServer & TClient & TShared>>;
 
 /**
- * Create a validated, type-safe environment configuration for Nuxt applications.
+ * Create a validated, typesafe environment configuration for Nuxt applications.
  */
 export function createEnv<
 	const TSchema extends SchemaShape & {

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -1,13 +1,12 @@
+import type { $ } from "@repo/scope";
 import type { SchemaShape } from "@repo/types";
 import type { EnvSchema, Infer } from "arkenv";
+import type { type as at, distill } from "arktype";
 import { createEnvInternal } from "./create-env";
+import type { MergeExtends } from "./types";
 
 /**
- * Create a validated, type-safe environment configuration for Nuxt applications.
- *
- * @param options The environment validation configuration options
- * @returns A validated, readonly environment variables object wrapped in a security proxy
- * @throws An error if any client-side variable is not prefixed with `NUXT_PUBLIC_`
+ * @deprecated Use the unified flat layout signature instead: `createEnv(schema, options)`
  */
 export function createEnv<
 	const TServer extends SchemaShape = {},
@@ -20,21 +19,59 @@ export function createEnv<
 	};
 	shared?: EnvSchema<TShared>;
 	runtimeEnv?: Record<string, unknown>;
-}): Readonly<Infer<TServer & TClient & TShared>> {
-	type ReturnType = Readonly<Infer<TServer & TClient & TShared>>;
-	// In Nuxt, we want to know whether we are in client or server.
-	// We can check if `typeof window === "undefined"` to dynamically detect server runtime.
+}): Readonly<Infer<TServer & TClient & TShared>>;
+
+/**
+ * Create a validated, type-safe environment configuration for Nuxt applications.
+ */
+export function createEnv<
+	const TSchema extends SchemaShape & {
+		runtimeEnv?: never;
+		server?: never;
+		client?: never;
+		shared?: never;
+	} = {},
+	const TExtends extends readonly unknown[] = [],
+>(
+	schema: EnvSchema<TSchema>,
+	options?: {
+		/**
+		 * Custom environment variables to expose to the client bundle.
+		 * By default, variables prefixed with `NUXT_PUBLIC_` and `NODE_ENV` are exposed automatically.
+		 * Use this option to expose custom variables that do not have the `NUXT_PUBLIC_` prefix.
+		 */
+		exposeToClient?: readonly (keyof TSchema)[];
+		/** @deprecated Use `exposeToClient` instead */
+		expose?: readonly (keyof TSchema)[];
+		/** @deprecated Use `exposeToClient` instead */
+		shared?: readonly (keyof TSchema)[];
+		extends?: [...TExtends];
+		runtimeEnv?: Record<string, unknown>;
+	},
+): Readonly<distill.Out<at.infer<TSchema, $>> & MergeExtends<TExtends>>;
+
+export function createEnv(schemaOrOptions: any, optionsOrIsServer?: any): any {
+	const isLegacy =
+		schemaOrOptions &&
+		typeof schemaOrOptions === "object" &&
+		("runtimeEnv" in schemaOrOptions ||
+			"server" in schemaOrOptions ||
+			"client" in schemaOrOptions ||
+			"shared" in schemaOrOptions);
+
 	const isServer = typeof window === "undefined";
-	return createEnvInternal(options, isServer) as ReturnType;
+
+	if (isLegacy) {
+		return createEnvInternal(schemaOrOptions, isServer);
+	}
+
+	return createEnvInternal(schemaOrOptions, optionsOrIsServer, {
+		isServer,
+	});
 }
 
 export type { Infer } from "arkenv";
 export { type } from "arkenv";
 
-/**
- * ArkEnv's Nuxt integration export, an alias for {@link createEnv}
- *
- * {@link https://arkenv.js.org | ArkEnv} is a typesafe environment variables validator from editor to runtime.
- */
 const arkenv = createEnv;
 export default arkenv;

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -29,6 +29,7 @@ function normalizeLayout(
 	if (layout === "simple") {
 		if (process.env.NODE_ENV === "development" && !hasWarnedSimpleLayout) {
 			hasWarnedSimpleLayout = true;
+			// biome-ignore lint/suspicious/noConsole: deprecation warning
 			console.warn(
 				"⚠️ [arkenv] The 'simple' layout option is deprecated and will be removed in the next major version. Use 'flat' instead.",
 			);

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,5 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
+import { defineNuxtModule } from "@nuxt/kit";
+import type { NuxtModule } from "@nuxt/schema";
+import { name, peerDependencies, version } from "../package.json";
 import {
 	extractClientKeys,
 	extractKeys,
@@ -7,15 +10,36 @@ import {
 	extractSharedKeys,
 	findSchemaPath,
 	resolveLayout,
-} from "@arkenv/build";
-import { defineNuxtModule } from "@nuxt/kit";
-import type { NuxtModule } from "@nuxt/schema";
-import { name, peerDependencies, version } from "../package.json";
+} from "./config";
 
 export type ModuleOptions = {
 	schemaPath?: string;
-	layout?: "simple" | "strict";
+	layout?:
+		| "flat"
+		| "strict"
+		/** @deprecated Use `"flat"` instead. `"simple"` will be removed in the next major version. */
+		| "simple";
 };
+
+let hasWarnedSimpleLayout = false;
+
+function normalizeLayout(
+	layout: ModuleOptions["layout"],
+): "simple" | "strict" | undefined {
+	if (layout === "simple") {
+		if (process.env.NODE_ENV === "development" && !hasWarnedSimpleLayout) {
+			hasWarnedSimpleLayout = true;
+			console.warn(
+				"⚠️ [arkenv] The 'simple' layout option is deprecated and will be removed in the next major version. Use 'flat' instead.",
+			);
+		}
+		return "simple";
+	}
+	if (layout === "flat") {
+		return "simple";
+	}
+	return layout;
+}
 
 const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 	meta: {
@@ -36,9 +60,11 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 			return;
 		}
 
+		const normalizedLayout = normalizeLayout(options.layout);
+
 		const { layout: resolvedLayout, baseDir } = resolveLayout(
 			schemaPath,
-			options.layout,
+			normalizedLayout,
 		);
 
 		// Register schema paths to watch so Nuxt restarts and updates runtimeConfig when they change

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -54,6 +54,7 @@ export function createEnv(schemaOrOptions: any, optionsOrIsServer?: any): any {
 
 	return createEnvInternal(schemaOrOptions, optionsOrIsServer, {
 		isServer: true,
+		strictLayout: "server",
 	});
 }
 

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -6,7 +6,7 @@ import { createEnvInternal } from "./create-env";
 import type { MergeExtends } from "./types";
 
 /**
- * Create a validated, type-safe environment configuration for Nuxt applications (Server entry point).
+ * Create a validated, typesafe environment configuration for Nuxt applications (Server entry point).
  *
  * @param schemaOrOptions The schema definition or configuration options containing server/shared schemas
  * @param optionsOrIsServer Optional configuration paths or a boolean indicating server status

--- a/packages/nuxt/src/shared.ts
+++ b/packages/nuxt/src/shared.ts
@@ -6,7 +6,7 @@ import { createEnvInternal } from "./create-env";
 import type { MergeExtends } from "./types";
 
 /**
- * Create a validated, type-safe environment configuration for Nuxt applications (Shared entry point).
+ * Create a validated, typesafe environment configuration for Nuxt applications (Shared entry point).
  *
  * @param schema The schema definition containing the shared variables
  * @param options Optional configuration options

--- a/packages/nuxt/src/type-regression.test-d.ts
+++ b/packages/nuxt/src/type-regression.test-d.ts
@@ -53,19 +53,16 @@ describe("@arkenv/nuxt type regression", () => {
 	});
 
 	it("rejects invalid ArkType schema strings across schema sections", () => {
+		// @ts-expect-error invalid ArkType schema string
 		createEnv({
 			server: {
-				// @ts-expect-error invalid ArkType schema string
 				DATABASE_URL: "not-a-valid-type",
-				// @ts-expect-error invalid ArkType schema string
 				PORT: "not-a-valid-type",
 			},
 			client: {
-				// @ts-expect-error invalid ArkType schema string
 				NUXT_PUBLIC_API_URL: "not-a-valid-type",
 			},
 			shared: {
-				// @ts-expect-error invalid ArkType schema string
 				NODE_ENV: "not-a-valid-type",
 			},
 			runtimeEnv: {

--- a/packages/nuxt/src/type-regression.test-d.ts
+++ b/packages/nuxt/src/type-regression.test-d.ts
@@ -85,4 +85,28 @@ describe("@arkenv/nuxt type regression", () => {
 			},
 		});
 	});
+
+	it("correctly types Flat Mode environment variables", () => {
+		const env = createEnv(
+			{
+				DATABASE_URL: "string",
+				NUXT_PUBLIC_API_URL: "string",
+				NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+				CUSTOM_VAR: "string",
+			},
+			{
+				exposeToClient: ["CUSTOM_VAR"],
+				runtimeEnv: {
+					NUXT_PUBLIC_API_URL: "https://api.example.com",
+					NODE_ENV: "development",
+					CUSTOM_VAR: "custom_val",
+				},
+			},
+		);
+
+		expectTypeOf(env.DATABASE_URL).toBeString();
+		expectTypeOf(env.NUXT_PUBLIC_API_URL).toBeString();
+		expectTypeOf(env.NODE_ENV).toBeString();
+		expectTypeOf(env.CUSTOM_VAR).toBeString();
+	});
 });


### PR DESCRIPTION
Fixes #1242

This PR adds core API and flat layout support to `@arkenv/nuxt`, aligning it with the Next.js integration features.

### Changes:
- Extended `ModuleOptions.layout` type to support `"flat"`, treating `"simple"` as a deprecated alias with dev-time warnings.
- Refactored build-time key extraction helper in `@arkenv/build` to support parameterized framework prefixes, avoiding duplicate AST RegExp parsing in `@arkenv/nuxt` and `@arkenv/nextjs`.
- Updated `createEnvInternal` to support runtime key categorization and proxy shielding under the flat layout using `NUXT_PUBLIC_`, `NODE_ENV`, and `exposeToClient`.
- Added flat signature overloads and runtime handlers to the main `createEnv` entrypoint in `@arkenv/nuxt` with robust TypeScript type inference.