### PR TITLE
feat(nuxt): Forward-port `arkenv` config-key typing from #1371 to v1

### DIFF
--- a/.changeset/nuxt-augment-config-key.md
+++ b/.changeset/nuxt-augment-config-key.md
@@ -1,0 +1,20 @@
+---
+"@arkenv/nuxt": patch
+---
+
+#### Type the `arkenv` key in `nuxt.config.ts` via `@nuxt/schema` augmentation
+
+Augment `@nuxt/schema`'s `NuxtConfig` and `NuxtOptions` so the `arkenv` module options key is fully typed. Consumers now get autocomplete, type-checking, and JSDoc hovers for `arkenv` options directly in `nuxt.config.ts`, instead of falling back to a loose index signature.
+
+`ModuleOptions` is now an alias of the documented `ArkEnvConfigOptions`, so option hovers surface the existing JSDoc / `@default` tags from a single source of truth.
+
+```ts
+export default defineNuxtConfig({
+  modules: ["@arkenv/nuxt/module"],
+  arkenv: {
+    schemaPath: "src/env.ts", // autocompleted & type-checked
+    layout: "flat",
+    validate: true,
+  },
+});
+```

--- a/packages/nuxt/src/config.ts
+++ b/packages/nuxt/src/config.ts
@@ -53,15 +53,55 @@ export function normalizeLayout(
 	return layout;
 }
 
