### PR TITLE
feat(cli): Forward-port trim short-flag aliases (-C, -a) from dev to v1

### DIFF
--- a/.changeset/trim-short-flag-aliases.md
+++ b/.changeset/trim-short-flag-aliases.md
@@ -1,0 +1,23 @@
+---
+"arkenv": major
+---
+
+#### Remove the `-C` (`--no-codegen`) and `-a` (`--agent`) short-flag aliases
+
+**BREAKING CHANGE**: The `-C` and `-a` short aliases are no longer recognized. Their long forms, `--no-codegen` and `--agent`, continue to work exactly as before (`--agent` still implies `--yes --quiet --json`).
+
+Short flags for an inverted boolean (`-C`) invite misreading as "enable codegen", and `--agent` targets machines and scripts that gain nothing from a keystroke shortcut. Passing `-C` or `-a` — standalone or inside a bundle like `-ya` — now fails with the standard `Unknown argument` error.
+
+Migration: replace the short aliases with their long forms.
+
+```bash
+# Before
+arkenv init -C
+arkenv init -a
+
+# After
+arkenv init --no-codegen
+arkenv init --agent
+```
+
+All other aliases (`-y`, `-f`, `-q`, `-j`, `-e`, `-h`) are unchanged.

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -30,10 +30,10 @@ Configure the CLI behavior using the following command-line flags:
 | `--yes`        | `-y`  | Skip all prompts and use the default configuration.                                                                                              |
 | `--quiet`      | `-q`  | Suppress all output logs unless an error occurs.                                                                                                 |
 | `--json`       | `-j`  | Print a structured JSON summary to `stdout` upon completion.                                                                                     |
-| `--agent`      | `-a`  | Enable non-interactive, machine-readable mode for AI agents. Bypasses all prompts and outputs structured JSON. Macro for `--yes --quiet --json`. |
+| `--agent`      |       | Enable non-interactive, machine-readable mode for AI agents. Bypasses all prompts and outputs structured JSON. Macro for `--yes --quiet --json`. |
 | `--example`    | `-e`  | Specify an example name when creating a new project.                                                                                             |
 | `--force`      | `-f`  | Bypass checks and force initialization.                                                                                                          |
-| `--no-codegen` | `-C`  | Disable automatic env.gen.ts code generation for Next.js (falls back to manual runtimeEnv destructuring).                                        |
+| `--no-codegen` |       | Disable automatic env.gen.ts code generation for Next.js (falls back to manual runtimeEnv destructuring).                                        |
 | `--help`       | `-h`  | Display the CLI help information.                                                                                                                |
 
 ## Machine-readable output

