### PR TITLE
feat: (v1) Forward-port hosting presets from #1288

### DIFF
--- a/.changeset/forward-port-hosting-presets.md
+++ b/.changeset/forward-port-hosting-presets.md
@@ -1,0 +1,15 @@
+---
+"arkenv": minor
+---
+
+#### Add hosting presets to `arkenv init`
+
+Support optional Vercel and Netlify presets when initializing a project. Preset fields render through validator dialects and client keys use each framework strategy's `clientPrefix`.
+
+Usage:
+
+```bash
+npx arkenv@alpha init --host-preset vercel
+```
+
+Or select **Vercel** / **Netlify** in the interactive hosting-preset step. Generated schemas include typed keys such as `VERCEL_ENV` (and `NEXT_PUBLIC_VERCEL_ENV` on Next.js).

--- a/docs/adr/0018-cli-hosting-preset-field-metadata.md
+++ b/docs/adr/0018-cli-hosting-preset-field-metadata.md
@@ -1,0 +1,35 @@
+# CLI hosting preset field metadata (codegen IR)
+
+To decide how the `arkenv` init flow describes hosting-provider preset fields (Vercel, Netlify, etc.) when generating validator-specific `env.ts` boilerplate, without pulling validator runtimes into the CLI or inventing an open-ended schema language.
+
+## Context & problem
+
+Phase 1 hosting presets ([#610](https://github.com/yamcodes/arkenv/issues/610), [#1288](https://github.com/yamcodes/arkenv/pull/1288), [#1322](https://github.com/yamcodes/arkenv/issues/1322)) need to emit typed schema lines for keys such as `VERCEL_ENV` across ArkType, Zod, and Valibot. Three approaches were considered on `dev`:
+
+1. **Runtime validator objects (rejected).** Store presets as live Zod/Valibot/ArkType schema instances, similar to [t3-env presets](https://github.com/t3-oss/t3-env/blob/main/packages/core/src/presets-zod.ts). This would add validator dependencies to the CLI and require serializing schema ASTs back into source text for `env.ts` codegen.
+2. **Standard Schema (rejected for this use case).** [Standard Schema](https://standard-schema.dev) is a runtime interop protocol (`~standard.validate`), not a declarative field-description format. It still implies holding validator instances, not describing fields for static emission.
+3. **Metadata descriptors.** A closed, typed intermediate representation (IR) on each preset field:
+
+   ```ts
+   { type: "string" }
+   | { type: "enum"; values: readonly string[] }
+   ```
+
+On `dev` (#1288), `getFieldDefinition` compiled these descriptors via validator string switches. On `v1`, escape hatch **(b)** from that decision is the chosen path: dialects own rendering.
+
+## Decision
+
+We adopt **metadata descriptors** as the Phase 1 codegen IR for hosting preset fields on `v1`, with dialect-owned compilation:
+
+1. **`PRESETS` owns host semantics only.** Labels, server/client key lists, and per-key field metadata live in `packages/arkenv/src/features/scaffold/presets.ts`.
+2. **Two field kinds only.** `string` and `enum` (with required `values`) via a discriminated `PresetField` union. No open-ended field vocabulary in Phase 1.
+3. **Dialects compile IR to source strings.** `formatOptionalString` / `formatOptionalEnum` on each validator dialect render fields; there is no `getFieldDefinition` validator switch in the presets module.
+4. **Client prefixes come from framework strategies.** Prefixed client keys use `FrameworkStrategy.clientPrefix` / `FRAMEWORK_CLIENT_PREFIXES`, not a local framework switch.
+5. **Growth constraint.** Do **not** grow `PresetField` into an ad-hoc schema language without an explicit follow-up decision (JSON Schema subset remains the preferred escape hatch if richer kinds are needed).
+
+## Consequences
+
+- **Lean CLI.** No Zod/Valibot/ArkType runtime deps for preset codegen.
+- **Aligned with scaffold seams.** Presets plug into dialects (#1311 / #1316) and universal `clientPrefix` (#1320 / #1321).
+- **Watch the IR boundary.** A third field kind is a design review trigger, not an incremental `PresetField` extension.
+- **Maintenance tripwire.** A `@remarks` note on `PresetField` references this ADR.

--- a/packages/arkenv/src/adapters/prompt.adapter.ts
+++ b/packages/arkenv/src/adapters/prompt.adapter.ts
@@ -37,7 +37,7 @@ export class ClackPromptAdapter implements PromptPort {
 		defaults?: Partial<
 			Pick<
 				ProjectOptions,
-				"mode" | "example" | "name" | "framework" | "bunFeatures"
+				"mode" | "example" | "name" | "framework" | "bunFeatures" | "hostPreset"
 			>
 		> & {
 			examples?: Example[];

--- a/packages/arkenv/src/cli/cli.test.ts
+++ b/packages/arkenv/src/cli/cli.test.ts
@@ -208,4 +208,44 @@ describe("CLI parser", () => {
 			expect(cli.validationError).toBeUndefined();
 		});
 	});
+
+	describe("Host preset flag", () => {
+		it("should parse --host-preset flag", () => {
+			const cli1 = new CLI([
+				"node",
+				"arkenv",
+				"init",
+				"--host-preset",
+				"vercel",
+			]);
+			expect(cli1.hostPreset).toBe("vercel");
+			expect(cli1.initInput.hostPreset).toBe("vercel");
+			expect(cli1.validationError).toBeUndefined();
+
+			const cli2 = new CLI([
+				"node",
+				"arkenv",
+				"init",
+				"--host-preset",
+				"netlify",
+			]);
+			expect(cli2.hostPreset).toBe("netlify");
+			expect(cli2.initInput.hostPreset).toBe("netlify");
+			expect(cli2.validationError).toBeUndefined();
+
+			const cli3 = new CLI(["node", "arkenv", "init", "--host-preset", "none"]);
+			expect(cli3.hostPreset).toBe("none");
+			expect(cli3.initInput.hostPreset).toBe("none");
+			expect(cli3.validationError).toBeUndefined();
+
+			const cli4 = new CLI([
+				"node",
+				"arkenv",
+				"init",
+				"--host-preset",
+				"vercle",
+			]);
+			expect(cli4.validationError).toBe("Invalid host preset: vercle");
+		});
+	});
 });

--- a/packages/arkenv/src/cli/cli.ts
+++ b/packages/arkenv/src/cli/cli.ts
@@ -1,4 +1,5 @@
 import { Logger } from "@/adapters";
+import { type HostPreset, isHostPreset } from "@/features/scaffold/presets";
 import type { InitInput } from "./commands/init";
 
 const FLAG_CONFIG = {
@@ -13,6 +14,7 @@ const FLAG_CONFIG = {
 	isSimple: { long: "--simple", short: "", kind: "boolean" },
 	isFlat: { long: "--flat", short: "", kind: "boolean" },
 	noCodegen: { long: "--no-codegen", short: "-C", kind: "boolean" },
+	hostPreset: { long: "--host-preset", short: "", kind: "value" },
 } as const;
 
 const knownFlags = new Set<string>(
@@ -100,6 +102,14 @@ export class CLI {
 		}
 
 		if (!this.validationError) {
+			const flag = FLAG_CONFIG.hostPreset;
+			const rawPresetVal = this.getFlagValue(flag.long, flag.short);
+			if (rawPresetVal !== undefined && !isHostPreset(rawPresetVal)) {
+				this.validationError = `Invalid host preset: ${rawPresetVal}`;
+			}
+		}
+
+		if (!this.validationError) {
 			if (positionalArgs.length > 1) {
 				this.validationError = `Unknown argument: ${positionalArgs[1]}`;
 			} else {
@@ -161,6 +171,15 @@ export class CLI {
 		return this.hasFlag("noCodegen");
 	}
 
+	get hostPreset(): HostPreset | undefined {
+		const flag = FLAG_CONFIG.hostPreset;
+		const val = this.getFlagValue(flag.long, flag.short);
+		if (val !== undefined && isHostPreset(val)) {
+			return val;
+		}
+		return undefined;
+	}
+
 	private hasFlag(prop: keyof typeof FLAG_CONFIG): boolean {
 		const flag = FLAG_CONFIG[prop];
 		return (
@@ -190,6 +209,9 @@ export class CLI {
 		}
 		if (this.noCodegen) {
 			input.noCodegen = true;
+		}
+		if (this.hostPreset !== undefined) {
+			input.hostPreset = this.hostPreset;
 		}
 		return input;
 	}

--- a/packages/arkenv/src/cli/commands/help.test.ts
+++ b/packages/arkenv/src/cli/commands/help.test.ts
@@ -29,35 +29,43 @@ describe("HelpUseCase", () => {
 			"  arkenv init [project-name]    Set up ArkEnv in your project",
 		);
 
-		// Options should be aligned based on the longest option (--no-codegen, -C) which is 16 chars
-		// leftPad (2) + longest flag (16) + colGap (4) = 22 characters start index for descriptions.
+		// Options should be aligned based on the longest option (--host-preset <preset>) which is 22 chars
+		// leftPad (2) + longest flag (22) + colGap (4) = 28 characters start index for descriptions.
 		const yesOptionLog = logs.find((l) => l.includes("--yes, -y"));
 		expect(yesOptionLog).toBeDefined();
-		// "--yes, -y" is 9 chars. max (16) - 9 + colGap (4) = 11 spaces padding.
-		// "  " (2) + "--yes, -y" (9) + "           " (11) + "Skip prompts..."
+		// "--yes, -y" is 9 chars. max (22) - 9 + colGap (4) = 17 spaces padding.
 		expect(yesOptionLog).toBe(
-			"  --yes, -y           Skip prompts and use defaults (also passed to subprocesses)",
+			"  --yes, -y                 Skip prompts and use defaults (also passed to subprocesses)",
 		);
 
 		const exampleOptionLog = logs.find((l) => l.includes("--example, -e"));
 		expect(exampleOptionLog).toBeDefined();
-		// "--example, -e" is 13 chars. max (16) - 13 + colGap (4) = 7 spaces padding.
-		// "  " (2) + "--example, -e" (13) + "       " (7) + "Specify..."
+		// "--example, -e" is 13 chars. max (22) - 13 + colGap (4) = 13 spaces padding.
 		expect(exampleOptionLog).toBe(
-			"  --example, -e       Specify an example name when creating a new project",
+			"  --example, -e             Specify an example name when creating a new project",
 		);
 
 		const noCodegenOptionLog = logs.find((l) => l.includes("--no-codegen, -C"));
 		expect(noCodegenOptionLog).toBeDefined();
-		// "--no-codegen, -C" is 16 chars. max (16) - 16 + colGap (4) = 4 spaces padding.
-		// "  " (2) + "--no-codegen, -C" (16) + "    " (4) + "Disable..."
+		// "--no-codegen, -C" is 16 chars. max (22) - 16 + colGap (4) = 10 spaces padding.
 		expect(noCodegenOptionLog).toBe(
-			"  --no-codegen, -C    Disable automatic env.gen.ts code generation for Next.js",
+			"  --no-codegen, -C          Disable automatic env.gen.ts code generation for Next.js",
+		);
+
+		const hostPresetOptionLog = logs.find((l) =>
+			l.includes("--host-preset <preset>"),
+		);
+		expect(hostPresetOptionLog).toBeDefined();
+		// "--host-preset <preset>" is 22 chars. max (22) - 22 + colGap (4) = 4 spaces padding.
+		expect(hostPresetOptionLog).toBe(
+			"  --host-preset <preset>    Specify a hosting provider preset (none, vercel, netlify)",
 		);
 
 		const helpOptionLog = logs.find((l) => l.includes("--help, -h"));
 		expect(helpOptionLog).toBeDefined();
-		// "--help, -h" is 10 chars. max (16) - 10 + colGap (4) = 10 spaces padding.
-		expect(helpOptionLog).toBe("  --help, -h          Show this help message");
+		// "--help, -h" is 10 chars. max (22) - 10 + colGap (4) = 16 spaces padding.
+		expect(helpOptionLog).toBe(
+			"  --help, -h                Show this help message",
+		);
 	});
 });

--- a/packages/arkenv/src/cli/commands/help.ts
+++ b/packages/arkenv/src/cli/commands/help.ts
@@ -72,6 +72,10 @@ export class HelpUseCase {
 				right: "Disable automatic env.gen.ts code generation for Next.js",
 			},
 			{
+				left: "--host-preset <preset>",
+				right: "Specify a hosting provider preset (none, vercel, netlify)",
+			},
+			{
 				left: "--help, -h",
 				right: "Show this help message",
 			},

--- a/packages/arkenv/src/cli/commands/init.ts
+++ b/packages/arkenv/src/cli/commands/init.ts
@@ -7,6 +7,7 @@ import {
 	Executor,
 	type Framework,
 } from "@/features/scaffold";
+import type { HostPreset } from "@/features/scaffold/presets";
 import { RegistryClient } from "@/shared/clients";
 import type {
 	LoggerPort,
@@ -29,6 +30,7 @@ export type InitInput = {
 	example?: string;
 	name?: string;
 	noCodegen?: boolean;
+	hostPreset?: HostPreset;
 };
 
 /**
@@ -294,6 +296,7 @@ export class InitUseCase {
 				isSimple: input.isSimple,
 				isFlat: input.isFlat,
 				disableCodegen: input.noCodegen,
+				hostPreset: input.hostPreset,
 			}),
 			isYes,
 		);

--- a/packages/arkenv/src/cli/ui/prompts.test.ts
+++ b/packages/arkenv/src/cli/ui/prompts.test.ts
@@ -75,6 +75,7 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // installTypeDefinitions
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
 
 		const result = await runPromptWizard({ framework: "bun-fullstack" });
@@ -90,6 +91,7 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // wrapNextjsConfig
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.select).mockResolvedValueOnce("zod"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
 
 		const result = await runPromptWizard({ framework: "nextjs" });
@@ -107,6 +109,7 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(false); // nextjsCodegen
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
 
 		const result = await runPromptWizard({ framework: "nextjs" });
@@ -123,6 +126,7 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(false); // wrapNextjsConfig
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
 
 		const result = await runPromptWizard({ framework: "nextjs" });
@@ -137,6 +141,7 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // installTypeDefinitions
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
 
 		const result = await runPromptWizard({ envKeys: ["API_KEY"] });
@@ -152,6 +157,7 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.text).mockResolvedValueOnce("./app/env.ts"); // path
 		vi.mocked(prompts.select).mockResolvedValueOnce("append"); // envDtsHandling
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 
 		const result = await runPromptWizard({
 			framework: "vite",
@@ -172,12 +178,44 @@ describe("runPromptWizard", () => {
 		vi.mocked(prompts.select).mockResolvedValueOnce("vanilla"); // framework
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
 		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("none"); // hostPreset
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(false); // useEnvExample
 
 		const result = await runPromptWizard({ envKeys: ["API_KEY"] });
 
 		expect(result?.envKeys).toBeUndefined();
 	});
+
+	it("should include hostPreset if selected in wizard", async () => {
+		vi.mocked(prompts.select).mockResolvedValueOnce("vanilla"); // framework
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // installTypeDefinitions
+		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.select).mockResolvedValueOnce("vercel"); // hostPreset
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
+
+		const result = await runPromptWizard();
+
+		expect(result?.hostPreset).toBe("vercel");
+	});
+
+	it("should default hostPreset to none in isYes mode", async () => {
+		const result = await runPromptWizard({}, true);
+		expect(result?.hostPreset).toBe("none");
+	});
+
+	it("should bypass hostPreset prompt if already provided in defaults", async () => {
+		vi.mocked(prompts.select).mockResolvedValueOnce("vanilla"); // framework
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useDefaultPath
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // installTypeDefinitions
+		vi.mocked(prompts.select).mockResolvedValueOnce("arktype"); // validator
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(true); // useEnvExample
+
+		const result = await runPromptWizard({ hostPreset: "vercel" });
+
+		expect(result?.hostPreset).toBe("vercel");
+	});
+
 	it("should abort immediately if user selects No (abort) on overwrite prompt", async () => {
 		vi.mocked(prompts.confirm).mockResolvedValueOnce(false);
 

--- a/packages/arkenv/src/cli/ui/prompts/steps.ts
+++ b/packages/arkenv/src/cli/ui/prompts/steps.ts
@@ -14,6 +14,7 @@ import {
 	nextjsCodegenStep,
 	validatorStep,
 } from "./steps/framework";
+import { hostPresetStep } from "./steps/host-preset";
 import { pathStep, useDefaultPathStep } from "./steps/path";
 
 /**
@@ -31,5 +32,6 @@ export const steps = {
 	installTypeDefinitions: installTypeDefinitionsStep,
 	envDtsHandling: envDtsHandlingStep,
 	validator: validatorStep,
+	hostPreset: hostPresetStep,
 	useEnvExample: useEnvExampleStep,
 };

--- a/packages/arkenv/src/cli/ui/prompts/steps/host-preset.ts
+++ b/packages/arkenv/src/cli/ui/prompts/steps/host-preset.ts
@@ -1,0 +1,33 @@
+import { isCancel, select } from "@clack/prompts";
+import type { ProjectOptions } from "@/features/scaffold";
+import { PRESETS } from "@/features/scaffold/presets";
+
+/**
+ * Prompt for an optional hosting provider preset.
+ *
+ * @param options Optional initial selection
+ * @returns Selected host preset, or `null` when cancelled
+ */
+export async function hostPresetStep(options?: {
+	initialValue?: ProjectOptions["hostPreset"] | undefined;
+}): Promise<ProjectOptions["hostPreset"] | null> {
+	const selectOptions = [
+		{
+			value: "none" as const,
+			label: "None",
+			hint: "Do not add any hosting-specific environment variables",
+		},
+		...Object.entries(PRESETS).map(([value, def]) => ({
+			value,
+			label: def.label,
+			hint: def.hint,
+		})),
+	];
+
+	const answer = await select({
+		message: "Select a hosting provider preset (optional):",
+		initialValue: options?.initialValue ?? "none",
+		options: selectOptions,
+	});
+	return isCancel(answer) ? null : (answer as ProjectOptions["hostPreset"]);
+}

--- a/packages/arkenv/src/cli/ui/prompts/wizard.ts
+++ b/packages/arkenv/src/cli/ui/prompts/wizard.ts
@@ -13,7 +13,10 @@ type HasTypeFileAtPath = (options: {
 }) => boolean | Promise<boolean>;
 
 type ExistingProjectDefaults = Partial<
-	Pick<ProjectOptions, "framework" | "bunFeatures" | "disableCodegen">
+	Pick<
+		ProjectOptions,
+		"framework" | "bunFeatures" | "disableCodegen" | "hostPreset"
+	>
 > & {
 	defaultEnvPath?: string;
 	tsConfig?: ParsedTsConfig | null;
@@ -44,6 +47,7 @@ export async function runPromptWizard(
 			| "framework"
 			| "bunFeatures"
 			| "disableCodegen"
+			| "hostPreset"
 		>
 	> & {
 		examples?: Example[];
@@ -212,6 +216,7 @@ async function runExistingProjectWizard(
 			envKeys: detectedKeys ?? undefined,
 			disableCodegen: defaults?.disableCodegen ?? false,
 			wrapNextjsConfig: framework === "nextjs" ? true : undefined,
+			hostPreset: defaults?.hostPreset || "none",
 		});
 	}
 
@@ -322,7 +327,17 @@ async function runExistingProjectWizard(
 		// 8. validator
 		const validator = unwrapPrompt(await steps.validator());
 
-		// 9. useEnvExample
+		// 9. hostPreset
+		const hostPreset =
+			defaults?.hostPreset !== undefined
+				? defaults.hostPreset
+				: unwrapPrompt(
+						await steps.hostPreset({
+							initialValue: defaults?.hostPreset,
+						}),
+					);
+
+		// 10. useEnvExample
 		const useEnvExample = unwrapPrompt(
 			await steps.useEnvExample({
 				detectedKeys,
@@ -346,6 +361,7 @@ async function runExistingProjectWizard(
 			installTypeDefinitions,
 			envDtsHandling,
 			validator,
+			hostPreset,
 			bunFeatures,
 			language: "ts",
 			installSkill: false,

--- a/packages/arkenv/src/features/scaffold/frameworks/layouts/codegen.ts
+++ b/packages/arkenv/src/features/scaffold/frameworks/layouts/codegen.ts
@@ -42,14 +42,83 @@ function appendPresetCodegenFields(
 	for (const key of presetKeys) {
 		if (clientPrefix && key.startsWith(clientPrefix)) {
 			buckets.clientFields.push(
-				`\t\t${dialect.formatCodegenField(key, "client", clientPrefix)}`,
+				`\t\t${dialect.formatCodegenField(key, "client", clientPrefix, hostPreset)}`,
 			);
 		} else {
 			buckets.serverFields.push(
-				`\t\t${dialect.formatCodegenField(key, "server", clientPrefix)}`,
+				`\t\t${dialect.formatCodegenField(key, "server", clientPrefix, hostPreset)}`,
 			);
 		}
 	}
+}
+
+/**
+ * Extract env key names from dialect field lines (`KEY: ...`).
+ *
+ * @param fields Schema field source lines
+ * @returns Key names in declaration order
+ */
+function extractFieldKeyNames(fields: string[]): string[] {
+	const keys: string[] = [];
+	for (const field of fields) {
+		const match = field.trim().match(/^([a-zA-Z0-9_]+)\s*:/);
+		if (match) {
+			keys.push(match[1]);
+		}
+	}
+	return keys;
+}
+
+/**
+ * Build `runtimeEnv` field lines for `--no-codegen` Next.js / Nuxt templates.
+ *
+ * When explicit `envKeys` are absent, includes default client/`NODE_ENV` entries
+ * plus any client-prefixed keys present in {@link clientFields} (e.g. hosting
+ * preset keys appended after defaults).
+ *
+ * @param envKeys Explicit env keys when provided
+ * @param clientPrefix Framework client prefix
+ * @param clientFields Populated client schema field lines
+ * @param extraKeys Additional keys to include (e.g. flat-layout exposed shared keys)
+ * @returns Indented `key: process.env.key,` lines
+ */
+function buildNoCodegenRuntimeEnvFields(
+	envKeys: string[] | undefined,
+	clientPrefix: string,
+	clientFields: string[],
+	extraKeys: string[] = [],
+): string[] {
+	const runtimeEnvFields: string[] = [];
+	const seen = new Set<string>();
+
+	const push = (key: string) => {
+		if (seen.has(key)) return;
+		seen.add(key);
+		runtimeEnvFields.push(`\t\t${key}: process.env.${key},`);
+	};
+
+	if (envKeys && envKeys.length > 0) {
+		for (const key of envKeys) {
+			if (
+				key.startsWith(clientPrefix) ||
+				key === "NODE_ENV" ||
+				extraKeys.includes(key)
+			) {
+				push(key);
+			}
+		}
+		return runtimeEnvFields;
+	}
+
+	push(`${clientPrefix}API_URL`);
+	push("NODE_ENV");
+	for (const key of extractFieldKeyNames(clientFields)) {
+		push(key);
+	}
+	for (const key of extraKeys) {
+		push(key);
+	}
+	return runtimeEnvFields;
 }
 
 /**
@@ -73,12 +142,7 @@ export function assembleCodegenTemplate(options: CodegenLayoutOptions): string {
 		hostPreset,
 	} = options;
 
-	const {
-		clientPrefix,
-		packageName: pkgName,
-		displayName: frameworkName,
-	} = config;
-	const framework = config.id;
+	const { clientPrefix } = config;
 
 	const serverFields: string[] = [];
 	const clientFields: string[] = [];
@@ -88,15 +152,15 @@ export function assembleCodegenTemplate(options: CodegenLayoutOptions): string {
 		for (const key of envKeys) {
 			if (key.startsWith(clientPrefix)) {
 				clientFields.push(
-					`\t\t${dialect.formatCodegenField(key, "client", clientPrefix)}`,
+					`\t\t${dialect.formatCodegenField(key, "client", clientPrefix, hostPreset)}`,
 				);
 			} else if (key === "NODE_ENV") {
 				sharedFields.push(
-					`\t\t${dialect.formatCodegenField(key, "shared", clientPrefix)}`,
+					`\t\t${dialect.formatCodegenField(key, "shared", clientPrefix, hostPreset)}`,
 				);
 			} else {
 				serverFields.push(
-					`\t\t${dialect.formatCodegenField(key, "server", clientPrefix)}`,
+					`\t\t${dialect.formatCodegenField(key, "server", clientPrefix, hostPreset)}`,
 				);
 			}
 		}
@@ -194,26 +258,12 @@ function assembleFlatLayout(params: FieldBuckets): string {
 	}
 
 	if (disableCodegen && framework === "nextjs") {
-		const runtimeEnvFields: string[] = [];
-		if (envKeys && envKeys.length > 0) {
-			for (const key of envKeys) {
-				if (
-					key.startsWith(clientPrefix) ||
-					key === "NODE_ENV" ||
-					exposedKeyNames.includes(key)
-				) {
-					runtimeEnvFields.push(`\t\t${key}: process.env.${key},`);
-				}
-			}
-		} else {
-			runtimeEnvFields.push(
-				`\t\t${clientPrefix}API_URL: process.env.${clientPrefix}API_URL,`,
-				"\t\tNODE_ENV: process.env.NODE_ENV,",
-			);
-			for (const key of exposedKeyNames) {
-				runtimeEnvFields.push(`\t\t${key}: process.env.${key},`);
-			}
-		}
+		const runtimeEnvFields = buildNoCodegenRuntimeEnvFields(
+			envKeys,
+			clientPrefix,
+			clientFields,
+			exposedKeyNames,
+		);
 		optionParts.push(`\truntimeEnv: {\n${runtimeEnvFields.join("\n")}\n\t}`);
 	}
 
@@ -282,19 +332,11 @@ function assembleNestedLayout(params: FieldBuckets): string {
 	}
 
 	if (disableCodegen || (framework === "nuxt" && layout === "simple")) {
-		const runtimeEnvFields: string[] = [];
-		if (envKeys && envKeys.length > 0) {
-			for (const key of envKeys) {
-				if (key.startsWith(clientPrefix) || key === "NODE_ENV") {
-					runtimeEnvFields.push(`\t\t${key}: process.env.${key},`);
-				}
-			}
-		} else {
-			runtimeEnvFields.push(
-				`\t\t${clientPrefix}API_URL: process.env.${clientPrefix}API_URL,`,
-				"\t\tNODE_ENV: process.env.NODE_ENV,",
-			);
-		}
+		const runtimeEnvFields = buildNoCodegenRuntimeEnvFields(
+			envKeys,
+			clientPrefix,
+			clientFields,
+		);
 		if (framework !== "nuxt") {
 			sections.push(`\truntimeEnv: {\n${runtimeEnvFields.join("\n")}\n\t}`);
 		}

--- a/packages/arkenv/src/features/scaffold/frameworks/layouts/codegen.ts
+++ b/packages/arkenv/src/features/scaffold/frameworks/layouts/codegen.ts
@@ -1,4 +1,5 @@
 import type { CodegenFrameworkConfig } from "@/features/scaffold/frameworks/codegen-config";
+import { getPresetKeys, type HostPreset } from "@/features/scaffold/presets";
 import type { Dialect } from "@/features/scaffold/validators/dialects";
 
 /**
@@ -16,7 +17,40 @@ export type CodegenLayoutOptions = {
 	 * path kept for test parity; primary codegen path is flat when unset/flat.
 	 */
 	layout?: "strict" | "simple" | "flat" | undefined;
+	/** Hosting provider preset — appended to defaults when `envKeys` is empty. */
+	hostPreset?: HostPreset | undefined;
 };
+
+/**
+ * Append hosting-preset field lines onto codegen field buckets.
+ *
+ * @param buckets Mutable server/client/shared field lines
+ * @param dialect Validator dialect
+ * @param clientPrefix Framework client prefix
+ * @param hostPreset Selected hosting preset
+ */
+function appendPresetCodegenFields(
+	buckets: {
+		serverFields: string[];
+		clientFields: string[];
+	},
+	dialect: Dialect,
+	clientPrefix: string,
+	hostPreset: HostPreset | undefined,
+): void {
+	const presetKeys = getPresetKeys(hostPreset ?? "none", clientPrefix);
+	for (const key of presetKeys) {
+		if (clientPrefix && key.startsWith(clientPrefix)) {
+			buckets.clientFields.push(
+				`\t\t${dialect.formatCodegenField(key, "client", clientPrefix)}`,
+			);
+		} else {
+			buckets.serverFields.push(
+				`\t\t${dialect.formatCodegenField(key, "server", clientPrefix)}`,
+			);
+		}
+	}
+}
 
 /**
  * Assemble a Next.js / Nuxt env schema template (flat or nested).
@@ -25,8 +59,8 @@ export type CodegenLayoutOptions = {
  * (`layout === "simple"`), and runtimeEnv injection. The dialect supplies only
  * field lines and extra imports.
  *
- * @param options Layout and dialect inputs.
- * @returns Generated TypeScript source.
+ * @param options Layout and dialect inputs
+ * @returns Generated TypeScript source
  */
 export function assembleCodegenTemplate(options: CodegenLayoutOptions): string {
 	const {
@@ -36,6 +70,7 @@ export function assembleCodegenTemplate(options: CodegenLayoutOptions): string {
 		importPath: nextjsImportPath,
 		disableCodegen,
 		layout,
+		hostPreset,
 	} = options;
 
 	const {
@@ -52,11 +87,17 @@ export function assembleCodegenTemplate(options: CodegenLayoutOptions): string {
 	if (envKeys && envKeys.length > 0) {
 		for (const key of envKeys) {
 			if (key.startsWith(clientPrefix)) {
-				clientFields.push(`\t\t${dialect.formatCodegenField(key, "client")}`);
+				clientFields.push(
+					`\t\t${dialect.formatCodegenField(key, "client", clientPrefix)}`,
+				);
 			} else if (key === "NODE_ENV") {
-				sharedFields.push(`\t\t${dialect.formatCodegenField(key, "shared")}`);
+				sharedFields.push(
+					`\t\t${dialect.formatCodegenField(key, "shared", clientPrefix)}`,
+				);
 			} else {
-				serverFields.push(`\t\t${dialect.formatCodegenField(key, "server")}`);
+				serverFields.push(
+					`\t\t${dialect.formatCodegenField(key, "server", clientPrefix)}`,
+				);
 			}
 		}
 	} else {
@@ -64,6 +105,12 @@ export function assembleCodegenTemplate(options: CodegenLayoutOptions): string {
 		serverFields.push(...defaults.serverFields);
 		clientFields.push(...defaults.clientFields);
 		sharedFields.push(...defaults.sharedFields);
+		appendPresetCodegenFields(
+			{ serverFields, clientFields },
+			dialect,
+			clientPrefix,
+			hostPreset,
+		);
 	}
 
 	const useFlatLayout = layout !== "simple" && layout !== "strict";

--- a/packages/arkenv/src/features/scaffold/index.ts
+++ b/packages/arkenv/src/features/scaffold/index.ts
@@ -1,5 +1,6 @@
 export * from "./executor";
 export * from "./plan";
 export * from "./planner";
+export * from "./presets";
 export * from "./scaffold";
 export type { StrictEnvTemplates } from "./validators";

--- a/packages/arkenv/src/features/scaffold/plan.ts
+++ b/packages/arkenv/src/features/scaffold/plan.ts
@@ -1,6 +1,7 @@
 import type { LoggerPort as Reporter } from "@/shared/ports/logger.port";
 import type { ParsedTsConfig } from "@/shared/ports/project-scanner.port";
 import type { WorkspacePort as Workspace } from "@/shared/ports/workspace.port";
+import type { HostPreset } from "./presets";
 
 export type { Reporter, Workspace };
 
@@ -37,6 +38,8 @@ export type ProjectOptions = {
 	envExampleContent?: string;
 	envContent?: string;
 	gitignoreContent?: string;
+	/** Hosting provider preset selected during init (`none` / Vercel / Netlify). */
+	hostPreset?: HostPreset;
 };
 
 /**

--- a/packages/arkenv/src/features/scaffold/planner.test.ts
+++ b/packages/arkenv/src/features/scaffold/planner.test.ts
@@ -759,4 +759,36 @@ PORT=3000`;
 			expect(gitignoreFile).toBeUndefined();
 		});
 	});
+
+	describe("hostPresets planning", () => {
+		it("includes hosting preset keys in generated config and .env templates", () => {
+			const state: CollectedState = {
+				...defaultState,
+				existingFiles: [],
+				options: {
+					...defaultState.options,
+					hostPreset: "vercel",
+				},
+			};
+			const plan = createPlan(state);
+
+			const envTs = plan.files.find((f) => f.path.endsWith("env.ts"));
+			const dotenv = plan.files.find((f) => f.path.endsWith(".env"));
+			const dotenvExample = plan.files.find((f) =>
+				f.path.endsWith(".env.example"),
+			);
+
+			expect(envTs).toBeDefined();
+			expect(envTs?.content).toContain("VERCEL_URL");
+			expect(envTs?.content).toContain("VERCEL_ENV");
+
+			expect(dotenv).toBeDefined();
+			expect(dotenv?.content).toContain("VERCEL_ENV=");
+			expect(dotenv?.content).toContain("VERCEL_URL=");
+
+			expect(dotenvExample).toBeDefined();
+			expect(dotenvExample?.content).toContain("VERCEL_ENV=");
+			expect(dotenvExample?.content).toContain("VERCEL_URL=");
+		});
+	});
 });

--- a/packages/arkenv/src/features/scaffold/planner.ts
+++ b/packages/arkenv/src/features/scaffold/planner.ts
@@ -3,6 +3,7 @@ import { shake } from "radashi";
 import { FRAMEWORKS } from "./frameworks";
 import { getEnvDefaultsForExample } from "./frameworks/example-env-defaults";
 import type { CollectedState, ScaffoldingPlan } from "./plan";
+import { mergeEnvKeysWithPreset } from "./presets";
 import { getDlxCommand } from "./scaffold";
 import { VALIDATORS } from "./validators";
 
@@ -133,11 +134,17 @@ export function planEnvFiles(
 	const hasEnv = existingFiles.includes(envPath);
 	const hasEnvExample = existingFiles.includes(envExamplePath);
 
+	const combinedEnvKeys = mergeEnvKeysWithPreset(
+		options.envKeys,
+		options.hostPreset,
+		frameworkStrategy.clientPrefix,
+	);
+
 	if (!hasEnv) {
 		const content =
 			options.envExampleContent !== undefined
 				? options.envExampleContent
-				: formatEnvContent(frameworkStrategy.getEnvDefaults(options.envKeys));
+				: formatEnvContent(frameworkStrategy.getEnvDefaults(combinedEnvKeys));
 		plan.files.push({
 			path: envPath,
 			content,
@@ -150,7 +157,7 @@ export function planEnvFiles(
 		const content =
 			options.envContent !== undefined
 				? stripValuesFromEnvContent(options.envContent)
-				: formatEnvContent(frameworkStrategy.getEnvDefaults(options.envKeys));
+				: formatEnvContent(frameworkStrategy.getEnvDefaults(combinedEnvKeys));
 		plan.files.push({
 			path: envExamplePath,
 			content,

--- a/packages/arkenv/src/features/scaffold/presets.ts
+++ b/packages/arkenv/src/features/scaffold/presets.ts
@@ -69,7 +69,8 @@ export type HostPreset = "none" | keyof typeof PRESETS;
  * @returns Whether `value` is a known host preset id
  */
 export function isHostPreset(value: string): value is HostPreset {
-	return value === "none" || Object.hasOwn(PRESETS, value);
+	// Own-key check compatible with es2020 (no Object.hasOwn) and noPrototypeBuiltins.
+	return value === "none" || Object.keys(PRESETS).includes(value);
 }
 
 /**

--- a/packages/arkenv/src/features/scaffold/presets.ts
+++ b/packages/arkenv/src/features/scaffold/presets.ts
@@ -97,26 +97,32 @@ export function getPresetKeys(
 /**
  * Look up preset field metadata for a schema key, stripping the client prefix when present.
  *
+ * Scoped to the active {@link hostPreset} so unrelated presets cannot influence
+ * how user-provided env keys are rendered.
+ *
  * @param key Environment variable name (possibly prefixed)
  * @param clientPrefix Framework client prefix used to recover the base key
- * @returns Matching {@link PresetField}, or `undefined` when the key is not from a preset
+ * @param hostPreset Active hosting preset; `"none"` / omitted yields no match
+ * @returns Matching {@link PresetField}, or `undefined` when not a preset field
  */
 export function lookupPresetField(
 	key: string,
 	clientPrefix: string,
+	hostPreset?: HostPreset,
 ): PresetField | undefined {
+	if (!hostPreset || hostPreset === "none") {
+		return undefined;
+	}
+
 	const baseKey =
 		clientPrefix && key.startsWith(clientPrefix)
 			? key.slice(clientPrefix.length)
 			: key;
 
-	for (const def of Object.values(PRESETS)) {
-		const fields = def.fields as Readonly<Record<string, PresetField>>;
-		if (baseKey in fields) {
-			return fields[baseKey];
-		}
-	}
-	return undefined;
+	const fields = PRESETS[hostPreset].fields as Readonly<
+		Record<string, PresetField>
+	>;
+	return baseKey in fields ? fields[baseKey] : undefined;
 }
 
 /**

--- a/packages/arkenv/src/features/scaffold/presets.ts
+++ b/packages/arkenv/src/features/scaffold/presets.ts
@@ -69,7 +69,7 @@ export type HostPreset = "none" | keyof typeof PRESETS;
  * @returns Whether `value` is a known host preset id
  */
 export function isHostPreset(value: string): value is HostPreset {
-	return value === "none" || value in PRESETS;
+	return value === "none" || Object.hasOwn(PRESETS, value);
 }
 
 /**

--- a/packages/arkenv/src/features/scaffold/presets.ts
+++ b/packages/arkenv/src/features/scaffold/presets.ts
@@ -69,7 +69,9 @@ export type HostPreset = "none" | keyof typeof PRESETS;
  * @returns Whether `value` is a known host preset id
  */
 export function isHostPreset(value: string): value is HostPreset {
-	return value === "none" || Object.hasOwn(PRESETS, value);
+	return (
+		value === "none" || Object.prototype.hasOwnProperty.call(PRESETS, value)
+	);
 }
 
 /**

--- a/packages/arkenv/src/features/scaffold/presets.ts
+++ b/packages/arkenv/src/features/scaffold/presets.ts
@@ -1,0 +1,140 @@
+/**
+ * Codegen IR for a single hosting-preset field.
+ *
+ * @remarks See `docs/adr/0018-cli-hosting-preset-field-metadata.md` (ADR 0018).
+ * Do not grow this union without an explicit decision — prefer JSON Schema subset
+ * or richer dialect rendering if more field kinds are needed.
+ */
+export type PresetField =
+	| { readonly type: "string" }
+	| { readonly type: "enum"; readonly values: readonly string[] };
+
+/**
+ * Declarative metadata for a hosting-provider preset.
+ */
+export type PresetDefinition = {
+	readonly label: string;
+	readonly hint: string;
+	readonly serverOnlyKeys: readonly string[];
+	readonly clientExposedKeys: readonly string[];
+	readonly fields: Readonly<Record<string, PresetField>>;
+};
+
+/**
+ * Hosting preset registry. Adding a host is one place: entry + field metadata.
+ */
+export const PRESETS = {
+	vercel: {
+		label: "Vercel",
+		hint: "Add VERCEL, VERCEL_ENV, VERCEL_URL, etc.",
+		serverOnlyKeys: ["VERCEL"],
+		clientExposedKeys: ["VERCEL_ENV", "VERCEL_URL"],
+		fields: {
+			VERCEL: { type: "string" },
+			VERCEL_ENV: {
+				type: "enum",
+				values: ["production", "preview", "development"],
+			},
+			VERCEL_URL: { type: "string" },
+		},
+	},
+	netlify: {
+		label: "Netlify",
+		hint: "Add NETLIFY, CONTEXT, URL, DEPLOY_URL, etc.",
+		serverOnlyKeys: ["NETLIFY", "DEPLOY_URL"],
+		clientExposedKeys: ["CONTEXT", "URL"],
+		fields: {
+			NETLIFY: { type: "string" },
+			DEPLOY_URL: { type: "string" },
+			CONTEXT: {
+				type: "enum",
+				values: ["production", "deploy-preview", "branch-deploy"],
+			},
+			URL: { type: "string" },
+		},
+	},
+} as const satisfies Record<string, PresetDefinition>;
+
+/**
+ * Hosting preset id including the explicit opt-out (`"none"`).
+ *
+ * Derived from {@link PRESETS} so adding a host stays a single registry edit.
+ */
+export type HostPreset = "none" | keyof typeof PRESETS;
+
+/**
+ * Type-guard for CLI / flag values against {@link HostPreset}.
+ *
+ * @param value Raw CLI string
+ * @returns Whether `value` is a known host preset id
+ */
+export function isHostPreset(value: string): value is HostPreset {
+	return value === "none" || value in PRESETS;
+}
+
+/**
+ * Collect environment keys for a hosting preset, including client-prefixed copies.
+ *
+ * @param preset Selected hosting preset (`"none"` yields an empty list)
+ * @param clientPrefix Framework client prefix from the active strategy (e.g. `NEXT_PUBLIC_`)
+ * @returns Deduplicated key list for schema and `.env` planning
+ */
+export function getPresetKeys(
+	preset: HostPreset,
+	clientPrefix: string,
+): string[] {
+	if (preset === "none") return [];
+	const def = PRESETS[preset];
+	const keys: string[] = [...def.serverOnlyKeys, ...def.clientExposedKeys];
+	if (clientPrefix) {
+		for (const key of def.clientExposedKeys) {
+			keys.push(`${clientPrefix}${key}`);
+		}
+	}
+	return keys;
+}
+
+/**
+ * Look up preset field metadata for a schema key, stripping the client prefix when present.
+ *
+ * @param key Environment variable name (possibly prefixed)
+ * @param clientPrefix Framework client prefix used to recover the base key
+ * @returns Matching {@link PresetField}, or `undefined` when the key is not from a preset
+ */
+export function lookupPresetField(
+	key: string,
+	clientPrefix: string,
+): PresetField | undefined {
+	const baseKey =
+		clientPrefix && key.startsWith(clientPrefix)
+			? key.slice(clientPrefix.length)
+			: key;
+
+	for (const def of Object.values(PRESETS)) {
+		const fields = def.fields as Readonly<Record<string, PresetField>>;
+		if (baseKey in fields) {
+			return fields[baseKey];
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Merge detected env keys with hosting-preset keys without dropping either set.
+ *
+ * @param envKeys Keys already chosen (e.g. from `.env.example`); may be undefined
+ * @param hostPreset Selected hosting preset
+ * @param clientPrefix Framework client prefix from the active strategy
+ * @returns Combined unique keys, or `undefined` when both sources are empty
+ */
+export function mergeEnvKeysWithPreset(
+	envKeys: string[] | undefined,
+	hostPreset: HostPreset | undefined,
+	clientPrefix: string,
+): string[] | undefined {
+	const presetKeys = getPresetKeys(hostPreset ?? "none", clientPrefix);
+	if (!envKeys?.length && presetKeys.length === 0) {
+		return undefined;
+	}
+	return Array.from(new Set([...(envKeys ?? []), ...presetKeys]));
+}

--- a/packages/arkenv/src/features/scaffold/presets.ts
+++ b/packages/arkenv/src/features/scaffold/presets.ts
@@ -69,9 +69,7 @@ export type HostPreset = "none" | keyof typeof PRESETS;
  * @returns Whether `value` is a known host preset id
  */
 export function isHostPreset(value: string): value is HostPreset {
-	return (
-		value === "none" || Object.prototype.hasOwnProperty.call(PRESETS, value)
-	);
+	return value === "none" || Object.hasOwn(PRESETS, value);
 }
 
 /**

--- a/packages/arkenv/src/features/scaffold/scaffold-context.ts
+++ b/packages/arkenv/src/features/scaffold/scaffold-context.ts
@@ -1,6 +1,7 @@
 import { FRAMEWORK_CLIENT_PREFIXES } from "@/features/scaffold/frameworks/client-prefixes";
 import { getCodegenConfig } from "@/features/scaffold/frameworks/codegen-config";
 import type { Framework, ProjectOptions } from "./plan";
+import type { HostPreset } from "./presets";
 
 /**
  * Shared context passed to validator strategies during template generation.
@@ -14,6 +15,8 @@ export type ScaffoldContext = {
 	disableCodegen: boolean;
 	layout?: "strict" | "simple" | "flat";
 	nextjsImportPath?: string;
+	/** Hosting provider preset for schema field enrichment. */
+	hostPreset?: HostPreset;
 };
 
 /**
@@ -23,9 +26,9 @@ export type ScaffoldContext = {
  * each framework strategy exposes as `clientPrefix`. Package name still comes
  * from codegen framework config for Next/Nuxt.
  *
- * @param options The selected project options.
- * @param nextjsImportPath The optional custom import path for generated env files.
- * @returns A scaffold context for validator strategies.
+ * @param options The selected project options
+ * @param nextjsImportPath The optional custom import path for generated env files
+ * @returns A scaffold context for validator strategies
  */
 export function createScaffoldContext(
 	options: ProjectOptions,
@@ -42,5 +45,8 @@ export function createScaffoldContext(
 		disableCodegen: options.disableCodegen === true,
 		...(options.layout !== undefined && { layout: options.layout }),
 		...(nextjsImportPath !== undefined && { nextjsImportPath }),
+		...(options.hostPreset !== undefined && {
+			hostPreset: options.hostPreset,
+		}),
 	};
 }

--- a/packages/arkenv/src/features/scaffold/validators.test.ts
+++ b/packages/arkenv/src/features/scaffold/validators.test.ts
@@ -11,6 +11,7 @@ type TemplateOptions = {
 	envKeys?: string[];
 	layout?: ProjectOptions["layout"];
 	disableCodegen?: boolean;
+	hostPreset?: ProjectOptions["hostPreset"];
 };
 
 /**
@@ -455,6 +456,83 @@ describe("validators templates", () => {
 			expect(templates.shared).toContain(
 				"export const SharedSchema = z.object({});",
 			);
+		});
+	});
+
+	describe("hosting presets", () => {
+		it("includes Vercel preset with ArkType validator", () => {
+			const options = {
+				validator: "arktype" as const,
+				framework: "vanilla" as const,
+				path: "env.ts",
+				language: "ts" as const,
+				hostPreset: "vercel" as const,
+			};
+			const template = getSimpleTemplate(options);
+			expect(template).toContain('VERCEL: "string?"');
+			expect(template).toContain(
+				"VERCEL_ENV: \"'production' | 'preview' | 'development'?\"",
+			);
+			expect(template).toContain('VERCEL_URL: "string?"');
+		});
+
+		it("includes Vercel preset with Zod validator in flat Next.js layout", () => {
+			const options = {
+				validator: "zod" as const,
+				framework: "nextjs" as const,
+				layout: "flat" as const,
+				path: "env.ts",
+				language: "ts" as const,
+				hostPreset: "vercel" as const,
+			};
+			const template = getSimpleTemplate(options);
+			expect(template).toContain("VERCEL: z.string().optional()");
+			expect(template).toContain(
+				'VERCEL_ENV: z.enum(["production", "preview", "development"]).optional()',
+			);
+			expect(template).toContain(
+				'NEXT_PUBLIC_VERCEL_ENV: z.enum(["production", "preview", "development"]).optional()',
+			);
+			expect(template).toContain(
+				"NEXT_PUBLIC_VERCEL_URL: z.string().optional()",
+			);
+		});
+
+		it("includes Netlify preset with Valibot in strict Next.js layout", () => {
+			const options = {
+				validator: "valibot" as const,
+				framework: "nextjs" as const,
+				layout: "strict" as const,
+				path: "env.ts",
+				language: "ts" as const,
+				disableCodegen: true,
+				hostPreset: "netlify" as const,
+			};
+			const templates = getStrictTemplates(options);
+			expect(templates.server).toContain("NETLIFY: v.optional(v.string())");
+			expect(templates.server).toContain(
+				'CONTEXT: v.optional(v.picklist(["production", "deploy-preview", "branch-deploy"]))',
+			);
+			expect(templates.client).toContain(
+				'NEXT_PUBLIC_CONTEXT: v.optional(v.picklist(["production", "deploy-preview", "branch-deploy"]))',
+			);
+			expect(templates.client).toContain(
+				"NEXT_PUBLIC_URL: v.optional(v.string())",
+			);
+		});
+
+		it("prefixes Vite client keys via framework clientPrefix", () => {
+			const options = {
+				validator: "arktype" as const,
+				framework: "vite" as const,
+				path: "env.ts",
+				language: "ts" as const,
+				hostPreset: "vercel" as const,
+			};
+			const template = getSimpleTemplate(options);
+			expect(template).toContain('VERCEL: "string?"');
+			expect(template).toContain("VITE_VERCEL_ENV:");
+			expect(template).toContain('VITE_VERCEL_URL: "string?"');
 		});
 	});
 });

--- a/packages/arkenv/src/features/scaffold/validators.test.ts
+++ b/packages/arkenv/src/features/scaffold/validators.test.ts
@@ -534,5 +534,61 @@ describe("validators templates", () => {
 			expect(template).toContain("VITE_VERCEL_ENV:");
 			expect(template).toContain('VITE_VERCEL_URL: "string?"');
 		});
+
+		it("includes preset client keys in no-codegen runtimeEnv for flat Next.js", () => {
+			const options = {
+				validator: "zod" as const,
+				framework: "nextjs" as const,
+				layout: "flat" as const,
+				path: "env.ts",
+				language: "ts" as const,
+				disableCodegen: true,
+				hostPreset: "vercel" as const,
+			};
+			const template = getSimpleTemplate(options);
+			expect(template).toContain("runtimeEnv: {");
+			expect(template).toContain(
+				"NEXT_PUBLIC_VERCEL_ENV: process.env.NEXT_PUBLIC_VERCEL_ENV,",
+			);
+			expect(template).toContain(
+				"NEXT_PUBLIC_VERCEL_URL: process.env.NEXT_PUBLIC_VERCEL_URL,",
+			);
+			expect(template).toContain(
+				"NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,",
+			);
+		});
+
+		it("includes preset client keys in no-codegen runtimeEnv for nested Next.js", () => {
+			const options = {
+				validator: "arktype" as const,
+				framework: "nextjs" as const,
+				layout: "simple" as const,
+				path: "env.ts",
+				language: "ts" as const,
+				disableCodegen: true,
+				hostPreset: "vercel" as const,
+			};
+			const template = getSimpleTemplate(options);
+			expect(template).toContain("runtimeEnv: {");
+			expect(template).toContain(
+				"NEXT_PUBLIC_VERCEL_ENV: process.env.NEXT_PUBLIC_VERCEL_ENV,",
+			);
+			expect(template).toContain(
+				"NEXT_PUBLIC_VERCEL_URL: process.env.NEXT_PUBLIC_VERCEL_URL,",
+			);
+		});
+
+		it("does not apply preset field kinds when no hostPreset is selected", () => {
+			const options = {
+				validator: "arktype" as const,
+				framework: "vanilla" as const,
+				path: "env.ts",
+				language: "ts" as const,
+				envKeys: ["VERCEL_ENV"],
+			};
+			const template = getSimpleTemplate(options);
+			expect(template).toContain('VERCEL_ENV: "string?"');
+			expect(template).not.toContain("production' | 'preview");
+		});
 	});
 });

--- a/packages/arkenv/src/features/scaffold/validators/assemble-simple.ts
+++ b/packages/arkenv/src/features/scaffold/validators/assemble-simple.ts
@@ -56,9 +56,10 @@ export function assembleSimpleFromDialect(
 		schemaFields = dialect.formatSimpleSchemaFields(
 			combined,
 			context.clientPrefix,
+			context.hostPreset,
 		);
 	} else if (presetKeys.length > 0) {
-		schemaFields = `${dialect.defaultSimpleSchemaFields}\n${dialect.formatSimpleSchemaFields(presetKeys, context.clientPrefix)}`;
+		schemaFields = `${dialect.defaultSimpleSchemaFields}\n${dialect.formatSimpleSchemaFields(presetKeys, context.clientPrefix, context.hostPreset)}`;
 	} else {
 		schemaFields = dialect.defaultSimpleSchemaFields;
 	}

--- a/packages/arkenv/src/features/scaffold/validators/assemble-simple.ts
+++ b/packages/arkenv/src/features/scaffold/validators/assemble-simple.ts
@@ -3,6 +3,7 @@ import {
 	assembleCodegenTemplate,
 	assemblePluginEnvTemplate,
 } from "@/features/scaffold/frameworks/layouts";
+import { getPresetKeys } from "@/features/scaffold/presets";
 import type { ScaffoldContext } from "@/features/scaffold/scaffold-context";
 import type { Dialect } from "./dialects";
 
@@ -10,31 +11,32 @@ import type { Dialect } from "./dialects";
  * Assemble a single-file env schema template for the active framework.
  *
  * Frameworks/layout assemblers own structure; the dialect supplies field lines
- * and imports only.
+ * and imports only. Hosting-preset keys are merged in without replacing
+ * framework defaults when no explicit env keys were provided.
  *
- * @param dialect Validator dialect.
- * @param keys Environment variable keys (empty uses dialect defaults).
- * @param context Shared scaffold context.
- * @returns Template source with trailing newline.
+ * @param dialect Validator dialect
+ * @param keys Environment variable keys (empty uses dialect defaults)
+ * @param context Shared scaffold context
+ * @returns Template source with trailing newline
  */
 export function assembleSimpleFromDialect(
 	dialect: Dialect,
 	keys: string[],
 	context: ScaffoldContext,
 ): string {
-	const schemaFields =
-		keys.length > 0
-			? dialect.formatSimpleSchemaFields(keys)
-			: dialect.defaultSimpleSchemaFields;
-
-	if (context.framework === "vite" || context.framework === "bun-fullstack") {
-		return `${assemblePluginEnvTemplate(dialect, context.framework, schemaFields)}\n`;
-	}
+	const presetKeys = getPresetKeys(
+		context.hostPreset ?? "none",
+		context.clientPrefix,
+	);
 
 	const codegenConfig = getCodegenConfig(context.framework);
 	if (codegenConfig) {
+		const combinedKeys =
+			keys.length > 0
+				? Array.from(new Set([...keys, ...presetKeys]))
+				: undefined;
 		return `${assembleCodegenTemplate({
-			...(keys.length > 0 ? { envKeys: keys } : {}),
+			...(combinedKeys !== undefined ? { envKeys: combinedKeys } : {}),
 			dialect,
 			config: codegenConfig,
 			...(context.nextjsImportPath !== undefined && {
@@ -42,7 +44,27 @@ export function assembleSimpleFromDialect(
 			}),
 			disableCodegen: context.disableCodegen,
 			...(context.layout !== undefined && { layout: context.layout }),
+			...(context.hostPreset !== undefined && {
+				hostPreset: context.hostPreset,
+			}),
 		})}\n`;
+	}
+
+	let schemaFields: string;
+	if (keys.length > 0) {
+		const combined = Array.from(new Set([...keys, ...presetKeys]));
+		schemaFields = dialect.formatSimpleSchemaFields(
+			combined,
+			context.clientPrefix,
+		);
+	} else if (presetKeys.length > 0) {
+		schemaFields = `${dialect.defaultSimpleSchemaFields}\n${dialect.formatSimpleSchemaFields(presetKeys, context.clientPrefix)}`;
+	} else {
+		schemaFields = dialect.defaultSimpleSchemaFields;
+	}
+
+	if (context.framework === "vite" || context.framework === "bun-fullstack") {
+		return `${assemblePluginEnvTemplate(dialect, context.framework, schemaFields)}\n`;
 	}
 
 	return `${dialect.assembleVanilla(schemaFields)}\n`;

--- a/packages/arkenv/src/features/scaffold/validators/assemble-strict.ts
+++ b/packages/arkenv/src/features/scaffold/validators/assemble-strict.ts
@@ -1,3 +1,4 @@
+import { getPresetKeys } from "@/features/scaffold/presets";
 import type { ScaffoldContext } from "@/features/scaffold/scaffold-context";
 import type { Dialect } from "./dialects";
 import {
@@ -11,15 +12,51 @@ import {
 import type { StrictEnvTemplates } from "./types";
 
 /**
+ * Append hosting-preset keys onto an existing strict field bucket set.
+ *
+ * @param fields Mutable field buckets from defaults or key categorisation
+ * @param dialect Validator dialect
+ * @param context Shared scaffold context
+ */
+function appendPresetStrictFields(
+	fields: {
+		serverFields: string[];
+		clientFields: string[];
+		sharedFields: string[];
+		runtimeEnvFields: string[];
+	},
+	dialect: Dialect,
+	context: ScaffoldContext,
+): void {
+	const presetKeys = getPresetKeys(
+		context.hostPreset ?? "none",
+		context.clientPrefix,
+	);
+	for (const key of presetKeys) {
+		if (context.clientPrefix && key.startsWith(context.clientPrefix)) {
+			fields.clientFields.push(
+				dialect.formatStrictField(key, "client", context.clientPrefix),
+			);
+			fields.runtimeEnvFields.push(`${key}: process.env.${key},`);
+		} else {
+			fields.serverFields.push(
+				dialect.formatStrictField(key, "server", context.clientPrefix),
+			);
+		}
+	}
+}
+
+/**
  * Build strict-layout templates from a validator dialect and scaffold context.
  *
  * Shared assembler for all dialects — only field formatting and import/wrapper
- * differences come from the dialect.
+ * differences come from the dialect. Preset keys merge with defaults rather
+ * than replacing them.
  *
- * @param dialect Validator dialect.
- * @param keys Environment variable keys (empty uses dialect defaults).
- * @param context Shared scaffold context.
- * @returns Shared, client, and server templates.
+ * @param dialect Validator dialect
+ * @param keys Environment variable keys (empty uses dialect defaults)
+ * @param context Shared scaffold context
+ * @returns Shared, client, and server templates
  */
 export function assembleStrictFromDialect(
 	dialect: Dialect,
@@ -28,13 +65,24 @@ export function assembleStrictFromDialect(
 ): StrictEnvTemplates {
 	const pkgName = getFrameworkPackageName(context);
 	const clientImportPath = getClientImportPath(context);
+	const presetKeys = getPresetKeys(
+		context.hostPreset ?? "none",
+		context.clientPrefix,
+	);
 
 	const fields =
 		keys.length > 0
-			? categorizeEnvKeys(keys, context, (key, role) =>
-					dialect.formatStrictField(key, role),
+			? categorizeEnvKeys(
+					Array.from(new Set([...keys, ...presetKeys])),
+					context,
+					(key, role) =>
+						dialect.formatStrictField(key, role, context.clientPrefix),
 				)
-			: dialect.getDefaultStrictFields(context.clientPrefix);
+			: (() => {
+					const defaults = dialect.getDefaultStrictFields(context.clientPrefix);
+					appendPresetStrictFields(defaults, dialect, context);
+					return defaults;
+				})();
 
 	const { serverFields, clientFields, sharedFields, runtimeEnvFields } = fields;
 

--- a/packages/arkenv/src/features/scaffold/validators/assemble-strict.ts
+++ b/packages/arkenv/src/features/scaffold/validators/assemble-strict.ts
@@ -35,12 +35,22 @@ function appendPresetStrictFields(
 	for (const key of presetKeys) {
 		if (context.clientPrefix && key.startsWith(context.clientPrefix)) {
 			fields.clientFields.push(
-				dialect.formatStrictField(key, "client", context.clientPrefix),
+				dialect.formatStrictField(
+					key,
+					"client",
+					context.clientPrefix,
+					context.hostPreset,
+				),
 			);
 			fields.runtimeEnvFields.push(`${key}: process.env.${key},`);
 		} else {
 			fields.serverFields.push(
-				dialect.formatStrictField(key, "server", context.clientPrefix),
+				dialect.formatStrictField(
+					key,
+					"server",
+					context.clientPrefix,
+					context.hostPreset,
+				),
 			);
 		}
 	}
@@ -76,7 +86,12 @@ export function assembleStrictFromDialect(
 					Array.from(new Set([...keys, ...presetKeys])),
 					context,
 					(key, role) =>
-						dialect.formatStrictField(key, role, context.clientPrefix),
+						dialect.formatStrictField(
+							key,
+							role,
+							context.clientPrefix,
+							context.hostPreset,
+						),
 				)
 			: (() => {
 					const defaults = dialect.getDefaultStrictFields(context.clientPrefix);

--- a/packages/arkenv/src/features/scaffold/validators/create-strategy.ts
+++ b/packages/arkenv/src/features/scaffold/validators/create-strategy.ts
@@ -13,7 +13,12 @@ import type { ValidatorStrategy } from "./types";
 export function createValidatorStrategy(dialect: Dialect): ValidatorStrategy {
 	return {
 		formatField(key, role, context) {
-			return dialect.formatStrictField(key, role, context.clientPrefix);
+			return dialect.formatStrictField(
+				key,
+				role,
+				context.clientPrefix,
+				context.hostPreset,
+			);
 		},
 
 		getSimpleTemplate(keys, context) {

--- a/packages/arkenv/src/features/scaffold/validators/create-strategy.ts
+++ b/packages/arkenv/src/features/scaffold/validators/create-strategy.ts
@@ -12,8 +12,8 @@ import type { ValidatorStrategy } from "./types";
  */
 export function createValidatorStrategy(dialect: Dialect): ValidatorStrategy {
 	return {
-		formatField(key, role) {
-			return dialect.formatStrictField(key, role);
+		formatField(key, role, context) {
+			return dialect.formatStrictField(key, role, context.clientPrefix);
 		},
 
 		getSimpleTemplate(keys, context) {

--- a/packages/arkenv/src/features/scaffold/validators/dialects/arktype.ts
+++ b/packages/arkenv/src/features/scaffold/validators/dialects/arktype.ts
@@ -1,29 +1,51 @@
 import dedent from "dedent";
 import type { Dialect } from "./types";
+import { tryFormatPresetFieldValue } from "./types";
 
 export const arktypeDialect: Dialect = {
-	formatStrictField(key, role) {
+	formatOptionalString() {
+		return `"string?"`;
+	},
+
+	formatOptionalEnum(values) {
+		return `"'${values.join("' | '")}'?"`;
+	},
+
+	formatStrictField(key, role, clientPrefix = "") {
 		if (role === "shared") {
 			return `${key}: "'development' | 'production' | 'test' = 'development'",`;
 		}
 		if (role === "server" && key === "PORT") {
 			return `PORT: "number.port = 3000",`;
 		}
+		const preset = tryFormatPresetFieldValue(arktypeDialect, key, clientPrefix);
+		if (preset) return `${key}: ${preset},`;
 		return `${key}: "string?",`;
 	},
 
-	formatCodegenField(key, role) {
+	formatCodegenField(key, role, clientPrefix = "") {
 		if (role === "shared") {
 			return `${key}: "'development' | 'production' | 'test' = 'development'",`;
 		}
+		const preset = tryFormatPresetFieldValue(arktypeDialect, key, clientPrefix);
+		if (preset) return `${key}: ${preset},`;
 		return `${key}: "string?",`;
 	},
 
 	defaultSimpleSchemaFields: `\t\tNODE_ENV: "'development' | 'production' | 'test' = 'development'",
 		PORT: "number.port = 3000",`,
 
-	formatSimpleSchemaFields(keys) {
-		return keys.map((key) => `\t\t${key}: "string?",`).join("\n");
+	formatSimpleSchemaFields(keys, clientPrefix = "") {
+		return keys
+			.map((key) => {
+				const preset = tryFormatPresetFieldValue(
+					arktypeDialect,
+					key,
+					clientPrefix,
+				);
+				return `\t\t${key}: ${preset ?? `"string?"`},`;
+			})
+			.join("\n");
 	},
 
 	getDefaultStrictFields(clientPrefix) {

--- a/packages/arkenv/src/features/scaffold/validators/dialects/arktype.ts
+++ b/packages/arkenv/src/features/scaffold/validators/dialects/arktype.ts
@@ -11,23 +11,33 @@ export const arktypeDialect: Dialect = {
 		return `"'${values.join("' | '")}'?"`;
 	},
 
-	formatStrictField(key, role, clientPrefix = "") {
+	formatStrictField(key, role, clientPrefix = "", hostPreset = undefined) {
 		if (role === "shared") {
 			return `${key}: "'development' | 'production' | 'test' = 'development'",`;
 		}
 		if (role === "server" && key === "PORT") {
 			return `PORT: "number.port = 3000",`;
 		}
-		const preset = tryFormatPresetFieldValue(arktypeDialect, key, clientPrefix);
+		const preset = tryFormatPresetFieldValue(
+			arktypeDialect,
+			key,
+			clientPrefix,
+			hostPreset,
+		);
 		if (preset) return `${key}: ${preset},`;
 		return `${key}: "string?",`;
 	},
 
-	formatCodegenField(key, role, clientPrefix = "") {
+	formatCodegenField(key, role, clientPrefix = "", hostPreset = undefined) {
 		if (role === "shared") {
 			return `${key}: "'development' | 'production' | 'test' = 'development'",`;
 		}
-		const preset = tryFormatPresetFieldValue(arktypeDialect, key, clientPrefix);
+		const preset = tryFormatPresetFieldValue(
+			arktypeDialect,
+			key,
+			clientPrefix,
+			hostPreset,
+		);
 		if (preset) return `${key}: ${preset},`;
 		return `${key}: "string?",`;
 	},
@@ -35,13 +45,14 @@ export const arktypeDialect: Dialect = {
 	defaultSimpleSchemaFields: `\t\tNODE_ENV: "'development' | 'production' | 'test' = 'development'",
 		PORT: "number.port = 3000",`,
 
-	formatSimpleSchemaFields(keys, clientPrefix = "") {
+	formatSimpleSchemaFields(keys, clientPrefix = "", hostPreset = undefined) {
 		return keys
 			.map((key) => {
 				const preset = tryFormatPresetFieldValue(
 					arktypeDialect,
 					key,
 					clientPrefix,
+					hostPreset,
 				);
 				return `\t\t${key}: ${preset ?? `"string?"`},`;
 			})

--- a/packages/arkenv/src/features/scaffold/validators/dialects/index.ts
+++ b/packages/arkenv/src/features/scaffold/validators/dialects/index.ts
@@ -14,3 +14,7 @@ export const DIALECTS = {
 } as const satisfies Record<Validator, Dialect>;
 
 export type { Dialect } from "./types";
+export {
+	formatPresetFieldValue,
+	tryFormatPresetFieldValue,
+} from "./types";

--- a/packages/arkenv/src/features/scaffold/validators/dialects/types.ts
+++ b/packages/arkenv/src/features/scaffold/validators/dialects/types.ts
@@ -21,12 +21,14 @@ export type Dialect = {
 	 * @param key Environment variable name
 	 * @param role Field scope within the strict layout
 	 * @param clientPrefix Framework client prefix for preset field lookup
+	 * @param hostPreset Active hosting preset for scoped field metadata lookup
 	 * @returns Field line without leading indentation (trailing comma)
 	 */
 	formatStrictField(
 		key: string,
 		role: "client" | "server" | "shared",
 		clientPrefix?: string,
+		hostPreset?: HostPreset,
 	): string;
 
 	/**
@@ -38,12 +40,14 @@ export type Dialect = {
 	 * @param key Environment variable name
 	 * @param role Field scope within the codegen layout
 	 * @param clientPrefix Framework client prefix for preset field lookup
+	 * @param hostPreset Active hosting preset for scoped field metadata lookup
 	 * @returns Field line without leading indentation (trailing comma)
 	 */
 	formatCodegenField(
 		key: string,
 		role: "client" | "server" | "shared",
 		clientPrefix?: string,
+		hostPreset?: HostPreset,
 	): string;
 
 	/**
@@ -57,9 +61,14 @@ export type Dialect = {
 	 *
 	 * @param keys Environment variable keys
 	 * @param clientPrefix Framework client prefix for preset field lookup
+	 * @param hostPreset Active hosting preset for scoped field metadata lookup
 	 * @returns Joined field lines
 	 */
-	formatSimpleSchemaFields(keys: string[], clientPrefix?: string): string;
+	formatSimpleSchemaFields(
+		keys: string[],
+		clientPrefix?: string,
+		hostPreset?: HostPreset,
+	): string;
 
 	/**
 	 * Render an optional string field value (no key, no trailing comma).
@@ -156,14 +165,16 @@ export function formatPresetFieldValue(
  * @param dialect Dialect providing optional string/enum renderers
  * @param key Environment variable name
  * @param clientPrefix Framework client prefix
+ * @param hostPreset Active hosting preset for scoped field metadata lookup
  * @returns Schema value fragment, or `undefined` when the key is not a preset field
  */
 export function tryFormatPresetFieldValue(
 	dialect: Pick<Dialect, "formatOptionalString" | "formatOptionalEnum">,
 	key: string,
 	clientPrefix: string,
+	hostPreset?: HostPreset,
 ): string | undefined {
-	const field = lookupPresetField(key, clientPrefix);
+	const field = lookupPresetField(key, clientPrefix, hostPreset);
 	if (!field) return undefined;
 	return formatPresetFieldValue(dialect, field);
 }

--- a/packages/arkenv/src/features/scaffold/validators/dialects/types.ts
+++ b/packages/arkenv/src/features/scaffold/validators/dialects/types.ts
@@ -1,3 +1,9 @@
+import {
+	type HostPreset,
+	lookupPresetField,
+	type PresetField,
+} from "@/features/scaffold/presets";
+
 /**
  * Dialect-owned field lines and wrappers for schema template generation.
  *
@@ -12,11 +18,16 @@ export type Dialect = {
 	/**
 	 * Format a schema field for strict (3-file) layouts.
 	 *
-	 * @param key Environment variable name.
-	 * @param role Field scope within the strict layout.
-	 * @returns Field line without leading indentation (trailing comma).
+	 * @param key Environment variable name
+	 * @param role Field scope within the strict layout
+	 * @param clientPrefix Framework client prefix for preset field lookup
+	 * @returns Field line without leading indentation (trailing comma)
 	 */
-	formatStrictField(key: string, role: "client" | "server" | "shared"): string;
+	formatStrictField(
+		key: string,
+		role: "client" | "server" | "shared",
+		clientPrefix?: string,
+	): string;
 
 	/**
 	 * Format a field for codegen flat/nested layouts (single-file Next/Nuxt).
@@ -24,11 +35,16 @@ export type Dialect = {
 	 * Unlike {@link formatStrictField}, PORT and similar keys stay as optional
 	 * strings — only `shared` (NODE_ENV) uses a richer type.
 	 *
-	 * @param key Environment variable name.
-	 * @param role Field scope within the codegen layout.
-	 * @returns Field line without leading indentation (trailing comma).
+	 * @param key Environment variable name
+	 * @param role Field scope within the codegen layout
+	 * @param clientPrefix Framework client prefix for preset field lookup
+	 * @returns Field line without leading indentation (trailing comma)
 	 */
-	formatCodegenField(key: string, role: "client" | "server" | "shared"): string;
+	formatCodegenField(
+		key: string,
+		role: "client" | "server" | "shared",
+		clientPrefix?: string,
+	): string;
 
 	/**
 	 * Default field lines for Env-only / vanilla simple schemas when no keys
@@ -39,15 +55,35 @@ export type Dialect = {
 	/**
 	 * Format simple-schema field lines from explicit keys (leading `\t\t`).
 	 *
-	 * @param keys Environment variable keys.
-	 * @returns Joined field lines.
+	 * @param keys Environment variable keys
+	 * @param clientPrefix Framework client prefix for preset field lookup
+	 * @returns Joined field lines
 	 */
-	formatSimpleSchemaFields(keys: string[]): string;
+	formatSimpleSchemaFields(keys: string[], clientPrefix?: string): string;
+
+	/**
+	 * Render an optional string field value (no key, no trailing comma).
+	 *
+	 * Used when compiling {@link PresetField} `string` kinds.
+	 *
+	 * @returns Validator-specific optional string schema fragment
+	 */
+	formatOptionalString(): string;
+
+	/**
+	 * Render an optional enum field value (no key, no trailing comma).
+	 *
+	 * Used when compiling {@link PresetField} `enum` kinds.
+	 *
+	 * @param values Allowed enum members
+	 * @returns Validator-specific optional enum schema fragment
+	 */
+	formatOptionalEnum(values: readonly string[]): string;
 
 	/**
 	 * Default strict-layout fields when no env keys are provided.
 	 *
-	 * @param clientPrefix Framework client prefix (`NEXT_PUBLIC_` / `NUXT_PUBLIC_`).
+	 * @param clientPrefix Framework client prefix (`NEXT_PUBLIC_` / `NUXT_PUBLIC_`)
 	 */
 	getDefaultStrictFields(clientPrefix: string): {
 		serverFields: string[];
@@ -59,7 +95,7 @@ export type Dialect = {
 	/**
 	 * Default codegen-layout field lines (with `\t\t` indent) when no keys.
 	 *
-	 * @param clientPrefix Framework client prefix.
+	 * @param clientPrefix Framework client prefix
 	 */
 	getDefaultCodegenFields(clientPrefix: string): {
 		serverFields: string[];
@@ -73,7 +109,7 @@ export type Dialect = {
 	/**
 	 * Wrap a formatted object literal as the SharedSchema value.
 	 *
-	 * @param schemaObject Object literal from {@link formatSchemaObject}.
+	 * @param schemaObject Object literal from {@link formatSchemaObject}
 	 */
 	wrapSharedSchema(schemaObject: string): string;
 
@@ -86,8 +122,8 @@ export type Dialect = {
 	/**
 	 * Assemble a vanilla (runtime arkenv) single-file template body.
 	 *
-	 * @param schemaFields Field lines with `\t\t` indentation.
-	 * @returns Full file content without trailing newline.
+	 * @param schemaFields Field lines with `\t\t` indentation
+	 * @returns Full file content without trailing newline
 	 */
 	assembleVanilla(schemaFields: string): string;
 
@@ -96,3 +132,40 @@ export type Dialect = {
 	 */
 	pluginEnvImports: string;
 };
+
+/**
+ * Compile a {@link PresetField} into a dialect-specific schema value fragment.
+ *
+ * @param dialect Dialect providing optional string/enum renderers
+ * @param field Preset field metadata
+ * @returns Schema value without key or trailing comma
+ */
+export function formatPresetFieldValue(
+	dialect: Pick<Dialect, "formatOptionalString" | "formatOptionalEnum">,
+	field: PresetField,
+): string {
+	if (field.type === "string") {
+		return dialect.formatOptionalString();
+	}
+	return dialect.formatOptionalEnum(field.values);
+}
+
+/**
+ * Resolve a key to a preset-backed schema value when metadata exists.
+ *
+ * @param dialect Dialect providing optional string/enum renderers
+ * @param key Environment variable name
+ * @param clientPrefix Framework client prefix
+ * @returns Schema value fragment, or `undefined` when the key is not a preset field
+ */
+export function tryFormatPresetFieldValue(
+	dialect: Pick<Dialect, "formatOptionalString" | "formatOptionalEnum">,
+	key: string,
+	clientPrefix: string,
+): string | undefined {
+	const field = lookupPresetField(key, clientPrefix);
+	if (!field) return undefined;
+	return formatPresetFieldValue(dialect, field);
+}
+
+export type { HostPreset };

--- a/packages/arkenv/src/features/scaffold/validators/dialects/valibot.ts
+++ b/packages/arkenv/src/features/scaffold/validators/dialects/valibot.ts
@@ -1,31 +1,53 @@
 import dedent from "dedent";
 import type { Dialect } from "./types";
+import { tryFormatPresetFieldValue } from "./types";
 
 export const valibotDialect: Dialect = {
 	extraImport: `import * as v from "valibot";`,
 
-	formatStrictField(key, role) {
+	formatOptionalString() {
+		return "v.optional(v.string())";
+	},
+
+	formatOptionalEnum(values) {
+		return `v.optional(v.picklist([${values.map((v) => `"${v}"`).join(", ")}]))`;
+	},
+
+	formatStrictField(key, role, clientPrefix = "") {
 		if (role === "shared") {
 			return `${key}: v.optional(v.picklist(["development", "production", "test"]), "development"),`;
 		}
 		if (role === "server" && key === "PORT") {
 			return "PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),";
 		}
+		const preset = tryFormatPresetFieldValue(valibotDialect, key, clientPrefix);
+		if (preset) return `${key}: ${preset},`;
 		return `${key}: v.optional(v.string()),`;
 	},
 
-	formatCodegenField(key, role) {
+	formatCodegenField(key, role, clientPrefix = "") {
 		if (role === "shared") {
 			return `${key}: v.optional(v.picklist(["development", "production", "test"]), "development"),`;
 		}
+		const preset = tryFormatPresetFieldValue(valibotDialect, key, clientPrefix);
+		if (preset) return `${key}: ${preset},`;
 		return `${key}: v.optional(v.string()),`;
 	},
 
 	defaultSimpleSchemaFields: `\t\tNODE_ENV: v.optional(v.picklist(["development", "production", "test"]), "development"),
 		PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),`,
 
-	formatSimpleSchemaFields(keys) {
-		return keys.map((key) => `\t\t${key}: v.optional(v.string()),`).join("\n");
+	formatSimpleSchemaFields(keys, clientPrefix = "") {
+		return keys
+			.map((key) => {
+				const preset = tryFormatPresetFieldValue(
+					valibotDialect,
+					key,
+					clientPrefix,
+				);
+				return `\t\t${key}: ${preset ?? "v.optional(v.string())"},`;
+			})
+			.join("\n");
 	},
 
 	getDefaultStrictFields(clientPrefix) {

--- a/packages/arkenv/src/features/scaffold/validators/dialects/valibot.ts
+++ b/packages/arkenv/src/features/scaffold/validators/dialects/valibot.ts
@@ -13,23 +13,33 @@ export const valibotDialect: Dialect = {
 		return `v.optional(v.picklist([${values.map((v) => `"${v}"`).join(", ")}]))`;
 	},
 
-	formatStrictField(key, role, clientPrefix = "") {
+	formatStrictField(key, role, clientPrefix = "", hostPreset = undefined) {
 		if (role === "shared") {
 			return `${key}: v.optional(v.picklist(["development", "production", "test"]), "development"),`;
 		}
 		if (role === "server" && key === "PORT") {
 			return "PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),";
 		}
-		const preset = tryFormatPresetFieldValue(valibotDialect, key, clientPrefix);
+		const preset = tryFormatPresetFieldValue(
+			valibotDialect,
+			key,
+			clientPrefix,
+			hostPreset,
+		);
 		if (preset) return `${key}: ${preset},`;
 		return `${key}: v.optional(v.string()),`;
 	},
 
-	formatCodegenField(key, role, clientPrefix = "") {
+	formatCodegenField(key, role, clientPrefix = "", hostPreset = undefined) {
 		if (role === "shared") {
 			return `${key}: v.optional(v.picklist(["development", "production", "test"]), "development"),`;
 		}
-		const preset = tryFormatPresetFieldValue(valibotDialect, key, clientPrefix);
+		const preset = tryFormatPresetFieldValue(
+			valibotDialect,
+			key,
+			clientPrefix,
+			hostPreset,
+		);
 		if (preset) return `${key}: ${preset},`;
 		return `${key}: v.optional(v.string()),`;
 	},
@@ -37,13 +47,14 @@ export const valibotDialect: Dialect = {
 	defaultSimpleSchemaFields: `\t\tNODE_ENV: v.optional(v.picklist(["development", "production", "test"]), "development"),
 		PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),`,
 
-	formatSimpleSchemaFields(keys, clientPrefix = "") {
+	formatSimpleSchemaFields(keys, clientPrefix = "", hostPreset = undefined) {
 		return keys
 			.map((key) => {
 				const preset = tryFormatPresetFieldValue(
 					valibotDialect,
 					key,
 					clientPrefix,
+					hostPreset,
 				);
 				return `\t\t${key}: ${preset ?? "v.optional(v.string())"},`;
 			})

--- a/packages/arkenv/src/features/scaffold/validators/dialects/zod.ts
+++ b/packages/arkenv/src/features/scaffold/validators/dialects/zod.ts
@@ -13,23 +13,33 @@ export const zodDialect: Dialect = {
 		return `z.enum([${values.map((v) => `"${v}"`).join(", ")}]).optional()`;
 	},
 
-	formatStrictField(key, role, clientPrefix = "") {
+	formatStrictField(key, role, clientPrefix = "", hostPreset = undefined) {
 		if (role === "shared") {
 			return `${key}: z.enum(["development", "production", "test"]).default("development"),`;
 		}
 		if (role === "server" && key === "PORT") {
 			return "PORT: z.coerce.number().int().min(1).max(65535).default(3000),";
 		}
-		const preset = tryFormatPresetFieldValue(zodDialect, key, clientPrefix);
+		const preset = tryFormatPresetFieldValue(
+			zodDialect,
+			key,
+			clientPrefix,
+			hostPreset,
+		);
 		if (preset) return `${key}: ${preset},`;
 		return `${key}: z.string().optional(),`;
 	},
 
-	formatCodegenField(key, role, clientPrefix = "") {
+	formatCodegenField(key, role, clientPrefix = "", hostPreset = undefined) {
 		if (role === "shared") {
 			return `${key}: z.enum(["development", "production", "test"]).default("development"),`;
 		}
-		const preset = tryFormatPresetFieldValue(zodDialect, key, clientPrefix);
+		const preset = tryFormatPresetFieldValue(
+			zodDialect,
+			key,
+			clientPrefix,
+			hostPreset,
+		);
 		if (preset) return `${key}: ${preset},`;
 		return `${key}: z.string().optional(),`;
 	},
@@ -37,10 +47,15 @@ export const zodDialect: Dialect = {
 	defaultSimpleSchemaFields: `\t\tNODE_ENV: z.enum(["development", "production", "test"]).default("development"),
 		PORT: z.coerce.number().int().min(1).max(65535).default(3000),`,
 
-	formatSimpleSchemaFields(keys, clientPrefix = "") {
+	formatSimpleSchemaFields(keys, clientPrefix = "", hostPreset = undefined) {
 		return keys
 			.map((key) => {
-				const preset = tryFormatPresetFieldValue(zodDialect, key, clientPrefix);
+				const preset = tryFormatPresetFieldValue(
+					zodDialect,
+					key,
+					clientPrefix,
+					hostPreset,
+				);
 				return `\t\t${key}: ${preset ?? "z.string().optional()"},`;
 			})
 			.join("\n");

--- a/packages/arkenv/src/features/scaffold/validators/dialects/zod.ts
+++ b/packages/arkenv/src/features/scaffold/validators/dialects/zod.ts
@@ -1,31 +1,49 @@
 import dedent from "dedent";
 import type { Dialect } from "./types";
+import { tryFormatPresetFieldValue } from "./types";
 
 export const zodDialect: Dialect = {
 	extraImport: `import { z } from "zod";`,
 
-	formatStrictField(key, role) {
+	formatOptionalString() {
+		return "z.string().optional()";
+	},
+
+	formatOptionalEnum(values) {
+		return `z.enum([${values.map((v) => `"${v}"`).join(", ")}]).optional()`;
+	},
+
+	formatStrictField(key, role, clientPrefix = "") {
 		if (role === "shared") {
 			return `${key}: z.enum(["development", "production", "test"]).default("development"),`;
 		}
 		if (role === "server" && key === "PORT") {
 			return "PORT: z.coerce.number().int().min(1).max(65535).default(3000),";
 		}
+		const preset = tryFormatPresetFieldValue(zodDialect, key, clientPrefix);
+		if (preset) return `${key}: ${preset},`;
 		return `${key}: z.string().optional(),`;
 	},
 
-	formatCodegenField(key, role) {
+	formatCodegenField(key, role, clientPrefix = "") {
 		if (role === "shared") {
 			return `${key}: z.enum(["development", "production", "test"]).default("development"),`;
 		}
+		const preset = tryFormatPresetFieldValue(zodDialect, key, clientPrefix);
+		if (preset) return `${key}: ${preset},`;
 		return `${key}: z.string().optional(),`;
 	},
 
 	defaultSimpleSchemaFields: `\t\tNODE_ENV: z.enum(["development", "production", "test"]).default("development"),
 		PORT: z.coerce.number().int().min(1).max(65535).default(3000),`,
 
-	formatSimpleSchemaFields(keys) {
-		return keys.map((key) => `\t\t${key}: z.string().optional(),`).join("\n");
+	formatSimpleSchemaFields(keys, clientPrefix = "") {
+		return keys
+			.map((key) => {
+				const preset = tryFormatPresetFieldValue(zodDialect, key, clientPrefix);
+				return `\t\t${key}: ${preset ?? "z.string().optional()"},`;
+			})
+			.join("\n");
 	},
 
 	getDefaultStrictFields(clientPrefix) {

--- a/packages/arkenv/src/shared/ports/prompt.port.ts
+++ b/packages/arkenv/src/shared/ports/prompt.port.ts
@@ -22,7 +22,7 @@ export type PromptPort = {
 		defaults?: Partial<
 			Pick<
 				ProjectOptions,
-				"mode" | "example" | "name" | "framework" | "bunFeatures"
+				"mode" | "example" | "name" | "framework" | "bunFeatures" | "hostPreset"
 			>
 		> & {
 			examples?: Example[];


### PR DESCRIPTION
Fixes #1322

## Summary
- Forward-port hosting presets from #1288 onto `v1` with behavioral parity: interactive None/Vercel/Netlify step and `--host-preset`
- Keep `PRESETS` as host semantics only; render `string`/`enum` fields through validator dialects
- Prefix client-exposed keys via framework strategy `clientPrefix` (no parallel `getFrameworkPrefix`)
- Merge preset keys into schema + `.env` / `.env.example` without replacing framework defaults
- Derive `HostPreset` from `PRESETS` (+ `"none"`); add ADR 0018 and an `arkenv` minor changeset

## Test plan
- [ ] `pnpm --filter arkenv test:run` (CLI flag, wizard, planner, dialect/preset paths)
- [ ] Interactive `arkenv init` shows hosting preset step after validator
- [ ] `arkenv init --host-preset vercel` injects Vercel keys with framework prefixes
- [ ] Invalid `--host-preset` values are rejected; help lists the flag


Made with [Cursor](https://cursor.com)