### PR TITLE
docs: document supported validators in the README and GitHub repo metadata

### DIFF
--- a/.changeset/document-supported-validators.md
+++ b/.changeset/document-supported-validators.md
@@ -1,0 +1,7 @@
+---
+"arkenv": patch
+---
+
+#### Document supported validators in the README
+
+Surface first-class multi-validator support near the top of the README. Name ArkType, Zod, and Valibot, state that any [Standard Schema](https://arkenv.js.org/docs/arkenv/integrations/standard-schema) validator works, and link to the [coercion docs](https://arkenv.js.org/docs/arkenv/coercion) for the full-parity tier (coercion + `.env.example` extraction) available to Standard JSON Schema validators.

--- a/.changeset/document-supported-validators.md
+++ b/.changeset/document-supported-validators.md
@@ -1,7 +1,0 @@
----
-"arkenv": patch
----
-
-#### Document supported validators in the README
-
-Surface first-class multi-validator support near the top of the README. Name ArkType, Zod, and Valibot, state that any [Standard Schema](https://arkenv.js.org/docs/arkenv/integrations/standard-schema) validator works, and link to the [coercion docs](https://arkenv.js.org/docs/arkenv/coercion) for the full-parity tier (coercion + `.env.example` extraction) available to Standard JSON Schema validators.

--- a/packages/arkenv/README.md
+++ b/packages/arkenv/README.md
@@ -5,6 +5,9 @@
     <p align="center">
       Environment variable validation from editor to runtime<br/> for <a href="https://nextjs.org/">Next.js</a>, <a href="https://nuxt.com/">Nuxt</a>, <a href="https://nodejs.org/">Node.js</a>, <a href="https://vite.dev/">Vite</a>, and <a href="https://bun.com/">Bun</a>
     </p>
+    <p align="center">
+      Bring your own validator — <a href="https://arktype.io/">ArkType</a>, <a href="https://zod.dev/">Zod</a>, <a href="https://valibot.dev/">Valibot</a>, or <a href="https://arkenv.js.org/docs/arkenv/integrations/standard-schema">any Standard Schema validator</a>,<br/> with <a href="https://arkenv.js.org/docs/arkenv/coercion">full parity</a> (coercion + <code>.env.example</code>) for Standard JSON Schema validators
+    </p>
     <a href="https://github.com/yamcodes/arkenv/actions/workflows/test.yml?query=branch%3Amain"><img alt="Test Status" src="https://github.com/yamcodes/arkenv/actions/workflows/tests-badge.yml/badge.svg?branch=main"></a>
     <a href="https://bundlephobia.com/package/arkenv"><img alt="npm bundle size" src="https://img.shields.io/bundlephobia/minzip/arkenv"></a>
     <a href="https://arktype.io/docs/ecosystem#arkenv"><img alt="ArkType Ecosystem" src="https://custom-icon-badges.demolab.com/badge/ArkType%20Ecosystem-0d1526?logo=arktype2&logoColor=e9eef9"></a>

--- a/packages/arkenv/README.md
+++ b/packages/arkenv/README.md
@@ -3,10 +3,7 @@
   <h1 align="center">ArkEnv</h1>
   <div align="center">
     <p align="center">
-      Environment variable validation from editor to runtime<br/> for <a href="https://nextjs.org/">Next.js</a>, <a href="https://nuxt.com/">Nuxt</a>, <a href="https://nodejs.org/">Node.js</a>, <a href="https://vite.dev/">Vite</a>, and <a href="https://bun.com/">Bun</a>
-    </p>
-    <p align="center">
-      Bring your own validator — <a href="https://arktype.io/">ArkType</a>, <a href="https://zod.dev/">Zod</a>, <a href="https://valibot.dev/">Valibot</a>, or <a href="https://arkenv.js.org/docs/arkenv/integrations/standard-schema">any Standard Schema validator</a>,<br/> with <a href="https://arkenv.js.org/docs/arkenv/coercion">full parity</a> (coercion + <code>.env.example</code>) for Standard JSON Schema validators
+      Validate environment variables with your favorite validator <br/> on <a href="https://nextjs.org/">Next.js</a>, <a href="https://nuxt.com/">Nuxt</a>, <a href="https://nodejs.org/">Node.js</a>, <a href="https://vite.dev/">Vite</a>, and <a href="https://bun.com/">Bun</a>
     </p>
     <a href="https://github.com/yamcodes/arkenv/actions/workflows/test.yml?query=branch%3Amain"><img alt="Test Status" src="https://github.com/yamcodes/arkenv/actions/workflows/tests-badge.yml/badge.svg?branch=main"></a>
     <a href="https://bundlephobia.com/package/arkenv"><img alt="npm bundle size" src="https://img.shields.io/bundlephobia/minzip/arkenv"></a>
@@ -17,12 +14,20 @@
 
 <div align="center">
   <a href="https://arkenv.js.org/docs/arkenv">Docs</a>
-  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <span>&nbsp;&nbsp;⛯&nbsp;&nbsp;</span>
   <a href="https://arkenv.js.org/docs/arkenv/faq">FAQ</a>
-  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <span>&nbsp;&nbsp;⛯&nbsp;&nbsp;</span>
   <a href="https://stackblitz.com/github/yamcodes/arkenv/tree/main/examples/stackblitz?file=index.ts">Try on StackBlitz</a>
   <br />
 </div>
+
+<br />
+<br />
+
+
+<h3 align="center">
+  Bring your own validator: <a href="https://arktype.io/">ArkType</a>, <a href="https://zod.dev/">Zod</a>, <a href="https://valibot.dev/">Valibot</a>, or <a href="https://arkenv.js.org/docs/arkenv/integrations/standard-schema">any Standard Schema validator</a>
+</h3>
 
 <br />
 <br />


### PR DESCRIPTION
Fixes #1337

## What changed

### README (`packages/arkenv/README.md`, symlinked as root `README.md`)
- Added a concise **prose line** directly below the top framework list surfacing first-class multi-validator support (no new badge rows; existing "ArkType Ecosystem" badge kept).
- Names **ArkType, Zod, and Valibot**, states **any Standard Schema validator** works, and conveys the two-tier model in one sentence:
  - **Tier A** — any [Standard Schema](https://arkenv.js.org/docs/arkenv/integrations/standard-schema) validator gets validation + type inference.
  - **Tier B** — validators also implementing Standard JSON Schema get [full parity](https://arkenv.js.org/docs/arkenv/coercion) (automatic coercion + `.env.example` extraction).
- Links to docs rather than restating version numbers, to avoid drift.

### GitHub repo metadata (via `gh repo edit`)
- Updated repo **description** to mention multi-validator support.
- Added topics `standard-schema`, `zod`, `valibot`, `arktype` (existing topics preserved).

## Validation
- `pnpm run typecheck` ✅
- `pnpm run test` ✅ (776 passed)
- `pnpm run fix` ✅