### PR TITLE
docs: (v1) document supported validators in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h1 align="center">ArkEnv</h1>
   <div align="center">
     <p align="center">
-      Environment variable validation from editor to runtime<br/> for <a href="https://nextjs.org/">Next.js</a>, <a href="https://nuxt.com/">Nuxt</a>, <a href="https://nodejs.org/">Node.js</a>, <a href="https://vite.dev/">Vite</a>, and <a href="https://bun.com/">Bun</a>
+      Validate environment variables from editor to runtime with your favorite library <br/> for <a href="https://nextjs.org/">Next.js</a>, <a href="https://nuxt.com/">Nuxt</a>, <a href="https://nodejs.org/">Node.js</a>, <a href="https://vite.dev/">Vite</a>, and <a href="https://bun.com/">Bun</a>
     </p>
     <a href="https://github.com/yamcodes/arkenv/actions/workflows/test.yml?query=branch%3Av1"><img alt="Test Status" src="https://github.com/yamcodes/arkenv/actions/workflows/test.yml/badge.svg?branch=v1"></a>
     <a href="https://bundlephobia.com/package/arkenv"><img alt="npm bundle size" src="https://img.shields.io/bundlephobia/minzip/arkenv"></a>
@@ -17,12 +17,20 @@
 
 <div align="center">
   <a href="https://arkenv-v1.vercel.app/docs/arkenv">Docs</a>
-  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <span>&nbsp;&nbsp;⛯&nbsp;&nbsp;</span>
   <a href="https://arkenv-v1.vercel.app/docs/arkenv/faq">FAQ</a>
-  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <span>&nbsp;&nbsp;⛯&nbsp;&nbsp;</span>
   <a href="https://stackblitz.com/github/yamcodes/arkenv/tree/v1/examples/stackblitz?file=index.ts">Try on StackBlitz</a>
   <br />
 </div>
+
+<br />
+<br />
+
+
+<h3 align="center">
+  Bring your own validator: <a href="https://arktype.io/">ArkType</a>, <a href="https://zod.dev/">Zod</a>, <a href="https://valibot.dev/">Valibot</a>, or <a href="https://arkenv-v1.vercel.app/docs/arkenv/integrations/standard-schema">any Standard Schema library</a>
+</h3>
 
 <br />
 <br />


### PR DESCRIPTION
Ports the validator-documentation changes from #1339 (which landed on `dev`) onto the **v1** branch landing page (the root `README.md`).

On `dev`, #1339 edited `packages/arkenv/README.md` (the marketing readme there). On `v1`, the marketing landing page lives at the root `README.md`, so the equivalent changes are applied there instead.

### Changes
- Tagline → "Validate environment variables from editor to runtime with your favorite library"
- Nav separators `•` → `⛯`
- New **Bring your own validator** section linking ArkType, Zod, Valibot, and any Standard Schema library

v1-specific bits (branch `v1`, `arkenv-v1.vercel.app` URLs, the v1 pre-release note) are preserved; the Standard Schema link points at the v1 docs domain.

Made with [Cursor](https://cursor.com)