### PR TITLE
fix: Forward-port unescapeMarkers scoping from #1393

### DIFF
--- a/scripts/fix.js
+++ b/scripts/fix.js
@@ -10,9 +10,8 @@
  */
 
 import { execSync } from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
 import { argv, env } from "node:process";
+import { unescapeMdxMarkers } from "./unescape-mdx-markers.js";
 
 const args = argv.slice(2);
 
@@ -32,46 +31,11 @@ execSync(`pnpm exec biome check ${biomeArgs.join(" ")}`, { stdio: "inherit" });
 console.log("Running mdxlint fix...");
 execSync("pnpm run fix:mdx", { stdio: "inherit" });
 
-// Post-process mdxlint output to fix over-aggressive escaping
+// Post-process mdxlint output to fix over-aggressive escaping.
+// Walks the repo but skips node_modules/.git/dist and CHANGELOG.md so
+// Changesets' intentional escapes are not corrupted.
 console.log("Unescaping MDX markers...");
-const docsDir = path.join(process.cwd(), "apps/www/content/docs");
-if (fs.existsSync(docsDir)) {
-	const unescapeMarkers = (dir) => {
-		const entries = fs.readdirSync(dir, { withFileTypes: true });
-		for (const entry of entries) {
-			const fullPath = path.join(dir, entry.name);
-			if (entry.isDirectory()) {
-				unescapeMarkers(fullPath);
-			} else if (
-				entry.isFile() &&
-				(entry.name.endsWith(".mdx") || entry.name.endsWith(".md"))
-			) {
-				let content = fs.readFileSync(fullPath, "utf8");
-				let changed = false;
-				if (content.includes("\\[!")) {
-					content = content.replace(/\\\[!/g, "[!");
-					changed = true;
-				}
-				if (content.includes("\\[step]")) {
-					content = content.replace(/\\\[step\]/g, "[step]");
-					changed = true;
-				}
-				if (content.includes("\\_")) {
-					content = content.replace(/\\_/g, "_");
-					changed = true;
-				}
-				if (/:::[a-z]+\\\[/.test(content)) {
-					content = content.replace(/(:::[a-z]+)\\\[/g, "$1[");
-					changed = true;
-				}
-				if (changed) {
-					fs.writeFileSync(fullPath, content);
-				}
-			}
-		}
-	};
-	unescapeMarkers(process.cwd()); // Apply to whole project for underscores, specific for markers
-}
+unescapeMdxMarkers(process.cwd());
 
 // Conditionally run manypkg fix
 if (!skipManypkg) {

--- a/scripts/unescape-mdx-markers.js
+++ b/scripts/unescape-mdx-markers.js
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/** Directory names that must never be walked (match mdxlint / build artifacts). */
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", ".next", ".source"]);
+
+/**
+ * Whether a path should be skipped during the MDX unescape walk.
+ *
+ * Skips build/VCS/deps trees and generated changelogs so Changesets'
+ * intentional escapes (e.g. `\_` closing an italic span) are preserved.
+ *
+ * @param entryName Basename of the entry
+ * @param isDirectory Whether the entry is a directory
+ * @returns `true` when the entry must not be processed
+ */
+export function shouldSkipUnescapePath(entryName, isDirectory) {
+	if (isDirectory && SKIP_DIRS.has(entryName)) {
+		return true;
+	}
+	if (!isDirectory && entryName === "CHANGELOG.md") {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Walk a directory tree and unescape MDX markers that mdxlint over-escapes
+ * (`\[!`, `\[step]`, `\_`, `:::x\[`).
+ *
+ * Honors the same practical exclusions as mdxlint: never enters
+ * `node_modules` / `.git` / `dist` (and similar), and never rewrites
+ * `CHANGELOG.md`.
+ *
+ * @param dir Root directory to walk
+ */
+export function unescapeMdxMarkers(dir) {
+	const entries = fs.readdirSync(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		const fullPath = path.join(dir, entry.name);
+		if (shouldSkipUnescapePath(entry.name, entry.isDirectory())) {
+			continue;
+		}
+		if (entry.isDirectory()) {
+			unescapeMdxMarkers(fullPath);
+		} else if (
+			entry.isFile() &&
+			(entry.name.endsWith(".mdx") || entry.name.endsWith(".md"))
+		) {
+			let content = fs.readFileSync(fullPath, "utf8");
+			let changed = false;
+			if (content.includes("\\[!")) {
+				content = content.replace(/\\\[!/g, "[!");
+				changed = true;
+			}
+			if (content.includes("\\[step]")) {
+				content = content.replace(/\\\[step\]/g, "[step]");
+				changed = true;
+			}
+			if (content.includes("\\_")) {
+				content = content.replace(/\\_/g, "_");
+				changed = true;
+			}
+			if (/:::[a-z]+\\\[/.test(content)) {
+				content = content.replace(/(:::[a-z]+)\\\[/g, "$1[");
+				changed = true;
+			}
+			if (changed) {
+				fs.writeFileSync(fullPath, content);
+			}
+		}
+	}
+}

--- a/scripts/unescape-mdx-markers.test.js
+++ b/scripts/unescape-mdx-markers.test.js
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	shouldSkipUnescapePath,
+	unescapeMdxMarkers,
+} from "./unescape-mdx-markers.js";
+
+/**
+ * @type {string | undefined}
+ */
+let tempRoot;
+
+beforeEach(() => {
+	tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "unescape-mdx-"));
+});
+
+afterEach(() => {
+	if (tempRoot) {
+		fs.rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+describe("shouldSkipUnescapePath", () => {
+	it("skips node_modules, .git, dist, and similar directories", () => {
+		for (const name of ["node_modules", ".git", "dist", ".next", ".source"]) {
+			expect(shouldSkipUnescapePath(name, true)).toBe(true);
+		}
+	});
+
+	it("skips CHANGELOG.md files", () => {
+		expect(shouldSkipUnescapePath("CHANGELOG.md", false)).toBe(true);
+	});
+
+	it("does not skip ordinary docs markdown", () => {
+		expect(shouldSkipUnescapePath("guide.mdx", false)).toBe(false);
+		expect(shouldSkipUnescapePath("docs", true)).toBe(false);
+	});
+});
+
+describe("unescapeMdxMarkers", () => {
+	it("unescapes docs markers under the given directory", () => {
+		const docsDir = path.join(tempRoot, "docs");
+		fs.mkdirSync(docsDir, { recursive: true });
+		const docPath = path.join(docsDir, "guide.mdx");
+		fs.writeFileSync(
+			docPath,
+			["\\[!NOTE]", "\\[step]", "hello\\_world", ":::tabs\\[group]"].join("\n"),
+		);
+
+		unescapeMdxMarkers(docsDir);
+
+		expect(fs.readFileSync(docPath, "utf8")).toBe(
+			["[!NOTE]", "[step]", "hello_world", ":::tabs[group]"].join("\n"),
+		);
+	});
+
+	it("does not rewrite CHANGELOG.md", () => {
+		const packagesDir = path.join(tempRoot, "packages", "cli");
+		fs.mkdirSync(packagesDir, { recursive: true });
+
+		const changelogPath = path.join(packagesDir, "CHANGELOG.md");
+		const escapedChangelog = "[@yamcodes](https://github.com/yamcodes)\\_";
+		fs.writeFileSync(changelogPath, escapedChangelog);
+		fs.writeFileSync(path.join(tempRoot, "readme.md"), "plain\\_ok");
+
+		unescapeMdxMarkers(tempRoot);
+
+		expect(fs.readFileSync(changelogPath, "utf8")).toBe(escapedChangelog);
+		expect(fs.readFileSync(path.join(tempRoot, "readme.md"), "utf8")).toBe(
+			"plain_ok",
+		);
+	});
+
+	it("does not enter node_modules or dist trees", () => {
+		const nodeModulesDoc = path.join(tempRoot, "node_modules", "pkg");
+		const distDoc = path.join(tempRoot, "dist");
+		fs.mkdirSync(nodeModulesDoc, { recursive: true });
+		fs.mkdirSync(distDoc, { recursive: true });
+
+		const nodeModulesPath = path.join(nodeModulesDoc, "readme.md");
+		const distPath = path.join(distDoc, "readme.md");
+		const escaped = "keep\\_escaped";
+		fs.writeFileSync(nodeModulesPath, escaped);
+		fs.writeFileSync(distPath, escaped);
+		fs.writeFileSync(path.join(tempRoot, "ok.mdx"), "plain\\_text");
+
+		unescapeMdxMarkers(tempRoot);
+
+		expect(fs.readFileSync(nodeModulesPath, "utf8")).toBe(escaped);
+		expect(fs.readFileSync(distPath, "utf8")).toBe(escaped);
+		expect(fs.readFileSync(path.join(tempRoot, "ok.mdx"), "utf8")).toBe(
+			"plain_text",
+		);
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
 			"!packages/cli",
 			"!apps/playwright-www",
 			"!**/*.md",
+			{
+				test: {
+					name: "scripts",
+					include: ["scripts/**/*.test.js"],
+				},
+			},
 		],
 		coverage: {
 			provider: "v8",


### PR DESCRIPTION
## Summary
- Forward-ports #1393 (fixes #1376) onto `v1`
- Stops `scripts/fix.js` from rewriting `CHANGELOG.md` / walking `node_modules`, `.git`, `dist`, etc.
- Adds unit tests and a `scripts` vitest project (preserving v1 vitest layout)

## Test plan
- [x] `pnpm exec vitest run --project scripts`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`


Made with [Cursor](https://cursor.com)