### PR TITLE
feat: (v1) Forward-port machine-actionable error codes from #1325

### DIFF
--- a/.changeset/machine-actionable-error-codes.md
+++ b/.changeset/machine-actionable-error-codes.md
@@ -1,0 +1,25 @@
+---
+"arkenv": patch
+---
+
+#### Add machine-actionable error codes to `init` JSON output
+
+In `--json` / `--agent` mode, every deliberate safety-check refusal now emits a stable, documented error `code` alongside a `retryWith` hint, so agents no longer have to pattern-match on prose to decide how to escalate. Human-readable (non-JSON) output is unchanged.
+
+- **`REQUIREMENTS_NOT_MET`** — a technical requirement failed. Includes per-requirement `details` with `current`/`expected`. `retryWith: ["--force"]`.
+- **`GIT_TREE_DIRTY`** — the git working tree is not clean. `retryWith: ["--force"]`.
+- **`NON_EMPTY_DIR`** — the target directory is not empty. `retryWith: ["--force"]`.
+- **`INTERNAL`** — an unexpected failure (the CLI broke rather than refused). `retryWith: []`.
+
+An empty `retryWith` means the refusal cannot be bypassed; a non-empty `retryWith` names the flag(s) to re-run with. Escalation pattern: run without `--force`, inspect `code`/`retryWith`, then retry deliberately.
+
+Example refusal payload written to `stdout`:
+
+```json
+{
+  "status": "error",
+  "code": "GIT_TREE_DIRTY",
+  "message": "Git working tree is not clean.",
+  "retryWith": ["--force"]
+}
+```

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -42,7 +42,7 @@ In `--json` mode (implied by `--agent`), the CLI writes a single structured JSON
 object to `stdout`. All human-oriented logs go to `stderr`, so `stdout` is safe to
 parse. The `status` field tells you what happened:
 
-| `status`      | Meaning                                                             |
+| `status`      | Meaning                                                            |
 | ------------- | ------------------------------------------------------------------ |
 | `"success"`   | Initialization completed. `details` describes what was scaffolded. |
 | `"cancelled"` | The operation was cancelled (e.g. an interrupt signal).            |
@@ -79,12 +79,12 @@ Every `"error"` payload is machine-actionable and shaped as follows:
 
 The `code` values are:
 
-| `code`                 | When it happens                                        | `retryWith`  |
-| ---------------------- | ------------------------------------------------------ | ------------ |
+| `code`                 | When it happens                                        | `retryWith`   |
+| ---------------------- | ------------------------------------------------------ | ------------- |
 | `REQUIREMENTS_NOT_MET` | A technical requirement (e.g. Node.js version) failed. | `["--force"]` |
 | `GIT_TREE_DIRTY`       | The git working tree has uncommitted changes.          | `["--force"]` |
 | `NON_EMPTY_DIR`        | The target directory is not empty and unsafe to touch. | `["--force"]` |
-| `INTERNAL`             | An unexpected failure — the CLI broke, not refused.    | `[]`         |
+| `INTERNAL`             | An unexpected failure — the CLI broke, not refused.    | `[]`          |
 
 A non-empty `retryWith` means the CLI *deliberately refused*; a `code` of
 `INTERNAL` means the CLI *broke* and retrying with flags will not help.

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -35,3 +35,63 @@ Configure the CLI behavior using the following command-line flags:
 | `--force`      | `-f`  | Bypass checks and force initialization.                                                                                                          |
 | `--no-codegen` | `-C`  | Disable automatic env.gen.ts code generation for Next.js (falls back to manual runtimeEnv destructuring).                                        |
 | `--help`       | `-h`  | Display the CLI help information.                                                                                                                |
