### PR TITLE
feat(nuxt): enforce strict-layout Vite boundary for userland server imports

### DIFF
--- a/.changeset/nuxt-strict-userland-boundary.md
+++ b/.changeset/nuxt-strict-userland-boundary.md
@@ -1,0 +1,13 @@
+---
+"@arkenv/nuxt": patch
+---
+
+#### Enforce strict-layout Vite boundary for userland server imports
+
+Extend the `@arkenv/nuxt/module` Vite plugin to block client-side imports of userland server-only schema files inside the configured strict-layout schema directory. The plugin now rejects any resolved module path ending with `/server` under the schema base directory, including imports via Nuxt aliases such as `~/env/server` and `~~/env/server`.
+
+Server-side builds remain unaffected, and the existing branded error message is preserved:
+
+```
+[ArkEnv] Importing server-only environment schema on the client is not allowed!
+```

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -77,4 +77,4 @@ This allows you to safely swap public configuration values in production without
 
 ## Client-Side Security
 
-The `@arkenv/nuxt` module includes a custom Vite plugin that strictly prevents any server-side environment definitions from leaking into the client bundle. If you attempt to import `@arkenv/nuxt/server` in a client component, the bundler will throw a compile-time error.
+The `@arkenv/nuxt` module includes a custom Vite plugin that strictly prevents any server-side environment definitions from leaking into the client bundle. If you attempt to import `@arkenv/nuxt/server` or a userland server schema file (for example, `~/env/server.ts` in the strict layout) in a client component, the bundler will throw a compile-time error.

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -185,12 +185,26 @@ describe("Nuxt module integration", () => {
 			expect(() => plugin.resolveId("~~/env/server.ts")).toThrow(errorMessage);
 			expect(() => plugin.resolveId("@/env/server.ts")).toThrow(errorMessage);
 
+			expect(() =>
+				plugin.resolveId("./server.ts", path.join(envDir, "client.ts")),
+			).toThrow(errorMessage);
+			expect(() =>
+				plugin.resolveId(
+					"../env/server.ts",
+					path.join(envDir, "internal", "shared.ts"),
+				),
+			).toThrow(errorMessage);
+
 			expect(() => plugin.resolveId("@arkenv/nuxt/server")).toThrow(
 				errorMessage,
 			);
 
 			expect(() =>
 				plugin.resolveId(path.join(envDir, "client.ts")),
+			).not.toThrow();
+
+			expect(() =>
+				plugin.resolveId("./client.ts", path.join(envDir, "server.ts")),
 			).not.toThrow();
 
 			expect(() =>

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -125,4 +125,86 @@ describe("Nuxt module integration", () => {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	it("should block userland server imports on the client but allow them on the server", async () => {
+		const tempDir = path.resolve(__dirname, "temp-strict-security-test");
+		const envDir = path.join(tempDir, "env");
+		fs.mkdirSync(envDir, { recursive: true });
+		fs.mkdirSync(path.join(envDir, "internal"), { recursive: true });
+
+		try {
+			fs.writeFileSync(path.join(envDir, "client.ts"), "export const env = {}");
+			fs.writeFileSync(path.join(envDir, "server.ts"), "export const env = {}");
+			fs.writeFileSync(
+				path.join(envDir, "internal", "shared.ts"),
+				"export const SharedSchema = {}",
+			);
+
+			const mockNuxt: any = {
+				options: {
+					dev: false,
+					rootDir: tempDir,
+					srcDir: tempDir,
+					runtimeConfig: {
+						public: {},
+					},
+				},
+				hook: vi.fn(),
+			};
+
+			await (module as any).setup(
+				{
+					schemaPath: "./env/server.ts",
+					layout: "strict",
+				},
+				mockNuxt,
+			);
+
+			const viteHook = mockNuxt.hook.mock.calls.find(
+				([name]: [string, ...any[]]) => name === "vite:extendConfig",
+			)?.[1];
+
+			expect(viteHook).toBeDefined();
+
+			const clientConfig: any = { plugins: [] };
+			viteHook(clientConfig, { isClient: true });
+
+			const plugin = clientConfig.plugins.find(
+				(p: any) => p.name === "arkenv-nuxt-client-security",
+			);
+			expect(plugin).toBeDefined();
+
+			const errorMessage =
+				"[ArkEnv] Importing server-only environment schema on the client is not allowed!";
+
+			expect(() => plugin.resolveId(path.join(envDir, "server.ts"))).toThrow(
+				errorMessage,
+			);
+
+			expect(() => plugin.resolveId("~/env/server.ts")).toThrow(errorMessage);
+			expect(() => plugin.resolveId("~~/env/server.ts")).toThrow(errorMessage);
+			expect(() => plugin.resolveId("@/env/server.ts")).toThrow(errorMessage);
+
+			expect(() => plugin.resolveId("@arkenv/nuxt/server")).toThrow(
+				errorMessage,
+			);
+
+			expect(() =>
+				plugin.resolveId(path.join(envDir, "client.ts")),
+			).not.toThrow();
+
+			expect(() =>
+				plugin.resolveId(path.join(tempDir, "server.ts")),
+			).not.toThrow();
+
+			const serverConfig: any = { plugins: [] };
+			viteHook(serverConfig, { isClient: false });
+			const serverPlugin = serverConfig.plugins.find(
+				(p: any) => p.name === "arkenv-nuxt-client-security",
+			);
+			expect(serverPlugin).toBeUndefined();
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -171,7 +171,7 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 				anyConfig.plugins = anyConfig.plugins || [];
 				anyConfig.plugins.push({
 					name: "arkenv-nuxt-client-security",
-					resolveId(id: string) {
+					resolveId(id: string, importer?: string) {
 						const isServerModule =
 							id === "@arkenv/nuxt/server" ||
 							/[/\\]@arkenv[/\\]nuxt[/\\](?:src|dist)[/\\]server(?:\.(?:js|mjs|cjs|ts))?$/.test(
@@ -183,8 +183,13 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 						}
 
 						if (resolvedLayout === "strict" && baseDir) {
+							let targetId = id;
+							if (id.startsWith(".") && importer) {
+								targetId = path.resolve(path.dirname(importer), id);
+							}
+
 							const resolvedId = resolveNuxtAlias(
-								id,
+								targetId,
 								nuxt.options.rootDir,
 								srcDir,
 							);

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -23,6 +23,31 @@ export type ModuleOptions = {
 
 let hasWarnedSimpleLayout = false;
 
+const CLIENT_SECURITY_ERROR =
+	"[ArkEnv] Importing server-only environment schema on the client is not allowed!";
+
+/**
+ * Resolve common Nuxt path aliases to absolute paths.
+ *
+ * @param id The module id as seen by Vite's resolveId hook
+ * @param rootDir The Nuxt project root directory
+ * @param srcDir The resolved Nuxt source directory
+ * @returns The absolute path the alias resolves to, or the original id if not a recognized alias
+ */
+function resolveNuxtAlias(id: string, rootDir: string, srcDir: string): string {
+	if (path.isAbsolute(id)) return id;
+
+	if (id.startsWith("~~/")) {
+		return path.resolve(rootDir, id.slice(3));
+	}
+
+	if (id.startsWith("~/") || id.startsWith("@/")) {
+		return path.resolve(srcDir, id.slice(2));
+	}
+
+	return id;
+}
+
 function normalizeLayout(
 	layout: ModuleOptions["layout"],
 ): "simple" | "strict" | undefined {
@@ -66,6 +91,11 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 		const { layout: resolvedLayout, baseDir } = resolveLayout(
 			schemaPath,
 			normalizedLayout,
+		);
+
+		const srcDir = path.resolve(
+			nuxt.options.rootDir,
+			nuxt.options.srcDir ?? nuxt.options.rootDir,
 		);
 
 		// Register schema paths to watch so Nuxt restarts and updates runtimeConfig when they change
@@ -149,9 +179,29 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 							);
 
 						if (isServerModule) {
-							throw new Error(
-								"[ArkEnv] Importing server-only environment schema on the client is not allowed!",
+							throw new Error(CLIENT_SECURITY_ERROR);
+						}
+
+						if (resolvedLayout === "strict" && baseDir) {
+							const resolvedId = resolveNuxtAlias(
+								id,
+								nuxt.options.rootDir,
+								srcDir,
 							);
+
+							if (path.isAbsolute(resolvedId)) {
+								const relativePath = path.relative(baseDir, resolvedId);
+								const isUnderBaseDir =
+									!relativePath.startsWith("..") &&
+									!path.isAbsolute(relativePath);
+								const isServerFile = /(^|[/\\])server(?:\.[^./\\]*)?$/.test(
+									relativePath,
+								);
+
+								if (isUnderBaseDir && isServerFile) {
+									throw new Error(CLIENT_SECURITY_ERROR);
+								}
+							}
 						}
 					},
 				});


### PR DESCRIPTION
Fixes #1244

Extend the Vite plugin registered by "@arkenv/nuxt/module" so it also rejects client-side imports of userland server-only schema files inside the configured strict-layout schema directory. The existing branded error message is preserved, and server-side builds remain unaffected.