### PR TITLE
docs: Forward-port ModuleOptions JSDoc from dev to v1

### DIFF
--- a/.changeset/nuxt-module-options-jsdoc-v1.md
+++ b/.changeset/nuxt-module-options-jsdoc-v1.md
@@ -1,0 +1,19 @@
+---
+"@arkenv/nuxt": patch
+---
+
+#### Document `ModuleOptions` with JSDoc for better editor DX
+
+Add descriptions and `@default` tags to the `ModuleOptions` type so hovering `schemaPath`, `layout`, `validate`, `logger`, and `logLevel` in `nuxt.config.ts` surfaces inline documentation.
+
+```ts title="nuxt.config.ts"
+export default defineNuxtConfig({
+  modules: ["@arkenv/nuxt/module"],
+  arkenv: {
+    // Hovering these keys now shows their description and default value
+    schemaPath: "src/env.ts",
+    layout: "flat",
+    validate: true,
+  },
+});
+```

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -16,11 +16,57 @@ import {
 	validateSchema,
 } from "./config";
 
+/**
+ * Configuration options for the ArkEnv Nuxt module.
+ *
+ * Provide these under the `arkenv` key in your `nuxt.config.ts`.
+ *
+ * @example
+ * ```ts
+ * export default defineNuxtConfig({
+ *   modules: ["@arkenv/nuxt/module"],
+ *   arkenv: {
+ *     schemaPath: "src/env.ts"
+ *   }
+ * });
+ * ```
+ */
 export type ModuleOptions = {
+	/**
+	 * Specify the path to the schema definition file or directory.
+	 *
+	 * Defaults to searching for `"env.ts"` or `"src/env.ts"` (flat layout), or the
+	 * `"env/"` or `"src/env/"` directory (strict layout) in the project root.
+	 *
+	 * @default "src/env.ts"
+	 */
 	schemaPath?: string;
+
+	/**
+	 * Specify the configuration layout.
+	 *
+	 * - `"flat"` (default): A single `env.ts` schema file.
+	 * - `"strict"`: A multi-file split schema layout (`env/internal/shared.ts`, `env/client.ts`, `env/server.ts`).
+	 *
+	 * @default "flat"
+	 */
 	layout?: ArkEnvConfigOptions["layout"];
+
+	/**
+	 * Enable or disable environment variable validation during dev startup and build.
+	 *
+	 * @default true
+	 */
 	validate?: boolean;
+
+	/**
+	 * Provide a custom logger to receive ArkEnv's build-time diagnostics.
+	 */
 	logger?: ArkEnvConfigOptions["logger"];
+
+	/**
+	 * Control the verbosity of ArkEnv's build-time logging.
+	 */
 	logLevel?: ArkEnvConfigOptions["logLevel"];
 };
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -35,20 +35,22 @@ export type ModuleOptions = {
 	/**
 	 * Specify the path to the schema definition file or directory.
 	 *
-	 * Defaults to searching for `"env.ts"` or `"src/env.ts"` (flat layout), or the
-	 * `"env/"` or `"src/env/"` directory (strict layout) in the project root.
-	 *
-	 * @default "src/env.ts"
+	 * When omitted, ArkEnv auto-discovers the schema, searching for `"env.ts"` or
+	 * `"src/env.ts"` (flat layout) or the `"env/"` / `"src/env/"` directory
+	 * (strict layout) in the project root.
 	 */
 	schemaPath?: string;
 
 	/**
 	 * Specify the configuration layout.
 	 *
-	 * - `"flat"` (default): A single `env.ts` schema file.
-	 * - `"strict"`: A multi-file split schema layout (`env/internal/shared.ts`, `env/client.ts`, `env/server.ts`).
+	 * When omitted, the layout is auto-detected from the schema structure: it is
+	 * `"strict"` when the split files (`env/internal/shared.ts`, `env/client.ts`,
+	 * `env/server.ts`) are present, and falls back to `"flat"` (a single
+	 * `env.ts`) otherwise.
 	 *
-	 * @default "flat"
+	 * - `"flat"`: A single `env.ts` schema file.
+	 * - `"strict"`: A multi-file split schema layout.
 	 */
 	layout?: ArkEnvConfigOptions["layout"];
 


### PR DESCRIPTION
Forward-ports the `@arkenv/nuxt` `ModuleOptions` JSDoc from dev PR #1352 (the only published-package change in that PR — the rest was `apps/www` docs, which aren't forward-ported).

## Change

Adds JSDoc descriptions + `@default` tags to `ModuleOptions` in `packages/nuxt/src/module.ts` (same path/package name on v1), so hovering the `arkenv` config keys in `nuxt.config.ts` surfaces inline documentation.

### v1 adaptations
- Preserved the v1-only fields `logger` and `logLevel` (part of the injectable-logger API that exists only on v1) and gave them concise JSDoc so the whole type is documented.
- Changeset uses the v1 package name — `@arkenv/nuxt` (unchanged between dev and v1).

## Verification
- `biome check` clean on the changed file and changeset.
- JSDoc-only change (comments): introduces **zero** new type errors — a `tsc --noEmit` on `packages/nuxt` yields the exact same environmental error set as pristine `origin/v1` (unbuilt `@repo/*` / `@arkenv/build` workspace deps); nothing references the edited declaration.

Source: dev PR #1352.

Made with [Cursor](https://cursor.com)