+
+## Machine-readable output
+
+In `--json` mode (implied by `--agent`), the CLI writes a single structured JSON
+object to `stdout`. All human-oriented logs go to `stderr`, so `stdout` is safe to
+parse. The `status` field tells you what happened:
+
+| `status`      | Meaning                                                             |
+| ------------- | ------------------------------------------------------------------ |
+| `"success"`   | Initialization completed. `details` describes what was scaffolded. |
+| `"cancelled"` | The operation was cancelled (e.g. an interrupt signal).            |
+| `"error"`     | The CLI refused to proceed, or an unexpected failure occurred.     |
+
+### Error payloads
+
+Every `"error"` payload is machine-actionable and shaped as follows:
+
+```json
+{
+  "status": "error",
+  "code": "REQUIREMENTS_NOT_MET",
+  "message": "Technical requirements not met.",
+  "retryWith": ["--force"],
+  "details": {
+    "requirements": [
+      {
+        "requirement": "Node.js Version",
+        "message": "Node.js version must be >= 22.0.0",
+        "current": "20.0.0",
+        "expected": ">= 22.0.0"
+      }
+    ]
+  }
+}
+```
+
+- **`code`** — a stable identifier for the failure. Treat it as a public contract:
+  it will not be renamed casually, so you can safely branch on it.
+- **`retryWith`** — the flag(s) that would bypass the check if you re-run the
+  command. Empty (`[]`) when the failure is not bypassable.
+- **`details`** — optional structured context for reporting the problem.
+
+The `code` values are:
+
+| `code`                 | When it happens                                        | `retryWith`  |
+| ---------------------- | ------------------------------------------------------ | ------------ |
+| `REQUIREMENTS_NOT_MET` | A technical requirement (e.g. Node.js version) failed. | `["--force"]` |
+| `GIT_TREE_DIRTY`       | The git working tree has uncommitted changes.          | `["--force"]` |
+| `NON_EMPTY_DIR`        | The target directory is not empty and unsafe to touch. | `["--force"]` |
+| `INTERNAL`             | An unexpected failure — the CLI broke, not refused.    | `[]`         |
+
+A non-empty `retryWith` means the CLI *deliberately refused*; a `code` of
+`INTERNAL` means the CLI *broke* and retrying with flags will not help.
+
+:::warning
+`--agent` never implies `--force`. This is intentional: an agent must escalate
+deliberately. The recommended pattern is to run the command **without** `--force`
+first, inspect the `code` and `retryWith` fields, and only re-run with the
+suggested flag(s) once you have decided the refusal is safe to bypass.
+:::

