### PR TITLE
docs: reconcile v1 ADR numbering and supersession stubs

### DIFF
--- a/docs/adr/0004-export-surface-tiers.md
+++ b/docs/adr/0004-export-surface-tiers.md
@@ -1,16 +1,16 @@
-# Three-tier export surface
+# ADR 0004: Three-tier export surface
 
 ## Status
 
 Superseded by [ADR 0007: Standard Mode Packaging Strategy](0007-standard-mode-packaging-strategy.md)
 
-## Context
+## Summary
 
-To clean up the ad-hoc package exports and provide an explicitly ArkType-free entry point for Standard Schema users. We reorganize the exports into three distinct tiers:
+Historical decision to organize package exports into three tiers (`arkenv`, `arkenv/standard`, and `arkenv/core`) so Standard Schema users had an explicitly ArkType-free entry point.
 
-1. `arkenv` (main): The default, ArkType-dependent entry point exposing `arkenv` and `type`.
-2. `arkenv/standard`: A clean, ArkType-free entry point for Standard Schema users.
-3. `arkenv/core`: Mode-agnostic types and primitives (like `ArkEnvError` and `ValidationIssue`).
+On `v1`, that packaging model was replaced by the asymmetric strategy in ADR 0007: separate `@arkenv/core` / `@arkenv/standard` packages, with framework plugins exposing both engines via subpath exports rather than a three-tier surface on a single package.
+
+Read [ADR 0007](0007-standard-mode-packaging-strategy.md) for the current decision.
 
 ---
 

--- a/docs/adr/0010-bundle-isolation-over-dryness.md
+++ b/docs/adr/0010-bundle-isolation-over-dryness.md
@@ -2,24 +2,12 @@
 
 ## Status
 
-Partially Superseded / Refined by [ADR 0011: Runtime Shared Logic Strategy](0011-runtime-shared-logic-strategy.md) (The core principle of bundle isolation remains 100% active, but the code-duplication mechanics have been replaced with build-time inlining of `@repo/utils`).
+Superseded by [ADR 0011: Runtime Shared Logic Strategy](0011-runtime-shared-logic-strategy.md)
 
-## Context
+## Summary
 
-ArkEnv operates as a zero-dependency environment variable parser. It uses ArkType as its primary validation engine (`arkenv`), while also offering a completely separate entry point (`arkenv/standard`) that leverages Standard Schema 1.0 (for users preferring Zod, Valibot, etc.).
+Historical decision that **bundle isolation strictly trumps DRYness** across the ArkType (`@arkenv/core`) and Standard Schema (`@arkenv/standard`) engine boundary. Shared source modules that bridge those entry points risk pulling ArkType into Standard Schema user bundles.
 
