### PR TITLE
fix: Scope unescapeMarkers in scripts/fix.js so it stops rewriting generated files

### DIFF
--- a/scripts/fix.js
+++ b/scripts/fix.js
@@ -10,9 +10,8 @@
  */
 
 import { execSync } from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
 import { argv, env } from "node:process";
+import { unescapeMdxMarkers } from "./unescape-mdx-markers.js";
 
 const args = argv.slice(2);
 
@@ -32,46 +31,11 @@ execSync(`pnpm exec biome check ${biomeArgs.join(" ")}`, { stdio: "inherit" });
 console.log("Running mdxlint fix...");
 execSync("pnpm run fix:mdx", { stdio: "inherit" });
 
-// Post-process mdxlint output to fix over-aggressive escaping
+// Post-process mdxlint output to fix over-aggressive escaping.
+// Walks the repo but skips node_modules/.git/dist and CHANGELOG.md so
+// Changesets' intentional escapes are not corrupted.
 console.log("Unescaping MDX markers...");
-const docsDir = path.join(process.cwd(), "apps/www/content/docs");
-if (fs.existsSync(docsDir)) {
-	const unescapeMarkers = (dir) => {
-		const entries = fs.readdirSync(dir, { withFileTypes: true });
-		for (const entry of entries) {
-			const fullPath = path.join(dir, entry.name);
-			if (entry.isDirectory()) {
-				unescapeMarkers(fullPath);
-			} else if (
-				entry.isFile() &&
-				(entry.name.endsWith(".mdx") || entry.name.endsWith(".md"))
-			) {
-				let content = fs.readFileSync(fullPath, "utf8");
-				let changed = false;
-				if (content.includes("\\[!")) {
-					content = content.replace(/\\\[!/g, "[!");
-					changed = true;
-				}
-				if (content.includes("\\[step]")) {
-					content = content.replace(/\\\[step\]/g, "[step]");
-					changed = true;
-				}
-				if (content.includes("\\_")) {
-					content = content.replace(/\\_/g, "_");
-					changed = true;
-				}
-				if (/:::[a-z]+\\\[/.test(content)) {
-					content = content.replace(/(:::[a-z]+)\\\[/g, "$1[");
-					changed = true;
-				}
-				if (changed) {
-					fs.writeFileSync(fullPath, content);
-				}
-			}
-		}
-	};
-	unescapeMarkers(process.cwd()); // Apply to whole project for underscores, specific for markers
-}
+unescapeMdxMarkers(process.cwd());
 
 // Conditionally run manypkg fix
 if (!skipManypkg) {

--- a/scripts/unescape-mdx-markers.js
+++ b/scripts/unescape-mdx-markers.js
@@ -10,20 +10,15 @@ const SKIP_DIRS = new Set(["node_modules", ".git", "dist", ".next", ".source"]);
  * Skips build/VCS/deps trees and generated changelogs so Changesets'
  * intentional escapes (e.g. `\_` closing an italic span) are preserved.
  *
- * @param fullPath Absolute or relative path to a file or directory
  * @param entryName Basename of the entry
  * @param isDirectory Whether the entry is a directory
  * @returns `true` when the entry must not be processed
  */
-export function shouldSkipUnescapePath(fullPath, entryName, isDirectory) {
+export function shouldSkipUnescapePath(entryName, isDirectory) {
 	if (isDirectory && SKIP_DIRS.has(entryName)) {
 		return true;
 	}
 	if (!isDirectory && entryName === "CHANGELOG.md") {
-		return true;
-	}
-	// Also skip nested changelogs matched by path segment (defensive).
-	if (!isDirectory && /(^|[/\\])CHANGELOG\.md$/.test(fullPath)) {
 		return true;
 	}
 	return false;
@@ -43,7 +38,7 @@ export function unescapeMdxMarkers(dir) {
 	const entries = fs.readdirSync(dir, { withFileTypes: true });
 	for (const entry of entries) {
 		const fullPath = path.join(dir, entry.name);
-		if (shouldSkipUnescapePath(fullPath, entry.name, entry.isDirectory())) {
+		if (shouldSkipUnescapePath(entry.name, entry.isDirectory())) {
 			continue;
 		}
 		if (entry.isDirectory()) {

--- a/scripts/unescape-mdx-markers.js
+++ b/scripts/unescape-mdx-markers.js
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/** Directory names that must never be walked (match mdxlint / build artifacts). */
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", ".next", ".source"]);
+
+/**
+ * Whether a path should be skipped during the MDX unescape walk.
+ *
+ * Skips build/VCS/deps trees and generated changelogs so Changesets'
+ * intentional escapes (e.g. `\_` closing an italic span) are preserved.
+ *
+ * @param fullPath Absolute or relative path to a file or directory
+ * @param entryName Basename of the entry
+ * @param isDirectory Whether the entry is a directory
+ * @returns `true` when the entry must not be processed
+ */
+export function shouldSkipUnescapePath(fullPath, entryName, isDirectory) {
+	if (isDirectory && SKIP_DIRS.has(entryName)) {
+		return true;
+	}
+	if (!isDirectory && entryName === "CHANGELOG.md") {
+		return true;
+	}
+	// Also skip nested changelogs matched by path segment (defensive).
+	if (!isDirectory && /(^|[/\\])CHANGELOG\.md$/.test(fullPath)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Walk a directory tree and unescape MDX markers that mdxlint over-escapes
+ * (`\[!`, `\[step]`, `\_`, `:::x\[`).
+ *
+ * Honors the same practical exclusions as mdxlint: never enters
+ * `node_modules` / `.git` / `dist` (and similar), and never rewrites
+ * `CHANGELOG.md`.
+ *
+ * @param dir Root directory to walk
+ */
+export function unescapeMdxMarkers(dir) {
+	const entries = fs.readdirSync(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		const fullPath = path.join(dir, entry.name);
+		if (shouldSkipUnescapePath(fullPath, entry.name, entry.isDirectory())) {
+			continue;
+		}
+		if (entry.isDirectory()) {
+			unescapeMdxMarkers(fullPath);
+		} else if (
+			entry.isFile() &&
+			(entry.name.endsWith(".mdx") || entry.name.endsWith(".md"))
+		) {
+			let content = fs.readFileSync(fullPath, "utf8");
+			let changed = false;
+			if (content.includes("\\[!")) {
+				content = content.replace(/\\\[!/g, "[!");
+				changed = true;
+			}
+			if (content.includes("\\[step]")) {
+				content = content.replace(/\\\[step\]/g, "[step]");
+				changed = true;
+			}
+			if (content.includes("\\_")) {
+				content = content.replace(/\\_/g, "_");
+				changed = true;
+			}
+			if (/:::[a-z]+\\\[/.test(content)) {
+				content = content.replace(/(:::[a-z]+)\\\[/g, "$1[");
+				changed = true;
+			}
+			if (changed) {
+				fs.writeFileSync(fullPath, content);
+			}
+		}
+	}
+}

--- a/scripts/unescape-mdx-markers.test.js
+++ b/scripts/unescape-mdx-markers.test.js
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	shouldSkipUnescapePath,
+	unescapeMdxMarkers,
+} from "./unescape-mdx-markers.js";
+
+/**
+ * @type {string | undefined}
+ */
+let tempRoot;
+
+beforeEach(() => {
+	tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "unescape-mdx-"));
+});
+
+afterEach(() => {
+	if (tempRoot) {
+		fs.rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+describe("shouldSkipUnescapePath", () => {
+	it("skips node_modules, .git, dist, and similar directories", () => {
+		for (const name of ["node_modules", ".git", "dist", ".next", ".source"]) {
+			expect(shouldSkipUnescapePath(`/repo/${name}`, name, true)).toBe(true);
+		}
+	});
+
+	it("skips CHANGELOG.md files", () => {
+		expect(
+			shouldSkipUnescapePath(
+				"/repo/packages/cli/CHANGELOG.md",
+				"CHANGELOG.md",
+				false,
+			),
+		).toBe(true);
+	});
+
+	it("does not skip ordinary docs markdown", () => {
+		expect(
+			shouldSkipUnescapePath(
+				"/repo/apps/www/content/docs/guide.mdx",
+				"guide.mdx",
+				false,
+			),
+		).toBe(false);
+		expect(shouldSkipUnescapePath("/repo/docs", "docs", true)).toBe(false);
+	});
+});
+
+describe("unescapeMdxMarkers", () => {
+	it("unescapes docs markers under the given directory", () => {
+		const docsDir = path.join(tempRoot, "docs");
+		fs.mkdirSync(docsDir, { recursive: true });
+		const docPath = path.join(docsDir, "guide.mdx");
+		fs.writeFileSync(
+			docPath,
+			["\\[!NOTE]", "\\[step]", "hello\\_world", ":::tabs\\[group]"].join("\n"),
+		);
+
+		unescapeMdxMarkers(docsDir);
+
+		expect(fs.readFileSync(docPath, "utf8")).toBe(
+			["[!NOTE]", "[step]", "hello_world", ":::tabs[group]"].join("\n"),
+		);
+	});
+
+	it("does not rewrite CHANGELOG.md", () => {
+		const packagesDir = path.join(tempRoot, "packages", "cli");
+		fs.mkdirSync(packagesDir, { recursive: true });
+
+		const changelogPath = path.join(packagesDir, "CHANGELOG.md");
+		const escapedChangelog = "[@yamcodes](https://github.com/yamcodes)\\_";
+		fs.writeFileSync(changelogPath, escapedChangelog);
+		fs.writeFileSync(path.join(tempRoot, "readme.md"), "plain\\_ok");
+
+		unescapeMdxMarkers(tempRoot);
+
+		expect(fs.readFileSync(changelogPath, "utf8")).toBe(escapedChangelog);
+		expect(fs.readFileSync(path.join(tempRoot, "readme.md"), "utf8")).toBe(
+			"plain_ok",
+		);
+	});
+
+	it("does not enter node_modules or dist trees", () => {
+		const nodeModulesDoc = path.join(tempRoot, "node_modules", "pkg");
+		const distDoc = path.join(tempRoot, "dist");
+		fs.mkdirSync(nodeModulesDoc, { recursive: true });
+		fs.mkdirSync(distDoc, { recursive: true });
+
+		const nodeModulesPath = path.join(nodeModulesDoc, "readme.md");
+		const distPath = path.join(distDoc, "readme.md");
+		const escaped = "keep\\_escaped";
+		fs.writeFileSync(nodeModulesPath, escaped);
+		fs.writeFileSync(distPath, escaped);
+		fs.writeFileSync(path.join(tempRoot, "ok.mdx"), "plain\\_text");
+
+		unescapeMdxMarkers(tempRoot);
+
+		expect(fs.readFileSync(nodeModulesPath, "utf8")).toBe(escaped);
+		expect(fs.readFileSync(distPath, "utf8")).toBe(escaped);
+		expect(fs.readFileSync(path.join(tempRoot, "ok.mdx"), "utf8")).toBe(
+			"plain_text",
+		);
+	});
+});

--- a/scripts/unescape-mdx-markers.test.js
+++ b/scripts/unescape-mdx-markers.test.js
@@ -25,29 +25,17 @@ afterEach(() => {
 describe("shouldSkipUnescapePath", () => {
 	it("skips node_modules, .git, dist, and similar directories", () => {
 		for (const name of ["node_modules", ".git", "dist", ".next", ".source"]) {
-			expect(shouldSkipUnescapePath(`/repo/${name}`, name, true)).toBe(true);
+			expect(shouldSkipUnescapePath(name, true)).toBe(true);
 		}
 	});
 
 	it("skips CHANGELOG.md files", () => {
-		expect(
-			shouldSkipUnescapePath(
-				"/repo/packages/cli/CHANGELOG.md",
-				"CHANGELOG.md",
-				false,
-			),
-		).toBe(true);
+		expect(shouldSkipUnescapePath("CHANGELOG.md", false)).toBe(true);
 	});
 
 	it("does not skip ordinary docs markdown", () => {
-		expect(
-			shouldSkipUnescapePath(
-				"/repo/apps/www/content/docs/guide.mdx",
-				"guide.mdx",
-				false,
-			),
-		).toBe(false);
-		expect(shouldSkipUnescapePath("/repo/docs", "docs", true)).toBe(false);
+		expect(shouldSkipUnescapePath("guide.mdx", false)).toBe(false);
+		expect(shouldSkipUnescapePath("docs", true)).toBe(false);
 	});
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,18 @@ import { coverageConfigDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
-		projects: ["packages/*", "apps/*", "!apps/playwright-www", "!**/*.md"],
+		projects: [
+			"packages/*",
+			"apps/*",
+			"!apps/playwright-www",
+			"!**/*.md",
+			{
+				test: {
+					name: "scripts",
+					include: ["scripts/**/*.test.js"],
+				},
+			},
+		],
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "json", "html"],


### PR DESCRIPTION
Fixes #1376

## Summary
- Extract `unescapeMdxMarkers` from `scripts/fix.js` and skip `node_modules` / `.git` / `dist` (and similar) plus `CHANGELOG.md` during the walk
- Preserve unescaping of docs markers (`\[!`, `\[step]`, `\_`, `:::x\[`) for normal markdown that mdxlint touches
- Add unit tests and wire a `scripts` vitest project

## Test plan
- [x] `pnpm exec vitest run --project scripts`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run fix` leaves no `CHANGELOG.md` diffs


Made with [Cursor](https://cursor.com)