### PR TITLE
docs: add twoslash to process.env / import.meta.env typing guides

### DIFF
--- a/apps/www/content/docs/arkenv/faq.mdx
+++ b/apps/www/content/docs/arkenv/faq.mdx
@@ -43,7 +43,9 @@ An empty value (e.g., `PORT=` in a `.env` file) is passed to ArkEnv as an empty 
 
 If you want empty values to be treated as missing (so defaults apply), enable the `emptyAsUndefined` option:
 
-```ts
+```ts twoslash
+import arkenv from "arkenv";
+// ---cut---
 const env = arkenv(
   { PORT: "number = 3000" },
   { emptyAsUndefined: true }

--- a/apps/www/content/docs/bun-plugin/index.mdx
+++ b/apps/www/content/docs/bun-plugin/index.mdx
@@ -125,7 +125,7 @@ await Bun.build({
 
 Create a custom plugin file and reference it in `bunfig.toml`:
 
-```ts title="plugins/arkenv.ts"
+```ts title="plugins/arkenv.ts" twoslash
 import arkenv from "@arkenv/bun-plugin";
 import { type } from "arkenv";
 

--- a/apps/www/content/docs/bun-plugin/typing-process-env.mdx
+++ b/apps/www/content/docs/bun-plugin/typing-process-env.mdx
@@ -39,7 +39,24 @@ Notice the line that references `"./src/env"` - if your `env.ts` file is somewhe
 
 Once set up, `process.env` is fully typesafe for your `BUN_PUBLIC_*` variables:
 
-```ts title="src/app.tsx"
+```ts twoslash title="src/app.tsx"
+// @filename: src/env.ts
+import { type } from "arkenv";
+export default type({
+	BUN_PUBLIC_API_URL: "string.url",
+	BUN_PUBLIC_DEBUG: "boolean",
+});
+
+// @filename: bun-env.d.ts
+type ProcessEnvAugmented = import("@arkenv/bun-plugin").ProcessEnvAugmented<
+	typeof import("./src/env").default
+>;
+declare namespace NodeJS {
+	interface ProcessEnv extends ProcessEnvAugmented {}
+}
+
+// @filename: src/app.tsx
+// ---cut---
 // TypeScript knows about your BUN_PUBLIC_* variables
 const apiUrl = process.env.BUN_PUBLIC_API_URL; // ✅ Typesafe
 const debug = process.env.BUN_PUBLIC_DEBUG; // ✅ Typesafe
@@ -47,7 +64,7 @@ const debug = process.env.BUN_PUBLIC_DEBUG; // ✅ Typesafe
 
 `NODE_ENV` is also supported - when defined in your schema, it is validated and correctly typed:
 
-```ts title="src/env.ts"
+```ts twoslash title="src/env.ts"
 import { type } from "arkenv";
 
 export default type({
@@ -56,8 +73,25 @@ export default type({
 });
 ```
 
-```ts title="src/app.tsx"
-process.env.NODE_ENV; // ✅ "development" | "production" | "test"
+```ts twoslash title="src/app.tsx"
+// @filename: src/env.ts
+import { type } from "arkenv";
+export default type({
+	BUN_PUBLIC_API_URL: "string.url",
+	NODE_ENV: "'development' | 'production' | 'test'",
+});
+
+// @filename: bun-env.d.ts
+type ProcessEnvAugmented = import("@arkenv/bun-plugin").ProcessEnvAugmented<
+	typeof import("./src/env").default
+>;
+declare namespace NodeJS {
+	interface ProcessEnv extends ProcessEnvAugmented {}
+}
+
+// @filename: src/app.tsx
+// ---cut---
+const nodeEnv = process.env.NODE_ENV; // ✅ "development" | "production" | "test"
 ```
 
 ## How it works

--- a/apps/www/content/docs/vite-plugin/typing-import-meta-env.mdx
+++ b/apps/www/content/docs/vite-plugin/typing-import-meta-env.mdx
@@ -47,13 +47,42 @@ The `interface ImportMeta` block is required in some TypeScript configurations t
 
 Once set up, `import.meta.env` is fully typesafe:
 
-```ts title="src/app.tsx"
+```ts twoslash title="src/app.tsx"
+// @errors: 2339
+// @filename: src/env.ts
+import { type } from "arkenv";
+export const Env = type({
+	PORT: "number.port",
+	VITE_API_URL: "string",
+	VITE_API_KEY: "string",
+	VITE_MY_NUMBER: "number",
+	VITE_MY_BOOLEAN: "boolean",
+});
+export type Env = typeof Env.infer;
+
+// @filename: src/vite-env.d.ts
+/// <reference types="vite/client" />
+type ImportMetaEnvAugmented =
+	import("@arkenv/vite-plugin").ImportMetaEnvAugmented<
+		typeof import("./env").Env
+	>;
+interface ImportMetaEnv extends ImportMetaEnvAugmented {}
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}
+interface ViteTypeOptions {
+	strictImportMetaEnv: unknown;
+}
+
+// @filename: src/app.tsx
+// ---cut---
 // TypeScript knows about your VITE_* variables
 const apiUrl = import.meta.env.VITE_API_URL; // ✅ Typesafe
-const port = import.meta.env.PORT; // ❌ Error: PORT is not in ImportMetaEnv
+const port = import.meta.env.PORT; // ❌ PORT is not in ImportMetaEnv
 
 // Autocomplete works too!
-import.meta.env.VITE_ // Shows all your VITE_* variables
+import.meta.env.VITE_MY_NUMBER;
+//              ^|
 ```
 
 ## How it works
@@ -86,7 +115,20 @@ export const Env = type({
 export type Env = typeof Env.infer;
 ```
 
-```ts title="vite.config.ts"
+```ts twoslash title="vite.config.ts"
+// @filename: src/env.ts
+import { type } from "arkenv";
+export const Env = type({
+	PORT: "number.port",
+	VITE_API_URL: "string",
+	VITE_API_KEY: "string",
+	VITE_MY_NUMBER: "number",
+	VITE_MY_BOOLEAN: "boolean",
+});
+export type Env = typeof Env.infer;
+
+// @filename: vite.config.ts
+// ---cut---
 import arkenvVitePlugin from "@arkenv/vite-plugin";
 import { defineConfig } from "vite";
 import { Env } from "./src/env";


### PR DESCRIPTION
## Summary

Follow-up to the config-page twoslash work: expands live `twoslash` coverage to the pages where interactive type hovers add the most value — the "Typing `process.env`" (Bun) and "Typing `import.meta.env`" (Vite) guides, which are literally about typesafety.

### Vite — `vite-plugin/typing-import-meta-env.mdx`
- **`src/app.tsx`**: now a multi-file twoslash block. Hovering shows `import.meta.env.VITE_API_URL: string`, `import.meta.env.PORT` renders the real `Property 'PORT' does not exist on type 'ImportMetaEnv'` error inline (server-only vars are correctly excluded), and a completion query demonstrates autocomplete. The `env.ts` + `vite-env.d.ts` augmentation setup is provided via hidden `// @filename` blocks so the visible code stays exactly what a user writes.
- **`vite.config.ts`**: twoslash showing `arkenvVitePlugin(options: CompiledEnvSchema, …)`.

### Bun — `bun-plugin/typing-process-env.mdx`
- **`src/app.tsx`** (both blocks): multi-file twoslash showing `process.env.BUN_PUBLIC_API_URL: string`, `BUN_PUBLIC_DEBUG: boolean`, and `NODE_ENV: "development" | "production" | "test"` narrowing.
- **`src/env.ts`**: simple twoslash.

### Smaller wins
- **`bun-plugin/index.mdx`**: `plugins/arkenv.ts` → twoslash (rich `arkenv(...)` plugin hover).
- **`arkenv/faq.mdx`**: the `arkenv(...)` `emptyAsUndefined` snippet → twoslash (hidden `import arkenv` via `---cut---`).

## Verification
Ran the shared `arktypeTwoslashOptions` twoslasher (`scripts/twoslash-mdx.ts`) over every edited file: all new blocks compile and resolve the expected hovers/errors. The only error emitted is the **intended** `PORT` error on the Vite page (marked with `// @errors: 2339`). `mdxlint` clean on all changed files.

> Note: `bun-plugin/index.mdx` shows one pre-existing local twoslash throw in a `bun-types`-referencing block, but it exists identically on `dev` (verified) and is a local dep-linking artifact — the deployed site builds it fine. Not introduced here.

## Out of scope (intentionally left plain)
- All `nuxt.config.ts` blocks: `defineNuxtConfig` (`nuxt/config`) isn't resolvable in the docs VFS, and `@arkenv/nuxt` doesn't augment `NuxtConfig`, so hovers wouldn't be useful. Filed separately as an enhancement.
- The `.d.ts` augmentation blocks (ambient definitions users copy), `build.ts` blocks (rely on the `Bun.build` global), and the competitor snippet.

No changeset — docs-only (`www` is ignored by changesets).

Made with [Cursor](https://cursor.com)