### PR TITLE
feat: (v1) Add clientPrefix to all FrameworkStrategy implementations

### DIFF
--- a/packages/arkenv/src/features/scaffold/frameworks/bun-fullstack.ts
+++ b/packages/arkenv/src/features/scaffold/frameworks/bun-fullstack.ts
@@ -1,11 +1,14 @@
 import path from "node:path";
 import { shake } from "radashi";
 import { bunTypesTemplate } from "@/features/scaffold/templates";
+import { FRAMEWORK_CLIENT_PREFIXES } from "./client-prefixes";
 import { planDtsFile } from "./dts-planning";
 import { getEnvDefaultsFromKeys, planSimpleSchemaFile } from "./shared";
 import type { FrameworkStrategy } from "./types";
 
 export const bunFullstackStrategy: FrameworkStrategy = {
+	clientPrefix: FRAMEWORK_CLIENT_PREFIXES["bun-fullstack"],
+
 	getEnvDefaults(keys) {
 		if (keys && keys.length > 0) {
 			return getEnvDefaultsFromKeys(keys);

--- a/packages/arkenv/src/features/scaffold/frameworks/client-prefixes.ts
+++ b/packages/arkenv/src/features/scaffold/frameworks/client-prefixes.ts
@@ -1,0 +1,16 @@
+import type { Framework } from "@/features/scaffold/plan";
+import { CODEGEN_FRAMEWORK_CONFIGS } from "./codegen-config";
+
+/**
+ * Canonical client env prefixes per framework.
+ *
+ * Assigned to each framework strategy's `clientPrefix`. Context creation reads
+ * from here rather than the FRAMEWORKS registry to avoid a circular import.
+ */
+export const FRAMEWORK_CLIENT_PREFIXES = {
+	nextjs: CODEGEN_FRAMEWORK_CONFIGS.nextjs.clientPrefix,
+	nuxt: CODEGEN_FRAMEWORK_CONFIGS.nuxt.clientPrefix,
+	vite: "VITE_",
+	"bun-fullstack": "BUN_PUBLIC_",
+	vanilla: "",
+} as const satisfies Record<Framework, string>;

--- a/packages/arkenv/src/features/scaffold/frameworks/codegen-framework.ts
+++ b/packages/arkenv/src/features/scaffold/frameworks/codegen-framework.ts
@@ -27,6 +27,8 @@ export function createCodegenFrameworkStrategy(
 	const defaultApiUrlKey = `${clientPrefix}API_URL`;
 
 	return {
+		clientPrefix,
+
 		getEnvDefaults(keys) {
 			if (keys && keys.length > 0) {
 				return getEnvDefaultsFromKeys(keys);

--- a/packages/arkenv/src/features/scaffold/frameworks/index.ts
+++ b/packages/arkenv/src/features/scaffold/frameworks/index.ts
@@ -16,6 +16,7 @@ export const FRAMEWORKS = {
 	vanilla: vanillaStrategy,
 } satisfies FrameworkRegistry;
 
+export { FRAMEWORK_CLIENT_PREFIXES } from "./client-prefixes";
 export type { CodegenFrameworkConfig } from "./codegen-config";
 export {
 	CODEGEN_FRAMEWORK_CONFIGS,

--- a/packages/arkenv/src/features/scaffold/frameworks/types.ts
+++ b/packages/arkenv/src/features/scaffold/frameworks/types.ts
@@ -26,6 +26,12 @@ export type FrameworkGetFilesParams = {
  */
 export type FrameworkStrategy = {
 	/**
+	 * Canonical client-exposed env var prefix for this framework
+	 * (e.g. `NEXT_PUBLIC_`, `VITE_`, or `""` for vanilla).
+	 */
+	clientPrefix: string;
+
+	/**
 	 * Default environment variable values for this framework.
 	 *
 	 * @param keys Optional explicit env keys to generate defaults for.

--- a/packages/arkenv/src/features/scaffold/frameworks/vanilla.ts
+++ b/packages/arkenv/src/features/scaffold/frameworks/vanilla.ts
@@ -1,7 +1,10 @@
+import { FRAMEWORK_CLIENT_PREFIXES } from "./client-prefixes";
 import { getEnvDefaultsFromKeys, planSimpleSchemaFile } from "./shared";
 import type { FrameworkStrategy } from "./types";
 
 export const vanillaStrategy: FrameworkStrategy = {
+	clientPrefix: FRAMEWORK_CLIENT_PREFIXES.vanilla,
+
 	getEnvDefaults(keys) {
 		if (keys && keys.length > 0) {
 			return getEnvDefaultsFromKeys(keys);

--- a/packages/arkenv/src/features/scaffold/frameworks/vite.ts
+++ b/packages/arkenv/src/features/scaffold/frameworks/vite.ts
@@ -1,11 +1,14 @@
 import path from "node:path";
 import { shake } from "radashi";
 import { viteTypesTemplate } from "@/features/scaffold/templates";
+import { FRAMEWORK_CLIENT_PREFIXES } from "./client-prefixes";
 import { planDtsFile } from "./dts-planning";
 import { getEnvDefaultsFromKeys, planSimpleSchemaFile } from "./shared";
 import type { FrameworkStrategy } from "./types";
 
 export const viteStrategy: FrameworkStrategy = {
+	clientPrefix: FRAMEWORK_CLIENT_PREFIXES.vite,
+
 	getEnvDefaults(keys) {
 		if (keys && keys.length > 0) {
 			return getEnvDefaultsFromKeys(keys);

--- a/packages/arkenv/src/features/scaffold/scaffold-context.test.ts
+++ b/packages/arkenv/src/features/scaffold/scaffold-context.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+	CODEGEN_FRAMEWORK_CONFIGS,
+	FRAMEWORK_CLIENT_PREFIXES,
+	FRAMEWORKS,
+} from "./frameworks";
+import type { Framework, ProjectOptions } from "./plan";
+import { createScaffoldContext } from "./scaffold-context";
+
+const EXPECTED_CLIENT_PREFIXES = {
+	nextjs: "NEXT_PUBLIC_",
+	nuxt: "NUXT_PUBLIC_",
+	vite: "VITE_",
+	"bun-fullstack": "BUN_PUBLIC_",
+	vanilla: "",
+} as const satisfies Record<Framework, string>;
+
+/**
+ * Build minimal project options for context creation tests.
+ *
+ * @param framework The framework under test
+ * @returns Project options sufficient for {@link createScaffoldContext}
+ */
+function optionsFor(framework: Framework): ProjectOptions {
+	return {
+		path: "src/env.ts",
+		validator: "arktype",
+		framework,
+		language: "ts",
+	};
+}
+
+describe("framework clientPrefix", () => {
+	it.each(
+		Object.entries(EXPECTED_CLIENT_PREFIXES) as [Framework, string][],
+	)("exposes %s as %j on the framework strategy", (framework, prefix) => {
+		expect(FRAMEWORKS[framework].clientPrefix).toBe(prefix);
+		expect(FRAMEWORK_CLIENT_PREFIXES[framework]).toBe(prefix);
+	});
+
+	it("sources Next.js and Nuxt prefixes from codegen config", () => {
+		expect(FRAMEWORKS.nextjs.clientPrefix).toBe(
+			CODEGEN_FRAMEWORK_CONFIGS.nextjs.clientPrefix,
+		);
+		expect(FRAMEWORKS.nuxt.clientPrefix).toBe(
+			CODEGEN_FRAMEWORK_CONFIGS.nuxt.clientPrefix,
+		);
+		expect(FRAMEWORK_CLIENT_PREFIXES.nextjs).toBe(
+			CODEGEN_FRAMEWORK_CONFIGS.nextjs.clientPrefix,
+		);
+		expect(FRAMEWORK_CLIENT_PREFIXES.nuxt).toBe(
+			CODEGEN_FRAMEWORK_CONFIGS.nuxt.clientPrefix,
+		);
+	});
+});
+
+describe("createScaffoldContext", () => {
+	it.each(
+		Object.entries(EXPECTED_CLIENT_PREFIXES) as [Framework, string][],
+	)("uses the %s strategy clientPrefix (%j)", (framework, prefix) => {
+		expect(createScaffoldContext(optionsFor(framework)).clientPrefix).toBe(
+			prefix,
+		);
+	});
+});

--- a/packages/arkenv/src/features/scaffold/scaffold-context.ts
+++ b/packages/arkenv/src/features/scaffold/scaffold-context.ts
@@ -1,3 +1,4 @@
+import { FRAMEWORK_CLIENT_PREFIXES } from "@/features/scaffold/frameworks/client-prefixes";
 import { getCodegenConfig } from "@/features/scaffold/frameworks/codegen-config";
 import type { Framework, ProjectOptions } from "./plan";
 
@@ -6,7 +7,7 @@ import type { Framework, ProjectOptions } from "./plan";
  */
 export type ScaffoldContext = {
 	framework: Framework;
-	/** Client env prefix from the codegen framework config (e.g. `NEXT_PUBLIC_`). */
+	/** Client env prefix from the active framework strategy (e.g. `NEXT_PUBLIC_`, `VITE_`). */
 	clientPrefix: string;
 	/** Integration package name when the framework is codegen-aware. */
 	packageName?: string;
@@ -18,8 +19,9 @@ export type ScaffoldContext = {
 /**
  * Build a {@link ScaffoldContext} from project options and optional import path.
  *
- * Client prefix and package name come from the centralized codegen framework
- * config so Next/Nuxt values are not re-derived elsewhere.
+ * Client prefix comes from {@link FRAMEWORK_CLIENT_PREFIXES}, the same source
+ * each framework strategy exposes as `clientPrefix`. Package name still comes
+ * from codegen framework config for Next/Nuxt.
  *
  * @param options The selected project options.
  * @param nextjsImportPath The optional custom import path for generated env files.
@@ -33,7 +35,7 @@ export function createScaffoldContext(
 
 	return {
 		framework: options.framework,
-		clientPrefix: codegen?.clientPrefix ?? "NEXT_PUBLIC_",
+		clientPrefix: FRAMEWORK_CLIENT_PREFIXES[options.framework],
 		...(codegen?.packageName !== undefined && {
 			packageName: codegen.packageName,
 		}),


### PR DESCRIPTION
Fixes #1320

## Summary
- Add `clientPrefix` to `FrameworkStrategy` for all five frameworks (`NEXT_PUBLIC_`, `NUXT_PUBLIC_`, `VITE_`, `BUN_PUBLIC_`, `""`)
- Source Next/Nuxt prefixes from `CODEGEN_FRAMEWORK_CONFIGS` (single SoT via `FRAMEWORK_CLIENT_PREFIXES`)
- Wire `createScaffoldContext` to the shared prefix map and remove the `NEXT_PUBLIC_` fallback for non-codegen frameworks
- Add unit tests covering strategy + context prefix values

Plumbing only — no change to generated init templates or `.env` defaults.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run fix`
- [ ] Confirm scaffold output for vite/bun/vanilla/next/nuxt is unchanged vs `v1`


Made with [Cursor](https://cursor.com)