### PR TITLE
Add hosting presets to init CLI

### DIFF
--- a/.changeset/add-hosting-presets-init.md
+++ b/.changeset/add-hosting-presets-init.md
@@ -10,7 +10,7 @@ Usage:
 
 1. Run initialization in an existing project:
    ```bash
-   npx arkenv init
+   npx @arkenv/cli@latest init
    ```
 2. Select Vercel or Netlify from the "Select a hosting provider preset (optional)" prompt.
 3. The generated environment configuration file (`env.ts`) will contain pre-typed environment variables, automatically prefixing them based on the active framework (e.g. `NEXT_PUBLIC_VERCEL_ENV` and `NEXT_PUBLIC_VERCEL_URL` for Next.js).

--- a/.changeset/add-hosting-presets-init.md
+++ b/.changeset/add-hosting-presets-init.md
@@ -1,0 +1,16 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Add hosting presets option to init CLI
+
+Support Vercel and Netlify presets when initializing a project via `arkenv init`.
+
+Usage:
+
+1. Run initialization in an existing project:
+   ```bash
+   npx arkenv init
+   ```
+2. Select Vercel or Netlify from the "Select a hosting provider preset (optional)" prompt.
+3. The generated environment configuration file (`env.ts`) will contain pre-typed environment variables, automatically prefixing them based on the active framework (e.g. `NEXT_PUBLIC_VERCEL_ENV` and `NEXT_PUBLIC_VERCEL_URL` for Next.js).

--- a/packages/cli/src/cli/cli.test.ts
+++ b/packages/cli/src/cli/cli.test.ts
@@ -207,5 +207,25 @@ describe("CLI parser", () => {
 			expect(cli.isFlat).toBe(true);
 			expect(cli.validationError).toBeUndefined();
 		});
+
+		it("should parse --host-preset flag", () => {
+			const cli1 = new CLI(["node", "arkenv", "init", "--host-preset", "vercel"]);
+			expect(cli1.hostPreset).toBe("vercel");
+			expect(cli1.initInput.hostPreset).toBe("vercel");
+			expect(cli1.validationError).toBeUndefined();
+
+			const cli2 = new CLI(["node", "arkenv", "init", "--host-preset", "netlify"]);
+			expect(cli2.hostPreset).toBe("netlify");
+			expect(cli2.initInput.hostPreset).toBe("netlify");
+			expect(cli2.validationError).toBeUndefined();
+
+			const cli3 = new CLI(["node", "arkenv", "init", "--host-preset", "none"]);
+			expect(cli3.hostPreset).toBe("none");
+			expect(cli3.initInput.hostPreset).toBe("none");
+			expect(cli3.validationError).toBeUndefined();
+
+			const cli4 = new CLI(["node", "arkenv", "init", "--host-preset", "vercle"]);
+			expect(cli4.validationError).toBe("Invalid host preset: vercle");
+		});
 	});
 });

