### PR TITLE
feat: drop `-e` short alias for `--example`

### DIFF
--- a/.changeset/drop-example-e-alias.md
+++ b/.changeset/drop-example-e-alias.md
@@ -1,0 +1,19 @@
+---
+"@arkenv/cli": minor
+---
+
+#### Drop the `-e` short alias for `init --example`
+
+**BREAKING CHANGE**: The `-e` short alias is no longer recognized. Its long form, `--example`, continues to work exactly as before.
+
+Across the broader CLI ecosystem, `-e` almost universally means `--env` / `--environment`. For a type-safe environment variable library, mapping `-e` to `--example` is a sharp trap: AI agents instinctively reach for `arkenv init -e NODE_ENV=production`, which silently bound to `--example` and consumed the next token as the example name. `-e` is now permanently reserved so it stays free for a future `--env` / `--environment` option. Passing `-e` — standalone or inside a bundle like `-ye` — now fails fast with the standard `Unknown argument: -e` error.
+
+Migration: replace the short alias with its long form.
+
+```bash
+# Before
+npx @arkenv/cli@latest init -e with-vite-react
+
+# After
+npx @arkenv/cli@latest init --example with-vite-react
+```

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -31,7 +31,7 @@ Configure the CLI behavior using the following command-line flags:
 | `--quiet`       | `-q`  | Suppress all output logs unless an error occurs.                                                                                                   |
 | `--json`        | `-j`  | Print a structured JSON summary to `stdout` upon completion.                                                                                       |
 | `--agent`       |       | Enable non-interactive, machine-readable mode for AI agents. Bypasses all prompts and outputs structured JSON. Macro for `--yes --quiet --json`.   |
-| `--example`     | `-e`  | Specify an example name when creating a new project.                                                                                               |
+| `--example`     |       | Specify an example name when creating a new project.                                                                                               |
 | `--force`       | `-f`  | Bypass checks and force initialization.                                                                                                            |
 | `--no-codegen`  |       | Disable automatic env.gen.ts code generation for Next.js (falls back to manual runtimeEnv destructuring).                                          |
 | `--host-preset` | `-H`  | Pre-populate the schema with a hosting provider's system env vars (`none`, `vercel`, `netlify`). See [Hosting presets](/docs/cli/hosting-presets). |

--- a/packages/cli/src/cli/cli.test.ts
+++ b/packages/cli/src/cli/cli.test.ts
@@ -80,6 +80,24 @@ describe("CLI parser", () => {
 		expect(cli.validationError).toBe("Unknown argument: -C");
 	});
 
