### PR TITLE
fix: Fix OG image text overlap for long titles and descriptions

### DIFF
--- a/apps/www/app/api/og/route.test.tsx
+++ b/apps/www/app/api/og/route.test.tsx
@@ -51,4 +51,20 @@ describe("api/og route", () => {
 			}),
 		);
 	});
+
+	it("should truncate long title and description for OG layout", async () => {
+		const req = new NextRequest(
+			"https://arkenv.js.org/api/og?title=Zod%2C%20Valibot%2C%20and%20other%20Standard%20Schema%20validators&description=Mix%20and%20match%20ArkType%20with%20Zod%2C%20Valibot%2C%20or%20other%20Standard%20Schema%20compatible%20libraries.",
+		);
+		const response = await GET(req);
+
+		expect(response.status).toBe(200);
+		expect(mockGenerateOGImage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "Zod, Valibot, and other Standard...",
+				description:
+					"Mix and match ArkType with Zod, Valibot, or other Standard Schema...",
+			}),
+		);
+	});
 });

--- a/apps/www/app/api/og/route.tsx
+++ b/apps/www/app/api/og/route.tsx
@@ -1,14 +1,16 @@
 import { generateOGImage } from "fumadocs-ui/og";
 import type { NextRequest } from "next/server";
+import { formatOgDescription, formatOgTitle } from "~/lib/og-text";
 
 export const runtime = "edge";
 
 export function GET(request: NextRequest) {
 	const { searchParams } = new URL(request.url);
-	const title = searchParams.get("title") || "ArkEnv";
-	const description =
+	const title = formatOgTitle(searchParams.get("title") || "ArkEnv");
+	const description = formatOgDescription(
 		searchParams.get("description") ||
-		"Environment variable validation from editor to runtime";
+			"Environment variable validation from editor to runtime",
+	);
 
 	return generateOGImage({
 		title,

--- a/apps/www/lib/og-text.test.ts
+++ b/apps/www/lib/og-text.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { formatOgDescription, formatOgTitle, truncateOgText } from "./og-text";
+
+describe("og-text", () => {
+	it("leaves short text unchanged", () => {
+		expect(formatOgTitle("Flat layout")).toBe("Flat layout");
+		expect(formatOgDescription("A short description.")).toBe(
+			"A short description.",
+		);
+	});
+
+	it("truncates a long title without affecting a short description", () => {
+		const title = formatOgTitle(
+			"Zod, Valibot, and other Standard Schema validators",
+		);
+
+		expect(title).toBe("Zod, Valibot, and other Standard...");
+		expect(title.length).toBeLessThanOrEqual(42);
+		expect(formatOgDescription("A short description.")).toBe(
+			"A short description.",
+		);
+	});
+
+	it("truncates a long description without affecting a short title", () => {
+		const description = formatOgDescription(
+			"Mix and match ArkType with Zod, Valibot, or other Standard Schema compatible libraries.",
+		);
+
+		expect(description).toBe(
+			"Mix and match ArkType with Zod, Valibot, or other Standard Schema...",
+		);
+		expect(description.length).toBeLessThanOrEqual(75);
+		expect(formatOgTitle("Flat layout")).toBe("Flat layout");
+	});
+
+	it("truncates at word boundaries when possible", () => {
+		expect(truncateOgText("one two three four five six", 15)).toBe(
+			"one two thre...",
+		);
+	});
+});

--- a/apps/www/lib/og-text.ts
+++ b/apps/www/lib/og-text.ts
@@ -1,0 +1,41 @@
+const OG_TITLE_MAX_LENGTH = 42;
+const OG_DESCRIPTION_MAX_LENGTH = 75;
+
+/**
+ * Truncate text to fit the OG image layout, preferring word boundaries.
+ *
+ * @param text The raw title or description from page metadata
+ * @param maxLength Maximum character count including the ellipsis suffix
+ * @returns Normalized text, truncated with "..." when it exceeds maxLength
+ */
+export function truncateOgText(text: string, maxLength: number): string {
+	const normalized = text.trim().replace(/\s+/g, " ");
+	if (normalized.length <= maxLength) return normalized;
+
+	const slice = normalized.slice(0, maxLength - 3);
+	const lastSpace = slice.lastIndexOf(" ");
+	const truncated =
+		lastSpace > maxLength * 0.5 ? slice.slice(0, lastSpace) : slice;
+
+	return `${truncated.trimEnd()}...`;
+}
+
+/**
+ * Format a page title for the OG image template.
+ *
+ * @param title The raw page title from metadata
+ * @returns Title truncated to the OG layout limit
+ */
+export function formatOgTitle(title: string): string {
+	return truncateOgText(title, OG_TITLE_MAX_LENGTH);
+}
+
+/**
+ * Format a page description for the OG image template.
+ *
+ * @param description The raw page description from metadata
+ * @returns Description truncated to the OG layout limit
+ */
+export function formatOgDescription(description: string): string {
+	return truncateOgText(description, OG_DESCRIPTION_MAX_LENGTH);
+}


### PR DESCRIPTION
Fixes #1302

Truncate long title and description strings in the `/api/og` route before passing them to `generateOGImage`, preventing text overlap in the fumadocs 1200×630 template. Short metadata is left unchanged.

## Test plan
- [x] Unit tests for `formatOgTitle` / `formatOgDescription` (short, long title, long description, word boundaries)
- [x] Route test for the `using-other-validators` page metadata
- [x] `pnpm run typecheck`, `pnpm run test`, `pnpm run fix` pass

Made with [Cursor](https://cursor.com)