### PR TITLE
docs: use AutoTypeTable for config options and expand twoslash coverage

### DIFF
--- a/.changeset/nuxt-module-options-jsdoc.md
+++ b/.changeset/nuxt-module-options-jsdoc.md
@@ -1,0 +1,19 @@
+---
+"@arkenv/nuxt": patch
+---
+
+#### Document `ModuleOptions` with JSDoc for better editor DX
+
+Add descriptions and `@default` tags to the `ModuleOptions` type so hovering `schemaPath`, `layout`, and `validate` in `nuxt.config.ts` surfaces inline documentation.
+
+```ts title="nuxt.config.ts"
+export default defineNuxtConfig({
+  modules: ["@arkenv/nuxt/module"],
+  arkenv: {
+    // Hovering these keys now shows their description and default value
+    schemaPath: "src/env.ts",
+    layout: "flat",
+    validate: true,
+  },
+});
+```

--- a/apps/www/content/docs/nextjs/configuration.mdx
+++ b/apps/www/content/docs/nextjs/configuration.mdx
@@ -91,7 +91,7 @@ Or set it up manually by passing the `{ codegen: false }` option to `withArkEnv`
 > **Build-time validation without codegen:**
 > When using `{ codegen: false }`, `withArkEnv` will skip compiling and generating `env.gen.ts` but will still execute build-time environment variable validation, ensuring invalid variables fail the build:
 >
-> ```ts title="next.config.ts"
+> ```ts title="next.config.ts" twoslash
 > import { withArkEnv } from "@arkenv/nextjs/config";
 > import type { NextConfig } from "next";
 >

--- a/apps/www/content/docs/nextjs/configuration.mdx
+++ b/apps/www/content/docs/nextjs/configuration.mdx
@@ -8,7 +8,7 @@ description: API reference and configuration options for @arkenv/nextjs.
 
 The idiomatic way to use ArkEnv in Next.js is the `withArkEnv` config wrapper. It runs ArkEnv's codegen and validation as part of the Next.js build lifecycle and returns your config object unchanged.
 
-```ts title="next.config.ts"
+```ts title="next.config.ts" twoslash
 import { withArkEnv } from "@arkenv/nextjs/config";
 import type { NextConfig } from "next";
 
@@ -25,7 +25,7 @@ By default, ArkEnv looks for your schema in `src/env.ts` or `env.ts` and writes 
 
 Pass options as the second argument:
 
-```ts title="next.config.ts"
+```ts title="next.config.ts" twoslash
 import { withArkEnv } from "@arkenv/nextjs/config";
 import type { NextConfig } from "next";
 