-During the refactoring to a single core repository with multiple internal exports, a code review raised concerns about code duplication between `src/arktype/index.ts` and `src/parse-standard.ts`. Both files implement similar logic for parsing objects, extracting issue metadata, and formatting validation results. The suggestion was to "aggressively unify or codeshare" these implementations to abide by the DRY (Don't Repeat Yourself) principle.
+The isolation principle remains in force. The original mechanic (intentional duplication of parse/format/issue-mapping logic) was refined by ADR 0011: shared stateless helpers live in internal `@repo/*` packages and are **build-time inlined** into each published engine, so isolation is preserved without hand-maintained duplicates.
 
-However, sharing utilities across the core ArkType engine and the Standard Schema engine introduces hidden module graph entanglements. Bundlers like Webpack, Rollup, and esbuild often rely on static imports for tree-shaking. A single shared `utils.ts` file imported by both entry points can easily trick the bundler's heuristics into statically tracing the dependency tree back to `arktype`. This would drag the entire 50kb+ ArkType AST engine into the production bundle of users who only wanted to use `arkenv/standard` with Zod.
-
-## Decision
-
-We intentionally duplicate parsing, formatting, and issue-mapping logic across the `arktype` and `standard` engine implementations to maintain an airtight module boundary. **Bundle isolation strictly trumps DRYness across core/standard boundaries.**
-
-We will not create shared abstractions or utility files that bridge these two domains. The small maintenance cost of duplicated internal logic is a worthwhile trade-off to guarantee that `arkenv/standard` users never incur a bundle size penalty from ArkType.
-
-## Consequences
-
-- The footprint of `@arkenv/standard` remains strictly minimal and fully decoupled from ArkType.
-- Contributors must be aware that fixing a bug in the error extraction logic for ArkType may require a mirrored fix in the Standard Schema logic.
-- Future code reviews raising concerns about DRYness between these files should be directed to this ADR.
+Read [ADR 0011](0011-runtime-shared-logic-strategy.md) for the current decision (including the folded isolation principle).

--- a/docs/adr/0011-runtime-shared-logic-strategy.md
+++ b/docs/adr/0011-runtime-shared-logic-strategy.md
@@ -23,14 +23,20 @@ We will avoid peer dependencies for **runtime** code sharing and avoid publishin
 
 Instead, we will adopt an **Inlined Internal Packages Strategy** (`@repo/*`) combined with **Subpath Exports** for sharing runtime logic.
 
+### Bundle isolation across engine boundaries
+
+**Bundle isolation strictly trumps DRYness** across the ArkType (`@arkenv/core`) and Standard Schema (`@arkenv/standard`) engines. A shared source module imported by both entry points can trick bundlers into tracing ArkType into Standard Schema user bundles.
+
+This principle originated in [ADR 0010](./0010-bundle-isolation-over-dryness.md) (now superseded). We preserve isolation by inlining `@repo/*` helpers into each published engine at build time — not by importing shared runtime modules across the core/standard boundary, and not by publishing a public `@arkenv/utils` package that both engines depend on.
+
 We distinguish between two categories of shared logic:
 
 ### Runtime Shared Logic
 
 Runtime logic must remain 100% dependency-free and must not suffer from version or singleton skew.
 
-1. **Stateless Logic (Helpers/Parsers):** Shared stateless logic will live in an internal monorepo package (e.g., `@repo/utils`). Using our bundler (`tsdown`), this logic will be physically inlined into the distributables of the consuming published packages (`arkenv`, `@arkenv/core`).
-2. **Stateful Logic (Singletons/Schemas):** Any stateful logic or singleton configuration will be managed via Subpath Exports directly from the core `arkenv` package, rather than using peer dependencies to enforce a single instance. The core package exposes named entry points such as `arkenv/standard` and `arkenv/core` via its `exports` field. Future stateful internals (e.g., shared ArkType scopes) may be exposed through additional subpaths like `arkenv/internal` if needed.
+1. **Stateless Logic (Helpers/Parsers):** Shared stateless logic will live in an internal monorepo package (e.g., `@repo/utils`). Using our bundler (`tsdown`), this logic will be physically inlined into the distributables of the consuming published packages (`@arkenv/core`, `@arkenv/standard`). Each engine gets its own copy in the published artifact, so the module graphs stay isolated.
+2. **Stateful Logic (Singletons/Schemas):** Any stateful logic or singleton configuration will be managed via Subpath Exports directly from the core package, rather than using peer dependencies to enforce a single instance. Future stateful internals (e.g., shared ArkType scopes) may be exposed through additional subpaths if needed.
 
 ### Build-Time Shared Logic
 
@@ -83,4 +89,6 @@ By routing build-time shared logic through `@arkenv/build` (a published but inte
 - **Positive:** Faster user installs with fewer runtime packages.
 - **Positive:** Reduced version bump cascading for internal runtime helpers.
 - **Positive:** Clean separation between runtime and build-time concerns.
+- **Positive:** `@arkenv/standard` stays fully decoupled from ArkType; isolation reviews should point here (not at hand-duplicated source files).
 - **Negative:** The compiled bundle size of the core packages might be trivially larger due to inlined helpers, but this is mitigated by tree-shaking and the lightweight nature of the utilities.
+- **Negative:** Contributors still must treat core/standard as separate publish graphs — a helper that accidentally imports `arktype` into `@repo/utils` would reintroduce the leak ADR 0010 warned about.

--- a/docs/adr/0019-framework-subpath-exports.md
+++ b/docs/adr/0019-framework-subpath-exports.md
@@ -1,6 +1,10 @@
-# Framework subpath exports for strict layout
+# ADR 0019: Framework subpath exports for strict layout
 
 To decide which `@arkenv/nextjs` and `@arkenv/nuxt` subpath exports remain published, and to document the import mental model for flat versus strict layout.
+
+## Status
+
+Accepted
 
 ## Context & problem
 
@@ -12,7 +16,7 @@ We evaluated three postures for the export surface:
 
 - **Option 1: Keep all subpaths including `./shared` (rejected).** Preserves backward compatibility but maintains a redundant export that confuses the mental model and suggests framework-specific schema tooling where core `@arkenv/core` suffices.
 - **Option 2: Remove `./shared`; keep `./client` and `./server` (chosen).** Strict-layout internal schema modules import `type` from `@arkenv/core`. Flat layout continues to use the default package entry. `/client` and `/server` retain their boundary guarantees.
-- **Option 3: Remove all subpaths (rejected).** Would break strict layout compile-time boundaries documented in [ADR 0012](./0012-nextjs-conditional-exports-boundary.md) and [ADR 0013](./0013-nuxt-vite-compile-time-boundary.md).
+- **Option 3: Remove all subpaths (rejected).** Would break strict layout compile-time boundaries documented in [ADR 0015](./0015-nextjs-conditional-exports-boundary.md) and [ADR 0016](./0016-nuxt-vite-compile-time-boundary.md).
 
 ## Decision
 
@@ -20,9 +24,9 @@ We adopt **Option 2**: remove `./shared`; keep the default entry, `./client`, an
 
 | Export                                      | Verdict    | Rationale                                                                                                                                                                                     |
 | :------------------------------------------ | :--------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@arkenv/nextjs` / `@arkenv/nuxt` (default) | **Keep**   | Flat layout entry; bundler resolves server vs client build ([ADR 0012](./0012-nextjs-conditional-exports-boundary.md) / Nuxt proxy)                                                           |
+| `@arkenv/nextjs` / `@arkenv/nuxt` (default) | **Keep**   | Flat layout entry; bundler resolves server vs client build ([ADR 0015](./0015-nextjs-conditional-exports-boundary.md) / Nuxt proxy)                                                           |
 | `./client`                                  | **Keep**   | Strict layout compile-time boundary + public-prefix type constraints                                                                                                                          |
-| `./server`                                  | **Keep**   | Strict layout compile-time boundary (`server-only` on Next.js; Vite plugin blocklist on Nuxt per [ADR 0013](./0013-nuxt-vite-compile-time-boundary.md)) + framework proxy/`extends` semantics |
+| `./server`                                  | **Keep**   | Strict layout compile-time boundary (`server-only` on Next.js; Vite plugin blocklist on Nuxt per [ADR 0016](./0016-nuxt-vite-compile-time-boundary.md)) + framework proxy/`extends` semantics |
 | `./shared`                                  | **Remove** | Documented strict-layout usage is schema-only (`import { type } from "…/shared"`); `@arkenv/core` already exports `type`                                                                      |
 
 ### Mental model
@@ -44,4 +48,4 @@ Replace `@arkenv/nextjs/shared` and `@arkenv/nuxt/shared` with `import { type } 
 - **Simpler mental model.** Strict layout has two boundary entry points plus `@arkenv/core` for schema-only modules.
 - **Lower maintenance.** One fewer conditional build artifact per framework package.
 - **Docs and scaffolding updated.** CLI output, examples, playgrounds, and layout guides reflect the new import path.
-- **`/client` and `/server` unchanged.** Compile-time boundary guarantees from ADR 0012 and ADR 0013 are preserved.
+- **`/client` and `/server` unchanged.** Compile-time boundary guarantees from ADR 0015 and ADR 0016 are preserved.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,14 +1,23 @@
-# Architecture decision records (adrs)
+# Architecture decision records (ADRs)
 
 This directory contains records of design and architectural decisions made for the ArkEnv project.
 
 ## Numbering
 
-ADRs use sequential numbering (e.g., `0001-slug.md`, `0002-slug.md`). When adding a new record, scan for the highest number and increment by one.
+ADRs use zero-padded sequential filenames (e.g. `0001-slug.md`, `0002-slug.md`).
+
+**Rules:**
+
+1. **Immutable numbers.** Once an ADR is merged, its number is never reused or renumbered. Filename changes that alter the number are reserved for fixing accidental collisions before (or immediately after) merge.
+2. **Next number = max + 1.** When adding a record, scan this directory for the highest existing number on **this branch** and increment by one. Do not fill gaps.
+3. **Gaps are fine.** Dual-tracking (`dev` / `v1`) means some numbers exist only on one line. A jump such as `0006` → `0009` on `dev` is expected when `0007`/`0008` live on `v1` only.
+4. **Numbers are branch-local.** The same slug may carry different numbers on `dev` vs `v1` (see [Index](#index)). Do not try to unify numbering across branches without a deliberate, repository-wide renumber — high cost, low value. Prefer slug-based links and the index below when comparing branches.
 
 ## Directory policy
 
 All ADRs are maintained centrally in this `docs/adr/` directory rather than per-package. This keeps the repository root clean while ensuring project-wide and package-specific architectural context remains in a single, discoverable location.
+
+Package and user-facing READMEs stay consumer-oriented; this directory is contributor territory for architectural rationale.
 
 ## When to write an ADR
 
@@ -17,6 +26,45 @@ An ADR should be written when a decision is:
 1. **Hard to reverse**: The cost of changing our mind later is meaningful.
 2. **Surprising without context**: A future developer might look at the code and wonder why it was done that way.
 3. **The result of a real trade-off**: There were genuine alternatives and we picked one for specific reasons.
+
+## Related clusters
+
+These groups share a theme. They remain separate ADRs (no nesting or history rewrites) — use the links when reviewing related decisions:
+
+| Cluster | Slugs (numbers differ by branch — see [Index](#index)) |
+| :------ | :----------------------------------------------------- |
+| Framework server/client boundaries | `nextjs-runtime-env`, `nextjs-conditional-exports-boundary`, `nuxt-vite-compile-time-boundary`, `flat-layout-codegen-type-strategy`, `framework-subpath-exports`, `strict-layout-complexity-budget` |
+| Packaging & module graph | `export-surface-tiers`, `standard-mode-packaging-strategy`, `bundle-isolation-over-dryness`, `runtime-shared-logic-strategy`, `shared-build-package` |
+| CLI / scaffold IR | `cli-hosting-preset-field-metadata`, `dotenv-linter-custom-parser-strategy` |
+
+## Index
+
+Numbers are per branch. A blank cell means the ADR is not present on that line.
+
+| Slug | `dev` | `v1` |
+| :--- | :---: | :---: |
+| `use-architecture-decision-records` | 0000 | 0000 |
+| `bun-plugin-config-patterns` | 0001 | 0001 |
+| `coercion-schema-transformer` | 0002 | 0002 |
+| `explicit-validator-mode` | 0003 | 0003 |
+| `export-surface-tiers` | 0004 | 0004 |
+| `nextjs-runtime-env` | 0005 | 0005 |
+| `branching-and-release-flow` | 0006 | 0006 |
+| `standard-mode-packaging-strategy` | — | 0007 |
+| `default-export-and-function-naming` | — | 0008 |
+| `shared-build-package` | 0009 | 0009 |
+| `bundle-isolation-over-dryness` | — | 0010 |
+| `flat-layout-codegen-type-strategy` | 0010 | 0013 |
+| `runtime-shared-logic-strategy` | — | 0011 |
+| `nextjs-jiti-build-time-validation` | 0011 | 0014 |
+| `independent-versioning-strategy` | — | 0012 |
+| `nextjs-conditional-exports-boundary` | 0012 | 0015 |
+| `nuxt-vite-compile-time-boundary` | 0013 | 0016 |
+| `cli-hosting-preset-field-metadata` | 0014 | 0018 |
+| `env-object-canonical-surface` | 0015 | — |
+| `strict-layout-complexity-budget` | 0016 | — |
+| `dotenv-linter-custom-parser-strategy` | — | 0017 |
+| `framework-subpath-exports` | — | 0019 |
 
 ## Tooling & agent skills
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,40 +31,40 @@ An ADR should be written when a decision is:
 
 These groups share a theme. They remain separate ADRs (no nesting or history rewrites) — use the links when reviewing related decisions:
 
-| Cluster | Slugs (numbers differ by branch — see [Index](#index)) |
-| :------ | :----------------------------------------------------- |
+| Cluster                            | Slugs (numbers differ by branch — see [Index](#index))                                                                                                                                              |
+| :--------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Framework server/client boundaries | `nextjs-runtime-env`, `nextjs-conditional-exports-boundary`, `nuxt-vite-compile-time-boundary`, `flat-layout-codegen-type-strategy`, `framework-subpath-exports`, `strict-layout-complexity-budget` |
-| Packaging & module graph | `export-surface-tiers`, `standard-mode-packaging-strategy`, `bundle-isolation-over-dryness`, `runtime-shared-logic-strategy`, `shared-build-package` |
-| CLI / scaffold IR | `cli-hosting-preset-field-metadata`, `dotenv-linter-custom-parser-strategy` |
+| Packaging & module graph           | `export-surface-tiers`, `standard-mode-packaging-strategy`, `bundle-isolation-over-dryness`, `runtime-shared-logic-strategy`, `shared-build-package`                                                |
+| CLI / scaffold IR                  | `cli-hosting-preset-field-metadata`, `dotenv-linter-custom-parser-strategy`                                                                                                                         |
 
 ## Index
 
 Numbers are per branch. A blank cell means the ADR is not present on that line.
 
-| Slug | `dev` | `v1` |
-| :--- | :---: | :---: |
-| `use-architecture-decision-records` | 0000 | 0000 |
-| `bun-plugin-config-patterns` | 0001 | 0001 |
-| `coercion-schema-transformer` | 0002 | 0002 |
-| `explicit-validator-mode` | 0003 | 0003 |
-| `export-surface-tiers` | 0004 | 0004 |
-| `nextjs-runtime-env` | 0005 | 0005 |
-| `branching-and-release-flow` | 0006 | 0006 |
-| `standard-mode-packaging-strategy` | — | 0007 |
-| `default-export-and-function-naming` | — | 0008 |
-| `shared-build-package` | 0009 | 0009 |
-| `bundle-isolation-over-dryness` | — | 0010 |
-| `flat-layout-codegen-type-strategy` | 0010 | 0013 |
-| `runtime-shared-logic-strategy` | — | 0011 |
-| `nextjs-jiti-build-time-validation` | 0011 | 0014 |
-| `independent-versioning-strategy` | — | 0012 |
-| `nextjs-conditional-exports-boundary` | 0012 | 0015 |
-| `nuxt-vite-compile-time-boundary` | 0013 | 0016 |
-| `cli-hosting-preset-field-metadata` | 0014 | 0018 |
-| `env-object-canonical-surface` | 0015 | — |
-| `strict-layout-complexity-budget` | 0016 | — |
-| `dotenv-linter-custom-parser-strategy` | — | 0017 |
-| `framework-subpath-exports` | — | 0019 |
+| Slug                                   | `dev` | `v1` |
+| :------------------------------------- | :---: | :--: |
+| `use-architecture-decision-records`    |  0000 | 0000 |
+| `bun-plugin-config-patterns`           |  0001 | 0001 |
+| `coercion-schema-transformer`          |  0002 | 0002 |
+| `explicit-validator-mode`              |  0003 | 0003 |
+| `export-surface-tiers`                 |  0004 | 0004 |
+| `nextjs-runtime-env`                   |  0005 | 0005 |
+| `branching-and-release-flow`           |  0006 | 0006 |
+| `standard-mode-packaging-strategy`     |   —   | 0007 |
+| `default-export-and-function-naming`   |   —   | 0008 |
+| `shared-build-package`                 |  0009 | 0009 |
+| `bundle-isolation-over-dryness`        |   —   | 0010 |
+| `flat-layout-codegen-type-strategy`    |  0010 | 0013 |
+| `runtime-shared-logic-strategy`        |   —   | 0011 |
+| `nextjs-jiti-build-time-validation`    |  0011 | 0014 |
+| `independent-versioning-strategy`      |   —   | 0012 |
+| `nextjs-conditional-exports-boundary`  |  0012 | 0015 |
+| `nuxt-vite-compile-time-boundary`      |  0013 | 0016 |
+| `cli-hosting-preset-field-metadata`    |  0014 | 0018 |
+| `env-object-canonical-surface`         |  0015 |   —  |
+| `strict-layout-complexity-budget`      |  0016 |   —  |
+| `dotenv-linter-custom-parser-strategy` |   —   | 0017 |
+| `framework-subpath-exports`            |   —   | 0019 |
 
 ## Tooling & agent skills
 


### PR DESCRIPTION
## Summary
- Rename colliding `0014-framework-subpath-exports` → `0019` and retarget boundary links to ADR 0015 / 0016.
- Fold the bundle-isolation principle into ADR 0011; shrink ADR 0010 and ADR 0004 to superseded historical stubs.
- Align `docs/adr/README.md` with the dual-track numbering policy and slug index (same content as the `dev` companion PR).

## Test plan
- [ ] Confirm only one `0014-*.md` remains (`nextjs-jiti-build-time-validation`)
- [ ] Open `0019-framework-subpath-exports.md` and verify links resolve to `0015` / `0016`
- [ ] Read ADR 0011 isolation section; ADR 0010 / 0004 should be short superseded pointers
- [ ] Cross-check README index against files on this branch


Made with [Cursor](https://cursor.com)