### PR TITLE
docs: Document the autofix.ci ↔ release safeguard interaction

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -11,11 +11,13 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     # Skip autofix for bot commits and Version Packages release pushes.
-    # Release pushes race with `release.yml`: if autofix pushes a fixup, the
-    # service cancels the in-flight release run and the re-triggered release
-    # is then skipped by the autofix-ci[bot] sender guard — zero publishes.
-    # Autofix on those commits has no value anyway (already autofixed on the
-    # changeset-release/* PR).
+    # Paired with release.yml's autofix-ci[bot] sender guard: if autofix runs on
+    # a Version Packages push and produces a fixup, the autofix.ci service
+    # cancels the in-flight release; the re-triggered release is then skipped
+    # by that guard — zero publishes. Removing either guard reopens a race
+    # (stranding or double-publish). Autofix on those commits has no value
+    # anyway (already autofixed on the changeset-release/* PR).
+    # See docs/adr/0006-branching-and-release-flow.md.
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && github.event.sender.type != 'Bot' && github.event.head_commit != null && !contains(github.event.head_commit.message, 'Version Packages'))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,12 @@ permissions:
 jobs:
   release:
     name: Release
-    # Skip release for autofix commits to avoid race conditions
+    # Skip release for autofix-ci[bot] pushes to preserve "publish exactly once".
+    # Paired with autofix.yml's Version Packages skip: that guard stops autofix
+    # from cancelling an in-flight release; this guard stops a re-triggered
+    # release on an autofix fixup from double-publishing. Removing either
+    # guard reopens a race (stranding or double-publish).
+    # See docs/adr/0006-branching-and-release-flow.md.
     if: github.event.sender.login != 'autofix-ci[bot]'
     runs-on: ubuntu-latest
     env:

--- a/docs/adr/0006-branching-and-release-flow.md
+++ b/docs/adr/0006-branching-and-release-flow.md
@@ -43,3 +43,12 @@ This architecture enforces synchronization at the Git/Infrastructure layer rathe
 To satisfy the third requirement (doc hotfixes without package releases), we are pairing this architecture with the `sync-main` workflow. If a typo needs fixing immediately, contributors can merge the fix directly into `main` (triggering a doc deploy) and the `sync-main` script will automatically cherry-pick and reconcile that commit back into `dev` to prevent Git history drift.
 
 This provides the exact guarantees of Astro's separated repositories, but kept within our unified monorepo.
+
+### Autofix ↔ release safeguards
+
+Two workflow guards must coexist so a `Version Packages` merge publishes **exactly once** (never zero times, never twice):
+
+1. **`autofix.yml`** skips push events whose head commit message contains `Version Packages`. Without this, autofix can push a fixup that cancels the concurrent `release` run; the re-triggered release is then skipped by guard (2), stranding the release with zero publishes.
+2. **`release.yml`** skips pushes whose sender is `autofix-ci[bot]`. Without this, an autofix fixup push could trigger a second publish.
+
+Removing either guard reintroduces a race. Both are documented inline next to the job-level `if` conditions in `.github/workflows/autofix.yml` and `.github/workflows/release.yml`.


### PR DESCRIPTION
## Summary
- Cross-reference the paired autofix ↔ release guards in both workflow files so removing either one is visibly unsafe.
- Amend ADR 0006 with the \"publish exactly once\" interaction (skip Version Packages in autofix; skip autofix-ci[bot] in release).

Fixes #1377

## Test plan
- [ ] Confirm both workflow comments name the other guard and point at ADR 0006
- [ ] Confirm ADR 0006 documents why both guards must coexist


Made with [Cursor](https://cursor.com)