@@ -43,13 +43,7 @@ export default withArkEnv(nextConfig, {
 
 The `withArkEnv()` wrapper accepts the following options:
 
-| Option       | Type                 | Default                            | Description                                                                      |
-| :----------- | :------------------- | :--------------------------------- | :------------------------------------------------------------------------------- |
-| `schemaPath` | `string`             | `src/env.ts` or `env.ts`           | The path to your environment schema file or directory.                           |
-| `outputPath` | `string`             | `[schemaDir]/generated/env.gen.ts` | The path where the generated helper (`env.gen.ts`) will be written.              |
-| `layout`     | `'flat' \| 'strict'` | `'flat'`                           | Specify the schema layout. Use `'strict'` if using the multi-file strict layout. |
-| `codegen`    | `boolean`            | `true`                             | Enable or disable automatic generation of the `env.gen.ts` helper.               |
-| `validate`   | `boolean`            | `true`                             | Enable or disable build-time environment variable validation.                    |
+<AutoTypeTable path="../../packages/nextjs/src/config.ts" name="ArkEnvConfigOptions" />
 
 ---
 
@@ -61,7 +55,7 @@ The `withArkEnv()` wrapper accepts the following options:
 
     `withArkEnv` is just a thin wrapper around `setupArkEnv` that calls it and returns your config object unchanged:
 
-    ```ts title="next.config.ts"
+    ```ts title="next.config.ts" twoslash
     import { setupArkEnv } from "@arkenv/nextjs/config";
     import type { NextConfig } from "next";
 

--- a/apps/www/content/docs/nextjs/faq.mdx
+++ b/apps/www/content/docs/nextjs/faq.mdx
@@ -34,7 +34,7 @@ Yes. If you prefer to maintain the `runtimeEnv` mapping manually (or if your bui
 
 Pass `{ codegen: false }` to `withArkEnv` to keep build-time environment variable validation active without generating `env.gen.ts`:
 
-```ts title="next.config.ts"
+```ts title="next.config.ts" twoslash
 import { withArkEnv } from "@arkenv/nextjs/config";
 import type { NextConfig } from "next";
 
@@ -44,7 +44,7 @@ export default withArkEnv(nextConfig, { codegen: false });
 
 When codegen is disabled, import `createEnv` directly from `@arkenv/nextjs` in your schema file and provide a manual `runtimeEnv` mapping:
 
-```ts title="src/env.ts"
+```ts title="src/env.ts" twoslash
 import { createEnv } from "@arkenv/nextjs";
 
 export const env = createEnv({

--- a/apps/www/content/docs/nextjs/layouts/flat.mdx
+++ b/apps/www/content/docs/nextjs/layouts/flat.mdx
@@ -134,7 +134,7 @@ export const env = arkenv({
 
     Wrap your Next.js configuration using the `withArkEnv` helper:
 
-    ```ts title="next.config.ts"
+    ```ts title="next.config.ts" twoslash
     import { withArkEnv } from "@arkenv/nextjs/config";
     import type { NextConfig } from "next";
 

--- a/apps/www/content/docs/nextjs/layouts/strict.mdx
+++ b/apps/www/content/docs/nextjs/layouts/strict.mdx
@@ -197,7 +197,7 @@ export const env = arkenv(
 
     Wrap your Next.js configuration using the `withArkEnv` helper:
 
-    ```ts title="next.config.ts"
+    ```ts title="next.config.ts" twoslash
     import { withArkEnv } from "@arkenv/nextjs/config";
     import type { NextConfig } from "next";
 

--- a/apps/www/content/docs/nuxt/configuration.mdx
+++ b/apps/www/content/docs/nuxt/configuration.mdx
@@ -25,11 +25,7 @@ By default, ArkEnv looks for your schema in `env.ts` or `src/env.ts` for the fla
 
 The `arkenv` configuration block accepts the following options:
 
-| Option       | Type                             | Default                 | Description                                                                                 |
-| :----------- | :------------------------------- | :---------------------- | :------------------------------------------------------------------------------------------ |
-| `schemaPath` | `string`                         | *(Automatic detection)* | The path to your environment schema file or directory.                                      |
-| `layout`     | `'flat' \| 'strict' \| 'simple'` | `'flat'`                | Specify the schema layout. Use `'strict'` for multi-file layouts. `'simple'` is deprecated. |
-| `validate`   | `boolean`                        | `true`                  | Enable or disable build-time and dev-time environment variable validation.                  |
+<AutoTypeTable path="../../packages/nuxt/src/module.ts" name="ModuleOptions" />
 
 ---
 

--- a/apps/www/lib/twoslash-options.ts
+++ b/apps/www/lib/twoslash-options.ts
@@ -59,6 +59,9 @@ export const arktypeTwoslashOptions: ArkTypeTwoslashOptions = {
 				"~~/env/client": ["env/client.ts"],
 				"~~/env/server": ["env/server.ts"],
 				"@arkenv/nextjs": [path.join(root, "packages/nextjs/src/index.ts")],
+				"@arkenv/nextjs/config": [
+					path.join(root, "packages/nextjs/src/config.ts"),
+				],
 				"@arkenv/nextjs/server": [
 					path.join(root, "packages/nextjs/src/server.ts"),
 				],

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -15,9 +15,47 @@ import {
 	validateSchema,
 } from "./config";
 
+/**
+ * Configuration options for the ArkEnv Nuxt module.
+ *
+ * Provide these under the `arkenv` key in your `nuxt.config.ts`.
+ *
+ * @example
+ * ```ts
+ * export default defineNuxtConfig({
+ *   modules: ["@arkenv/nuxt/module"],
+ *   arkenv: {
+ *     schemaPath: "src/env.ts"
+ *   }
+ * });
+ * ```
+ */
 export type ModuleOptions = {
+	/**
+	 * Specify the path to the schema definition file or directory.
+	 *
+	 * Defaults to searching for `"env.ts"` or `"src/env.ts"` (flat layout), or the
+	 * `"env/"` or `"src/env/"` directory (strict layout) in the project root.
+	 *
+	 * @default "src/env.ts"
+	 */
 	schemaPath?: string;
+
+	/**
+	 * Specify the configuration layout.
+	 *
+	 * - `"flat"` (default): A single `env.ts` schema file.
+	 * - `"strict"`: A multi-file split schema layout (`env/internal/shared.ts`, `env/client.ts`, `env/server.ts`).
+	 *
+	 * @default "flat"
+	 */
 	layout?: ArkEnvConfigOptions["layout"];
+
+	/**
+	 * Enable or disable environment variable validation during dev startup and build.
+	 *
+	 * @default true
+	 */
 	validate?: boolean;
 };
 


### PR DESCRIPTION
## Summary

Follows up on an audit of the [Next.js configuration page](https://arkenv-7pjewqvtn-yamcodes.vercel.app/docs/nextjs/configuration) for two recurring opportunities across the docs: replacing hand-written option tables with `AutoTypeTable`, and expanding `twoslash` coverage on config examples.

### `AutoTypeTable`
- Replace the hand-written "Configuration options" table on **`nextjs/configuration.mdx`** with `<AutoTypeTable path="../../packages/nextjs/src/config.ts" name="ArkEnvConfigOptions" />`. The type is already fully JSDoc-annotated, so the table now stays in sync with the source.
- Do the same on **`nuxt/configuration.mdx`** using `ModuleOptions`. Since that type had no JSDoc, add descriptions and `@default` tags to `ModuleOptions` in `packages/nuxt/src/module.ts` so the generated table keeps its descriptions/defaults.

### twoslash
- Add a `@arkenv/nextjs/config` entry to the twoslash path map in `lib/twoslash-options.ts`. Previously **every** `next.config.ts` example importing `withArkEnv`/`setupArkEnv` resolved to `any` (the module-resolution error was silently filtered), so twoslash produced no useful hovers.
- Convert the now-resolvable `next.config.ts` / `src/env.ts` examples to `ts twoslash` across:
  - `nextjs/configuration.mdx` (register, custom paths, `setupArkEnv` escape hatch)
  - `nextjs/faq.mdx` (`{ codegen: false }` wrapper + manual `createEnv`)
  - `nextjs/layouts/flat.mdx` and `nextjs/layouts/strict.mdx` (config wrapper steps)

Nuxt `nuxt.config.ts` blocks were intentionally left plain — `defineNuxtConfig` is a Nuxt auto-import and would error under twoslash without extra setup.

## Verification
- Ran the shared `arktypeTwoslashOptions` twoslasher (`scripts/twoslash-mdx.ts`) over every edited file: all new blocks compile, resolve `NextConfig`/`withArkEnv`/`ArkEnvConfigOptions` with correct hovers, and add **zero** new errors. (The pre-existing intentional error demo in `strict.mdx` is unchanged.)
- `biome check` clean on changed source files.

## Changeset
- `@arkenv/nuxt` patch — the `ModuleOptions` JSDoc improves editor DX on the public type.

Made with [Cursor](https://cursor.com)