--- a/packages/arkenv/src/adapters/logger.adapter.ts
+++ b/packages/arkenv/src/adapters/logger.adapter.ts
@@ -1,3 +1,4 @@
+import type { Refusal } from "@/shared/errors";
 import type { LoggerPort } from "@/shared/ports";
 import {
 	JsonReporter,
@@ -96,6 +97,10 @@ export class Logger implements LoggerPort {
 
 	fatal(message: string, error?: unknown): never {
 		this.reporter.fatal(message, error);
+	}
+
+	refuse(refusal: Refusal) {
+		this.reporter.refuse(refusal);
 	}
 
 	finish(message: string, details?: Record<string, unknown>) {

--- a/packages/arkenv/src/adapters/reporters.test.ts
+++ b/packages/arkenv/src/adapters/reporters.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ERROR_CODES } from "@/shared/errors";
 import {
 	JsonReporter,
 	MemoryReporter,
@@ -82,6 +83,16 @@ describe("Reporters", () => {
 				expect.stringContaining("✘ fatal error"),
 			);
 		});
+
+		it("refuse is a no-op for human output (no stdout/stderr writes)", () => {
+			reporter.refuse({
+				code: ERROR_CODES.GIT_TREE_DIRTY,
+				message: "Git working tree is not clean.",
+				retryWith: ["--force"],
+			});
+			expect(stdoutSpy).not.toHaveBeenCalled();
+			expect(stderrSpy).not.toHaveBeenCalled();
+		});
 	});
 
 	describe("JsonReporter", () => {
@@ -114,6 +125,71 @@ describe("Reporters", () => {
 			expect(stdoutSpy).toHaveBeenCalledWith(
 				expect.stringContaining('"message": "fatal error"'),
 			);
+		});
+
+		it("fatal carries the generic INTERNAL code and empty retryWith", () => {
+			expect(() => reporter.fatal("boom", new Error("kaboom"))).toThrow(
+				"kaboom",
+			);
+			const payload = JSON.parse(stdoutSpy.mock.calls.at(-1)?.[0] as string);
+			expect(payload).toEqual({
+				status: "error",
+				code: ERROR_CODES.INTERNAL,
+				message: "boom",
+				retryWith: [],
+				details: { error: "kaboom" },
+			});
+		});
+
+		it("refuse logs a structured, coded error payload to stdout", () => {
+			reporter.refuse({
+				code: ERROR_CODES.REQUIREMENTS_NOT_MET,
+				message: "Technical requirements not met.",
+				retryWith: ["--force"],
+				details: {
+					requirements: [
+						{
+							requirement: "Node.js Version",
+							message: "Node.js version must be >= 22.0.0",
+							current: "20.0.0",
+							expected: ">= 22.0.0",
+						},
+					],
+				},
+			});
+			const payload = JSON.parse(stdoutSpy.mock.calls.at(-1)?.[0] as string);
+			expect(payload).toEqual({
+				status: "error",
+				code: ERROR_CODES.REQUIREMENTS_NOT_MET,
+				message: "Technical requirements not met.",
+				retryWith: ["--force"],
+				details: {
+					requirements: [
+						{
+							requirement: "Node.js Version",
+							message: "Node.js version must be >= 22.0.0",
+							current: "20.0.0",
+							expected: ">= 22.0.0",
+						},
+					],
+				},
+			});
+		});
+
+		it("refuse omits details when none are provided", () => {
+			reporter.refuse({
+				code: ERROR_CODES.GIT_TREE_DIRTY,
+				message: "Git working tree is not clean.",
+				retryWith: ["--force"],
+			});
+			const payload = JSON.parse(stdoutSpy.mock.calls.at(-1)?.[0] as string);
+			expect(payload).toEqual({
+				status: "error",
+				code: ERROR_CODES.GIT_TREE_DIRTY,
+				message: "Git working tree is not clean.",
+				retryWith: ["--force"],
+			});
+			expect(payload).not.toHaveProperty("details");
 		});
 
 		it("cancel logs json to stdout", () => {
@@ -173,6 +249,22 @@ describe("Reporters", () => {
 				type: "json",
 				message: JSON.stringify({ foo: "bar" }),
 				data: { foo: "bar" },
+			});
+		});
+
+		it("records refusals with their structured payload", () => {
+			const refusal = {
+				code: ERROR_CODES.NON_EMPTY_DIR,
+				message: "Directory is not empty and no package.json was found.",
+				retryWith: ["--force"],
+			};
+			reporter.refuse(refusal);
+
+			expect(reporter.logs).toHaveLength(1);
+			expect(reporter.logs[0]).toEqual({
+				type: "refuse",
+				message: refusal.message,
+				data: refusal,
 			});
 		});
 	});

--- a/packages/arkenv/src/adapters/reporters/json.reporter.ts
+++ b/packages/arkenv/src/adapters/reporters/json.reporter.ts
@@ -81,9 +81,7 @@ export class JsonReporter implements Reporter {
 			code: refusal.code,
 			message: refusal.message,
 			retryWith: refusal.retryWith,
-			...(refusal.details !== undefined
-				? { details: refusal.details }
-				: {}),
+			...(refusal.details !== undefined ? { details: refusal.details } : {}),
 		});
 	}
 

--- a/packages/arkenv/src/adapters/reporters/json.reporter.ts
+++ b/packages/arkenv/src/adapters/reporters/json.reporter.ts
@@ -1,4 +1,5 @@
 import pc from "picocolors";