--- a/packages/arkenv/src/cli/cli.test.ts
+++ b/packages/arkenv/src/cli/cli.test.ts
@@ -69,13 +69,15 @@ describe("CLI parser", () => {
 		expect(cli1.noCodegen).toBe(true);
 		expect(cli1.initInput.noCodegen).toBe(true);
 
-		const cli2 = new CLI(["node", "arkenv", "init", "-C"]);
-		expect(cli2.noCodegen).toBe(true);
-		expect(cli2.initInput.noCodegen).toBe(true);
-
 		const cli3 = new CLI(["node", "arkenv", "init"]);
 		expect(cli3.noCodegen).toBe(false);
 		expect(cli3.initInput.noCodegen).toBeUndefined();
+	});
+
+	it("should reject the removed -C alias as an unknown argument", () => {
+		const cli = new CLI(["node", "arkenv", "init", "-C"]);
+		expect(cli.noCodegen).toBe(false);
+		expect(cli.validationError).toBe("Unknown argument: -C");
 	});
 
 	describe("Agent presets override", () => {
@@ -88,13 +90,10 @@ describe("CLI parser", () => {
 			expect(cli.isForce).toBe(false);
 		});
 
-		it("should set isYes, isQuiet, and isJson to true when -a is passed", () => {
+		it("should reject the removed -a alias as an unknown argument", () => {
 			const cli = new CLI(["node", "arkenv", "init", "-a"]);
-			expect(cli.isAgent).toBe(true);
-			expect(cli.isYes).toBe(true);
-			expect(cli.isQuiet).toBe(true);
-			expect(cli.isJson).toBe(true);
-			expect(cli.isForce).toBe(false);
+			expect(cli.isAgent).toBe(false);
+			expect(cli.validationError).toBe("Unknown argument: -a");
 		});
 
 		it("should evaluate isYes, isQuiet, and isJson normally when --agent is not passed", () => {
@@ -112,6 +111,16 @@ describe("CLI parser", () => {
 			expect(cli.isYes).toBe(true);
 			expect(cli.isQuiet).toBe(true);
 			expect(cli.validationError).toBeUndefined();
+		});
+
+		it("should reject bundles containing removed aliases (-a, -C)", () => {
+			const cli1 = new CLI(["node", "arkenv", "init", "-ya"]);
+			expect(cli1.isAgent).toBe(false);
+			expect(cli1.validationError).toBe("Unknown argument: -a");
+
+			const cli2 = new CLI(["node", "arkenv", "init", "-yC"]);
+			expect(cli2.noCodegen).toBe(false);
+			expect(cli2.validationError).toBe("Unknown argument: -C");
 		});
 
 		it("should expand a bundle of multiple short flags including force", () => {

--- a/packages/arkenv/src/cli/cli.ts
+++ b/packages/arkenv/src/cli/cli.ts
@@ -7,13 +7,13 @@ const FLAG_CONFIG = {
 	isForce: { long: "--force", short: "-f", kind: "boolean" },
 	isQuiet: { long: "--quiet", short: "-q", kind: "boolean" },
 	isJson: { long: "--json", short: "-j", kind: "boolean" },
-	isAgent: { long: "--agent", short: "-a", kind: "boolean" },
+	isAgent: { long: "--agent", short: "", kind: "boolean" },
 	helpRequested: { long: "--help", short: "-h", kind: "boolean" },
 	example: { long: "--example", short: "-e", kind: "value" },
 	isStrict: { long: "--strict", short: "", kind: "boolean" },
 	isSimple: { long: "--simple", short: "", kind: "boolean" },
 	isFlat: { long: "--flat", short: "", kind: "boolean" },
-	noCodegen: { long: "--no-codegen", short: "-C", kind: "boolean" },
+	noCodegen: { long: "--no-codegen", short: "", kind: "boolean" },
 	hostPreset: { long: "--host-preset", short: "", kind: "value" },
 } as const;
 

--- a/packages/arkenv/src/cli/commands/help.test.ts
+++ b/packages/arkenv/src/cli/commands/help.test.ts
@@ -45,11 +45,18 @@ describe("HelpUseCase", () => {
 			"  --example, -e             Specify an example name when creating a new project",
 		);
 
-		const noCodegenOptionLog = logs.find((l) => l.includes("--no-codegen, -C"));
+		const agentOptionLog = logs.find((l) => l.includes("--agent"));
+		expect(agentOptionLog).toBeDefined();
+		// "--agent" is 7 chars. max (22) - 7 + colGap (4) = 19 spaces padding.
+		expect(agentOptionLog).toBe(
+			"  --agent                   Enable non-interactive, machine-readable mode for AI agents. Bypasses all prompts and outputs structured JSON. Macro for --yes --quiet --json",
+		);
+
+		const noCodegenOptionLog = logs.find((l) => l.includes("--no-codegen"));
 		expect(noCodegenOptionLog).toBeDefined();
-		// "--no-codegen, -C" is 16 chars. max (22) - 16 + colGap (4) = 10 spaces padding.
+		// "--no-codegen" is 12 chars. max (22) - 12 + colGap (4) = 14 spaces padding.
 		expect(noCodegenOptionLog).toBe(
-			"  --no-codegen, -C          Disable automatic env.gen.ts code generation for Next.js",
+			"  --no-codegen              Disable automatic env.gen.ts code generation for Next.js",
 		);
 
 		const hostPresetOptionLog = logs.find((l) =>

--- a/packages/arkenv/src/cli/commands/help.ts
+++ b/packages/arkenv/src/cli/commands/help.ts
@@ -51,7 +51,7 @@ export class HelpUseCase {
 					"Bypass technical requirement checks and dirty git working tree check, then force scaffolding",
 			},
 			{
-				left: "--agent, -a",
+				left: "--agent",
 				right:
 					"Enable non-interactive, machine-readable mode for AI agents. Bypasses all prompts and outputs structured JSON. Macro for --yes --quiet --json",
 			},
@@ -68,7 +68,7 @@ export class HelpUseCase {
 				right: "Output structured JSON to stdout",
 			},
 			{
-				left: "--no-codegen, -C",
+				left: "--no-codegen",
 				right: "Disable automatic env.gen.ts code generation for Next.js",
 			},
 			{

--- a/skills/arkenv/SKILL.md
+++ b/skills/arkenv/SKILL.md
@@ -28,7 +28,7 @@ ArkEnv is a typesafe environment variable validator for modern JavaScript runtim
 - Initialize ArkEnv in new or existing projects using `pnpm dlx arkenv@latest init`.
 - Scaffold schema files and detect framework-specific configurations (`Next.js`, `Vite`, `Bun`, etc.).
 - Support layout selection (`--strict` for 3-file split vs `--simple` for a single file).
-- Support option to skip codegen (`--no-codegen` / `-C`).
+- Support option to skip codegen (`--no-codegen`).
 - Automatically configure `tsconfig.json` and environment types for optimal typesafety.
 
 ### Agent setup (machine-readable)
@@ -233,7 +233,7 @@ pnpm dlx arkenv@latest init [options]
 
 - `--strict`: Use strict 3-file split layout.
 - `--simple`: Use simple 1-file layout (default).
-- `--no-codegen`, `-C`: Disable Next.js codegen/`withArkEnv` configuration setup.
+- `--no-codegen`: Disable Next.js codegen/`withArkEnv` configuration setup.
 
 ## Best practices
 


### PR DESCRIPTION
Forward-port of #1353 (issue #1351) from `dev` to `v1`.

Removes the `-C` (`--no-codegen`) and `-a` (`--agent`) short-flag aliases, keeping their long forms fully functional. Re-implemented at v1 paths (`packages/arkenv/src/**`) rather than cherry-picked.

## Changes
- `packages/arkenv/src/cli/cli.ts`: emptied the `short` entries for `isAgent` and `noCodegen` in `FLAG_CONFIG`. Existing `filter(Boolean)` / `!!flag.short` guards make these fall through to the standard `Unknown argument` path — including inside bundles like `-ya`.
- `packages/arkenv/src/cli/commands/help.ts`: `--agent` and `--no-codegen` rows no longer advertise a short alias.
- Tests: updated `cli.test.ts` (`-C`/`-a` assert `Unknown argument`, added bundle-rejection test) and `help.test.ts` column-alignment snapshots; added a `--agent`-without-alias assertion.
- Docs: CLI flags table and arkenv skill reference.
- Changeset: `arkenv` **major** (breaking change under v1 standard SemVer), renamed from the dev changeset's `@arkenv/cli` key.

## Verification
- `arkenv init --no-codegen` / `--agent` behave as before (`--agent` still implies `--yes --quiet --json`).
- `arkenv init -C` → `Unknown argument: -C`; `-a` → `Unknown argument: -a`; `-ya` → `Unknown argument: -a`.
- `--help` lists `--no-codegen`/`--agent` without short aliases; other aliases unchanged.
- `pnpm --filter arkenv typecheck` clean; `pnpm --filter arkenv test` → 311 passed.

Refs #1351, #1353.

Made with [Cursor](https://cursor.com)