### PR TITLE
fix: render Twoslash popover `{@link}` JSDoc as inline links

### DIFF
--- a/apps/www/lib/twoslash-options.test.ts
+++ b/apps/www/lib/twoslash-options.test.ts
@@ -1,6 +1,6 @@
 import { createTwoslasher } from "twoslash";
 import { describe, expect, it } from "vitest";
-import { arktypeTwoslashOptions } from "./twoslash-options";
+import { arktypeTwoslashOptions, transformDocs } from "./twoslash-options";
 
 // Use createTwoslasher so vfsRoot is applied at factory time.
 // The standalone twoslasher() only reads compilerOptions/handbookOptions per-call
@@ -36,6 +36,53 @@ const apiUrl = env.NEXT_PUBLIC_API_URL;
 				target: "apiUrl",
 			}),
 		);
+	});
+
+	describe("transformDocs", () => {
+		it("renders a {@link symbol} tag inline as a code reference", () => {
+			expect(transformDocs("An alias for {@link createEnv}.")).toBe(
+				"An alias for `createEnv`.",
+			);
+		});
+
+		it("renders a {@link url | label} tag as a single inline anchor", () => {
+			expect(
+				transformDocs("See {@link https://arkenv.js.org | ArkEnv} for docs."),
+			).toBe("See [ArkEnv](https://arkenv.js.org) for docs.");
+		});
+
+		it("falls back to the raw URL as link text when no label is given", () => {
+			expect(transformDocs("See {@link https://arkenv.js.org}.")).toBe(
+				"See [https://arkenv.js.org](https://arkenv.js.org).",
+			);
+		});
+
+		it("handles TypeScript's serialized {@link} form (newlines, no pipe)", () => {
+			// This is the exact shape Twoslash yields for the `arkenv` default export:
+			// tags are wrapped in newlines and the `|` label separator is dropped.
+			const raw =
+				"ArkEnv's main export, an alias for \n{@link \ncreateEnv\n}\n\n\n\n{@link \nhttps://arkenv.js.org ArkEnv\n}\n is a typesafe environment variables validator from editor to runtime.";
+
+			const result = transformDocs(raw);
+
+			// {@link symbol} flows inline as a code reference.
+			expect(result).toContain("`createEnv`");
+			// {@link url | label} becomes a single inline anchor with the label as text.
+			expect(result).toContain("[ArkEnv](https://arkenv.js.org)");
+			// No dangling raw URL text is left outside the anchor.
+			expect(result).not.toMatch(/https:\/\/arkenv\.js\.org(?!\))/);
+			// The genuine paragraph break is preserved as exactly one blank line...
+			expect(result).toContain("\n\n");
+			expect(result).not.toContain("\n\n\n");
+			// ...and no line breaks are introduced within a sentence.
+			expect(result.split("\n\n")[1]).not.toContain("\n");
+		});
+
+		it("collapses single newlines to spaces but preserves paragraph breaks", () => {
+			expect(
+				transformDocs("line one\nstill line one\n\nsecond paragraph"),
+			).toBe("line one still line one\n\nsecond paragraph");
+		});
 	});
 
 	it("filters out module resolution errors in filterNode", () => {

--- a/apps/www/lib/twoslash-options.ts
+++ b/apps/www/lib/twoslash-options.ts
@@ -39,9 +39,49 @@ export type ArkTypeTwoslashOptions = Omit<
 	filterNode?: (node: TwoslashNode) => boolean;
 };
 
+/**
+ * Normalizes a JSDoc docs string so it renders as inline prose in the
+ * Twoslash hover popover, matching the IDE hover experience.
+ *
+ * TypeScript serializes `{@link}` tags with surrounding newlines (and drops the
+ * `|` label separator), e.g. `{@link \nhttps://arkenv.js.org ArkEnv\n}`. Left
+ * untouched, `fumadocs-twoslash` strips the tag to its raw contents, producing a
+ * bare autolinked URL with a dangling label and spurious line breaks.
+ *
+ * This converts each tag into Markdown and collapses accidental line breaks:
+ * - `{@link url | label}` → `[label](url)` (a single inline anchor)
+ * - `{@link symbol}` → `` `symbol` `` (inline code reference)
+ * - single newlines become spaces (inline prose), while genuine paragraph
+ *   breaks (blank lines) are preserved.
+ *
+ * @param docs - The raw JSDoc docs string from Twoslash.
+ * @returns The transformed Markdown string.
+ */
+export function transformDocs(docs: string): string {
+	return docs
+		.replace(/{@link\s+([\s\S]*?)}/g, (_raw: string, content: string) => {
+			const cleaned = content.replace(/\s+/g, " ").trim();
+			const parts = cleaned.split(/\s*(?:\||\s)\s*/);
+			const target = parts[0] ?? cleaned;
+			const text = parts.slice(1).join(" ") || target;
+
+			return target.startsWith("http") ? `[${text}](${target})` : `\`${text}\``;
+		})
+		.replace(/(?<!\n)\n(?!\n)/g, " ")
+		.replace(/\n{2,}/g, "\n\n")
+		.trim();
+}
+
 export const arktypeTwoslashOptions: ArkTypeTwoslashOptions = {
 	explicitTrigger: true,
 	langs: ["ts", "tsx", "js", "jsx"],
+	// `processHoverDocs` is the hook `fumadocs-twoslash`'s rich renderer actually
+	// invokes on a hover's JSDoc before rendering it to Markdown. `filterNode`
+	// (below) is only applied in isolated tooling, so the popover transform must
+	// live here to take effect on the docs site.
+	rendererRich: {
+		processHoverDocs: (docs) => transformDocs(docs),
+	},
 	twoslashOptions: {
 		vfsRoot: wwwRoot,
 		compilerOptions: {
@@ -161,23 +201,7 @@ declare global {
 				}
 
 				if (node.docs) {
-					node.docs = node.docs
-						.replace(
-							/{@link\s+([\s\S]*?)}/g,
-							(_raw: string, content: string) => {
-								const cleaned = content.replace(/\s+/g, " ").trim();
-								const parts = cleaned.split(/\s*(?:\||\s)\s*/);
-								const target = parts[0];
-								const text = parts.slice(1).join(" ") || target;
-
-								return target.startsWith("http")
-									? `[${text}](${target})`
-									: `\`${text}\``;
-							},
-						)
-						.replace(/(?<!\n)\n(?!\n)/g, " ")
-						.replace(/\n{2,}/g, "\n\n")
-						.trim();
+					node.docs = transformDocs(node.docs);
 				}
 
 				const text = node.text.toLowerCase();


### PR DESCRIPTION
Fixes #1343

## Problem

On the docs site the Twoslash hover popover rendered JSDoc `{@link}` tags incorrectly: `{@link url | label}` showed the raw autolinked URL with the label dangling after it, `{@link symbol}` landed on its own line, and prose was broken into blocks with large vertical gaps.

## Root cause

The docs transform lived inside `filterNode`, but `filterNode` is only consumed by `twoslash` core when passed via `twoslashOptions.filterNode`. In `arktypeTwoslashOptions` it sits at the top level, so `fumadocs-twoslash` never applies it — the transform was effectively dead in the rendered popover. Left untransformed, `fumadocs-twoslash`'s `renderMarkdown` strips `{@link ...}` down to its raw contents, producing the broken output.

## Fix

- Extract the docs normalization into an exported, unit-testable `transformDocs` function.
- Wire it into the real rendering pipeline via `rendererRich.processHoverDocs` (the hook `fumadocs-twoslash`'s rich renderer actually invokes on each hover's JSDoc), so it applies to **every** documented symbol's popover.
- Reuse `transformDocs` inside `filterNode` to avoid duplication.

`transformDocs` handles TypeScript's serialized form (tags wrapped in newlines with the `|` separator dropped):
- `{@link url | label}` → `[label](url)` (single inline anchor)
- `{@link symbol}` → inline code reference
- single newlines collapse to spaces; genuine paragraph breaks are preserved.

## Verification

Rendered the `arkenv` popover end-to-end through the real shiki + `fumadocs-twoslash` pipeline:

```html
<div><p>ArkEnv's main export, an alias for <code>createEnv</code></p>
<p><a href="https://arkenv.js.org">ArkEnv</a> is a typesafe environment variables validator from editor to runtime.</p></div>
```

`apps/www/lib/twoslash-options.test.ts` is extended to cover both `{@link symbol}` and `{@link url | label}` (including TypeScript's newline-wrapped form and paragraph-break preservation). `typecheck`, the `www` test suite, and `fix` all pass.

No changeset: changes are isolated to the docs site (`www`), which is in the changeset `ignore` list and not imported by other packages.

Made with [Cursor](https://cursor.com)