+import { ERROR_CODES, type Refusal } from "@/shared/errors";
 import type { Reporter, Spinner } from "./types";
 
 /**
@@ -58,19 +59,32 @@ export class JsonReporter implements Reporter {
 	}
 
 	fatal(message: string, error?: unknown): never {
+		const errorText =
+			error instanceof Error
+				? error.message
+				: error
+					? String(error)
+					: undefined;
 		this.json({
 			status: "error",
-			details: {
-				message,
-				error:
-					error instanceof Error
-						? error.message
-						: error
-							? String(error)
-							: undefined,
-			},
+			code: ERROR_CODES.INTERNAL,
+			message,
+			retryWith: [],
+			...(errorText !== undefined ? { details: { error: errorText } } : {}),
 		});
 		throw error instanceof Error ? error : new Error(message);
+	}
+
+	refuse(refusal: Refusal) {
+		this.json({
+			status: "error",
+			code: refusal.code,
+			message: refusal.message,
+			retryWith: refusal.retryWith,
+			...(refusal.details !== undefined
+				? { details: refusal.details }
+				: {}),
+		});
 	}
 
 	finish(message: string, details?: Record<string, unknown>) {

--- a/packages/arkenv/src/adapters/reporters/memory.reporter.ts
+++ b/packages/arkenv/src/adapters/reporters/memory.reporter.ts
@@ -1,3 +1,4 @@
+import type { Refusal } from "@/shared/errors";
 import type { Reporter, Spinner } from "./types";
 
 /**
@@ -54,6 +55,14 @@ export class MemoryReporter implements Reporter {
 	fatal(message: string, error?: unknown): never {
 		this.logs.push({ type: "fatal", message, data: error });
 		throw error instanceof Error ? error : new Error(message);
+	}
+
+	refuse(refusal: Refusal) {
+		this.logs.push({
+			type: "refuse",
+			message: refusal.message,
+			data: refusal,
+		});
 	}
 
 	finish(message: string, details?: Record<string, unknown>) {

--- a/packages/arkenv/src/adapters/reporters/silent.reporter.ts
+++ b/packages/arkenv/src/adapters/reporters/silent.reporter.ts
@@ -1,3 +1,4 @@
+import type { Refusal } from "@/shared/errors";
 import type { Reporter, Spinner } from "./types";
 
 /**
@@ -45,6 +46,8 @@ export class SilentReporter implements Reporter {
 		}
 		throw error instanceof Error ? error : new Error(message);
 	}
+
+	refuse(_refusal: Refusal) {}
 
 	finish(_message: string, _details?: Record<string, unknown>) {}
 

--- a/packages/arkenv/src/adapters/reporters/text.reporter.ts
+++ b/packages/arkenv/src/adapters/reporters/text.reporter.ts
@@ -1,5 +1,6 @@
 import { spinner as clackSpinner, note, outro } from "@clack/prompts";
 import pc from "picocolors";
+import type { Refusal } from "@/shared/errors";
 import type { Reporter, Spinner } from "./types";
 
 /**
@@ -54,6 +55,11 @@ export class TextReporter implements Reporter {
 			process.stderr.write(detail);
 		}
 		throw error instanceof Error ? error : new Error(message);
+	}
+
+	refuse(_refusal: Refusal) {
+		// Human-oriented refusal guidance is emitted via error()/info();
+		// the structured payload is reserved for JSON output.
 	}
 
 	finish(message: string, _details?: Record<string, unknown>) {

--- a/packages/arkenv/src/adapters/reporters/types.ts
+++ b/packages/arkenv/src/adapters/reporters/types.ts
@@ -1,3 +1,5 @@
+import type { Refusal } from "@/shared/errors";
+
 /**
  * Defines a long-running progress indicator.
  */
@@ -22,6 +24,15 @@ export type Reporter = {
 	json(data: unknown): void;
 	cancel(message: string): void;
 	fatal(message: string, error?: unknown): never;
+	/**
+	 * Reports a deliberate, machine-readable refusal (a tripped safety check).
+	 *
+	 * In JSON mode this emits a structured `status: "error"` payload carrying the
+	 * refusal's stable `code` and `retryWith` hint to `stdout`; human-oriented
+	 * reporters treat it as a no-op since the equivalent guidance is already
+	 * surfaced via {@link Reporter.error}/{@link Reporter.info}.
+	 */
+	refuse(refusal: Refusal): void;
 	finish(message: string, details?: Record<string, unknown>): void;
 	flush(): Promise<void>;
 };