+/**
+ * Configuration options for ArkEnv's build-time integration.
+ *
+ * This is the single source of truth for the options exposed under the `arkenv`
+ * key in framework configs (e.g. `nuxt.config.ts`), which is why the field-level
+ * JSDoc and `@default` tags live here.
+ */
 export type ArkEnvConfigOptions = {
+	/**
+	 * Specify the path to the schema definition file or directory.
+	 *
+	 * When omitted, ArkEnv auto-discovers the schema, searching for `"env.ts"` or
+	 * `"src/env.ts"` (flat layout) or the `"env/"` / `"src/env/"` directory
+	 * (strict layout) in the project root.
+	 */
 	schemaPath?: string;
+
+	/**
+	 * Specify the configuration layout.
+	 *
+	 * When omitted, the layout is auto-detected from the schema structure: it is
+	 * `"strict"` when the split files (`env/internal/shared.ts`, `env/client.ts`,
+	 * `env/server.ts`) are present, and falls back to `"flat"` (a single
+	 * `env.ts`) otherwise.
+	 *
+	 * - `"flat"`: A single `env.ts` schema file.
+	 * - `"strict"`: A multi-file split schema layout.
+	 */
 	layout?:
 		| "flat"
 		| "strict"
 		/** @deprecated Use `"flat"` instead. */
 		| "simple";
+
+	/**
+	 * Enable or disable environment variable validation during dev startup and build.
+	 *
+	 * @default true
+	 */
 	validate?: boolean;
+
+	/**
+	 * Provide a custom logger to receive ArkEnv's build-time diagnostics.
+	 */
 	logger?: Logger;
+
+	/**
+	 * Control the verbosity of ArkEnv's build-time logging.
+	 */
 	logLevel?: LogLevel;
 };
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -21,6 +21,9 @@ import {
  *
  * Provide these under the `arkenv` key in your `nuxt.config.ts`.
  *
+ * Aliased to {@link ArkEnvConfigOptions} so the documented options remain the
+ * single source of truth (field-level JSDoc, `@default` tags, and so on).
+ *
  * @example
  * ```ts
  * export default defineNuxtConfig({
@@ -31,46 +34,18 @@ import {
  * });
  * ```
  */
-export type ModuleOptions = {
-	/**
-	 * Specify the path to the schema definition file or directory.
-	 *
-	 * When omitted, ArkEnv auto-discovers the schema, searching for `"env.ts"` or
-	 * `"src/env.ts"` (flat layout) or the `"env/"` / `"src/env/"` directory
-	 * (strict layout) in the project root.
-	 */
-	schemaPath?: string;
+export type ModuleOptions = ArkEnvConfigOptions;
 
-	/**
-	 * Specify the configuration layout.
-	 *
-	 * When omitted, the layout is auto-detected from the schema structure: it is
-	 * `"strict"` when the split files (`env/internal/shared.ts`, `env/client.ts`,
-	 * `env/server.ts`) are present, and falls back to `"flat"` (a single
-	 * `env.ts`) otherwise.
-	 *
-	 * - `"flat"`: A single `env.ts` schema file.
-	 * - `"strict"`: A multi-file split schema layout.
-	 */
-	layout?: ArkEnvConfigOptions["layout"];
-
-	/**
-	 * Enable or disable environment variable validation during dev startup and build.
-	 *
-	 * @default true
-	 */
-	validate?: boolean;
-
-	/**
-	 * Provide a custom logger to receive ArkEnv's build-time diagnostics.
-	 */
-	logger?: ArkEnvConfigOptions["logger"];
-
-	/**
-	 * Control the verbosity of ArkEnv's build-time logging.
-	 */
-	logLevel?: ArkEnvConfigOptions["logLevel"];
-};
+declare module "@nuxt/schema" {
+	// biome-ignore lint/style/useConsistentTypeDefinitions: module augmentation requires an interface for declaration merging
+	interface NuxtConfig {
+		arkenv?: ModuleOptions;
+	}
+	// biome-ignore lint/style/useConsistentTypeDefinitions: module augmentation requires an interface for declaration merging
+	interface NuxtOptions {
+		arkenv?: ModuleOptions;
+	}
+}
 
 const CLIENT_SECURITY_ERROR = formatBuildError(
 	"Importing server-only environment schema on the client is not allowed!",

--- a/packages/nuxt/src/type-regression.test-d.ts
+++ b/packages/nuxt/src/type-regression.test-d.ts
@@ -1,5 +1,8 @@
+import type { NuxtConfig, NuxtOptions } from "@nuxt/schema";
 import { describe, expectTypeOf, it } from "vitest";
+import type { ArkEnvConfigOptions } from "./config";
 import { arkenv } from "./index";
+import type { ModuleOptions } from "./module";
 import arkenvStandard from "./standard";
 
 const createMockStandardSchema = <TOutput>(outputValue: TOutput) => ({
@@ -144,5 +147,43 @@ describe("@arkenv/nuxt type regression", () => {
 
 		// @ts-expect-error server-only variable is omitted/never on the client
 		env.DATABASE_URL;
+	});
+});
+
+describe("@arkenv/nuxt module options augmentation", () => {
+	it("aliases ModuleOptions to the documented ArkEnvConfigOptions", () => {
+		expectTypeOf<ModuleOptions>().toEqualTypeOf<ArkEnvConfigOptions>();
+	});
+
+	it("types the arkenv config key on NuxtConfig and NuxtOptions", () => {
+		expectTypeOf<NuxtConfig["arkenv"]>().toEqualTypeOf<
+			ModuleOptions | undefined
+		>();
+		expectTypeOf<NuxtOptions["arkenv"]>().toEqualTypeOf<
+			ModuleOptions | undefined
+		>();
+	});
+
+	it("accepts known arkenv options in a nuxt config", () => {
+		const config = {
+			arkenv: {
+				schemaPath: "src/env.ts",
+				layout: "flat",
+				validate: true,
+			},
+		} satisfies NuxtConfig;
+
+		expectTypeOf(config.arkenv).toMatchTypeOf<ModuleOptions>();
+	});
+
+	it("rejects unknown keys in the arkenv config block", () => {
+		const config: NuxtConfig = {
+			arkenv: {
+				// @ts-expect-error unknown option is not part of ModuleOptions
+				unknownOption: true,
+			},
+		};
+
+		expectTypeOf(config.arkenv).toEqualTypeOf<ModuleOptions | undefined>();
 	});
 });


### PR DESCRIPTION
Forward-ports #1371 (merged to `dev`) to the `v1` branch.

## Change

Types the `arkenv` module options key in `nuxt.config.ts` so consumers get autocomplete, type-checking, and JSDoc hovers instead of the loose index-signature fallback.

- Alias `ModuleOptions` to the documented `ArkEnvConfigOptions` (single source of truth for field-level JSDoc / `@default` tags).
- Augment `@nuxt/schema`'s `NuxtConfig` and `NuxtOptions` with `arkenv?: ModuleOptions` (lives in `module.ts`, ships in `dist/module.d.ts`).
- Add type-level regression tests covering the `ModuleOptions` alias and the `arkenv` config key (known keys accepted, unknown keys rejected).

## v1 adaptations

- v1's `ArkEnvConfigOptions` already covers `logger` / `logLevel`, so aliasing `ModuleOptions` to it picks those up automatically — the previously hand-maintained `ModuleOptions` fields are dropped in favor of the alias.
- Regression-test imports keep the v1 `arkenv` / `arkenvStandard` API instead of dev's `createEnv`.

## Verification

- `pnpm --filter @arkenv/nuxt run typecheck` passes (after building workspace deps).
- `vitest run --typecheck` on `@arkenv/nuxt`: **36 tests passed, no type errors**.
- `biome check` clean on the changed files and changeset.

Source: dev PR #1371 (`7d541b4e`).

Made with [Cursor](https://cursor.com)
