### PR TITLE
fix: ArkEnv init fails in pnpm - requiring approved builds

### DIFF
--- a/.changeset/pnpm-esbuild-allow-build.md
+++ b/.changeset/pnpm-esbuild-allow-build.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Configure pnpm whitelisting for esbuild during scaffolding
+
+Automatically configure pnpm build whitelisting for `esbuild` during project scaffolding if `pnpm` is the detected package manager. This writes the `onlyBuiltDependencies` field to `package.json` and creates or updates a `pnpm-workspace.yaml` file with the `allowBuilds` configuration before running the installation phase.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,8 @@
 		"jsonc-parser": "^3.3.1",
 		"magicast": "^0.5.2",
 		"picocolors": "^1.1.1",
-		"radashi": "^12.9.1"
+		"radashi": "^12.9.1",
+		"yaml": "^2.4.5"
 	},
 	"devDependencies": {
 		"@types/node": "catalog:",

--- a/packages/cli/src/features/scaffold/executor.test.ts
+++ b/packages/cli/src/features/scaffold/executor.test.ts
@@ -355,4 +355,163 @@ describe("Executor", () => {
 		// Verify fsp.cp was NOT called
 		expect(fsp.cp).not.toHaveBeenCalled();
 	});
+
+	describe("pnpm build whitelisting", () => {
+		beforeEach(() => {
+			vi.mocked(mockWorkspace.exists).mockReset();
+			vi.mocked(mockWorkspace.readFile).mockReset();
+			vi.mocked(mockWorkspace.writeFile).mockReset();
+		});
+
+		it("should configure pnpm whitelisting when packageManager is pnpm", async () => {
+			const plan: ScaffoldingPlan = {
+				...defaultPlan,
+				install: { packageManager: "pnpm", dependencies: [] },
+			};
+
+			vi.mocked(mockWorkspace.exists).mockImplementation(async (p) => {
+				if (p.endsWith("package.json")) return true;
+				if (p.endsWith("pnpm-workspace.yaml")) return false;
+				return false;
+			});
+
+			vi.mocked(mockWorkspace.readFile).mockImplementation(async (p) => {
+				if (p.endsWith("package.json")) {
+					return JSON.stringify({ name: "test-pkg" });
+				}
+				return "";
+			});
+
+			await executor.execute(plan);
+
+			// Should update package.json
+			expect(mockWorkspace.writeFile).toHaveBeenCalledWith(
+				expect.stringContaining("package.json"),
+				expect.stringContaining(
+					'"onlyBuiltDependencies": [\n      "esbuild"\n    ]',
+				),
+			);
+
+			// Should create pnpm-workspace.yaml
+			expect(mockWorkspace.writeFile).toHaveBeenCalledWith(
+				expect.stringContaining("pnpm-workspace.yaml"),
+				expect.stringContaining("allowBuilds:\n  esbuild: true"),
+			);
+		});
+
+		it("should not configure pnpm whitelisting when packageManager is not pnpm", async () => {
+			const plan: ScaffoldingPlan = {
+				...defaultPlan,
+				install: { packageManager: "npm", dependencies: [] },
+			};
+
+			vi.mocked(mockWorkspace.exists).mockResolvedValue(true);
+			vi.mocked(mockWorkspace.readFile).mockResolvedValue(
+				JSON.stringify({ name: "test-pkg" }),
+			);
+
+			await executor.execute(plan);
+
+			// Should not write to package.json for npm
+			expect(mockWorkspace.writeFile).not.toHaveBeenCalledWith(
+				expect.stringContaining("package.json"),
+				expect.stringContaining("onlyBuiltDependencies"),
+			);
+
+			// Should not write to pnpm-workspace.yaml
+			expect(mockWorkspace.writeFile).not.toHaveBeenCalledWith(
+				expect.stringContaining("pnpm-workspace.yaml"),
+				expect.any(String),
+			);
+		});
+
+		it("should update existing pnpm-workspace.yaml containing allowBuilds", async () => {
+			const plan: ScaffoldingPlan = {
+				...defaultPlan,
+				install: { packageManager: "pnpm", dependencies: [] },
+			};
+
+			vi.mocked(mockWorkspace.exists).mockImplementation(async (p) => {
+				if (p.endsWith("package.json")) return false;
+				if (p.endsWith("pnpm-workspace.yaml")) return true;
+				return false;
+			});
+
+			vi.mocked(mockWorkspace.readFile).mockImplementation(async (p) => {
+				if (p.endsWith("pnpm-workspace.yaml")) {
+					return "allowBuilds:\n  foo: true\n";
+				}
+				return "";
+			});
+
+			await executor.execute(plan);
+
+			expect(mockWorkspace.writeFile).toHaveBeenCalledWith(
+				expect.stringContaining("pnpm-workspace.yaml"),
+				expect.stringContaining("esbuild: true"),
+			);
+			expect(mockWorkspace.writeFile).toHaveBeenCalledWith(
+				expect.stringContaining("pnpm-workspace.yaml"),
+				expect.stringContaining("foo: true"),
+			);
+		});
+
+		it("should override existing esbuild: false to true", async () => {
+			const plan: ScaffoldingPlan = {
+				...defaultPlan,
+				install: { packageManager: "pnpm", dependencies: [] },
+			};
+
+			vi.mocked(mockWorkspace.exists).mockImplementation(async (p) => {
+				if (p.endsWith("package.json")) return false;
+				if (p.endsWith("pnpm-workspace.yaml")) return true;
+				return false;
+			});
+
+			vi.mocked(mockWorkspace.readFile).mockImplementation(async (p) => {
+				if (p.endsWith("pnpm-workspace.yaml")) {
+					return "allowBuilds:\n  esbuild: false\n";
+				}
+				return "";
+			});
+
+			await executor.execute(plan);
+
+			expect(mockWorkspace.writeFile).toHaveBeenCalledWith(
+				expect.stringContaining("pnpm-workspace.yaml"),
+				expect.stringContaining("esbuild: true"),
+			);
+		});
+
+		it("should support existing quoted keys, comments, and allowBuilds: ~ in pnpm-workspace.yaml", async () => {
+			const plan: ScaffoldingPlan = {
+				...defaultPlan,
+				install: { packageManager: "pnpm", dependencies: [] },
+			};
+
+			vi.mocked(mockWorkspace.exists).mockImplementation(async (p) => {
+				if (p.endsWith("package.json")) return false;
+				if (p.endsWith("pnpm-workspace.yaml")) return true;
+				return false;
+			});
+
+			vi.mocked(mockWorkspace.readFile).mockImplementation(async (p) => {
+				if (p.endsWith("pnpm-workspace.yaml")) {
+					return "# Some comments\nallowBuilds: ~\n";
+				}
+				return "";
+			});
+
+			await executor.execute(plan);
+
+			expect(mockWorkspace.writeFile).toHaveBeenCalledWith(
+				expect.stringContaining("pnpm-workspace.yaml"),
+				expect.stringContaining("esbuild: true"),
+			);
+			expect(mockWorkspace.writeFile).toHaveBeenCalledWith(
+				expect.stringContaining("pnpm-workspace.yaml"),
+				expect.stringContaining("# Some comments"),
+			);
+		});
+	});
 });