--- a/packages/arkenv/src/cli/commands/init.test.ts
+++ b/packages/arkenv/src/cli/commands/init.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ERROR_CODES } from "@/shared/errors";
 import type {
 	LoggerPort,
 	ProjectScannerPort,
@@ -20,6 +21,7 @@ describe("InitUseCase", () => {
 			warn: vi.fn(),
 			error: vi.fn(),
 			fatal: vi.fn(),
+			refuse: vi.fn(),
 			step: vi.fn(),
 			success: vi.fn(),
 			cancel: vi.fn(),
@@ -113,6 +115,12 @@ describe("InitUseCase", () => {
 		);
 		expect(logger.info).toHaveBeenCalledWith(
 			expect.stringContaining("--force"),
+		);
+		expect(logger.refuse).toHaveBeenCalledWith(
+			expect.objectContaining({
+				code: ERROR_CODES.NON_EMPTY_DIR,
+				retryWith: ["--force"],
+			}),
 		);
 	});
 
@@ -221,6 +229,12 @@ describe("InitUseCase", () => {
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.stringContaining("Cannot scaffold into"),
 		);
+		expect(logger.refuse).toHaveBeenCalledWith(
+			expect.objectContaining({
+				code: ERROR_CODES.NON_EMPTY_DIR,
+				retryWith: ["--force"],
+			}),
+		);
 	});
 
 	it("should allow scaffolding when --example, project-name '.', and --force are used in a non-empty directory", async () => {
@@ -275,6 +289,21 @@ describe("InitUseCase", () => {
 		expect(logger.info).toHaveBeenCalledWith(
 			"Use --force to bypass these checks.",
 		);
+		expect(logger.refuse).toHaveBeenCalledWith({
+			code: ERROR_CODES.REQUIREMENTS_NOT_MET,
+			message: "Technical requirements not met.",
+			retryWith: ["--force"],
+			details: {
+				requirements: [
+					{
+						requirement: "Node.js Version",
+						message: "Node.js version must be >= 22.0.0",
+						current: "20.0.0",
+						expected: ">= 22.0.0",
+					},
+				],
+			},
+		});
 	});
 
 	it("should continue if requirements fail but --force is used", async () => {
@@ -303,6 +332,7 @@ describe("InitUseCase", () => {
 		expect(logger.warn).toHaveBeenCalledWith(
 			"Technical requirements not met, but continuing due to --force flag.",
 		);
+		expect(logger.refuse).not.toHaveBeenCalled();
 	});
 
 	it("should display warnings if requirements have warnings", async () => {
@@ -426,6 +456,11 @@ describe("InitUseCase", () => {
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.stringContaining("Git working tree is not clean"),
 		);
+		expect(logger.refuse).toHaveBeenCalledWith({
+			code: ERROR_CODES.GIT_TREE_DIRTY,
+			message: "Git working tree is not clean.",
+			retryWith: ["--force"],
+		});
 	});
 
 	it("should continue with a warning when git working tree is dirty and --force is set", async () => {
@@ -450,6 +485,7 @@ describe("InitUseCase", () => {
 		expect(logger.warn).toHaveBeenCalledWith(
 			expect.stringContaining("Git working tree is not clean"),
 		);
+		expect(logger.refuse).not.toHaveBeenCalled();
 	});
 
 	it("should proceed normally when git status is not_a_repo", async () => {

--- a/packages/arkenv/src/cli/commands/init.ts
+++ b/packages/arkenv/src/cli/commands/init.ts
@@ -9,6 +9,7 @@ import {
 } from "@/features/scaffold";
 import type { HostPreset } from "@/features/scaffold/presets";
 import { RegistryClient } from "@/shared/clients";
+import { ERROR_CODES } from "@/shared/errors";
 import type {
 	LoggerPort,
 	ProjectScannerPort,
@@ -119,6 +120,11 @@ export class InitUseCase {
 			this.logger.info(
 				`To scaffold a new project, run ${code("arkenv init")} in an empty directory or use ${code("--force")} to proceed anyway.`,
 			);
+			this.logger.refuse({
+				code: ERROR_CODES.NON_EMPTY_DIR,
+				message: "Directory is not empty and no package.json was found.",
+				retryWith: ["--force"],
+			});
 			return null;
 		} finally {
 			this.logger.interactiveStdout(false);
@@ -158,6 +164,21 @@ export class InitUseCase {
 					);
 				}
 				this.logger.info("Use --force to bypass these checks.");
+				this.logger.refuse({
+					code: ERROR_CODES.REQUIREMENTS_NOT_MET,
+					message: "Technical requirements not met.",
+					retryWith: ["--force"],
+					details: {
+						requirements: failures.map((fail) =>
+							shake({
+								requirement: fail.requirement,
+								message: fail.message,
+								current: fail.current,
+								expected: fail.expected,
+							}),
+						),
+					},
+				});
 				return null;
 			}
 		}
@@ -173,6 +194,11 @@ export class InitUseCase {
 					"Git working tree is not clean. Commit or stash your changes (use 'git stash -u' for untracked files) before running arkenv init.",
 				);
 				this.logger.info("Use --force to bypass this check.");
+				this.logger.refuse({
+					code: ERROR_CODES.GIT_TREE_DIRTY,
+					message: "Git working tree is not clean.",
+					retryWith: ["--force"],
+				});
 				return null;
 			}
 		}
@@ -483,6 +509,12 @@ export class InitUseCase {
 			this.logger.info(
 				`Run ${code("arkenv init")} in an empty directory or choose a sub-directory name instead.`,
 			);
+			this.logger.refuse({
+				code: ERROR_CODES.NON_EMPTY_DIR,
+				message:
+					"Cannot scaffold into the current directory because it is not empty.",
+				retryWith: ["--force"],
+			});
 			return null;
 		}
 

--- a/packages/arkenv/src/features/scaffold/executor.test.ts
+++ b/packages/arkenv/src/features/scaffold/executor.test.ts
@@ -61,6 +61,7 @@ describe("Executor", () => {
 		fatal: vi.fn(() => {
 			throw new Error("fatal");
 		}),
+		refuse: vi.fn(),
 		finish: vi.fn(),
 		flush: vi.fn().mockResolvedValue(undefined),
 	};

--- a/packages/arkenv/src/shared/errors.ts
+++ b/packages/arkenv/src/shared/errors.ts
@@ -1,0 +1,50 @@
+/**
+ * Stable, machine-actionable error codes emitted in the CLI's JSON output
+ * (`--json` / `--agent` mode).
+ *
+ * These codes are part of the CLI's **public contract**: consumers such as AI
+ * agents and scripts may branch on them to decide how to escalate, so they must
+ * never be renamed casually. Codes fall into two groups:
+ *
+ * - **Refusals** — deliberate safety-check refusals. When bypassable, the emitted
+ *   payload includes a `retryWith` array naming the flag(s) that would proceed
+ *   anyway (e.g. `["--force"]`).
+ * - **`INTERNAL`** — an unexpected failure (the CLI *broke* rather than *refused*).
+ *   This lets consumers distinguish a deliberate refusal from a crash.
+ */
+export const ERROR_CODES = {
+	/** Technical requirements (e.g. Node.js version) were not met. Bypassable with `--force`. */
+	REQUIREMENTS_NOT_MET: "REQUIREMENTS_NOT_MET",
+	/** The git working tree is not clean. Bypassable with `--force`. */
+	GIT_TREE_DIRTY: "GIT_TREE_DIRTY",
+	/** The target directory is not empty (and holds no `package.json`). Bypassable with `--force`. */
+	NON_EMPTY_DIR: "NON_EMPTY_DIR",
+	/** An unexpected, internal failure. Not a deliberate refusal and not bypassable. */
+	INTERNAL: "INTERNAL",
+} as const;
+
+/**
+ * One of the stable {@link ERROR_CODES} string values.
+ */
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
+
+/**
+ * A deliberate, machine-readable refusal emitted when a safety check trips.
+ *
+ * Refusals are distinct from unexpected failures: they carry a stable {@link ErrorCode}
+ * and a `retryWith` hint so a calling agent can decide whether (and how) to escalate
+ * without pattern-matching on human-oriented prose.
+ */
+export type Refusal = {
+	/** Stable, documented code identifying the refusal reason. */
+	code: ErrorCode;
+	/** Human-readable summary of what was refused. */
+	message: string;
+	/**
+	 * Flags that would bypass the check when re-run (e.g. `["--force"]`).
+	 * Empty when the refusal cannot be bypassed.
+	 */
+	retryWith: string[];
+	/** Structured detail sufficient for a consumer to report the problem. */
+	details?: Record<string, unknown>;
+};

--- a/packages/arkenv/src/shared/ports/logger.port.ts
+++ b/packages/arkenv/src/shared/ports/logger.port.ts
@@ -1,3 +1,5 @@
+import type { Refusal } from "@/shared/errors";
+
 /**
  * Represents a CLI spinner for long-running tasks.
  */
@@ -23,6 +25,11 @@ export type LoggerPort = {
 	json(data: unknown): void;
 	cancel(message: string): void;
 	fatal(message: string, error?: unknown): never;
+	/**
+	 * Reports a deliberate, machine-readable refusal (a tripped safety check).
+	 * Emits structured JSON in `--json`/`--agent` mode; a no-op for human output.
+	 */
+	refuse(refusal: Refusal): void;
 	finish(message: string, details?: Record<string, unknown>): void;
 	flush(): Promise<void>;
 	interactiveStdout(enable: boolean): void;

--- a/skills/arkenv/SKILL.md
+++ b/skills/arkenv/SKILL.md
@@ -42,6 +42,24 @@ AI agents SHOULD always use the CLI for project initialization to ensure consist
   - **`--json`**: Emits a structured JSON summary to `stdout` upon completion (all other output is sent to `stderr`).
 - **Success Verification**: Parse the JSON output to verify `status: "success"` and retrieve details like the scaffolded file path.
 
+#### Handling refusals (`status: "error"`)
+
+`--agent` **never** implies `--force`. When a safety check trips, the CLI refuses and emits a machine-actionable JSON payload to `stdout`:
+
+```json
+{
+  "status": "error",
+  "code": "GIT_TREE_DIRTY",
+  "message": "Git working tree is not clean.",
+  "retryWith": ["--force"]
+}
+```
+
+- **`code`**: a stable identifier you can branch on. Refusal codes: `REQUIREMENTS_NOT_MET`, `GIT_TREE_DIRTY`, `NON_EMPTY_DIR`. A `code` of `INTERNAL` means the CLI *broke* rather than *refused* — retrying with flags will not help.
+- **`retryWith`**: the flag(s) that would bypass the check (e.g. `["--force"]`). Empty (`[]`) means the refusal is not bypassable.
+
+**Escalation pattern**: always run `init --agent` **without** `--force` first. If you get `status: "error"`, inspect `code` and `retryWith`. Only re-run with the flag(s) from `retryWith` (e.g. append `--force`) once you have deliberately decided the refusal is safe to bypass — do not add `--force` pre-emptively.
+
 ## Operational logic
 
 1. **Detection**:


### PR DESCRIPTION
Forward-ports the machine-actionable error codes work from dev PR #1325 (issue #1313) onto the `v1` branch, re-implemented at the v1 package layout (`packages/arkenv/src/**`, package `arkenv`).

## Summary

In `--json` / `--agent` mode, every deliberate `init` safety-check refusal now emits a stable, documented error `code` alongside a `retryWith` hint on `stdout`, so agents can escalate deliberately instead of pattern-matching prose. Human-readable (`stderr`) output is unchanged.

## Error codes (public contract)

| `code` | When | `retryWith` |
| --- | --- | --- |
| `REQUIREMENTS_NOT_MET` | A technical requirement failed (includes per-requirement `details` with `current`/`expected`) | `["--force"]` |
| `GIT_TREE_DIRTY` | The git working tree is not clean | `["--force"]` |
| `NON_EMPTY_DIR` | The target directory is not empty | `["--force"]` |
| `INTERNAL` | An unexpected failure — the CLI *broke* rather than *refused* | `[]` |

## Forward-port notes

- Adapted paths: dev `packages/cli/src/**` → v1 `packages/arkenv/src/**`.
- Changeset renamed from `"@arkenv/cli"` to `"arkenv"` (v1 package name).
- Skill command left as v1's `pnpm dlx arkenv@latest`.
- No dev-only structure introduced; `@repo/log` (v1 injectable-logging helpers) is unrelated to this reporter change and untouched.

## Verification

- `arkenv` typecheck passes (via turbo, with internal deps built).
- All 309 `arkenv` package tests pass; new tests assert the exact JSON shape for each refusal path.
- Verified end-to-end against the built v1 CLI (`NON_EMPTY_DIR` refusal emits the structured payload on `stdout`).

Ports #1325 · relates to #1313

Made with [Cursor](https://cursor.com)