+	it("should still accept --example in long form", () => {
+		const cli = new CLI([
+			"node",
+			"arkenv",
+			"init",
+			"--example",
+			"with-vite-react",
+		]);
+		expect(cli.example).toBe("with-vite-react");
+		expect(cli.validationError).toBeUndefined();
+	});
+
+	it("should reject the reserved -e alias as an unknown argument", () => {
+		const cli = new CLI(["node", "arkenv", "init", "-e", "with-vite-react"]);
+		expect(cli.example).toBeUndefined();
+		expect(cli.validationError).toBe("Unknown argument: -e");
+	});
+
 	describe("Agent presets override", () => {
 		it("should set isYes, isQuiet, and isJson to true when --agent is passed", () => {
 			const cli = new CLI(["node", "arkenv", "init", "--agent"]);
@@ -123,6 +141,12 @@ describe("CLI parser", () => {
 			expect(cli2.validationError).toBe("Unknown argument: -C");
 		});
 
+		it("should reject the reserved -e alias when bundled with other short flags", () => {
+			const cli = new CLI(["node", "arkenv", "init", "-ye"]);
+			expect(cli.example).toBeUndefined();
+			expect(cli.validationError).toBe("Unknown argument: -e");
+		});
+
 		it("should expand a bundle of multiple short flags including force", () => {
 			const cli = new CLI(["node", "arkenv", "init", "-yfq"]);
 			expect(cli.isYes).toBe(true);
@@ -139,12 +163,12 @@ describe("CLI parser", () => {
 			expect(cli.validationError).toBeUndefined();
 		});
 
-		it("should not expand flag values immediately following value-taking flags (e.g. -e / --example)", () => {
-			const cli1 = new CLI(["node", "arkenv", "init", "-e", "-yq"]);
-			expect(cli1.args).toEqual(["init", "-e", "-yq"]);
+		it("should not expand flag values immediately following value-taking flags (e.g. -H / --example)", () => {
+			const cli1 = new CLI(["node", "arkenv", "init", "-H", "-yq"]);
+			expect(cli1.args).toEqual(["init", "-H", "-yq"]);
 			expect(cli1.isYes).toBe(false);
 			expect(cli1.isQuiet).toBe(false);
-			expect(cli1.validationError).toBe("Missing value for option: -e");
+			expect(cli1.validationError).toBe("Missing value for option: -H");
 
 			const cli2 = new CLI(["node", "arkenv", "init", "--example", "-abc"]);
 			expect(cli2.args).toEqual(["init", "--example", "-abc"]);
@@ -153,20 +177,20 @@ describe("CLI parser", () => {
 		});
 
 		it("should expand a bundle ending in a value-taking flag and parse its value correctly", () => {
-			const cli = new CLI(["node", "arkenv", "init", "-yqe", "my-example"]);
+			const cli = new CLI(["node", "arkenv", "init", "-yqH", "netlify"]);
 			expect(cli.isYes).toBe(true);
 			expect(cli.isQuiet).toBe(true);
-			expect(cli.example).toBe("my-example");
+			expect(cli.hostPreset).toBe("netlify");
 			expect(cli.validationError).toBeUndefined();
 		});
 
 		it("should not expand dash-prefixed values after bundled value-taking flags", () => {
-			const cli = new CLI(["node", "arkenv", "init", "-yqe", "-abc"]);
-			expect(cli.args).toEqual(["init", "-y", "-q", "-e", "-abc"]);
+			const cli = new CLI(["node", "arkenv", "init", "-yqH", "-abc"]);
+			expect(cli.args).toEqual(["init", "-y", "-q", "-H", "-abc"]);
 			expect(cli.isYes).toBe(true);
 			expect(cli.isQuiet).toBe(true);
 			expect(cli.isAgent).toBe(false);
-			expect(cli.validationError).toBe("Missing value for option: -e");
+			expect(cli.validationError).toBe("Missing value for option: -H");
 		});
 
 		it("should ignore single-letter flags with dash or long flags", () => {
@@ -183,14 +207,16 @@ describe("CLI parser", () => {
 			const cli1 = new CLI(["node", "arkenv", "init", "--example"]);
 			expect(cli1.validationError).toBe("Missing value for option: --example");
 
-			const cli2 = new CLI(["node", "arkenv", "init", "-e"]);
-			expect(cli2.validationError).toBe("Missing value for option: -e");
+			const cli2 = new CLI(["node", "arkenv", "init", "--host-preset"]);
+			expect(cli2.validationError).toBe(
+				"Missing value for option: --host-preset",
+			);
 
 			const cli3 = new CLI(["node", "arkenv", "init", "--example", "--yes"]);
 			expect(cli3.validationError).toBe("Missing value for option: --example");
 
-			const cli4 = new CLI(["node", "arkenv", "init", "-yqe"]);
-			expect(cli4.validationError).toBe("Missing value for option: -e");
+			const cli4 = new CLI(["node", "arkenv", "init", "-yqH"]);
+			expect(cli4.validationError).toBe("Missing value for option: -H");
 		});
 	});
 

--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -8,7 +8,10 @@ const FLAG_CONFIG = {
 	isJson: { long: "--json", short: "-j", kind: "boolean" },
 	isAgent: { long: "--agent", short: "", kind: "boolean" },
 	helpRequested: { long: "--help", short: "-h", kind: "boolean" },
-	example: { long: "--example", short: "-e", kind: "value" },
+	// `-e` is intentionally reserved: it universally means `--env`/`--environment`
+	// elsewhere, so it must never be aliased to `--example` (or any other flag).
+	// Keeping it unassigned makes `-e` fail fast as an unknown argument.
+	example: { long: "--example", short: "", kind: "value" },
 	isStrict: { long: "--strict", short: "", kind: "boolean" },
 	isSimple: { long: "--simple", short: "", kind: "boolean" },
 	isFlat: { long: "--flat", short: "", kind: "boolean" },

--- a/packages/cli/src/cli/commands/help.test.ts
+++ b/packages/cli/src/cli/commands/help.test.ts
@@ -38,11 +38,11 @@ describe("HelpUseCase", () => {
 			"  --yes, -y                     Skip prompts and use defaults (also passed to subprocesses)",
 		);
 
-		const exampleOptionLog = logs.find((l) => l.includes("--example, -e"));
+		const exampleOptionLog = logs.find((l) => l.includes("--example"));
 		expect(exampleOptionLog).toBeDefined();
-		// "--example, -e" is 13 chars. max (26) - 13 + colGap (4) = 17 spaces padding.
+		// "--example" is 9 chars. max (26) - 9 + colGap (4) = 21 spaces padding.
 		expect(exampleOptionLog).toBe(
-			"  --example, -e                 Specify an example name when creating a new project",
+			"  --example                     Specify an example name when creating a new project",
 		);
 
 		const agentOptionLog = logs.find((l) => l.includes("--agent"));

--- a/packages/cli/src/cli/commands/help.ts
+++ b/packages/cli/src/cli/commands/help.ts
@@ -56,7 +56,7 @@ export class HelpUseCase {
 					"Enable non-interactive, machine-readable mode for AI agents. Bypasses all prompts and outputs structured JSON. Macro for --yes --quiet --json",
 			},
 			{
-				left: "--example, -e",
+				left: "--example",
 				right: "Specify an example name when creating a new project",
 			},
 			{


### PR DESCRIPTION
Fixes #1367

Drops the `-e` short alias for `--example`, making `--example` **long-form only**. `-e` is permanently reserved so it stays free for a possible future `--env` / `--environment` option.

## Why
Across the CLI ecosystem (Docker, Kubernetes, Unix), `-e` almost universally means `--env` / `--environment`. AI agents instinctively reach for `arkenv init -e NODE_ENV=production`, which silently bound to the unrelated `--example` flag and consumed the next token — producing behavior that didn't match intent and triggering retry/hallucination loops.

## Changes
- `packages/cli/src/cli/cli.ts`: drop the `-e` short alias from the `--example` flag config (kept as `value` kind, long-form only). Added a comment marking `-e` as reserved. Removal flows automatically through `knownFlags`, `valuedFlags`, bundled-short-flag expansion, and the `example` accessor.
- `packages/cli/src/cli/commands/help.ts`: help output shows `--example` with no short alias.
- `apps/www/content/docs/cli/index.mdx`: flags table no longer lists `-e` for `--example`.
- Tests updated: assertions that `-e` maps to `--example` are removed/replaced (value-flag coverage repurposed to `-H`/`--example`); new coverage asserts `-e` and `-ye` are rejected as `Unknown argument: -e` while `--example` still works.
- Changeset: `@arkenv/cli` **minor**, documented as a **BREAKING CHANGE** (mirrors the `-C`/`-a` removal precedent).

## Behavior
- `arkenv init --example <name>` works exactly as before.
- `arkenv init -e <name>` → `Unknown argument: -e`.
- `-ye` (bundled) → `Unknown argument: -e`.

## Follow-up
After merge to `dev`, run `/forward-port` to bring this to the `v1` branch (`packages/cli/src/**` → `packages/arkenv/src/**`, changeset key `@arkenv/cli` → `arkenv`).

Made with [Cursor](https://cursor.com)