### PR TITLE
Forward-port OG text fix from dev to v1

### DIFF
--- a/apps/www/app/api/og/route.test.tsx
+++ b/apps/www/app/api/og/route.test.tsx
@@ -51,4 +51,20 @@ describe("api/og route", () => {
 			}),
 		);
 	});
+
+	it("should truncate long title and description for OG layout", async () => {
+		const req = new NextRequest(
+			"https://arkenv.js.org/api/og?title=Zod%2C%20Valibot%2C%20and%20other%20Standard%20Schema%20validators&description=Mix%20and%20match%20ArkType%20with%20Zod%2C%20Valibot%2C%20or%20other%20Standard%20Schema%20compatible%20libraries.",
+		);
+		const response = await GET(req);
+
+		expect(response.status).toBe(200);
+		expect(mockGenerateOGImage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "Zod, Valibot, and other Standard...",
+				description:
+					"Mix and match ArkType with Zod, Valibot, or other Standard Schema...",
+			}),
+		);
+	});
 });

--- a/apps/www/app/api/og/route.tsx
+++ b/apps/www/app/api/og/route.tsx
@@ -1,14 +1,16 @@
 import { generateOGImage } from "fumadocs-ui/og";
 import type { NextRequest } from "next/server";
+import { formatOgDescription, formatOgTitle } from "~/lib/og-text";
 
 export const runtime = "edge";
 
 export function GET(request: NextRequest) {
 	const { searchParams } = new URL(request.url);
-	const title = searchParams.get("title") || "ArkEnv";
-	const description =
+	const title = formatOgTitle(searchParams.get("title") || "ArkEnv");
+	const description = formatOgDescription(
 		searchParams.get("description") ||
-		"Environment variable validation from editor to runtime";
+			"Environment variable validation from editor to runtime",
+	);
 
 	return generateOGImage({
 		title,

--- a/apps/www/lib/og-text.test.ts
+++ b/apps/www/lib/og-text.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { formatOgDescription, formatOgTitle, truncateOgText } from "./og-text";
+
+describe("og-text", () => {
+	it("leaves short text unchanged", () => {
+		expect(formatOgTitle("Flat layout")).toBe("Flat layout");
+		expect(formatOgDescription("A short description.")).toBe(
+			"A short description.",
+		);
+	});
+
+	it("truncates a long title without affecting a short description", () => {
+		const title = formatOgTitle(
+			"Zod, Valibot, and other Standard Schema validators",
+		);
+
+		expect(title).toBe("Zod, Valibot, and other Standard...");
+		expect(title.length).toBeLessThanOrEqual(42);
+		expect(formatOgDescription("A short description.")).toBe(
+			"A short description.",
+		);
+	});
+
+	it("truncates a long description without affecting a short title", () => {
+		const description = formatOgDescription(
+			"Mix and match ArkType with Zod, Valibot, or other Standard Schema compatible libraries.",
+		);
+
+		expect(description).toBe(
+			"Mix and match ArkType with Zod, Valibot, or other Standard Schema...",
+		);
+		expect(description.length).toBeLessThanOrEqual(75);
+		expect(formatOgTitle("Flat layout")).toBe("Flat layout");
+	});
+
+	it("truncates at word boundaries when possible", () => {
+		expect(truncateOgText("one two three four five six", 15)).toBe(
+			"one two thre...",
+		);
+	});
+});

--- a/apps/www/lib/og-text.ts
+++ b/apps/www/lib/og-text.ts
@@ -1,0 +1,41 @@
+const OG_TITLE_MAX_LENGTH = 42;
+const OG_DESCRIPTION_MAX_LENGTH = 75;
+
+/**
+ * Truncate text to fit the OG image layout, preferring word boundaries.
+ *
+ * @param text The raw title or description from page metadata
+ * @param maxLength Maximum character count including the ellipsis suffix
+ * @returns Normalized text, truncated with "..." when it exceeds maxLength
+ */
+export function truncateOgText(text: string, maxLength: number): string {
+	const normalized = text.trim().replace(/\s+/g, " ");
+	if (normalized.length <= maxLength) return normalized;
+
+	const slice = normalized.slice(0, maxLength - 3);
+	const lastSpace = slice.lastIndexOf(" ");
+	const truncated =
+		lastSpace > maxLength * 0.5 ? slice.slice(0, lastSpace) : slice;
+
+	return `${truncated.trimEnd()}...`;
+}
+
+/**
+ * Format a page title for the OG image template.
+ *
+ * @param title The raw page title from metadata
+ * @returns Title truncated to the OG layout limit
+ */
+export function formatOgTitle(title: string): string {
+	return truncateOgText(title, OG_TITLE_MAX_LENGTH);
+}
+
+/**
+ * Format a page description for the OG image template.
+ *
+ * @param description The raw page description from metadata
+ * @returns Description truncated to the OG layout limit
+ */
+export function formatOgDescription(description: string): string {
+	return truncateOgText(description, OG_DESCRIPTION_MAX_LENGTH);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,13 @@ import { coverageConfigDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
-		projects: ["packages/*", "apps/*", "!apps/playwright-www", "!**/*.md"],
+		projects: [
+			"packages/*",
+			"apps/*",
+			"!packages/cli",
+			"!apps/playwright-www",
+			"!**/*.md",
+		],
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "json", "html"],


### PR DESCRIPTION
## Summary

Forward-ports two clean fixes from `dev` to `v1` using cherry-pick (not a bulk merge):

- **OG text overflow fix** (#1303 / #1302) — cherry-picked `ba2111ab`
- **Vitest project name collision** — exclude legacy `packages/cli` stub from root vitest projects

## Context

`dev` and `v1` are intentionally diverged (see CONTRIBUTING Use Case 4). The recent reconciliation (#1292) only covered v0 feature parity (#1281, #1282) — it did not eliminate the ~48 file conflicts that appear when bulk-merging the branches. Those conflicts are expected due to structural differences (`packages/cli` → `packages/arkenv`, removed `/shared` exports, etc.).

This PR uses the documented **forward-porting** workflow instead.

## Test plan

- [x] `pnpm test run lib/og-text.test.ts app/api/og/route.test.tsx` passes (7/7)
- [x] Root vitest starts without duplicate project name error

Made with [Cursor](https://cursor.com)