### PR TITLE
feat: Forward-port with-valibot example from dev

### DIFF
--- a/.changeset/valibot-example-registry.md
+++ b/.changeset/valibot-example-registry.md
@@ -1,0 +1,10 @@
+---
+"arkenv": minor
+---
+
+#### Add `with-valibot` to the bundled example registry and scaffold defaults
+
+Register the new standalone `with-valibot` example so it is offered alongside `with-zod` when scaffolding, including in the offline fallback registry used when the remote registry fetch fails.
+
+- Add a `with-valibot` entry to the bundled fallback example registry.
+- Add `with-valibot` env defaults (`HOST`, `PORT`, `NODE_ENV`) to the scaffold defaults map.

--- a/arkenv.code-workspace
+++ b/arkenv.code-workspace
@@ -156,6 +156,10 @@
 			"name": "💡 with-zod"
 		},
 		{
+			"path": "examples/with-valibot",
+			"name": "💡 with-valibot"
+		},
+		{
 			"path": "examples/with-standard-schema",
 			"name": "💡 with-standard-schema"
 		},

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@ This directory contains a collection of example projects that demonstrate variou
 | [with-bun-react](https://github.com/yamcodes/arkenv/tree/main/examples/with-bun-react)             | Minimal example of *using ArkEnv in a [Bun + React](https://bun.com/docs/guides/ecosystem/react) full-stack app*.        |
 | [with-solid-start](https://github.com/yamcodes/arkenv/tree/main/examples/with-solid-start)         | Minimal example of *using ArkEnv in a [SolidStart](https://start.solidjs.com) app*.                                      |
 | [with-zod](https://github.com/yamcodes/arkenv/tree/main/examples/with-zod)                         | Example of *using ArkEnv with [Zod](https://zod.dev/)* for validation (without ArkType).                                 |
+| [with-valibot](https://github.com/yamcodes/arkenv/tree/main/examples/with-valibot)                 | Example of *using ArkEnv with [Valibot](https://valibot.dev/)* for validation (without ArkType).                         |
 | [with-standard-schema](https://github.com/yamcodes/arkenv/tree/main/examples/with-standard-schema) | Example of *mixing ArkType with [Standard Schema](https://standardschema.dev/) validators like [Zod](https://zod.dev/)*. |
 
 > These examples are written in TypeScript, [the recommended way to work with ArkEnv](https://arkenv.js.org/docs/arkenv/quickstart#configure-typescript). That said, ArkEnv works with plain JavaScript. See the [basic-js](https://github.com/yamcodes/arkenv/tree/main/examples/basic-js) example for details and tradeoffs.

--- a/examples/basic-js/package.json
+++ b/examples/basic-js/package.json
@@ -8,7 +8,7 @@
 		"clean": "rimraf dist node_modules"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.3",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"arktype": "^2.2.0"
 	},
 	"engines": {

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -9,7 +9,7 @@
 		"clean": "rimraf dist node_modules"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.3",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"arktype": "^2.2.0",
 		"zod": "^4.4.1"
 	},

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -47,6 +47,12 @@
 			"name": "Zod",
 			"description": "Minimal Node.js project using Zod instead of ArkType",
 			"framework": "vanilla"
+		},
+		{
+			"id": "with-valibot",
+			"name": "Valibot",
+			"description": "Minimal Node.js project using Valibot instead of ArkType",
+			"framework": "vanilla"
 		}
 	]
 }

--- a/examples/with-bun-react/package.json
+++ b/examples/with-bun-react/package.json
@@ -11,8 +11,8 @@
 		"clean": "rimraf dist node_modules"
 	},
 	"dependencies": {
-		"@arkenv/bun-plugin": "1.0.0-alpha.4",
-		"@arkenv/core": "1.0.0-alpha.3",
+		"@arkenv/bun-plugin": "1.0.0-alpha.5",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"arktype": "^2.2.0",
 		"react": "^19.2.5",
 		"react-dom": "^19.2.5"

--- a/examples/with-bun/package.json
+++ b/examples/with-bun/package.json
@@ -10,7 +10,7 @@
 		"clean": "rimraf dist node_modules"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.3",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"arktype": "^2.2.0"
 	},
 	"devDependencies": {

--- a/examples/with-nextjs-strict/package.json
+++ b/examples/with-nextjs-strict/package.json
@@ -8,8 +8,8 @@
 		"start": "next start"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.3",
-		"@arkenv/nextjs": "1.0.0-alpha.5",
+		"@arkenv/core": "1.0.0-alpha.6",
+		"@arkenv/nextjs": "1.0.0-alpha.7",
 		"arktype": "^2.2.0",
 		"next": "^16.2.6",
 		"react": "^19.2.5",

--- a/examples/with-nextjs/package.json
+++ b/examples/with-nextjs/package.json
@@ -8,8 +8,8 @@
 		"start": "next start"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.3",
-		"@arkenv/nextjs": "1.0.0-alpha.5",
+		"@arkenv/core": "1.0.0-alpha.6",
+		"@arkenv/nextjs": "1.0.0-alpha.7",
 		"arktype": "^2.2.0",
 		"next": "^16.2.6",
 		"react": "^19.2.5",

--- a/examples/with-nuxt/package-lock.json
+++ b/examples/with-nuxt/package-lock.json
@@ -7,8 +7,8 @@
 			"name": "arkenv-example-with-nuxt",
 			"hasInstallScript": true,
 			"dependencies": {
-				"@arkenv/core": "1.0.0-alpha.3",
-				"@arkenv/nuxt": "1.0.0-alpha.2",
+				"@arkenv/core": "1.0.0-alpha.6",
+				"@arkenv/nuxt": "1.0.0-alpha.6",
 				"arktype": "^2.2.0",
 				"nuxt": "^4.4.8"
 			},
@@ -36,21 +36,22 @@
 			"license": "MIT"
 		},
 		"node_modules/@arkenv/build": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/@arkenv/build/-/build-0.0.1.tgz",
-			"integrity": "sha512-XTWzByIAby+u0uLwOrxAxMPyf1IXoCMxk2itWL6UsvhTQ36cJqZGA6neAEDK1vN6NkgxDKIStvXvhf4l5jk0pA==",
+			"version": "0.0.2-alpha.1",
+			"resolved": "https://registry.npmjs.org/@arkenv/build/-/build-0.0.2-alpha.1.tgz",
+			"integrity": "sha512-1bzSYiGWKEV2t+hAsJnJxCZGJDqYQ2vGwxroDWZxd9ntaa+z8s2VNz4Lt8z7m87ci7bkLZVI3tNfqKmgeHmkqQ==",
 			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^4.0.3"
 			}
 		},
 		"node_modules/@arkenv/nuxt": {
-			"version": "1.0.0-alpha.2",
-			"resolved": "https://registry.npmjs.org/@arkenv/nuxt/-/nuxt-1.0.0-alpha.2.tgz",
-			"integrity": "sha512-HVF5UFPMaRVv3K1jnfTeWBJubMwop4VHZxrjk/uEiXSmuyenR7QkI/5KUCZI3DtSODTi6CdWA9c8ymP7szOxKg==",
+			"version": "1.0.0-alpha.6",
+			"resolved": "https://registry.npmjs.org/@arkenv/nuxt/-/nuxt-1.0.0-alpha.6.tgz",
+			"integrity": "sha512-0YSmGhgNcDFzGAqnKuzYKMFTnrK/SjThzepwTab0MOzpAcCeINo+iO/tlk2aXvLmthc2ALMZkaBx3WNT4qCD2w==",
 			"license": "MIT",
 			"dependencies": {
-				"@arkenv/build": "0.0.1"
+				"@arkenv/build": "0.0.2-alpha.1",
+				"jiti": "2.7.0"
 			},
 			"peerDependencies": {
 				"@arkenv/core": "^1.0.0",

--- a/examples/with-nuxt/package.json
+++ b/examples/with-nuxt/package.json
@@ -10,8 +10,8 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.3",
-		"@arkenv/nuxt": "1.0.0-alpha.3",
+		"@arkenv/core": "1.0.0-alpha.6",
+		"@arkenv/nuxt": "1.0.0-alpha.6",
 		"arktype": "^2.2.0",
 		"nuxt": "^4.4.8"
 	},

--- a/examples/with-solid-start/package-lock.json
+++ b/examples/with-solid-start/package-lock.json
@@ -6,8 +6,8 @@
 		"": {
 			"name": "arkenv-example-with-solid-start",
 			"dependencies": {
-				"@arkenv/core": "1.0.0-alpha.3",
-				"@arkenv/vite-plugin": "1.0.0-alpha.4",
+				"@arkenv/core": "1.0.0-alpha.6",
+				"@arkenv/vite-plugin": "1.0.0-alpha.5",
 				"@solidjs/start": "1.3.2",
 				"arktype": "^2.2.0",
 				"solid-js": "1.9.12",
@@ -33,9 +33,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@arkenv/vite-plugin": {
-			"version": "1.0.0-alpha.4",
-			"resolved": "https://registry.npmjs.org/@arkenv/vite-plugin/-/vite-plugin-1.0.0-alpha.4.tgz",
-			"integrity": "sha512-4vdKfdj/QKGhXq9KnbTlXFeqrIWjRlWlJSlA7bhgo7aXJfjhT8lf8XzCNVSmfwaUqyWxjFuF4ZOK/PIruj5AOA==",
+			"version": "1.0.0-alpha.5",
+			"resolved": "https://registry.npmjs.org/@arkenv/vite-plugin/-/vite-plugin-1.0.0-alpha.5.tgz",
+			"integrity": "sha512-f6dyV0jpZ8WVopmY8uwz+rQ0yUpSiCq7pLI/nLfK0Vl0HZXooykcF0k8XY3RWLLQaQY43YigK/3xaYGw2tnpSQ==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@arkenv/core": "^1.0.0",

--- a/examples/with-solid-start/package.json
+++ b/examples/with-solid-start/package.json
@@ -8,8 +8,8 @@
 		"start": "vinxi start"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.3",
-		"@arkenv/vite-plugin": "1.0.0-alpha.4",
+		"@arkenv/core": "1.0.0-alpha.6",
+		"@arkenv/vite-plugin": "1.0.0-alpha.5",
 		"@solidjs/start": "1.3.2",
 		"arktype": "^2.2.0",
 		"solid-js": "1.9.12",

--- a/examples/with-valibot/README.md
+++ b/examples/with-valibot/README.md
@@ -1,0 +1,54 @@
+# ArkEnv with Valibot example
+
+This example demonstrates how to use ArkEnv with [Valibot](https://valibot.dev/) for validation, without ArkType.
+
+Because Valibot implements the [Standard Schema](https://standardschema.dev/) specification, its schemas can be passed straight to ArkEnv via the `@arkenv/standard` package.
+
+## What's inside?
+
+- Pure Valibot usage via `@arkenv/standard` (no ArkType dependency)
+- A minimal schema validating a URL, a coerced number, and a hostname
+- Full TypeScript type inference for the validated environment
+
+## Getting started
+
+### Prerequisites
+
+Make sure you have [Node.js](https://nodejs.org) installed. We recommend using [nvm](https://github.com/nvm-sh/nvm) to install it.
+
+### Quickstart
+
+1. #### Install dependencies
+
+   ```bash
+   npm install
+   ```
+
+2. #### Create a `.env` file
+
+   ```bash
+   HOST=localhost
+   PORT=3000
+   TEST_VALUE=https://example.com
+   ```
+
+3. #### Start the development server with hot reloading enabled
+
+   ```bash
+   npm run dev
+   ```
+
+   :white_check_mark: You will see the validated environment variables printed in the console.
+
+## Environment Variables
+
+- `TEST_VALUE` - A URL (validated by Valibot)
+- `PORT` - A port number (coerced from string to number)
+- `HOST` - `localhost` or a hostname
+
+## Next steps
+
+- [ArkEnv Standard Schema docs](https://arkenv.js.org/docs/standard-schema)
+- [ArkEnv docs](https://arkenv.js.org/docs/arkenv)
+- [Valibot docs](https://valibot.dev/)
+- [Standard Schema specification](https://standardschema.dev/)

--- a/examples/with-valibot/package-lock.json
+++ b/examples/with-valibot/package-lock.json
@@ -1,0 +1,561 @@
+{
+	"name": "arkenv-example-with-valibot",
+	"version": "0.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "arkenv-example-with-valibot",
+			"version": "0.0.0",
+			"license": "ISC",
+			"dependencies": {
+				"@arkenv/standard": "^1.0.0-alpha.2",
+				"valibot": "^1.3.1"
+			},
+			"devDependencies": {
+				"tsx": "^4.21.0"
+			},
+			"engines": {
+				"node": "24"
+			}
+		},
+		"node_modules/@arkenv/standard": {
+			"version": "1.0.0-alpha.3",
+			"resolved": "https://registry.npmjs.org/@arkenv/standard/-/standard-1.0.0-alpha.3.tgz",
+			"integrity": "sha512-K9kc5TFu1bQa/MXn6JITJhcrFcEBAEoY8abIaYCOUVQnFgYvMygXvpM5HAYc2+LE54+r5Al6CVHnozLSjcs4Qw==",
+			"license": "MIT"
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/tsx": {
+			"version": "4.23.1",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+			"integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.28.0"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
+		"node_modules/valibot": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+			"integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"typescript": ">=5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		}
+	}
+}

--- a/examples/with-valibot/package.json
+++ b/examples/with-valibot/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "arkenv-example-with-valibot",
+	"version": "0.0.0",
+	"description": "",
+	"main": "index.js",
+	"type": "module",
+	"scripts": {
+		"dev": "tsx watch --env-file .env src/index.ts",
+		"start": "tsx --env-file .env src",
+		"build": "tsc",
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"devDependencies": {
+		"tsx": "^4.21.0"
+	},
+	"dependencies": {
+		"@arkenv/standard": "^1.0.0-alpha.2",
+		"valibot": "^1.3.1"
+	},
+	"engines": {
+		"node": "24"
+	},
+	"packageManager": "npm@11.13.0"
+}

--- a/examples/with-valibot/src/index.ts
+++ b/examples/with-valibot/src/index.ts
@@ -1,0 +1,16 @@
+import arkenv from "@arkenv/standard";
+import * as v from "valibot";
+
+const env = arkenv({
+	TEST_VALUE: v.pipe(v.string(), v.url()),
+	PORT: v.pipe(v.string(), v.transform(Number), v.number()),
+	HOST: v.union([
+		v.literal("localhost"),
+		v.pipe(v.string(), v.regex(/^[a-z0-9.-]+$/i)),
+	]),
+});
+
+console.log(`Value: ${String(env.TEST_VALUE)}`);
+console.log(`Type: ${typeof env.TEST_VALUE}`);
+console.log("---");
+console.log(env);

--- a/examples/with-valibot/tsconfig.json
+++ b/examples/with-valibot/tsconfig.json
@@ -1,0 +1,44 @@
+{
+	// Visit https://aka.ms/tsconfig to read more about this file
+	"compilerOptions": {
+		// File Layout
+		"rootDir": "./src",
+		"outDir": "./dist",
+
+		// Environment Settings
+		// See also https://aka.ms/tsconfig/module
+		"module": "nodenext",
+		"target": "ES2023",
+		"types": [],
+		// For nodejs:
+		// "lib": ["ES2023"],
+		// "types": ["node"],
+		// and npm install -D @types/node
+
+		// Other Outputs
+		"sourceMap": true,
+		"declaration": true,
+		"declarationMap": true,
+
+		// Stricter Typechecking Options
+		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true,
+
+		// Style Options
+		// "noImplicitReturns": true,
+		// "noImplicitOverride": true,
+		// "noUnusedLocals": true,
+		// "noUnusedParameters": true,
+		// "noFallthroughCasesInSwitch": true,
+		// "noPropertyAccessFromIndexSignature": true,
+
+		// Recommended Options
+		"strict": true,
+		"jsx": "react-jsx",
+		"verbatimModuleSyntax": true,
+		"isolatedModules": true,
+		"noUncheckedSideEffectImports": true,
+		"moduleDetection": "force",
+		"skipLibCheck": true
+	}
+}

--- a/examples/with-vite-react/package-lock.json
+++ b/examples/with-vite-react/package-lock.json
@@ -8,8 +8,8 @@
 			"name": "arkenv-example-with-vite-react",
 			"version": "0.0.0",
 			"dependencies": {
-				"@arkenv/core": "1.0.0-alpha.3",
-				"@arkenv/vite-plugin": "1.0.0-alpha.4",
+				"@arkenv/core": "1.0.0-alpha.6",
+				"@arkenv/vite-plugin": "1.0.0-alpha.5",
 				"arktype": "^2.2.0",
 				"react": "^19.2.5",
 				"react-dom": "^19.2.5"
@@ -41,9 +41,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@arkenv/vite-plugin": {
-			"version": "1.0.0-alpha.4",
-			"resolved": "https://registry.npmjs.org/@arkenv/vite-plugin/-/vite-plugin-1.0.0-alpha.4.tgz",
-			"integrity": "sha512-4vdKfdj/QKGhXq9KnbTlXFeqrIWjRlWlJSlA7bhgo7aXJfjhT8lf8XzCNVSmfwaUqyWxjFuF4ZOK/PIruj5AOA==",
+			"version": "1.0.0-alpha.5",
+			"resolved": "https://registry.npmjs.org/@arkenv/vite-plugin/-/vite-plugin-1.0.0-alpha.5.tgz",
+			"integrity": "sha512-f6dyV0jpZ8WVopmY8uwz+rQ0yUpSiCq7pLI/nLfK0Vl0HZXooykcF0k8XY3RWLLQaQY43YigK/3xaYGw2tnpSQ==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@arkenv/core": "^1.0.0",

--- a/examples/with-vite-react/package.json
+++ b/examples/with-vite-react/package.json
@@ -11,8 +11,8 @@
 		"clean": "rimraf dist node_modules"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.3",
-		"@arkenv/vite-plugin": "1.0.0-alpha.4",
+		"@arkenv/core": "1.0.0-alpha.6",
+		"@arkenv/vite-plugin": "1.0.0-alpha.5",
 		"arktype": "^2.2.0",
 		"react": "^19.2.5",
 		"react-dom": "^19.2.5"

--- a/examples/with-zod/README.md
+++ b/examples/with-zod/README.md
@@ -1,0 +1,54 @@
+# ArkEnv with Zod example
+
+This example demonstrates how to use ArkEnv with [Zod](https://zod.dev/) for validation, without ArkType.
+
+Because Zod implements the [Standard Schema](https://standardschema.dev/) specification, its schemas can be passed straight to ArkEnv via the `@arkenv/standard` package.
+
+## What's inside?
+
+- Pure Zod usage via `@arkenv/standard` (no ArkType dependency)
+- A minimal schema validating a URL, a coerced number, and a hostname
+- Full TypeScript type inference for the validated environment
+
+## Getting started
+
+### Prerequisites
+
+Make sure you have [Node.js](https://nodejs.org) installed. We recommend using [nvm](https://github.com/nvm-sh/nvm) to install it.
+
+### Quickstart
+
+1. #### Install dependencies
+
+   ```bash
+   npm install
+   ```
+
+2. #### Create a `.env` file
+
+   ```bash
+   HOST=localhost
+   PORT=3000
+   TEST_VALUE=https://example.com
+   ```
+
+3. #### Start the development server with hot reloading enabled
+
+   ```bash
+   npm run dev
+   ```
+
+   :white_check_mark: You will see the validated environment variables printed in the console.
+
+## Environment Variables
+
+- `TEST_VALUE` - A URL (validated by Zod)
+- `PORT` - A port number (coerced from string to number)
+- `HOST` - `localhost` or a hostname
+
+## Next steps
+
+- [ArkEnv Standard Schema docs](https://arkenv.js.org/docs/standard-schema)
+- [ArkEnv docs](https://arkenv.js.org/docs/arkenv)
+- [Zod docs](https://zod.dev/)
+- [Standard Schema specification](https://standardschema.dev/)

--- a/packages/arkenv/src/features/scaffold/frameworks/example-env-defaults.ts
+++ b/packages/arkenv/src/features/scaffold/frameworks/example-env-defaults.ts
@@ -50,6 +50,11 @@ export const exampleEnvDefaults: Record<string, Record<string, string>> = {
 		PORT: "3000",
 		NODE_ENV: "development",
 	},
+	"with-valibot": {
+		HOST: "localhost",
+		PORT: "3000",
+		NODE_ENV: "development",
+	},
 	"with-standard-schema": {
 		HOST: "localhost",
 		PORT: "3000",

--- a/packages/arkenv/src/shared/clients/registry.client.ts
+++ b/packages/arkenv/src/shared/clients/registry.client.ts
@@ -61,6 +61,12 @@ export class RegistryClient {
 						description: "ArkEnv with Zod in Node.js",
 						framework: "vanilla",
 					},
+					{
+						id: "with-valibot",
+						name: "Valibot",
+						description: "ArkEnv with Valibot in Node.js",
+						framework: "vanilla",
+					},
 				],
 			};
 		}

--- a/scripts/test-e2e-package.js
+++ b/scripts/test-e2e-package.js
@@ -69,8 +69,12 @@ try {
 		.replace(/\\/g, "/");
 	const standardTarballDependency = `file:${normalizedStandardTarballPath}`;
 
-	// We will run tests against examples/basic and examples/with-zod
-	const fixtures = ["basic", "with-zod"];
+	// We will run tests against examples/basic and the standard-only examples
+	const fixtures = ["basic", "with-zod", "with-valibot"];
+
+	// Standard-only fixtures use a Standard Schema validator (e.g. Zod, Valibot)
+	// via `@arkenv/standard` and must NOT pull in the optional `arktype` peer.
+	const standardOnlyFixtures = new Set(["with-zod", "with-valibot"]);
 
 	for (const fixture of fixtures) {
 		console.log(`\n=== Testing fixture: examples/${fixture} ===`);
@@ -110,7 +114,7 @@ try {
 				pkg.dependencies = pkg.dependencies || {};
 				pkg.dependencies["@arkenv/core"] = coreTarballDependency;
 			}
-		} else if (fixture === "with-zod") {
+		} else if (standardOnlyFixtures.has(fixture)) {
 			if (pkg.dependencies && pkg.dependencies["@arkenv/standard"]) {
 				pkg.dependencies["@arkenv/standard"] = standardTarballDependency;
 			} else {
@@ -120,8 +124,8 @@ try {
 		}
 		fs.writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2));
 
-		// Remove lockfile for with-zod to ensure npm installs all dependencies fresh based on the modified package.json
-		if (fixture === "with-zod") {
+		// Remove lockfile for standard-only fixtures to ensure npm installs all dependencies fresh based on the modified package.json
+		if (standardOnlyFixtures.has(fixture)) {
 			const lockfilePath = path.join(fixtureDestDir, "package-lock.json");
 			if (fs.existsSync(lockfilePath)) {
 				fs.rmSync(lockfilePath, { force: true });
@@ -143,16 +147,16 @@ try {
 			},
 		);
 
-		// For with-zod, assert that arktype is NOT installed
-		if (fixture === "with-zod") {
+		// For standard-only fixtures, assert that arktype is NOT installed
+		if (standardOnlyFixtures.has(fixture)) {
 			const arktypePath = path.join(fixtureDestDir, "node_modules", "arktype");
 			if (fs.existsSync(arktypePath)) {
 				throw new Error(
-					"Optional peer dependency 'arktype' was mistakenly installed in clean-room standard-only fixture.",
+					`Optional peer dependency 'arktype' was mistakenly installed in clean-room standard-only fixture '${fixture}'.`,
 				);
 			}
 			console.log(
-				"✅ Verified: 'arktype' is NOT present in standard-schema fixture node_modules",
+				`✅ Verified: 'arktype' is NOT present in ${fixture} fixture node_modules`,
 			);
 		}
 
@@ -177,10 +181,10 @@ try {
 					"Fixture 'basic' did not print expected output: 'Environment variables validated successfully by ArkEnv!'",
 				);
 			}
-		} else if (fixture === "with-zod") {
+		} else if (standardOnlyFixtures.has(fixture)) {
 			if (!stdout.includes("Value: https://example.com")) {
 				throw new Error(
-					"Fixture 'with-zod' did not print expected output: 'Value: https://example.com'",
+					`Fixture '${fixture}' did not print expected output: 'Value: https://example.com'`,
 				);
 			}
 		}


### PR DESCRIPTION
Forward-ports the standalone `with-valibot` example (and its registration everywhere `with-zod` is wired) from the merged dev PR #1382 to `v1`.

Tracks #1372 (dev). Re-implemented against v1's package layout rather than cherry-picked.

## v1 adaptations vs dev
- Example imports the standard entry from the dedicated **`@arkenv/standard`** package (v1) instead of `arkenv/standard` (dev). Deps: `@arkenv/standard` + `valibot` only (no `arktype`), mirroring v1's `with-zod`.
- CLI wiring targets **`packages/arkenv/src/**`** (v1 layout): `shared/clients/registry.client.ts` (fallback registry) and `features/scaffold/frameworks/example-env-defaults.ts` (env defaults map — a separate file on v1).
- E2E (`scripts/test-e2e-package.js`): added `with-valibot` as a standard-only fixture (points `@arkenv/standard` at the packed tarball, removes lockfile, asserts `arktype` absent, asserts output), refactored the special-casing into a `standardOnlyFixtures` set.
- Changeset renamed to **`"arkenv": minor`** (v1+ SemVer; new feature).

## Also included (parity)
- Added `examples/with-valibot/README.md` and `examples/with-zod/README.md` (v1's `with-zod` had none), plus registry.json, examples README table, and `arkenv.code-workspace` entries.

## Verification
- Example runs standalone (temp dir, outside the monorepo): `Value: https://example.com`, `PORT` coerced to `3000`; `arktype` confirmed absent.
- `pnpm run typecheck` — 29/29 tasks pass.
- `pnpm run test` — 952/952 pass.

Made with [Cursor](https://cursor.com)