### PR TITLE
docs: clarify auto-detected schemaPath/layout in Nuxt ModuleOptions

### DIFF
--- a/.changeset/nuxt-module-options-jsdoc-accuracy.md
+++ b/.changeset/nuxt-module-options-jsdoc-accuracy.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/nuxt": patch
+---
+
+#### Clarify auto-detected `schemaPath` and `layout` in `ModuleOptions` docs
+
+Reword the `ModuleOptions` JSDoc to accurately describe auto-detection and drop the misleading `@default` tags: `schemaPath` is auto-discovered via `findSchemaPath`, and `layout` is auto-detected from the schema structure (`"strict"` when the split files are present, `"flat"` as the fallback) rather than defaulting to a fixed value.

--- a/packages/nuxt/src/config.ts
+++ b/packages/nuxt/src/config.ts
@@ -54,9 +54,9 @@ export type ArkEnvConfigOptions = {
 	/**
 	 * Specify the path to the schema definition file.
 	 *
-	 * Defaults to searching for `"src/env.ts"` or `"env.ts"` in the project root.
+	 * When omitted, ArkEnv auto-discovers the schema, searching for `"src/env.ts"`
+	 * or `"env.ts"` in the project root.
 	 *
-	 * @default "src/env.ts"
 	 * @example
 	 * ```ts
 	 * export default defineNuxtConfig({
@@ -70,10 +70,13 @@ export type ArkEnvConfigOptions = {
 	/**
 	 * Specify the configuration layout.
 	 *
-	 * - `"flat"` (default): A single `env.ts` schema file.
-	 * - `"strict"`: A 3-file split schema layout (`env/internal/shared.ts`, `env/client.ts`, `env/server.ts`).
+	 * When omitted, the layout is auto-detected from the schema structure: it is
+	 * `"strict"` when the split files (`env/internal/shared.ts`, `env/client.ts`,
+	 * `env/server.ts`) are present, and falls back to `"flat"` (a single
+	 * `env.ts`) otherwise.
 	 *
-	 * @default "flat"
+	 * - `"flat"`: A single `env.ts` schema file.
+	 * - `"strict"`: A 3-file split schema layout (`env/internal/shared.ts`, `env/client.ts`, `env/server.ts`).
 	 */
 	layout?:
 		| "flat"

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -34,20 +34,22 @@ export type ModuleOptions = {
 	/**
 	 * Specify the path to the schema definition file or directory.
 	 *
-	 * Defaults to searching for `"env.ts"` or `"src/env.ts"` (flat layout), or the
-	 * `"env/"` or `"src/env/"` directory (strict layout) in the project root.
-	 *
-	 * @default "src/env.ts"
+	 * When omitted, ArkEnv auto-discovers the schema, searching for `"env.ts"` or
+	 * `"src/env.ts"` (flat layout) or the `"env/"` / `"src/env/"` directory
+	 * (strict layout) in the project root.
 	 */
 	schemaPath?: string;
 
 	/**
 	 * Specify the configuration layout.
 	 *
-	 * - `"flat"` (default): A single `env.ts` schema file.
-	 * - `"strict"`: A multi-file split schema layout (`env/internal/shared.ts`, `env/client.ts`, `env/server.ts`).
+	 * When omitted, the layout is auto-detected from the schema structure: it is
+	 * `"strict"` when the split files (`env/internal/shared.ts`, `env/client.ts`,
+	 * `env/server.ts`) are present, and falls back to `"flat"` (a single
+	 * `env.ts`) otherwise.
 	 *
-	 * @default "flat"
+	 * - `"flat"`: A single `env.ts` schema file.
+	 * - `"strict"`: A multi-file split schema layout.
 	 */
 	layout?: ArkEnvConfigOptions["layout"];
 


### PR DESCRIPTION
Follow-up to #1352 aligning `dev` with a review note from the v1 forward-port (#1361).

## Problem

The `ModuleOptions` JSDoc added in #1352 uses `@default "src/env.ts"` and `@default "flat"`, which are misleading:

- `schemaPath` is **not** literally defaulted — the module calls `findSchemaPath` to auto-discover among `env.ts`, `src/env.ts`, and strict-layout directories.
- `layout` is **auto-detected** by `resolveLayout` from the schema structure (`"strict"` when the split files exist, `"flat"` as the fallback), not defaulted to a fixed value.

## Change

- Drop the misleading `@default` tags on `schemaPath` and `layout`; reword the prose to describe the auto-detection accurately.
- Keep `@default true` on `validate` (accurate: `defaults.validate = true` / `options?.validate ?? true`).

This brings `dev` in line with the corrected v1 docs and keeps future forward-ports clean.

`@arkenv/nuxt` patch changeset included.

Made with [Cursor](https://cursor.com)