### PR TITLE
Clarify contributor guide and triage labels for human contributors

### DIFF
--- a/.agents/docs/triage-labels.md
+++ b/.agents/docs/triage-labels.md
@@ -2,14 +2,14 @@
 
 The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
-| -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`             | `needs triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `needs more info`    | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready for agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `ready for human`    | Requires human implementation            |
-| `wontfix`                  | `wontfix`            | Will not be actioned                     |
-| `meta`                     | `meta`               | Living docs (dashboards, roadmaps)       |
+| Label in mattpocock/skills | Label in our tracker | Meaning                                                        |
+| -------------------------- | -------------------- | ------------------------------------------------------------- |
+| `needs-triage`             | `needs triage`       | Maintainer needs to evaluate this issue                       |
+| `needs-info`               | `needs more info`    | Waiting on reporter for more information                      |
+| `ready-for-agent`          | `ready for agent`    | Fully specified, ready for immediate implementation           |
+| `ready-for-human`          | `ready for human`    | Needs a judgment call or design decision before implementation |
+| `wontfix`                  | `wontfix`            | Will not be actioned                                          |
+| `meta`                     | `meta`               | Living docs (dashboards, roadmaps)                            |
 
 When a skill mentions a role (e.g. "apply the ready for agent triage label"), use the corresponding label string from this table.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,8 +8,8 @@ Human and agent-assisted contributions are equally welcome here. Whether you wri
 
 To help you find work, triaged issues carry a readiness label:
 
-- **`ready for agent`** — Fully specified and ready for immediate implementation. Pick it up yourself or hand it to an agent; the requirements are clear enough to start coding right away.
-- **`ready for human`** — Needs a judgment call or design decision before implementation. These aren't off-limits, they just want a person to weigh in on direction first.
+- **`ready for agent`** - Fully specified and ready for immediate implementation. Pick it up yourself or hand it to an agent; the requirements are clear enough to start coding right away.
+- **`ready for human`** - Needs a judgment call or design decision before implementation. These aren't off-limits, they just want a person to weigh in on direction first.
 
 Don't let the label names give you the wrong impression: `ready for agent` simply means "ready to build," not "reserved for bots." Feel free to grab either kind of issue.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,6 +2,17 @@
 
 Thank you for considering a contribution to ArkEnv! As an open source project, ArkEnv welcomes contributions of all kinds.
 
+## Who can contribute
+
+Human and agent-assisted contributions are equally welcome here. Whether you write every line by hand or lean on an AI agent, you're a first-class contributor, and a human maintainer reviews every pull request before it lands.
+
+To help you find work, triaged issues carry a readiness label:
+
+- **`ready for agent`** — Fully specified and ready for immediate implementation. Pick it up yourself or hand it to an agent; the requirements are clear enough to start coding right away.
+- **`ready for human`** — Needs a judgment call or design decision before implementation. These aren't off-limits, they just want a person to weigh in on direction first.
+
+Don't let the label names give you the wrong impression: `ready for agent` simply means "ready to build," not "reserved for bots." Feel free to grab either kind of issue.
+
 ## Development setup
 
 1. ### Install pnpm

--- a/skills/setup-matt-pocock-skills/SKILL.md
+++ b/skills/setup-matt-pocock-skills/SKILL.md
@@ -54,8 +54,8 @@ The five canonical roles:
 
 - `needs-triage` - maintainer needs to evaluate
 - `needs-info` - waiting on reporter
-- `ready-for-agent` - fully specified, AFK-ready (an agent can pick it up with no human context)
-- `ready-for-human` - needs human implementation
+- `ready-for-agent` - fully specified, ready for immediate implementation (pick it up yourself or with an agent)
+- `ready-for-human` - needs a judgment call or design decision before implementation
 - `wontfix` - will not be actioned
 
 Default: each role's string equals its name. Ask the user if they want to override any. If their issue tracker has no existing labels, the defaults are fine.

--- a/skills/setup-matt-pocock-skills/triage-labels.md
+++ b/skills/setup-matt-pocock-skills/triage-labels.md
@@ -2,13 +2,13 @@
 
 The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
-| -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
-| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+| Label in mattpocock/skills | Label in our tracker | Meaning                                                        |
+| -------------------------- | -------------------- | ------------------------------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue                       |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information                      |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for immediate implementation           |
+| `ready-for-human`          | `ready-for-human`    | Needs a judgment call or design decision before implementation |
+| `wontfix`                  | `wontfix`            | Will not be actioned                                          |
 
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -31,8 +31,8 @@ Five **state** roles:
 
 - `needs-triage` - maintainer needs to evaluate
 - `needs-info` - waiting on reporter for more information
-- `ready-for-agent` - fully specified, ready for an AFK agent
-- `ready-for-human` - needs human implementation
+- `ready-for-agent` - fully specified, ready for immediate implementation
+- `ready-for-human` - needs a judgment call or design decision before implementation
 - `wontfix` - will not be actioned
 
 One **exempt** role:


### PR DESCRIPTION
Fixes #1364

## What changed

- **`docs/CONTRIBUTING.md`**: Added an early "Who can contribute" section that welcomes human and agent-assisted contributions equally, explains the `ready for agent` / `ready for human` triage labels in plain language, and notes that a human still reviews every PR. Kept the maintainer philosophy brief.
- **GitHub label descriptions** (applied via `gh label edit`, no renames):
  - `ready for agent` → `Fully specified, ready for immediate implementation`
  - `ready for human` → `Needs a judgment call or design decision before implementation`
- **`skills/triage/SKILL.md`**: Aligned the internal meaning text for those two roles with the new public wording (canonical role names unchanged).

## Notes

- No changeset: changes are limited to docs and internal tooling; no published/private package code is affected.
- Triage state machine and label names are unchanged.
- `pnpm typecheck`, `pnpm test` (784 passed), and `pnpm fix` all pass.

Made with [Cursor](https://cursor.com)