### PR TITLE
docs(core): Forward-port RuntimeEnvironment type-DX fix from dev to v1

### DIFF
--- a/apps/www/content/docs/arkenv/coercion.mdx
+++ b/apps/www/content/docs/arkenv/coercion.mdx
@@ -10,7 +10,7 @@ Coercion in [@arkenv/standard](/docs/arkenv/standard) only works with:
 
 - [Zod](https://zod.dev) (v4.2+)
 - [Valibot](https://valibot.dev) (v1.2+ via `@valibot/to-json-schema`)
-- [Zod Mini](https://zod.dev)
+- [Zod Mini](https://zod.dev/packages/mini)
 - [VineJS](https://vinejs.dev/) (v4.3.0+)
 - Any validator compliant with [Standard JSON Schema v1](https://standardschema.dev/json-schema#what-schema-libraries-support-this-spec)
   :::

--- a/packages/core/src/arkenv.ts
+++ b/packages/core/src/arkenv.ts
@@ -1,7 +1,6 @@
 import type { $ } from "@repo/scope";
 import type {
 	CompiledEnvSchema,
-	Dict,
 	InferType,
 	SchemaShape,
 	StandardSchemaV1,
@@ -44,21 +43,15 @@ export type Infer<T> =
 					: InferType<T>;
 
 /**
- * The environment variables passed to `arkenv`.
- * Uses `Dict<string>` to enforce
- * compile-time safety: all input environment variables must be strings
- * (or undefined), matching `process.env` semantics.
- */
-type RuntimeEnvironment = Dict<string>;
-
-/**
  * Configuration options for `arkenv`
  */
 export type ArkEnvConfig = {
 	/**
-	 * The environment variables to parse. Defaults to `process.env`
+	 * The environment variables to parse. Defaults to `process.env`.
+	 *
+	 * All values must be strings (or `undefined`) to match `process.env` semantics.
 	 */
-	env?: RuntimeEnvironment;
+	env?: Record<string, string | undefined>;
 	/**
 	 * Whether to coerce environment variables to their defined types. Defaults to `true`
 	 */

--- a/packages/internal/utils/src/parse-standard.ts
+++ b/packages/internal/utils/src/parse-standard.ts
@@ -37,9 +37,11 @@ import {
  */
 export type ParseStandardConfig = {
 	/**
-	 * The environment variables to parse. Defaults to `process.env`
+	 * The environment variables to parse. Defaults to `process.env`.
+	 *
+	 * All values must be strings (or `undefined`) to match `process.env` semantics.
 	 */
-	env?: Dict<string>;
+	env?: Record<string, string | undefined>;
 	/**
 	 * Control how ArkEnv handles environment variables that are not defined in your schema.
 	 *


### PR DESCRIPTION
Forward-port of #1278 from `dev` to `v1`.

Improves the resolved type of the public `env` option so editor hovers show a clear `Record<string, string | undefined>` instead of the opaque internal `Dict<string>` alias. Also fixes the Zod Mini docs link.

## Changes
- `packages/core/src/arkenv.ts`: drop the `RuntimeEnvironment = Dict<string>` alias and inline `env?: Record<string, string | undefined>` on `ArkEnvConfig` (removes the now-unused `Dict` import).
- `packages/internal/utils/src/parse-standard.ts`: same inline type on `ParseStandardConfig.env` (`Dict` import retained — still used elsewhere).
- `apps/www/content/docs/arkenv/coercion.mdx`: fix Zod Mini link to `https://zod.dev/packages/mini`.

## Mapping note
On `dev` this touched `packages/arkenv/src/{create-env,parse-standard,index}.ts` (core lib). On `v1` the core moved to `@arkenv/core` (`packages/core/src/arkenv.ts`) and `ParseStandardConfig` now lives in `@repo/utils` — changes were re-implemented at those paths.

## Non-breaking
`Dict<T>` is defined as `Record<string, T | undefined>`, so `Dict<string>` and `Record<string, string | undefined>` are structurally identical — a pure DX improvement with no API/behavior change. No changeset (matching the source PR).

## Verification
- Typecheck clean across `@arkenv/core`, `@arkenv/standard`, and consumers (`vite-plugin`, `bun-plugin`, `nextjs`, `nuxt`).
- `@arkenv/core` tests: 224 passed; `@arkenv/standard` tests pass.

Refs #1278.

Made with [Cursor](https://cursor.com)