--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -13,6 +13,7 @@ const FLAG_CONFIG = {
 	isSimple: { long: "--simple", short: "", kind: "boolean" },
 	isFlat: { long: "--flat", short: "", kind: "boolean" },
 	noCodegen: { long: "--no-codegen", short: "-C", kind: "boolean" },
+	hostPreset: { long: "--host-preset", short: "", kind: "value" },
 } as const;
 
 const knownFlags = new Set<string>(
@@ -100,6 +101,19 @@ export class CLI {
 		}
 
 		if (!this.validationError) {
+			const flag = FLAG_CONFIG.hostPreset;
+			const rawPresetVal = this.getFlagValue(flag.long, flag.short);
+			if (
+				rawPresetVal !== undefined &&
+				rawPresetVal !== "none" &&
+				rawPresetVal !== "vercel" &&
+				rawPresetVal !== "netlify"
+			) {
+				this.validationError = `Invalid host preset: ${rawPresetVal}`;
+			}
+		}
+
+		if (!this.validationError) {
 			if (positionalArgs.length > 1) {
 				this.validationError = `Unknown argument: ${positionalArgs[1]}`;
 			} else {
@@ -161,6 +175,15 @@ export class CLI {
 		return this.hasFlag("noCodegen");
 	}
 
+	get hostPreset(): "none" | "vercel" | "netlify" | undefined {
+		const flag = FLAG_CONFIG.hostPreset;
+		const val = this.getFlagValue(flag.long, flag.short);
+		if (val === "none" || val === "vercel" || val === "netlify") {
+			return val;
+		}
+		return undefined;
+	}
+
 	private hasFlag(prop: keyof typeof FLAG_CONFIG): boolean {
 		const flag = FLAG_CONFIG[prop];
 		return (
@@ -190,6 +213,9 @@ export class CLI {
 		}
 		if (this.noCodegen) {
 			input.noCodegen = true;
+		}
+		if (this.hostPreset !== undefined) {
+			input.hostPreset = this.hostPreset;
 		}
 		return input;
 	}

--- a/packages/cli/src/cli/commands/help.test.ts
+++ b/packages/cli/src/cli/commands/help.test.ts
@@ -29,35 +29,42 @@ describe("HelpUseCase", () => {
 			"  arkenv init [project-name]    Set up ArkEnv in your project",
 		);
 
-		// Options should be aligned based on the longest option (--no-codegen, -C) which is 16 chars
-		// leftPad (2) + longest flag (16) + colGap (4) = 22 characters start index for descriptions.
+		// Options should be aligned based on the longest option (--host-preset <preset>) which is 22 chars
+		// leftPad (2) + longest flag (22) + colGap (4) = 28 characters start index for descriptions.
 		const yesOptionLog = logs.find((l) => l.includes("--yes, -y"));
 		expect(yesOptionLog).toBeDefined();
-		// "--yes, -y" is 9 chars. max (16) - 9 + colGap (4) = 11 spaces padding.
-		// "  " (2) + "--yes, -y" (9) + "           " (11) + "Skip prompts..."
+		// "--yes, -y" is 9 chars. max (22) - 9 + colGap (4) = 17 spaces padding.
+		// "  " (2) + "--yes, -y" (9) + "                 " (17) + "Skip prompts..."
 		expect(yesOptionLog).toBe(
-			"  --yes, -y           Skip prompts and use defaults (also passed to subprocesses)",
+			"  --yes, -y                 Skip prompts and use defaults (also passed to subprocesses)",
 		);
 
 		const exampleOptionLog = logs.find((l) => l.includes("--example, -e"));
 		expect(exampleOptionLog).toBeDefined();
-		// "--example, -e" is 13 chars. max (16) - 13 + colGap (4) = 7 spaces padding.
-		// "  " (2) + "--example, -e" (13) + "       " (7) + "Specify..."
+		// "--example, -e" is 13 chars. max (22) - 13 + colGap (4) = 13 spaces padding.
+		// "  " (2) + "--example, -e" (13) + "             " (13) + "Specify..."
 		expect(exampleOptionLog).toBe(
-			"  --example, -e       Specify an example name when creating a new project",
+			"  --example, -e             Specify an example name when creating a new project",
 		);
 
 		const noCodegenOptionLog = logs.find((l) => l.includes("--no-codegen, -C"));
 		expect(noCodegenOptionLog).toBeDefined();
-		// "--no-codegen, -C" is 16 chars. max (16) - 16 + colGap (4) = 4 spaces padding.
-		// "  " (2) + "--no-codegen, -C" (16) + "    " (4) + "Disable..."
+		// "--no-codegen, -C" is 16 chars. max (22) - 16 + colGap (4) = 10 spaces padding.
+		// "  " (2) + "--no-codegen, -C" (16) + "          " (10) + "Disable..."
 		expect(noCodegenOptionLog).toBe(
-			"  --no-codegen, -C    Disable automatic env.gen.ts code generation for Next.js",
+			"  --no-codegen, -C          Disable automatic env.gen.ts code generation for Next.js",
+		);
+
+		const hostPresetOptionLog = logs.find((l) => l.includes("--host-preset <preset>"));
+		expect(hostPresetOptionLog).toBeDefined();
+		// "--host-preset <preset>" is 22 chars. max (22) - 22 + colGap (4) = 4 spaces padding.
+		expect(hostPresetOptionLog).toBe(
+			"  --host-preset <preset>    Specify a hosting provider preset (none, vercel, netlify)",
 		);
 
 		const helpOptionLog = logs.find((l) => l.includes("--help, -h"));
 		expect(helpOptionLog).toBeDefined();
-		// "--help, -h" is 10 chars. max (16) - 10 + colGap (4) = 10 spaces padding.
-		expect(helpOptionLog).toBe("  --help, -h          Show this help message");
+		// "--help, -h" is 10 chars. max (22) - 10 + colGap (4) = 16 spaces padding.
+		expect(helpOptionLog).toBe("  --help, -h                Show this help message");
 	});
 });

--- a/packages/cli/src/cli/commands/help.ts
+++ b/packages/cli/src/cli/commands/help.ts
@@ -72,6 +72,10 @@ export class HelpUseCase {
 				right: "Disable automatic env.gen.ts code generation for Next.js",
 			},
 			{
+				left: "--host-preset <preset>",
+				right: "Specify a hosting provider preset (none, vercel, netlify)",
+			},
+			{
 				left: "--help, -h",
 				right: "Show this help message",
 			},

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -6,6 +6,7 @@ import {
 	createPlan,
 	Executor,
 	type Framework,
+	type HostPreset,
 } from "@/features/scaffold";
 import { RegistryClient } from "@/shared/clients";
 import type {
@@ -29,6 +30,7 @@ export type InitInput = {
 	example?: string;
 	name?: string;
 	noCodegen?: boolean;
+	hostPreset?: HostPreset;
 };
 
 /**
@@ -294,6 +296,7 @@ export class InitUseCase {
 				isSimple: input.isSimple,
 				isFlat: input.isFlat,
 				disableCodegen: input.noCodegen,
+				hostPreset: input.hostPreset,
 			}),
 			isYes,
 		);

--- a/packages/cli/src/cli/ui/prompts.test.ts
+++ b/packages/cli/src/cli/ui/prompts.test.ts
@@ -196,6 +196,19 @@ describe("runPromptWizard", () => {
 		const result = await runPromptWizard({}, true);
 		expect(result?.hostPreset).toBe("none");
 	});
+
+	it("should bypass hostPreset prompt if already provided in defaults", async () => {
+		vi.mocked(prompts.select).mockResolvedValueOnce("vanilla"); // framework
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // installTypeDefinitions
+		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		// No select mock for hostPreset because it should be bypassed
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
+
+		const result = await runPromptWizard({ hostPreset: "vercel" });
+
+		expect(result?.hostPreset).toBe("vercel");
+	});
 	it("should abort immediately if user selects No (abort) on overwrite prompt", async () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(false);
 

--- a/packages/cli/src/cli/ui/prompts.test.ts
+++ b/packages/cli/src/cli/ui/prompts.test.ts
@@ -68,6 +68,7 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // installTypeDefinitions
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
 
 		const result = await runPromptWizard({ framework: "bun-fullstack" });
@@ -83,6 +84,7 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // wrapNextjsConfig
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.select).mockResolvedValueOnce("zod"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
 
 		const result = await runPromptWizard({ framework: "nextjs" });
@@ -100,6 +102,7 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(false); // nextjsCodegen
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
 
 		const result = await runPromptWizard({ framework: "nextjs" });
@@ -116,6 +119,7 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(false); // wrapNextjsConfig
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
 
 		const result = await runPromptWizard({ framework: "nextjs" });
@@ -130,6 +134,7 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // installTypeDefinitions
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
 
 		const result = await runPromptWizard({ envKeys: ["API_KEY"] });
@@ -145,6 +150,7 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.text).mockResolvedValueOnce("./app/env.ts"); // path
 		vi.mocked(prompts.select).mockResolvedValueOnce("append"); // envDtsHandling
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 
 		const result = await runPromptWizard({
 			framework: "vite",
@@ -165,11 +171,30 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.select).mockResolvedValueOnce("vanilla"); // framework
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(false); // useEnvExample
 
 		const result = await runPromptWizard({ envKeys: ["API_KEY"] });
 
 		expect(result?.envKeys).toBeUndefined();
+	});
+
+	it("should include hostPreset if selected in wizard", async () => {
+		vi.mocked(prompts.select).mockResolvedValueOnce("vanilla"); // framework
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // installTypeDefinitions
+		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("vercel"); // hostPreset
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
+
+		const result = await runPromptWizard();
+
+		expect(result?.hostPreset).toBe("vercel");
+	});
+
+	it("should default hostPreset to none in isYes mode", async () => {
+		const result = await runPromptWizard({}, true);
+		expect(result?.hostPreset).toBe("none");
 	});
 	it("should abort immediately if user selects No (abort) on overwrite prompt", async () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(false);

--- a/packages/cli/src/cli/ui/prompts/steps.ts
+++ b/packages/cli/src/cli/ui/prompts/steps.ts
@@ -14,6 +14,7 @@ import {
 	nextjsCodegenStep,
 	validatorStep,
 } from "./steps/framework";
+import { hostPresetStep } from "./steps/host-preset";
 import { pathStep, useDefaultPathStep } from "./steps/path";
 
 /**
@@ -31,5 +32,6 @@ export const steps = {
 	installTypeDefinitions: installTypeDefinitionsStep,
 	envDtsHandling: envDtsHandlingStep,
 	validator: validatorStep,
+	hostPreset: hostPresetStep,
 	useEnvExample: useEnvExampleStep,
 };

--- a/packages/cli/src/cli/ui/prompts/steps/host-preset.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/host-preset.ts
@@ -1,0 +1,29 @@
+import { isCancel, select } from "@clack/prompts";
+import type { ProjectOptions } from "@/features/scaffold";
+
+export async function hostPresetStep(options?: {
+	initialValue?: ProjectOptions["hostPreset"] | undefined;
+}): Promise<ProjectOptions["hostPreset"] | null> {
+	const answer = await select({
+		message: "Select a hosting provider preset (optional):",
+		initialValue: options?.initialValue ?? "none",
+		options: [
+			{
+				value: "none",
+				label: "None",
+				hint: "Do not add any hosting-specific environment variables",
+			},
+			{
+				value: "vercel",
+				label: "Vercel",
+				hint: "Add VERCEL, VERCEL_ENV, VERCEL_URL, etc.",
+			},
+			{
+				value: "netlify",
+				label: "Netlify",
+				hint: "Add NETLIFY, CONTEXT, URL, DEPLOY_URL, etc.",
+			},
+		],
+	});
+	return isCancel(answer) ? null : (answer as ProjectOptions["hostPreset"]);
+}

--- a/packages/cli/src/cli/ui/prompts/steps/host-preset.ts
+++ b/packages/cli/src/cli/ui/prompts/steps/host-preset.ts
@@ -1,29 +1,27 @@
 import { isCancel, select } from "@clack/prompts";
 import type { ProjectOptions } from "@/features/scaffold";
+import { PRESETS } from "@/features/scaffold/templates/presets";
 
 export async function hostPresetStep(options?: {
 	initialValue?: ProjectOptions["hostPreset"] | undefined;
 }): Promise<ProjectOptions["hostPreset"] | null> {
+	const selectOptions = [
+		{
+			value: "none",
+			label: "None",
+			hint: "Do not add any hosting-specific environment variables",
+		},
+		...Object.entries(PRESETS).map(([value, def]) => ({
+			value,
+			label: def.label,
+			hint: def.hint,
+		})),
+	];
+
 	const answer = await select({
 		message: "Select a hosting provider preset (optional):",
 		initialValue: options?.initialValue ?? "none",
-		options: [
-			{
-				value: "none",
-				label: "None",
-				hint: "Do not add any hosting-specific environment variables",
-			},
-			{
-				value: "vercel",
-				label: "Vercel",
-				hint: "Add VERCEL, VERCEL_ENV, VERCEL_URL, etc.",
-			},
-			{
-				value: "netlify",
-				label: "Netlify",
-				hint: "Add NETLIFY, CONTEXT, URL, DEPLOY_URL, etc.",
-			},
-		],
+		options: selectOptions,
 	});
 	return isCancel(answer) ? null : (answer as ProjectOptions["hostPreset"]);
 }

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -13,7 +13,7 @@ type HasTypeFileAtPath = (options: {
 }) => boolean | Promise<boolean>;
 
 type ExistingProjectDefaults = Partial<
-	Pick<ProjectOptions, "framework" | "bunFeatures" | "disableCodegen">
+	Pick<ProjectOptions, "framework" | "bunFeatures" | "disableCodegen" | "hostPreset">
 > & {
 	defaultEnvPath?: string;
 	tsConfig?: ParsedTsConfig | null;
@@ -44,6 +44,7 @@ export async function runPromptWizard(
 			| "framework"
 			| "bunFeatures"
 			| "disableCodegen"
+			| "hostPreset"
 		>
 	> & {
 		examples?: Example[];
@@ -212,6 +213,7 @@ async function runExistingProjectWizard(
 			envKeys: detectedKeys ?? undefined,
 			disableCodegen: defaults?.disableCodegen ?? false,
 			wrapNextjsConfig: framework === "nextjs" ? true : undefined,
+			hostPreset: defaults?.hostPreset || "none",
 		});
 	}
 
@@ -322,6 +324,13 @@ async function runExistingProjectWizard(
 		// 8. validator
 		const validator = unwrapPrompt(await steps.validator());
 
+		// 8b. hostPreset
+		const hostPreset = unwrapPrompt(
+			await steps.hostPreset({
+				initialValue: defaults?.hostPreset,
+			}),
+		);
+
 		// 9. useEnvExample
 		const useEnvExample = unwrapPrompt(
 			await steps.useEnvExample({
@@ -346,6 +355,7 @@ async function runExistingProjectWizard(
 			installTypeDefinitions,
 			envDtsHandling,
 			validator,
+			hostPreset,
 			bunFeatures,
 			language: "ts",
 			installSkill: false,

--- a/packages/cli/src/cli/ui/prompts/wizard.ts
+++ b/packages/cli/src/cli/ui/prompts/wizard.ts
@@ -324,14 +324,16 @@ async function runExistingProjectWizard(
 		// 8. validator
 		const validator = unwrapPrompt(await steps.validator());
 
-		// 8b. hostPreset
-		const hostPreset = unwrapPrompt(
-			await steps.hostPreset({
-				initialValue: defaults?.hostPreset,
-			}),
-		);
+		// 9. hostPreset
+		const hostPreset = defaults?.hostPreset !== undefined
+			? defaults.hostPreset
+			: unwrapPrompt(
+				await steps.hostPreset({
+					initialValue: defaults?.hostPreset,
+				}),
+			);
 
-		// 9. useEnvExample
+		// 10. useEnvExample
 		const useEnvExample = unwrapPrompt(
 			await steps.useEnvExample({
 				detectedKeys,

--- a/packages/cli/src/features/scaffold/env-template.test.ts
+++ b/packages/cli/src/features/scaffold/env-template.test.ts
@@ -197,7 +197,7 @@ describe("env-template", () => {
 			expect(template).toContain(
 				"NODE_ENV: \"'development' | 'production' | 'test' = 'development'\"",
 			);
-			expect(template).toContain('PORT: "number.port = 3000"');
+			expect(template).toContain("BUN_PUBLIC_API_URL: \"string = 'https://api.example.com'\"");
 			expect(template).not.toContain("export const env = arkenv(Env)");
 			expect(template).toContain("export const Env = type({");
 			expect(template).toContain(

--- a/packages/cli/src/features/scaffold/env-template.test.ts
+++ b/packages/cli/src/features/scaffold/env-template.test.ts
@@ -407,5 +407,61 @@ describe("env-template", () => {
 				"export const SharedSchema = z.object({});",
 			);
 		});
+
+		it("returns strict templates with Netlify preset and Valibot", () => {
+			const options = {
+				validator: "valibot" as any,
+				framework: "nextjs" as any,
+				path: "env.ts",
+				language: "ts" as const,
+				shouldUpdateTsConfig: false,
+				shouldInstall: false,
+				disableCodegen: true,
+				hostPreset: "netlify" as const,
+			};
+			const templates = getStrictEnvTemplates(options);
+			// Check that standard Netlify keys are present and mapped with correct Valibot validators
+			expect(templates.server).toContain("NETLIFY: v.optional(v.string())");
+			expect(templates.server).toContain("CONTEXT: v.optional(v.picklist([\"production\", \"deploy-preview\", \"branch-deploy\"]))");
+			expect(templates.server).toContain("DEPLOY_URL: v.optional(v.string())");
+			expect(templates.client).toContain("NEXT_PUBLIC_CONTEXT: v.optional(v.picklist([\"production\", \"deploy-preview\", \"branch-deploy\"]))");
+			expect(templates.client).toContain("NEXT_PUBLIC_URL: v.optional(v.string())");
+		});
+	});
+
+	describe("hosting presets", () => {
+		it("includes Vercel preset with ArkType validator", () => {
+			const options = {
+				validator: "arktype" as any,
+				framework: "vanilla" as any,
+				path: "env.ts",
+				language: "ts" as const,
+				shouldUpdateTsConfig: false,
+				shouldInstall: false,
+				hostPreset: "vercel" as const,
+			};
+			const template = getEnvTemplate(options);
+			expect(template).toContain("VERCEL: \"string?\"");
+			expect(template).toContain("VERCEL_ENV: \"'production' | 'preview' | 'development'?\"");
+			expect(template).toContain("VERCEL_URL: \"string?\"");
+		});
+
+		it("includes Vercel preset with Zod validator in flat Next.js layout", () => {
+			const options = {
+				validator: "zod" as any,
+				framework: "nextjs" as any,
+				layout: "flat" as const,
+				path: "env.ts",
+				language: "ts" as const,
+				shouldUpdateTsConfig: false,
+				shouldInstall: false,
+				hostPreset: "vercel" as const,
+			};
+			const template = getEnvTemplate(options);
+			expect(template).toContain("VERCEL: z.string().optional()");
+			expect(template).toContain("VERCEL_ENV: z.enum([\"production\", \"preview\", \"development\"]).optional()");
+			expect(template).toContain("NEXT_PUBLIC_VERCEL_ENV: z.enum([\"production\", \"preview\", \"development\"]).optional()");
+			expect(template).toContain("NEXT_PUBLIC_VERCEL_URL: z.string().optional()");
+		});
 	});
 });

--- a/packages/cli/src/features/scaffold/env-template.ts
+++ b/packages/cli/src/features/scaffold/env-template.ts
@@ -1,5 +1,6 @@
 import type { ProjectOptions } from "./plan";
 import { arktypeTemplate, valibotTemplate, zodTemplate } from "./templates";
+import { getPresetKeys, getFieldDefinition } from "./templates/presets";
 
 /**
  * Generate the complete environment configuration template
@@ -13,15 +14,15 @@ export function getEnvTemplate(
 	options: ProjectOptions,
 	nextjsImportPath?: string,
 ): string {
-	const { validator, envKeys, framework, disableCodegen, layout } = options;
+	const { validator, envKeys, framework, disableCodegen, layout, hostPreset } = options;
 
 	switch (validator) {
 		case "arktype":
-			return `${arktypeTemplate(envKeys, framework, nextjsImportPath, disableCodegen, layout)}\n`;
+			return `${arktypeTemplate(envKeys, framework, nextjsImportPath, disableCodegen, layout, hostPreset)}\n`;
 		case "zod":
-			return `${zodTemplate(envKeys, framework, nextjsImportPath, disableCodegen, layout)}\n`;
+			return `${zodTemplate(envKeys, framework, nextjsImportPath, disableCodegen, layout, hostPreset)}\n`;
 		case "valibot":
-			return `${valibotTemplate(envKeys, framework, nextjsImportPath, disableCodegen, layout)}\n`;
+			return `${valibotTemplate(envKeys, framework, nextjsImportPath, disableCodegen, layout, hostPreset)}\n`;
 		default:
 			throw new Error(`Unsupported validator: ${validator}`);
 	}
@@ -62,7 +63,7 @@ export function getStrictEnvTemplates(
 	options: ProjectOptions,
 	nextjsImportPath?: string,
 ): StrictEnvTemplates {
-	const { validator, envKeys } = options;
+	const { validator, envKeys, hostPreset } = options;
 	const disableCodegen = options.disableCodegen || options.framework === "nuxt";
 
 	const serverFields: string[] = [];
@@ -75,16 +76,19 @@ export function getStrictEnvTemplates(
 	const pkgName =
 		options.framework === "nuxt" ? "@arkenv/nuxt" : "@arkenv/nextjs";
 
+	const existingKeys = envKeys && envKeys.length > 0
+		? envKeys
+		: (options.framework === "nuxt" ? ["DATABASE_URL", "NUXT_PUBLIC_API_URL", "NODE_ENV"] : ["DATABASE_URL", "NEXT_PUBLIC_API_URL", "NODE_ENV"]);
+
+	const presetKeys = hostPreset
+		? getPresetKeys(hostPreset, clientPrefix).filter((k) => !existingKeys.includes(k))
+		: [];
+
 	if (envKeys && envKeys.length > 0) {
-		for (const key of envKeys) {
+		const combined = Array.from(new Set([...envKeys, ...presetKeys]));
+		for (const key of combined) {
 			if (key.startsWith(clientPrefix)) {
-				if (validator === "arktype") {
-					clientFields.push(`${key}: "string?",`);
-				} else if (validator === "zod") {
-					clientFields.push(`${key}: z.string().optional(),`);
-				} else if (validator === "valibot") {
-					clientFields.push(`${key}: v.optional(v.string()),`);
-				}
+				clientFields.push(`${key}: ${getFieldDefinition(key, validator, clientPrefix)},`);
 				runtimeEnvFields.push(`${key}: process.env.${key},`);
 			} else if (key === "NODE_ENV") {
 				if (validator === "arktype") {
@@ -115,13 +119,7 @@ export function getStrictEnvTemplates(
 						);
 					}
 				} else {
-					if (validator === "arktype") {
-						serverFields.push(`${key}: "string?",`);
-					} else if (validator === "zod") {
-						serverFields.push(`${key}: z.string().optional(),`);
-					} else if (validator === "valibot") {
-						serverFields.push(`${key}: v.optional(v.string()),`);
-					}
+					serverFields.push(`${key}: ${getFieldDefinition(key, validator, clientPrefix)},`);
 				}
 			}
 		}
@@ -166,6 +164,15 @@ export function getStrictEnvTemplates(
 			`${defaultClientKey}: process.env.${defaultClientKey},`,
 			"NODE_ENV: process.env.NODE_ENV,",
 		);
+
+		for (const key of presetKeys) {
+			if (key.startsWith(clientPrefix)) {
+				clientFields.push(`${key}: ${getFieldDefinition(key, validator, clientPrefix)},`);
+				runtimeEnvFields.push(`${key}: process.env.${key},`);
+			} else {
+				serverFields.push(`${key}: ${getFieldDefinition(key, validator, clientPrefix)},`);
+			}
+		}
 	}
 
 	const runtimeEnvOptions =

--- a/packages/cli/src/features/scaffold/env-template.ts
+++ b/packages/cli/src/features/scaffold/env-template.ts
@@ -76,12 +76,8 @@ export function getStrictEnvTemplates(
 	const pkgName =
 		options.framework === "nuxt" ? "@arkenv/nuxt" : "@arkenv/nextjs";
 
-	const existingKeys = envKeys && envKeys.length > 0
-		? envKeys
-		: (options.framework === "nuxt" ? ["DATABASE_URL", "NUXT_PUBLIC_API_URL", "NODE_ENV"] : ["DATABASE_URL", "NEXT_PUBLIC_API_URL", "NODE_ENV"]);
-
 	const presetKeys = hostPreset
-		? getPresetKeys(hostPreset, clientPrefix).filter((k) => !existingKeys.includes(k))
+		? getPresetKeys(hostPreset, clientPrefix).filter((k) => !(envKeys || []).includes(k))
 		: [];
 
 	if (envKeys && envKeys.length > 0) {

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -37,6 +37,7 @@ export type ProjectOptions = {
 	envExampleContent?: string;
 	envContent?: string;
 	gitignoreContent?: string;
+	hostPreset?: "none" | "vercel" | "netlify";
 };
 
 /**

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -2,7 +2,9 @@ import type { LoggerPort as Reporter } from "@/shared/ports/logger.port";
 import type { ParsedTsConfig } from "@/shared/ports/project-scanner.port";
 import type { WorkspacePort as Workspace } from "@/shared/ports/workspace.port";
 
-export type { Reporter, Workspace };
+import type { HostPreset } from "./templates/presets";
+
+export type { Reporter, Workspace, HostPreset };
 
 export type Validator = "arktype" | "zod" | "valibot";
 export type Framework =
@@ -37,7 +39,7 @@ export type ProjectOptions = {
 	envExampleContent?: string;
 	envContent?: string;
 	gitignoreContent?: string;
-	hostPreset?: "none" | "vercel" | "netlify";
+	hostPreset?: HostPreset;
 };
 
 /**

--- a/packages/cli/src/features/scaffold/plan.ts
+++ b/packages/cli/src/features/scaffold/plan.ts
@@ -2,9 +2,9 @@ import type { LoggerPort as Reporter } from "@/shared/ports/logger.port";
 import type { ParsedTsConfig } from "@/shared/ports/project-scanner.port";
 import type { WorkspacePort as Workspace } from "@/shared/ports/workspace.port";
 
-import type { HostPreset } from "./templates/presets";
+export type HostPreset = "none" | "vercel" | "netlify";
 
-export type { Reporter, Workspace, HostPreset };
+export type { Reporter, Workspace };
 
 export type Validator = "arktype" | "zod" | "valibot";
 export type Framework =

--- a/packages/cli/src/features/scaffold/planner.test.ts
+++ b/packages/cli/src/features/scaffold/planner.test.ts
@@ -673,5 +673,35 @@ UNRELATED=`);
 				expect(gitignoreFile).toBeUndefined();
 			});
 		});
+
+		describe("hostPresets planning", () => {
+			it("includes hosting preset keys in generated config and .env templates", () => {
+				const state: CollectedState = {
+					...defaultState,
+					existingFiles: [], // So .env and .env.example will be planned for creation
+					options: {
+						...defaultState.options,
+						hostPreset: "vercel",
+					},
+				};
+				const plan = createPlan(state);
+				
+				const envTs = plan.files.find((f) => f.path.endsWith("env.ts"));
+				const dotenv = plan.files.find((f) => f.path.endsWith(".env"));
+				const dotenvExample = plan.files.find((f) => f.path.endsWith(".env.example"));
+
+				expect(envTs).toBeDefined();
+				expect(envTs?.content).toContain("VERCEL_URL");
+				expect(envTs?.content).toContain("VERCEL_ENV");
+
+				expect(dotenv).toBeDefined();
+				expect(dotenv?.content).toContain("VERCEL_ENV=");
+				expect(dotenv?.content).toContain("VERCEL_URL=");
+
+				expect(dotenvExample).toBeDefined();
+				expect(dotenvExample?.content).toContain("VERCEL_ENV=");
+				expect(dotenvExample?.content).toContain("VERCEL_URL=");
+			});
+		});
 	});
 });

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -4,6 +4,7 @@ import { getEnvTemplate, getStrictEnvTemplates } from "./env-template";
 import type { CollectedState, ScaffoldingPlan } from "./plan";
 import { getDlxCommand } from "./scaffold";
 import { bunTypesTemplate, viteTypesTemplate } from "./templates";
+import { getFrameworkPrefix, getPresetKeys } from "./templates/presets";
 
 const exampleEnvDefaults: Record<string, Record<string, string>> = {
 	basic: {
@@ -400,13 +401,20 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 	const hasEnv = existingFiles.includes(envPath);
 	const hasEnvExample = existingFiles.includes(envExamplePath);
 
+	const clientPrefix =
+		options.framework === "nuxt" ? "NUXT_PUBLIC_" : (options.framework === "nextjs" ? "NEXT_PUBLIC_" : getFrameworkPrefix(options.framework));
+	const presetKeys = options.hostPreset ? getPresetKeys(options.hostPreset, clientPrefix) : [];
+	const combinedEnvKeys = options.envKeys || presetKeys.length > 0
+		? Array.from(new Set([...(options.envKeys || []), ...presetKeys]))
+		: undefined;
+
 	if (!hasEnv) {
 		const content =
 			options.envExampleContent !== undefined
 				? options.envExampleContent
 				: (() => {
 						const defaults = getEnvDefaultsFromKeys(
-							options.envKeys,
+							combinedEnvKeys,
 							options.framework,
 						);
 						return (
@@ -429,7 +437,7 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 				? stripValuesFromEnvContent(options.envContent)
 				: (() => {
 						const defaults = getEnvDefaultsFromKeys(
-							options.envKeys,
+							combinedEnvKeys,
 							options.framework,
 						);
 						return (

--- a/packages/cli/src/features/scaffold/planner.ts
+++ b/packages/cli/src/features/scaffold/planner.ts
@@ -5,112 +5,7 @@ import type { CollectedState, ScaffoldingPlan } from "./plan";
 import { getDlxCommand } from "./scaffold";
 import { bunTypesTemplate, viteTypesTemplate } from "./templates";
 import { getFrameworkPrefix, getPresetKeys } from "./templates/presets";
-
-const exampleEnvDefaults: Record<string, Record<string, string>> = {
-	basic: {
-		HOST: "localhost",
-		PORT: "3000",
-		NODE_ENV: "development",
-	},
-	"basic-js": {
-		HOST: "localhost",
-		PORT: "3000",
-		NODE_ENV: "development",
-	},
-	"with-bun": {
-		HOST: "localhost",
-		PORT: "3000",
-		NODE_ENV: "development",
-	},
-	"with-nextjs": {
-		DATABASE_URL: "postgres://localhost:5432/mydb",
-		NEXT_PUBLIC_API_URL: "https://api.example.com",
-		NODE_ENV: "development",
-	},
-	"with-nextjs-strict": {
-		DATABASE_URL: "postgres://localhost:5432/mydb",
-		NEXT_PUBLIC_API_URL: "https://api.example.com",
-		NODE_ENV: "development",
-	},
-	"with-nuxt": {
-		DATABASE_URL: "postgres://localhost:5432/mydb",
-		NUXT_PUBLIC_API_URL: "https://api.example.com",
-		NODE_ENV: "development",
-	},
-	"with-vite-react": {
-		PORT: "3000",
-		VITE_MY_VAR: "hello",
-		VITE_MY_NUMBER: "42",
-		VITE_MY_BOOLEAN: "true",
-	},
-	"with-bun-react": {
-		BUN_PUBLIC_API_URL: "https://api.example.com",
-		BUN_PUBLIC_DEBUG: "true",
-		NODE_ENV: "development",
-	},
-	"with-zod": {
-		HOST: "localhost",
-		PORT: "3000",
-		NODE_ENV: "development",
-	},
-	"with-standard-schema": {
-		HOST: "localhost",
-		PORT: "3000",
-		NODE_ENV: "development",
-	},
-};
-
-function getEnvDefaultsFromKeys(
-	keys?: string[],
-	framework?: string,
-): Record<string, string> {
-	const defaults: Record<string, string> = {};
-	if (keys && keys.length > 0) {
-		for (const key of keys) {
-			if (key === "NODE_ENV") {
-				defaults[key] = "development";
-			} else if (key === "PORT") {
-				defaults[key] = "3000";
-			} else if (key === "DATABASE_URL") {
-				defaults[key] = "postgres://localhost:5432/mydb";
-			} else {
-				defaults[key] = "";
-			}
-		}
-		return defaults;
-	}
-
-	if (framework === "nextjs") {
-		return {
-			DATABASE_URL: "postgres://localhost:5432/mydb",
-			NEXT_PUBLIC_API_URL: "https://api.example.com",
-			NODE_ENV: "development",
-		};
-	}
-	if (framework === "nuxt") {
-		return {
-			DATABASE_URL: "postgres://localhost:5432/mydb",
-			NUXT_PUBLIC_API_URL: "https://api.example.com",
-			NODE_ENV: "development",
-		};
-	}
-	if (framework === "vite") {
-		return {
-			PORT: "3000",
-			VITE_API_URL: "https://api.example.com",
-		};
-	}
-	if (framework === "bun-fullstack") {
-		return {
-			BUN_PUBLIC_API_URL: "https://api.example.com",
-			NODE_ENV: "development",
-		};
-	}
-	return {
-		PORT: "3000",
-		NODE_ENV: "development",
-	};
-}
+import { exampleEnvDefaults, getEnvDefaultsFromKeys } from "./utils";
 
 function getEnvDefaultsForExample(
 	example: string,
@@ -401,8 +296,7 @@ export function createPlan(state: CollectedState): ScaffoldingPlan {
 	const hasEnv = existingFiles.includes(envPath);
 	const hasEnvExample = existingFiles.includes(envExamplePath);
 
-	const clientPrefix =
-		options.framework === "nuxt" ? "NUXT_PUBLIC_" : (options.framework === "nextjs" ? "NEXT_PUBLIC_" : getFrameworkPrefix(options.framework));
+	const clientPrefix = getFrameworkPrefix(options.framework);
 	const presetKeys = options.hostPreset ? getPresetKeys(options.hostPreset, clientPrefix) : [];
 	const combinedEnvKeys = options.envKeys || presetKeys.length > 0
 		? Array.from(new Set([...(options.envKeys || []), ...presetKeys]))

--- a/packages/cli/src/features/scaffold/templates/arktype.ts
+++ b/packages/cli/src/features/scaffold/templates/arktype.ts
@@ -1,5 +1,6 @@
 import dedent from "dedent";
 import { buildNextjsTemplate } from "./nextjs-template";
+import { getFrameworkPrefix, getPresetKeys, getFieldDefinition, type HostPreset } from "./presets";
 
 /**
  * Generate a TypeScript template string for an ArkType environment configuration.
@@ -7,6 +8,9 @@ import { buildNextjsTemplate } from "./nextjs-template";
  * @param envKeys Optional array of environment variable keys to include in the schema
  * @param framework The framework being used (vite, bun-fullstack, or vanilla)
  * @param nextjsImportPath The optional custom import path for the generated file in Next.js
+ * @param disableCodegen Whether automatic Next.js code generation is disabled
+ * @param layout The layout structure to use (strict, simple, or flat)
+ * @param hostPreset The selected hosting provider preset
  * @returns The generated TypeScript template string
  */
 export const arktypeTemplate = (
@@ -15,11 +19,20 @@ export const arktypeTemplate = (
 	nextjsImportPath?: string,
 	disableCodegen?: boolean,
 	layout?: "strict" | "simple" | "flat",
+	hostPreset?: HostPreset,
 ) => {
-	const schemaFields = envKeys?.length
-		? envKeys.map((key) => `\t\t${key}: "string?",`).join("\n")
-		: `\t\tNODE_ENV: "'development' | 'production' | 'test' = 'development'",
+	const prefix = getFrameworkPrefix(framework as any);
+	const presetKeys = hostPreset ? getPresetKeys(hostPreset, prefix) : [];
+
+	let schemaFields = "";
+	if (envKeys?.length || presetKeys.length) {
+		const baseKeys = envKeys || [];
+		const uniqueKeys = Array.from(new Set([...baseKeys, ...presetKeys]));
+		schemaFields = uniqueKeys.map((key) => `\t\t${key}: ${getFieldDefinition(key, "arktype", prefix)},`).join("\n");
+	} else {
+		schemaFields = `\t\tNODE_ENV: "'development' | 'production' | 'test' = 'development'",
 		PORT: "number.port = 3000",`;
+	}
 
 	if (framework === "vite") {
 		return dedent /* ts */`
@@ -56,10 +69,10 @@ export const arktypeTemplate = (
 		return buildNextjsTemplate(
 			envKeys,
 			{
-				serverField: (key) => `\t\t${key}: "string?",`,
-				clientField: (key) => `\t\t${key}: "string?",`,
+				serverField: (key) => `\t\t${key}: ${getFieldDefinition(key, "arktype", clientPrefix)},`,
+				clientField: (key) => `\t\t${key}: ${getFieldDefinition(key, "arktype", clientPrefix)},`,
 				sharedField: (key) =>
-					`\t\t${key}: "'development' | 'production' | 'test' = 'development'",`,
+					`\t\t${key}: ${getFieldDefinition(key, "arktype", clientPrefix)},`,
 				defaultServerFields: [
 					`\t\tDATABASE_URL: "string = 'postgres://localhost:5432/mydb'",`,
 				],
@@ -74,6 +87,7 @@ export const arktypeTemplate = (
 			disableCodegen,
 			framework,
 			layout,
+			hostPreset,
 		);
 	}
 
@@ -84,7 +98,7 @@ export const arktypeTemplate = (
 	 * Environment variable schema for server-side or runtime-only validation.
 	 */
 	export const Env = type({
-${schemaFields}
+		${schemaFields}
 	});
 
 	export const env = arkenv(Env);

--- a/packages/cli/src/features/scaffold/templates/arktype.ts
+++ b/packages/cli/src/features/scaffold/templates/arktype.ts
@@ -24,15 +24,32 @@ export const arktypeTemplate = (
 	const prefix = getFrameworkPrefix(framework as any);
 	const presetKeys = hostPreset ? getPresetKeys(hostPreset, prefix) : [];
 
-	let schemaFields = "";
-	if (envKeys?.length || presetKeys.length) {
-		const baseKeys = envKeys || [];
-		const uniqueKeys = Array.from(new Set([...baseKeys, ...presetKeys]));
-		schemaFields = uniqueKeys.map((key) => `\t\t${key}: ${getFieldDefinition(key, "arktype", prefix)},`).join("\n");
-	} else {
-		schemaFields = `\t\tNODE_ENV: "'development' | 'production' | 'test' = 'development'",
-		PORT: "number.port = 3000",`;
-	}
+	const getDefaultKeys = (fw?: string, pref?: string): string[] => {
+		if (fw === "vite") {
+			return ["PORT", `${pref}API_URL`, "NODE_ENV"];
+		}
+		if (fw === "bun-fullstack") {
+			return [`${pref}API_URL`, "NODE_ENV"];
+		}
+		return ["NODE_ENV", "PORT"];
+	};
+
+	const defaultKeys = getDefaultKeys(framework, prefix);
+	const baseKeys = envKeys?.length ? envKeys : defaultKeys;
+	const uniqueKeys = Array.from(new Set([...baseKeys, ...presetKeys]));
+	const getFieldSchema = (key: string) => {
+		if (key === "NODE_ENV") {
+			return `"'development' | 'production' | 'test' = 'development'"`;
+		}
+		if (key === "PORT") {
+			return `"number.port = 3000"`;
+		}
+		if (prefix && key === `${prefix}API_URL`) {
+			return `"string = 'https://api.example.com'"`;
+		}
+		return getFieldDefinition(key, "arktype", prefix);
+	};
+	const schemaFields = uniqueKeys.map((key) => `\t\t${key}: ${getFieldSchema(key)},`).join("\n");
 
 	if (framework === "vite") {
 		return dedent /* ts */`
@@ -44,7 +61,7 @@ export const arktypeTemplate = (
 	 * and provide typesafety for \`import.meta.env\` on the client-side.
 	 */
 	export const Env = type({
-		${schemaFields}
+${schemaFields}
 	});
 	`;
 	}
@@ -59,7 +76,7 @@ export const arktypeTemplate = (
 	 * and provide typesafety for \`process.env\` on the client-side.
 	 */
 	export const Env = type({
-		${schemaFields}
+${schemaFields}
 	});
 	`;
 	}
@@ -98,7 +115,7 @@ export const arktypeTemplate = (
 	 * Environment variable schema for server-side or runtime-only validation.
 	 */
 	export const Env = type({
-		${schemaFields}
+${schemaFields}
 	});
 
 	export const env = arkenv(Env);

--- a/packages/cli/src/features/scaffold/templates/index.ts
+++ b/packages/cli/src/features/scaffold/templates/index.ts
@@ -1,5 +1,6 @@
 export * from "./arktype";
 export * from "./nextjs-template";
+export * from "./presets";
 export * from "./types";
 export * from "./valibot";
 export * from "./zod";

--- a/packages/cli/src/features/scaffold/templates/nextjs-template.ts
+++ b/packages/cli/src/features/scaffold/templates/nextjs-template.ts
@@ -35,6 +35,8 @@ export type NextjsFieldBuilders = {
 	defaultSharedFields: string[];
 };
 
+import { getPresetKeys, type HostPreset } from "./presets";
+
 /**
  * Generate a Next.js `env.ts` template string for any supported validator.
  *
@@ -46,6 +48,10 @@ export type NextjsFieldBuilders = {
  * @param envKeys Optional array of env keys scanned from the project
  * @param builders Validator-specific field formatters and default field values
  * @param nextjsImportPath The optional custom import path for the generated file
+ * @param disableCodegen Whether automatic Next.js code generation is disabled
+ * @param framework The framework name
+ * @param layout The layout structure
+ * @param hostPreset The selected hosting preset
  * @returns The generated TypeScript source string
  */
 export function buildNextjsTemplate(
@@ -55,6 +61,7 @@ export function buildNextjsTemplate(
 	disableCodegen?: boolean,
 	framework?: string,
 	layout?: "strict" | "simple" | "flat",
+	hostPreset?: HostPreset,
 ): string {
 	const {
 		extraImports,
@@ -88,6 +95,24 @@ export function buildNextjsTemplate(
 		serverFields.push(...defaultServerFields);
 		clientFields.push(...defaultClientFields);
 		sharedFields.push(...defaultSharedFields);
+	}
+
+	const existingKeys = envKeys && envKeys.length > 0
+		? envKeys
+		: (framework === "nuxt" ? ["DATABASE_URL", "NUXT_PUBLIC_API_URL", "NODE_ENV"] : ["DATABASE_URL", "NEXT_PUBLIC_API_URL", "NODE_ENV"]);
+
+	const presetKeys = hostPreset
+		? getPresetKeys(hostPreset, clientPrefix).filter((k) => !existingKeys.includes(k))
+		: [];
+
+	for (const key of presetKeys) {
+		if (key.startsWith(clientPrefix)) {
+			clientFields.push(clientField(key));
+		} else if (key === "NODE_ENV") {
+			sharedFields.push(sharedField(key));
+		} else {
+			serverFields.push(serverField(key));
+		}
 	}
 
 	if (framework === "nextjs" && layout !== "simple") {

--- a/packages/cli/src/features/scaffold/templates/nextjs-template.ts
+++ b/packages/cli/src/features/scaffold/templates/nextjs-template.ts
@@ -97,12 +97,8 @@ export function buildNextjsTemplate(
 		sharedFields.push(...defaultSharedFields);
 	}
 
-	const existingKeys = envKeys && envKeys.length > 0
-		? envKeys
-		: (framework === "nuxt" ? ["DATABASE_URL", "NUXT_PUBLIC_API_URL", "NODE_ENV"] : ["DATABASE_URL", "NEXT_PUBLIC_API_URL", "NODE_ENV"]);
-
 	const presetKeys = hostPreset
-		? getPresetKeys(hostPreset, clientPrefix).filter((k) => !existingKeys.includes(k))
+		? getPresetKeys(hostPreset, clientPrefix).filter((k) => !(envKeys || []).includes(k))
 		: [];
 
 	for (const key of presetKeys) {

--- a/packages/cli/src/features/scaffold/templates/presets.ts
+++ b/packages/cli/src/features/scaffold/templates/presets.ts
@@ -1,5 +1,17 @@
-type Validator = "arktype" | "zod" | "valibot";
-type Framework = "vite" | "bun-fullstack" | "vanilla" | "nextjs" | "nuxt";
+import type { Framework, HostPreset, Validator } from "../plan";
+
+export interface PresetField {
+	readonly type: "string" | "enum";
+	readonly values?: readonly string[];
+}
+
+export interface PresetDefinition {
+	readonly label: string;
+	readonly hint: string;
+	readonly serverOnlyKeys: readonly string[];
+	readonly clientExposedKeys: readonly string[];
+	readonly fields: Readonly<Record<string, PresetField>>;
+}
 
 export const PRESETS = {
 	vercel: {
@@ -8,21 +20,12 @@ export const PRESETS = {
 		serverOnlyKeys: ["VERCEL"],
 		clientExposedKeys: ["VERCEL_ENV", "VERCEL_URL"],
 		fields: {
-			VERCEL: {
-				arktype: `"string?"`,
-				zod: `z.string().optional()`,
-				valibot: `v.optional(v.string())`,
-			},
+			VERCEL: { type: "string" },
 			VERCEL_ENV: {
-				arktype: `"'production' | 'preview' | 'development'?"`,
-				zod: `z.enum(["production", "preview", "development"]).optional()`,
-				valibot: `v.optional(v.picklist(["production", "preview", "development"]))`,
+				type: "enum",
+				values: ["production", "preview", "development"],
 			},
-			VERCEL_URL: {
-				arktype: `"string?"`,
-				zod: `z.string().optional()`,
-				valibot: `v.optional(v.string())`,
-			},
+			VERCEL_URL: { type: "string" },
 		},
 	},
 	netlify: {
@@ -31,31 +34,18 @@ export const PRESETS = {
 		serverOnlyKeys: ["NETLIFY", "DEPLOY_URL"],
 		clientExposedKeys: ["CONTEXT", "URL"],
 		fields: {
-			NETLIFY: {
-				arktype: `"string?"`,
-				zod: `z.string().optional()`,
-				valibot: `v.optional(v.string())`,
-			},
-			DEPLOY_URL: {
-				arktype: `"string?"`,
-				zod: `z.string().optional()`,
-				valibot: `v.optional(v.string())`,
-			},
+			NETLIFY: { type: "string" },
+			DEPLOY_URL: { type: "string" },
 			CONTEXT: {
-				arktype: `"'production' | 'deploy-preview' | 'branch-deploy'?"`,
-				zod: `z.enum(["production", "deploy-preview", "branch-deploy"]).optional()`,
-				valibot: `v.optional(v.picklist(["production", "deploy-preview", "branch-deploy"]))`,
+				type: "enum",
+				values: ["production", "deploy-preview", "branch-deploy"],
 			},
-			URL: {
-				arktype: `"string?"`,
-				zod: `z.string().optional()`,
-				valibot: `v.optional(v.string())`,
-			},
+			URL: { type: "string" },
 		},
 	},
-} as const;
+} satisfies Record<string, PresetDefinition>;
 
-export type HostPreset = "none" | keyof typeof PRESETS;
+export type { HostPreset };
 
 /**
  * Get the framework-specific client prefix.
@@ -97,23 +87,51 @@ export function getFieldDefinition(
 
 	// Search all presets for this baseKey definition
 	for (const def of Object.values(PRESETS)) {
-		const fields = def.fields as Record<string, Record<Validator, string>>;
+		const fields = def.fields as Record<string, PresetField>;
 		if (baseKey in fields) {
 			const field = fields[baseKey];
-			if (validator === "arktype") return field.arktype;
-			if (validator === "zod") return field.zod;
-			if (validator === "valibot") return field.valibot;
-			
-			const _exhaustiveCheck: never = validator;
-			throw new Error(`Unsupported validator: ${_exhaustiveCheck}`);
+			if (field.type === "string") {
+				switch (validator) {
+					case "arktype":
+						return `"string?"`;
+					case "zod":
+						return `z.string().optional()`;
+					case "valibot":
+						return `v.optional(v.string())`;
+					default: {
+						const _exhaustiveCheck: never = validator;
+						throw new Error(`Unsupported validator: ${_exhaustiveCheck}`);
+					}
+				}
+			} else if (field.type === "enum") {
+				const values = field.values || [];
+				switch (validator) {
+					case "arktype":
+						return `"'${values.join("' | '")}'?"`;
+					case "zod":
+						return `z.enum([${values.map((v: string) => `"${v}"`).join(", ")}]).optional()`;
+					case "valibot":
+						return `v.optional(v.picklist([${values.map((v: string) => `"${v}"`).join(", ")}]))`;
+					default: {
+						const _exhaustiveCheck: never = validator;
+						throw new Error(`Unsupported validator: ${_exhaustiveCheck}`);
+					}
+				}
+			}
 		}
 	}
 
 	// Fallback to default optional string if not matched by any preset
-	if (validator === "arktype") return `"string?"`;
-	if (validator === "zod") return `z.string().optional()`;
-	if (validator === "valibot") return `v.optional(v.string())`;
-
-	const _exhaustiveCheck: never = validator;
-	throw new Error(`Unsupported validator: ${_exhaustiveCheck}`);
+	switch (validator) {
+		case "arktype":
+			return `"string?"`;
+		case "zod":
+			return `z.string().optional()`;
+		case "valibot":
+			return `v.optional(v.string())`;
+		default: {
+			const _exhaustiveCheck: never = validator;
+			throw new Error(`Unsupported validator: ${_exhaustiveCheck}`);
+		}
+	}
 }

--- a/packages/cli/src/features/scaffold/templates/presets.ts
+++ b/packages/cli/src/features/scaffold/templates/presets.ts
@@ -1,9 +1,8 @@
 import type { Framework, HostPreset, Validator } from "../plan";
 
-export interface PresetField {
-	readonly type: "string" | "enum";
-	readonly values?: readonly string[];
-}
+export type PresetField =
+	| { readonly type: "string" }
+	| { readonly type: "enum"; readonly values: readonly string[] };
 
 export interface PresetDefinition {
 	readonly label: string;
@@ -104,7 +103,7 @@ export function getFieldDefinition(
 					}
 				}
 			} else if (field.type === "enum") {
-				const values = field.values || [];
+				const values = field.values;
 				switch (validator) {
 					case "arktype":
 						return `"'${values.join("' | '")}'?"`;

--- a/packages/cli/src/features/scaffold/templates/presets.ts
+++ b/packages/cli/src/features/scaffold/templates/presets.ts
@@ -1,6 +1,61 @@
-import type { Framework, Validator } from "../plan";
+type Validator = "arktype" | "zod" | "valibot";
+type Framework = "vite" | "bun-fullstack" | "vanilla" | "nextjs" | "nuxt";
 
-export type HostPreset = "none" | "vercel" | "netlify";
+export const PRESETS = {
+	vercel: {
+		label: "Vercel",
+		hint: "Add VERCEL, VERCEL_ENV, VERCEL_URL, etc.",
+		serverOnlyKeys: ["VERCEL"],
+		clientExposedKeys: ["VERCEL_ENV", "VERCEL_URL"],
+		fields: {
+			VERCEL: {
+				arktype: `"string?"`,
+				zod: `z.string().optional()`,
+				valibot: `v.optional(v.string())`,
+			},
+			VERCEL_ENV: {
+				arktype: `"'production' | 'preview' | 'development'?"`,
+				zod: `z.enum(["production", "preview", "development"]).optional()`,
+				valibot: `v.optional(v.picklist(["production", "preview", "development"]))`,
+			},
+			VERCEL_URL: {
+				arktype: `"string?"`,
+				zod: `z.string().optional()`,
+				valibot: `v.optional(v.string())`,
+			},
+		},
+	},
+	netlify: {
+		label: "Netlify",
+		hint: "Add NETLIFY, CONTEXT, URL, DEPLOY_URL, etc.",
+		serverOnlyKeys: ["NETLIFY", "DEPLOY_URL"],
+		clientExposedKeys: ["CONTEXT", "URL"],
+		fields: {
+			NETLIFY: {
+				arktype: `"string?"`,
+				zod: `z.string().optional()`,
+				valibot: `v.optional(v.string())`,
+			},
+			DEPLOY_URL: {
+				arktype: `"string?"`,
+				zod: `z.string().optional()`,
+				valibot: `v.optional(v.string())`,
+			},
+			CONTEXT: {
+				arktype: `"'production' | 'deploy-preview' | 'branch-deploy'?"`,
+				zod: `z.enum(["production", "deploy-preview", "branch-deploy"]).optional()`,
+				valibot: `v.optional(v.picklist(["production", "deploy-preview", "branch-deploy"]))`,
+			},
+			URL: {
+				arktype: `"string?"`,
+				zod: `z.string().optional()`,
+				valibot: `v.optional(v.string())`,
+			},
+		},
+	},
+} as const;
+
+export type HostPreset = "none" | keyof typeof PRESETS;
 
 /**
  * Get the framework-specific client prefix.
@@ -17,21 +72,16 @@ export function getFrameworkPrefix(framework?: Framework): string {
  * Returns standard environment keys for the given hosting preset.
  */
 export function getPresetKeys(preset: HostPreset, prefix: string): string[] {
-	if (preset === "vercel") {
-		const keys = ["VERCEL", "VERCEL_ENV", "VERCEL_URL"];
-		if (prefix) {
-			keys.push(`${prefix}VERCEL_ENV`, `${prefix}VERCEL_URL`);
+	if (preset === "none") return [];
+	const def = PRESETS[preset];
+	if (!def) return [];
+	const keys: string[] = [...def.serverOnlyKeys, ...def.clientExposedKeys];
+	if (prefix) {
+		for (const key of def.clientExposedKeys) {
+			keys.push(`${prefix}${key}`);
 		}
-		return keys;
 	}
-	if (preset === "netlify") {
-		const keys = ["NETLIFY", "CONTEXT", "URL", "DEPLOY_URL"];
-		if (prefix) {
-			keys.push(`${prefix}CONTEXT`, `${prefix}URL`);
-		}
-		return keys;
-	}
-	return [];
+	return keys;
 }
 
 /**
@@ -42,40 +92,28 @@ export function getFieldDefinition(
 	validator: Validator,
 	prefix: string,
 ): string {
-	if (key === "VERCEL_ENV" || (prefix && key === `${prefix}VERCEL_ENV`)) {
-		if (validator === "arktype") {
-			return `"'production' | 'preview' | 'development'?"`;
-		}
-		if (validator === "zod") {
-			return `z.enum(["production", "preview", "development"]).optional()`;
-		}
-		if (validator === "valibot") {
-			return `v.optional(v.picklist(["production", "preview", "development"]))`;
+	// Strip prefix if the key is a client exposed key
+	const baseKey = prefix && key.startsWith(prefix) ? key.slice(prefix.length) : key;
+
+	// Search all presets for this baseKey definition
+	for (const def of Object.values(PRESETS)) {
+		const fields = def.fields as Record<string, Record<Validator, string>>;
+		if (baseKey in fields) {
+			const field = fields[baseKey];
+			if (validator === "arktype") return field.arktype;
+			if (validator === "zod") return field.zod;
+			if (validator === "valibot") return field.valibot;
+			
+			const _exhaustiveCheck: never = validator;
+			throw new Error(`Unsupported validator: ${_exhaustiveCheck}`);
 		}
 	}
 
-	if (key === "CONTEXT" || (prefix && key === `${prefix}CONTEXT`)) {
-		if (validator === "arktype") {
-			return `"'production' | 'deploy-preview' | 'branch-deploy'?"`;
-		}
-		if (validator === "zod") {
-			return `z.enum(["production", "deploy-preview", "branch-deploy"]).optional()`;
-		}
-		if (validator === "valibot") {
-			return `v.optional(v.picklist(["production", "deploy-preview", "branch-deploy"]))`;
-		}
-	}
+	// Fallback to default optional string if not matched by any preset
+	if (validator === "arktype") return `"string?"`;
+	if (validator === "zod") return `z.string().optional()`;
+	if (validator === "valibot") return `v.optional(v.string())`;
 
-	// Default optional string mapping
-	if (validator === "arktype") {
-		return `"string?"`;
-	}
-	if (validator === "zod") {
-		return `z.string().optional()`;
-	}
-	if (validator === "valibot") {
-		return `v.optional(v.string())`;
-	}
-
-	return "";
+	const _exhaustiveCheck: never = validator;
+	throw new Error(`Unsupported validator: ${_exhaustiveCheck}`);
 }

--- a/packages/cli/src/features/scaffold/templates/presets.ts
+++ b/packages/cli/src/features/scaffold/templates/presets.ts
@@ -1,0 +1,81 @@
+import type { Framework, Validator } from "../plan";
+
+export type HostPreset = "none" | "vercel" | "netlify";
+
+/**
+ * Get the framework-specific client prefix.
+ */
+export function getFrameworkPrefix(framework?: Framework): string {
+	if (framework === "nextjs") return "NEXT_PUBLIC_";
+	if (framework === "nuxt") return "NUXT_PUBLIC_";
+	if (framework === "vite") return "VITE_";
+	if (framework === "bun-fullstack") return "BUN_PUBLIC_";
+	return "";
+}
+
+/**
+ * Returns standard environment keys for the given hosting preset.
+ */
+export function getPresetKeys(preset: HostPreset, prefix: string): string[] {
+	if (preset === "vercel") {
+		const keys = ["VERCEL", "VERCEL_ENV", "VERCEL_URL"];
+		if (prefix) {
+			keys.push(`${prefix}VERCEL_ENV`, `${prefix}VERCEL_URL`);
+		}
+		return keys;
+	}
+	if (preset === "netlify") {
+		const keys = ["NETLIFY", "CONTEXT", "URL", "DEPLOY_URL"];
+		if (prefix) {
+			keys.push(`${prefix}CONTEXT`, `${prefix}URL`);
+		}
+		return keys;
+	}
+	return [];
+}
+
+/**
+ * Returns validator-specific schema fields for preset keys, falling back to a default optional string.
+ */
+export function getFieldDefinition(
+	key: string,
+	validator: Validator,
+	prefix: string,
+): string {
+	if (key === "VERCEL_ENV" || (prefix && key === `${prefix}VERCEL_ENV`)) {
+		if (validator === "arktype") {
+			return `"'production' | 'preview' | 'development'?"`;
+		}
+		if (validator === "zod") {
+			return `z.enum(["production", "preview", "development"]).optional()`;
+		}
+		if (validator === "valibot") {
+			return `v.optional(v.picklist(["production", "preview", "development"]))`;
+		}
+	}
+
+	if (key === "CONTEXT" || (prefix && key === `${prefix}CONTEXT`)) {
+		if (validator === "arktype") {
+			return `"'production' | 'deploy-preview' | 'branch-deploy'?"`;
+		}
+		if (validator === "zod") {
+			return `z.enum(["production", "deploy-preview", "branch-deploy"]).optional()`;
+		}
+		if (validator === "valibot") {
+			return `v.optional(v.picklist(["production", "deploy-preview", "branch-deploy"]))`;
+		}
+	}
+
+	// Default optional string mapping
+	if (validator === "arktype") {
+		return `"string?"`;
+	}
+	if (validator === "zod") {
+		return `z.string().optional()`;
+	}
+	if (validator === "valibot") {
+		return `v.optional(v.string())`;
+	}
+
+	return "";
+}

--- a/packages/cli/src/features/scaffold/templates/valibot.ts
+++ b/packages/cli/src/features/scaffold/templates/valibot.ts
@@ -1,5 +1,6 @@
 import dedent from "dedent";
 import { buildNextjsTemplate } from "./nextjs-template";
+import { getFrameworkPrefix, getPresetKeys, getFieldDefinition, type HostPreset } from "./presets";
 
 /**
  * Generate a TypeScript template string for a Valibot environment configuration.
@@ -7,6 +8,9 @@ import { buildNextjsTemplate } from "./nextjs-template";
  * @param envKeys Optional array of environment variable keys to include in the schema
  * @param framework The framework being used (vite, bun-fullstack, or vanilla)
  * @param nextjsImportPath The optional custom import path for the generated file in Next.js
+ * @param disableCodegen Whether automatic Next.js code generation is disabled
+ * @param layout The layout structure to use (strict, simple, or flat)
+ * @param hostPreset The selected hosting provider preset
  * @returns The generated TypeScript template string
  */
 export const valibotTemplate = (
@@ -15,11 +19,20 @@ export const valibotTemplate = (
 	nextjsImportPath?: string,
 	disableCodegen?: boolean,
 	layout?: "strict" | "simple" | "flat",
+	hostPreset?: HostPreset,
 ) => {
-	const schemaFields = envKeys?.length
-		? envKeys.map((key) => `\t\t${key}: v.optional(v.string()),`).join("\n")
-		: `\t\tNODE_ENV: v.optional(v.picklist(["development", "production", "test"]), "development"),
+	const prefix = getFrameworkPrefix(framework as any);
+	const presetKeys = hostPreset ? getPresetKeys(hostPreset, prefix) : [];
+
+	let schemaFields = "";
+	if (envKeys?.length || presetKeys.length) {
+		const baseKeys = envKeys || [];
+		const uniqueKeys = Array.from(new Set([...baseKeys, ...presetKeys]));
+		schemaFields = uniqueKeys.map((key) => `\t\t${key}: ${getFieldDefinition(key, "valibot", prefix)},`).join("\n");
+	} else {
+		schemaFields = `\t\tNODE_ENV: v.optional(v.picklist(["development", "production", "test"]), "development"),
 		PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),`;
+	}
 
 	if (framework === "vite") {
 		return dedent /* ts */`
@@ -59,10 +72,10 @@ export const valibotTemplate = (
 			envKeys,
 			{
 				extraImports: `import * as v from "valibot";`,
-				serverField: (key) => `\t\t${key}: v.optional(v.string()),`,
-				clientField: (key) => `\t\t${key}: v.optional(v.string()),`,
+				serverField: (key) => `\t\t${key}: ${getFieldDefinition(key, "valibot", clientPrefix)},`,
+				clientField: (key) => `\t\t${key}: ${getFieldDefinition(key, "valibot", clientPrefix)},`,
 				sharedField: (key) =>
-					`\t\t${key}: v.optional(v.picklist(["development", "production", "test"]), "development"),`,
+					`\t\t${key}: ${getFieldDefinition(key, "valibot", clientPrefix)},`,
 				defaultServerFields: [
 					`\t\tDATABASE_URL: v.optional(v.pipe(v.string(), v.url()), "postgres://localhost:5432/mydb"),`,
 				],
@@ -77,6 +90,7 @@ export const valibotTemplate = (
 			disableCodegen,
 			framework,
 			layout,
+			hostPreset,
 		);
 	}
 

--- a/packages/cli/src/features/scaffold/templates/valibot.ts
+++ b/packages/cli/src/features/scaffold/templates/valibot.ts
@@ -24,15 +24,32 @@ export const valibotTemplate = (
 	const prefix = getFrameworkPrefix(framework as any);
 	const presetKeys = hostPreset ? getPresetKeys(hostPreset, prefix) : [];
 
-	let schemaFields = "";
-	if (envKeys?.length || presetKeys.length) {
-		const baseKeys = envKeys || [];
-		const uniqueKeys = Array.from(new Set([...baseKeys, ...presetKeys]));
-		schemaFields = uniqueKeys.map((key) => `\t\t${key}: ${getFieldDefinition(key, "valibot", prefix)},`).join("\n");
-	} else {
-		schemaFields = `\t\tNODE_ENV: v.optional(v.picklist(["development", "production", "test"]), "development"),
-		PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),`;
-	}
+	const getDefaultKeys = (fw?: string, pref?: string): string[] => {
+		if (fw === "vite") {
+			return ["PORT", `${pref}API_URL`, "NODE_ENV"];
+		}
+		if (fw === "bun-fullstack") {
+			return [`${pref}API_URL`, "NODE_ENV"];
+		}
+		return ["NODE_ENV", "PORT"];
+	};
+
+	const defaultKeys = getDefaultKeys(framework, prefix);
+	const baseKeys = envKeys?.length ? envKeys : defaultKeys;
+	const uniqueKeys = Array.from(new Set([...baseKeys, ...presetKeys]));
+	const getFieldSchema = (key: string) => {
+		if (key === "NODE_ENV") {
+			return `v.optional(v.picklist(["development", "production", "test"]), "development")`;
+		}
+		if (key === "PORT") {
+			return `v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000)`;
+		}
+		if (prefix && key === `${prefix}API_URL`) {
+			return `v.optional(v.pipe(v.string(), v.url()), "https://api.example.com")`;
+		}
+		return getFieldDefinition(key, "valibot", prefix);
+	};
+	const schemaFields = uniqueKeys.map((key) => `\t\t${key}: ${getFieldSchema(key)},`).join("\n");
 
 	if (framework === "vite") {
 		return dedent /* ts */`
@@ -45,7 +62,7 @@ export const valibotTemplate = (
 	 * and provide typesafety for \`import.meta.env\` on the client-side.
 	 */
 	export const Env = type({
-		${schemaFields}
+${schemaFields}
 	});
 	`;
 	}
@@ -61,7 +78,7 @@ export const valibotTemplate = (
 	 * and provide typesafety for \`process.env\` on the client-side.
 	 */
 	export const Env = type({
-		${schemaFields}
+${schemaFields}
 	});
 	`;
 	}
@@ -102,7 +119,7 @@ export const valibotTemplate = (
 	 * Environment variable schema for server-side or runtime-only validation.
 	 */
 	export const env = arkenv({
-	${schemaFields}
+${schemaFields}
 	});
 `;
 };

--- a/packages/cli/src/features/scaffold/templates/zod.ts
+++ b/packages/cli/src/features/scaffold/templates/zod.ts
@@ -1,5 +1,6 @@
 import dedent from "dedent";
 import { buildNextjsTemplate } from "./nextjs-template";
+import { getFrameworkPrefix, getPresetKeys, getFieldDefinition, type HostPreset } from "./presets";
 
 /**
  * Generate a TypeScript template string for a Zod environment configuration.
@@ -7,6 +8,9 @@ import { buildNextjsTemplate } from "./nextjs-template";
  * @param envKeys Optional array of environment variable keys to include in the schema
  * @param framework The framework being used (vite, bun-fullstack, or vanilla)
  * @param nextjsImportPath The optional custom import path for the generated file in Next.js
+ * @param disableCodegen Whether automatic Next.js code generation is disabled
+ * @param layout The layout structure to use (strict, simple, or flat)
+ * @param hostPreset The selected hosting provider preset
  * @returns The generated TypeScript template string
  */
 export const zodTemplate = (
@@ -15,11 +19,20 @@ export const zodTemplate = (
 	nextjsImportPath?: string,
 	disableCodegen?: boolean,
 	layout?: "strict" | "simple" | "flat",
+	hostPreset?: HostPreset,
 ) => {
-	const schemaFields = envKeys?.length
-		? envKeys.map((key) => `\t\t${key}: z.string().optional(),`).join("\n")
-		: `\t\tNODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+	const prefix = getFrameworkPrefix(framework as any);
+	const presetKeys = hostPreset ? getPresetKeys(hostPreset, prefix) : [];
+
+	let schemaFields = "";
+	if (envKeys?.length || presetKeys.length) {
+		const baseKeys = envKeys || [];
+		const uniqueKeys = Array.from(new Set([...baseKeys, ...presetKeys]));
+		schemaFields = uniqueKeys.map((key) => `\t\t${key}: ${getFieldDefinition(key, "zod", prefix)},`).join("\n");
+	} else {
+		schemaFields = `\t\tNODE_ENV: z.enum(["development", "production", "test"]).default("development"),
 		PORT: z.coerce.number().int().min(1).max(65535).default(3000),`;
+	}
 
 	if (framework === "vite") {
 		return dedent /* ts */`
@@ -59,10 +72,10 @@ export const zodTemplate = (
 			envKeys,
 			{
 				extraImports: `import { z } from "zod";`,
-				serverField: (key) => `\t\t${key}: z.string().optional(),`,
-				clientField: (key) => `\t\t${key}: z.string().optional(),`,
+				serverField: (key) => `\t\t${key}: ${getFieldDefinition(key, "zod", clientPrefix)},`,
+				clientField: (key) => `\t\t${key}: ${getFieldDefinition(key, "zod", clientPrefix)},`,
 				sharedField: (key) =>
-					`\t\t${key}: z.enum(["development", "production", "test"]).default("development"),`,
+					`\t\t${key}: ${getFieldDefinition(key, "zod", clientPrefix)},`,
 				defaultServerFields: [
 					`\t\tDATABASE_URL: z.string().url().default("postgres://localhost:5432/mydb"),`,
 				],
@@ -77,6 +90,7 @@ export const zodTemplate = (
 			disableCodegen,
 			framework,
 			layout,
+			hostPreset,
 		);
 	}
 

--- a/packages/cli/src/features/scaffold/templates/zod.ts
+++ b/packages/cli/src/features/scaffold/templates/zod.ts
@@ -24,15 +24,32 @@ export const zodTemplate = (
 	const prefix = getFrameworkPrefix(framework as any);
 	const presetKeys = hostPreset ? getPresetKeys(hostPreset, prefix) : [];
 
-	let schemaFields = "";
-	if (envKeys?.length || presetKeys.length) {
-		const baseKeys = envKeys || [];
-		const uniqueKeys = Array.from(new Set([...baseKeys, ...presetKeys]));
-		schemaFields = uniqueKeys.map((key) => `\t\t${key}: ${getFieldDefinition(key, "zod", prefix)},`).join("\n");
-	} else {
-		schemaFields = `\t\tNODE_ENV: z.enum(["development", "production", "test"]).default("development"),
-		PORT: z.coerce.number().int().min(1).max(65535).default(3000),`;
-	}
+	const getDefaultKeys = (fw?: string, pref?: string): string[] => {
+		if (fw === "vite") {
+			return ["PORT", `${pref}API_URL`, "NODE_ENV"];
+		}
+		if (fw === "bun-fullstack") {
+			return [`${pref}API_URL`, "NODE_ENV"];
+		}
+		return ["NODE_ENV", "PORT"];
+	};
+
+	const defaultKeys = getDefaultKeys(framework, prefix);
+	const baseKeys = envKeys?.length ? envKeys : defaultKeys;
+	const uniqueKeys = Array.from(new Set([...baseKeys, ...presetKeys]));
+	const getFieldSchema = (key: string) => {
+		if (key === "NODE_ENV") {
+			return `z.enum(["development", "production", "test"]).default("development")`;
+		}
+		if (key === "PORT") {
+			return `z.coerce.number().int().min(1).max(65535).default(3000)`;
+		}
+		if (prefix && key === `${prefix}API_URL`) {
+			return `z.string().url().default("https://api.example.com")`;
+		}
+		return getFieldDefinition(key, "zod", prefix);
+	};
+	const schemaFields = uniqueKeys.map((key) => `\t\t${key}: ${getFieldSchema(key)},`).join("\n");
 
 	if (framework === "vite") {
 		return dedent /* ts */`
@@ -45,7 +62,7 @@ export const zodTemplate = (
 	 * and provide typesafety for \`import.meta.env\` on the client-side.
 	 */
 	export const Env = type({
-		${schemaFields}
+${schemaFields}
 	});
 	`;
 	}
@@ -61,7 +78,7 @@ export const zodTemplate = (
 	 * and provide typesafety for \`process.env\` on the client-side.
 	 */
 	export const Env = type({
-		${schemaFields}
+${schemaFields}
 	});
 	`;
 	}
@@ -102,7 +119,7 @@ export const zodTemplate = (
 	 * Environment variable schema for server-side or runtime-only validation.
 	 */
 	export const env = arkenv({
-	${schemaFields}
+${schemaFields}
 	});
 `;
 };

--- a/packages/cli/src/features/scaffold/utils.ts
+++ b/packages/cli/src/features/scaffold/utils.ts
@@ -145,3 +145,110 @@ export function getNextStepsNote(
 		title: "Next steps",
 	};
 }
+
+export const exampleEnvDefaults: Record<string, Record<string, string>> = {
+	basic: {
+		HOST: "localhost",
+		PORT: "3000",
+		NODE_ENV: "development",
+	},
+	"basic-js": {
+		HOST: "localhost",
+		PORT: "3000",
+		NODE_ENV: "development",
+	},
+	"with-bun": {
+		HOST: "localhost",
+		PORT: "3000",
+		NODE_ENV: "development",
+	},
+	"with-nextjs": {
+		DATABASE_URL: "postgres://localhost:5432/mydb",
+		NEXT_PUBLIC_API_URL: "https://api.example.com",
+		NODE_ENV: "development",
+	},
+	"with-nextjs-strict": {
+		DATABASE_URL: "postgres://localhost:5432/mydb",
+		NEXT_PUBLIC_API_URL: "https://api.example.com",
+		NODE_ENV: "development",
+	},
+	"with-nuxt": {
+		DATABASE_URL: "postgres://localhost:5432/mydb",
+		NUXT_PUBLIC_API_URL: "https://api.example.com",
+		NODE_ENV: "development",
+	},
+	"with-vite-react": {
+		PORT: "3000",
+		VITE_MY_VAR: "hello",
+		VITE_MY_NUMBER: "42",
+		VITE_MY_BOOLEAN: "true",
+	},
+	"with-bun-react": {
+		BUN_PUBLIC_API_URL: "https://api.example.com",
+		BUN_PUBLIC_DEBUG: "true",
+		NODE_ENV: "development",
+	},
+	"with-zod": {
+		HOST: "localhost",
+		PORT: "3000",
+		NODE_ENV: "development",
+	},
+	"with-standard-schema": {
+		HOST: "localhost",
+		PORT: "3000",
+		NODE_ENV: "development",
+	},
+};
+
+export function getEnvDefaultsFromKeys(
+	keys?: string[],
+	framework?: string,
+): Record<string, string> {
+	const defaults: Record<string, string> = {};
+	if (keys && keys.length > 0) {
+		for (const key of keys) {
+			if (key === "NODE_ENV") {
+				defaults[key] = "development";
+			} else if (key === "PORT") {
+				defaults[key] = "3000";
+			} else if (key === "DATABASE_URL") {
+				defaults[key] = "postgres://localhost:5432/mydb";
+			} else {
+				defaults[key] = "";
+			}
+		}
+		return defaults;
+	}
+
+	if (framework === "nextjs") {
+		return {
+			DATABASE_URL: "postgres://localhost:5432/mydb",
+			NEXT_PUBLIC_API_URL: "https://api.example.com",
+			NODE_ENV: "development",
+		};
+	}
+	if (framework === "nuxt") {
+		return {
+			DATABASE_URL: "postgres://localhost:5432/mydb",
+			NUXT_PUBLIC_API_URL: "https://api.example.com",
+			NODE_ENV: "development",
+		};
+	}
+	if (framework === "vite") {
+		return {
+			PORT: "3000",
+			VITE_API_URL: "https://api.example.com",
+		};
+	}
+	if (framework === "bun-fullstack") {
+		return {
+			BUN_PUBLIC_API_URL: "https://api.example.com",
+			NODE_ENV: "development",
+		};
+	}
+	return {
+		PORT: "3000",
+		NODE_ENV: "development",
+	};
+}
+


### PR DESCRIPTION
Supporting hosting presets in **arkenv init** (Phase 1)
This PR implements Phase 1 of the hosting presets (#610 / #1266) to offer opt in Vercel/Netlify variables during intialization.

#### What Changed 
1. CLI prompt: Added hosting preset step to the arkenv init wizard (None / Vercel / Netlify).
2. Static Codegen: Created static type mapping logic for Vercel/Netlify preset keys, automatically adapts validation enums to Zod, Valibot, and ArkType schemas.
3. Framework Prefix Adaptation: Prefixing applies client variables dynamically based on the active framework (e.g. NEXT_PUBLIC_, VITE_, NUXT_PUBLIC_).
4. Planner integration: Combines preset keys into .env and .env.example boilerplate files.
### Verification
Added prompt, template, and planner unit tests. All 278 test cases pass successfully.
<img width="1453" height="708" alt="Screenshot 2026-07-10 232054" src="https://github.com/user-attachments/assets/48899e90-6f53-4cc6-93ab-ee166d351fd6" />
