### PR TITLE
fix: Skip autofix.ci on "Version Packages" release pushes (dev + v1)

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -10,11 +10,15 @@ permissions:
 jobs:
   autofix:
     runs-on: ubuntu-latest
-    # Skip autofix for bot commits to avoid race conditions
-    # where manypkg fix updates to unpublished versions
+    # Skip autofix for bot commits and Version Packages release pushes.
+    # Release pushes race with `release.yml`: if autofix pushes a fixup, the
+    # service cancels the in-flight release run and the re-triggered release
+    # is then skipped by the autofix-ci[bot] sender guard — zero publishes.
+    # Autofix on those commits has no value anyway (already autofixed on the
+    # changeset-release/* PR).
     if: |
       github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && github.event.sender.type != 'Bot' && github.event.head_commit != null)
+      (github.event_name == 'push' && github.event.sender.type != 'Bot' && github.event.head_commit != null && !contains(github.event.head_commit.message, 'Version Packages'))
     steps:
       - uses: actions/checkout@v6
 
@@ -33,10 +37,10 @@ jobs:
       # Note: We only skip manypkg for Changesets-driven version bumps.
       # This avoids touching versions that haven't been published yet,
       # while still letting autofix handle normal PRs and pushes.
+      # (Version Packages pushes never reach this job — see job-level `if`.)
       - name: Decide if manypkg should be skipped
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           SKIP_MANYPKG=false
 
@@ -44,10 +48,6 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ] && \
              ([ "$HEAD_REF" = "changeset-release/dev" ] || [ "$HEAD_REF" = "dev" ] || [ "$HEAD_REF" = "changeset-release/v1" ] || [ "$HEAD_REF" = "v1" ]); then
             SKIP_MANYPKG=true
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            if echo "$COMMIT_MESSAGE" | grep -qi "Version Packages"; then
-              SKIP_MANYPKG=true
-            fi
           fi
 
           echo "SKIP_MANYPKG=$SKIP_MANYPKG" >> "$GITHUB_ENV"


### PR DESCRIPTION
Fixes #1375

## Summary
- Skip the `autofix` job on push events whose head commit message contains `Version Packages`, so autofix.ci cannot cancel a concurrent `release` run by pushing a fixup.
- Simplify the `SKIP_MANYPKG` step to the PR-only check (the push branch is unreachable once those commits are skipped at the job level).
- Leave the `release.yml` `autofix-ci[bot]` sender guard unchanged.

Verified against the actual squash-merge title format (`Version Packages (#1374)`); `contains()` also covers merge commits that put the title on line 2.

## Test plan
- [ ] Confirm a `Version Packages` push to `dev` does not start the `autofix` job
- [ ] Confirm the same for `v1`
- [ ] Confirm normal PRs and non-release pushes still run `autofix`


Made with [Cursor](https://cursor.com)