### PR TITLE
feat(nuxt): augment NuxtConfig to type the `arkenv` module options key

### DIFF
--- a/.changeset/nuxt-augment-config-key.md
+++ b/.changeset/nuxt-augment-config-key.md
@@ -1,0 +1,20 @@
+---
+"@arkenv/nuxt": patch
+---
+
+#### Type the `arkenv` key in `nuxt.config.ts` via `@nuxt/schema` augmentation
+
+Augment `@nuxt/schema`'s `NuxtConfig` and `NuxtOptions` so the `arkenv` module options key is fully typed. Consumers now get autocomplete, type-checking, and JSDoc hovers for `arkenv` options directly in `nuxt.config.ts`, instead of falling back to a loose index signature.
+
+`ModuleOptions` is now an alias of the documented `ArkEnvConfigOptions`, so option hovers surface the existing JSDoc / `@default` tags from a single source of truth.
+
+```ts
+export default defineNuxtConfig({
+  modules: ["@arkenv/nuxt/module"],
+  arkenv: {
+    schemaPath: "src/env.ts", // autocompleted & type-checked
+    layout: "flat",
+    validate: true,
+  },
+});
+```

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -20,6 +20,9 @@ import {
  *
  * Provide these under the `arkenv` key in your `nuxt.config.ts`.
  *
+ * Aliased to {@link ArkEnvConfigOptions} so the documented options remain the
+ * single source of truth (field-level JSDoc, `@default` tags, and so on).
+ *
  * @example
  * ```ts
  * export default defineNuxtConfig({
@@ -30,36 +33,18 @@ import {
  * });
  * ```
  */
-export type ModuleOptions = {
-	/**
-	 * Specify the path to the schema definition file or directory.
-	 *
-	 * When omitted, ArkEnv auto-discovers the schema, searching for `"env.ts"` or
-	 * `"src/env.ts"` (flat layout) or the `"env/"` / `"src/env/"` directory
-	 * (strict layout) in the project root.
-	 */
-	schemaPath?: string;
+export type ModuleOptions = ArkEnvConfigOptions;
 
-	/**
-	 * Specify the configuration layout.
-	 *
-	 * When omitted, the layout is auto-detected from the schema structure: it is
-	 * `"strict"` when the split files (`env/internal/shared.ts`, `env/client.ts`,
-	 * `env/server.ts`) are present, and falls back to `"flat"` (a single
-	 * `env.ts`) otherwise.
-	 *
-	 * - `"flat"`: A single `env.ts` schema file.
-	 * - `"strict"`: A multi-file split schema layout.
-	 */
-	layout?: ArkEnvConfigOptions["layout"];
-
-	/**
-	 * Enable or disable environment variable validation during dev startup and build.
-	 *
-	 * @default true
-	 */
-	validate?: boolean;
-};
+declare module "@nuxt/schema" {
+	// biome-ignore lint/style/useConsistentTypeDefinitions: module augmentation requires an interface for declaration merging
+	interface NuxtConfig {
+		arkenv?: ModuleOptions;
+	}
+	// biome-ignore lint/style/useConsistentTypeDefinitions: module augmentation requires an interface for declaration merging
+	interface NuxtOptions {
+		arkenv?: ModuleOptions;
+	}
+}
 
 const CLIENT_SECURITY_ERROR =
 	"[ArkEnv] Importing server-only environment schema on the client is not allowed!";

--- a/packages/nuxt/src/type-regression.test-d.ts
+++ b/packages/nuxt/src/type-regression.test-d.ts
@@ -1,5 +1,8 @@
+import type { NuxtConfig, NuxtOptions } from "@nuxt/schema";
 import { describe, expectTypeOf, it } from "vitest";
+import type { ArkEnvConfigOptions } from "./config";
 import { createEnv } from "./index";
+import type { ModuleOptions } from "./module";
 
 describe("@arkenv/nuxt type regression", () => {
 	it("infers client variables as their validated type", () => {
@@ -108,5 +111,43 @@ describe("@arkenv/nuxt type regression", () => {
 		expectTypeOf(env.NUXT_PUBLIC_API_URL).toBeString();
 		expectTypeOf(env.NODE_ENV).toBeString();
 		expectTypeOf(env.CUSTOM_VAR).toBeString();
+	});
+});
+
+describe("@arkenv/nuxt module options augmentation", () => {
+	it("aliases ModuleOptions to the documented ArkEnvConfigOptions", () => {
+		expectTypeOf<ModuleOptions>().toEqualTypeOf<ArkEnvConfigOptions>();
+	});
+
+	it("types the arkenv config key on NuxtConfig and NuxtOptions", () => {
+		expectTypeOf<NuxtConfig["arkenv"]>().toEqualTypeOf<
+			ModuleOptions | undefined
+		>();
+		expectTypeOf<NuxtOptions["arkenv"]>().toEqualTypeOf<
+			ModuleOptions | undefined
+		>();
+	});
+
+	it("accepts known arkenv options in a nuxt config", () => {
+		const config = {
+			arkenv: {
+				schemaPath: "src/env.ts",
+				layout: "flat",
+				validate: true,
+			},
+		} satisfies NuxtConfig;
+
+		expectTypeOf(config.arkenv).toMatchTypeOf<ModuleOptions>();
+	});
+
+	it("rejects unknown keys in the arkenv config block", () => {
+		const config: NuxtConfig = {
+			arkenv: {
+				// @ts-expect-error unknown option is not part of ModuleOptions
+				unknownOption: true,
+			},
+		};
+
+		expectTypeOf(config.arkenv).toEqualTypeOf<ModuleOptions | undefined>();
 	});
 });


### PR DESCRIPTION
Fixes #1359

## Summary

Types the `arkenv` module options key in `nuxt.config.ts` so consumers get autocomplete, type-checking, and JSDoc hovers instead of the loose index-signature fallback.

## Changes

- Alias `ModuleOptions` to the documented `ArkEnvConfigOptions` (single source of truth; no hand-maintained duplicate). Option hovers now surface the existing JSDoc / `@default` tags.
- Augment `@nuxt/schema`'s `NuxtConfig` and `NuxtOptions` with `arkenv?: ModuleOptions`. The augmentation lives in `module.ts` and ships in the built `dist/module.d.ts`, so it is picked up when consumers register `@arkenv/nuxt/module`.
- Add type-level regression tests covering the `ModuleOptions` alias and the `arkenv` config key (known keys accepted, unknown keys rejected).

## Verification

- `pnpm --filter @arkenv/nuxt run typecheck` passes (confirms the augmentation resolves and unknown-key rejection works).
- `@arkenv/nuxt` test suite passes (26 tests).
- `biome` clean; module augmentation interfaces carry a scoped `useConsistentTypeDefinitions` ignore because declaration merging requires `interface`.
- Verified the augmentation is present in the built `dist/module.d.ts`.

## Notes

- Docs Twoslash conversion for the Nuxt `nuxt.config.ts` examples is out of scope (follow-up).
- Requires `/forward-port`ing to `v1` once merged into `dev` (on `v1`, `ArkEnvConfigOptions` also covers `logger` / `logLevel`, which the alias picks up automatically).

Made with [Cursor](https://cursor.com)