### PR TITLE
docs: Forward-port validator-agnostic README refresh from dev to v1

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,7 +3,7 @@
   <h1 align="center">ArkEnv</h1>
   <div align="center">
     <p align="center">
-      Environment variable validation from editor to runtime<br/> for <a href="https://nextjs.org/">Next.js</a>, <a href="https://nuxt.com/">Nuxt</a>, <a href="https://nodejs.org/">Node.js</a>, <a href="https://vite.dev/">Vite</a>, and <a href="https://bun.com/">Bun</a>
+      Validate environment variables with your favorite validator <br/> on <a href="https://nextjs.org/">Next.js</a>, <a href="https://nuxt.com/">Nuxt</a>, <a href="https://nodejs.org/">Node.js</a>, <a href="https://vite.dev/">Vite</a>, and <a href="https://bun.com/">Bun</a>
     </p>
     <a href="https://github.com/yamcodes/arkenv/actions/workflows/test.yml?query=branch%3Amain"><img alt="Test Status" src="https://github.com/yamcodes/arkenv/actions/workflows/tests-badge.yml/badge.svg?branch=main"></a>
     <a href="https://bundlephobia.com/package/arkenv"><img alt="npm bundle size" src="https://img.shields.io/bundlephobia/minzip/arkenv"></a>
@@ -14,12 +14,20 @@
 
 <div align="center">
   <a href="https://arkenv.js.org/docs/arkenv">Docs</a>
-  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <span>&nbsp;&nbsp;⛯&nbsp;&nbsp;</span>
   <a href="https://arkenv.js.org/docs/arkenv/faq">FAQ</a>
-  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <span>&nbsp;&nbsp;⛯&nbsp;&nbsp;</span>
   <a href="https://stackblitz.com/github/yamcodes/arkenv/tree/main/examples/stackblitz?file=index.ts">Try on StackBlitz</a>
   <br />
 </div>
+
+<br />
+<br />
+
+
+<h3 align="center">
+  Bring your own validator: <a href="https://arktype.io/">ArkType</a>, <a href="https://zod.dev/">Zod</a>, <a href="https://valibot.dev/">Valibot</a>, or <a href="https://arkenv.js.org/docs/arkenv/integrations/standard-schema">any Standard Schema validator</a>
+</h3>
 
 <br />
 <br />


### PR DESCRIPTION
Forward-port of #1339 from `dev` to `v1`.

Refreshes the flagship ArkEnv README marketing copy: new validator-agnostic tagline, a "Bring your own validator: ArkType, Zod, Valibot, or any Standard Schema validator" heading, and a separator glyph swap.

## Mapping note
On `dev` the change targeted `packages/arkenv/README.md` (the `arkenv` core package). On `v1` the package names swapped, so the flagship marketing README now lives at `packages/core/README.md` (`@arkenv/core`) — which still carried the identical pre-refresh copy. Applied there.

Docs-only; no changeset (matching the source PR).

Refs #1339.

Made with [Cursor](https://cursor.com)