--- a/packages/cli/src/features/scaffold/executor.ts
+++ b/packages/cli/src/features/scaffold/executor.ts
@@ -1,8 +1,11 @@
 import path from "node:path";
+import { isMap, parseDocument } from "yaml";
 import { code, symbol } from "@/shared/visuals";
 import { cloneExample } from "./cloner";
 import type { Reporter, ScaffoldingPlan, Workspace } from "./plan";
 import { getInstallCommand, getNextStepsNote } from "./utils";
+
+const APPROVED_PNPM_BUILDS = ["esbuild"];
 
 /**
  * Executes a ScaffoldingPlan by performing workspace modifications,
@@ -83,6 +86,9 @@ export class Executor {
 
 			// 2. Install dependencies
 			if (plan.install && process.env.SKIP_INSTALL !== "true") {
+				if (plan.install.packageManager === "pnpm") {
+					await this.configurePnpmBuilds(plan.install.cwd ?? plan.cwd);
+				}
 				this.reporter.step(
 					`Installing dependencies with ${code(plan.install.packageManager)}...`,
 				);
@@ -287,5 +293,83 @@ export class Executor {
 			s.stop("Scaffolding failed.");
 			throw error;
 		}
+	}
+
+	/**
+	 * Configure pnpm-specific whitelisting for esbuild and other native build dependencies.
+	 *
+	 * @param installCwd The directory where the installation will run
+	 */
+	private async configurePnpmBuilds(installCwd: string): Promise<void> {
+		const packageJsonPath = path.join(installCwd, "package.json");
+		if (await this.workspace.exists(packageJsonPath)) {
+			try {
+				const pkgContent = await this.workspace.readFile(packageJsonPath);
+				const pkg = JSON.parse(pkgContent);
+				pkg.pnpm = pkg.pnpm || {};
+				pkg.pnpm.onlyBuiltDependencies = pkg.pnpm.onlyBuiltDependencies || [];
+				for (const dep of APPROVED_PNPM_BUILDS) {
+					if (!pkg.pnpm.onlyBuiltDependencies.includes(dep)) {
+						pkg.pnpm.onlyBuiltDependencies.push(dep);
+					}
+				}
+				await this.workspace.writeFile(
+					packageJsonPath,
+					JSON.stringify(pkg, null, 2) + "\n",
+				);
+			} catch (e) {
+				this.reporter.warn(
+					`Could not update package.json with pnpm whitelisting: ${e}`,
+				);
+			}
+		}
+
+		const pnpmWorkspacePath = path.join(installCwd, "pnpm-workspace.yaml");
+		let workspaceContent = "";
+		if (await this.workspace.exists(pnpmWorkspacePath)) {
+			try {
+				workspaceContent = await this.workspace.readFile(pnpmWorkspacePath);
+			} catch (e) {
+				// Ignore and treat as empty/non-existent
+			}
+		}
+
+		const updatedContent = this.updatePnpmWorkspaceYaml(workspaceContent);
+		try {
+			await this.workspace.writeFile(pnpmWorkspacePath, updatedContent);
+		} catch (e) {
+			this.reporter.warn(`Could not write pnpm-workspace.yaml: ${e}`);
+		}
+	}
+
+	/**
+	 * Update the content of a pnpm-workspace.yaml file to allow approved builds.
+	 *
+	 * @param content The original content of the pnpm-workspace.yaml file
+	 * @returns The updated content with allowBuilds populated
+	 */
+	private updatePnpmWorkspaceYaml(content: string): string {
+		const doc = parseDocument(content || "");
+
+		if (!doc.has("allowBuilds")) {
+			doc.set("allowBuilds", doc.createNode({}));
+		}
+
+		let allowBuilds = doc.get("allowBuilds");
+
+		if (!isMap(allowBuilds)) {
+			doc.set("allowBuilds", doc.createNode({}));
+			allowBuilds = doc.get("allowBuilds");
+		}
+
+		if (isMap(allowBuilds)) {
+			for (const dep of APPROVED_PNPM_BUILDS) {
+				if (allowBuilds.get(dep) !== true) {
+					allowBuilds.set(dep, true);
+				}
+			}
+		}
+
+		return String(doc);
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -928,6 +928,9 @@ importers:
       radashi:
         specifier: ^12.9.1
         version: 12.9.1
+      yaml:
+        specifier: ^2.4.5
+        version: 2.9.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -22399,7 +22402,7 @@ snapshots:
       vfile-message: 4.0.3
       vfile-reporter: 8.1.1
       vfile-statistics: 3.0.0
-      yaml: 2.8.4
+      yaml: 2.9.0
     transitivePeerDependencies:
       - bluebird
       - supports-color


### PR DESCRIPTION
Fixes #1279

Automatically write onlyBuiltDependencies to package.json and allowBuilds to pnpm-workspace.yaml if pnpm is detected as the package manager before executing pnpm install.