### PR TITLE
docs: drop ADR slug/number index

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,7 +11,7 @@ ADRs use zero-padded sequential filenames (e.g. `0001-slug.md`, `0002-slug.md`).
 1. **Immutable numbers.** Once an ADR is merged, its number is never reused or renumbered. Filename changes that alter the number are reserved for fixing accidental collisions before (or immediately after) merge.
 2. **Next number = max + 1.** When adding a record, scan this directory for the highest existing number on **this branch** and increment by one. Do not fill gaps.
 3. **Gaps are fine.** Dual-tracking (`dev` / `v1`) means some numbers exist only on one line. A jump such as `0006` → `0009` on `dev` is expected when `0007`/`0008` live on `v1` only.
-4. **Numbers are branch-local.** The same slug may carry different numbers on `dev` vs `v1` (see [Index](#index)). Do not try to unify numbering across branches without a deliberate, repository-wide renumber — high cost, low value. Prefer slug-based links and the index below when comparing branches.
+4. **Numbers are branch-local.** The same slug may carry different numbers on `dev` vs `v1`. Do not try to unify numbering across branches without a deliberate, repository-wide renumber — high cost, low value. Prefer slug-based links, and always open the file on the branch you are working on.
 
 ## Directory policy
 
@@ -29,42 +29,13 @@ An ADR should be written when a decision is:
 
 ## Related clusters
 
-These groups share a theme. They remain separate ADRs (no nesting or history rewrites) — use the links when reviewing related decisions:
+These groups share a theme. They remain separate ADRs (no nesting or history rewrites) — use the links when reviewing related decisions. Numbers differ by branch; prefer slugs.
 
-| Cluster                            | Slugs (numbers differ by branch — see [Index](#index))                                                                                                                                              |
+| Cluster                            | Slugs                                                                                                                                                                                               |
 | :--------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Framework server/client boundaries | `nextjs-runtime-env`, `nextjs-conditional-exports-boundary`, `nuxt-vite-compile-time-boundary`, `flat-layout-codegen-type-strategy`, `framework-subpath-exports`, `strict-layout-complexity-budget` |
 | Packaging & module graph           | `export-surface-tiers`, `standard-mode-packaging-strategy`, `bundle-isolation-over-dryness`, `runtime-shared-logic-strategy`, `shared-build-package`                                                |
 | CLI / scaffold IR                  | `cli-hosting-preset-field-metadata`, `dotenv-linter-custom-parser-strategy`                                                                                                                         |
-
-## Index
-
-Numbers are per branch. A blank cell means the ADR is not present on that line.
-
-| Slug                                   | `dev` | `v1` |
-| :------------------------------------- | :---: | :--: |
-| `use-architecture-decision-records`    |  0000 | 0000 |
-| `bun-plugin-config-patterns`           |  0001 | 0001 |
-| `coercion-schema-transformer`          |  0002 | 0002 |
-| `explicit-validator-mode`              |  0003 | 0003 |
-| `export-surface-tiers`                 |  0004 | 0004 |
-| `nextjs-runtime-env`                   |  0005 | 0005 |
-| `branching-and-release-flow`           |  0006 | 0006 |
-| `standard-mode-packaging-strategy`     |   —   | 0007 |
-| `default-export-and-function-naming`   |   —   | 0008 |
-| `shared-build-package`                 |  0009 | 0009 |
-| `bundle-isolation-over-dryness`        |   —   | 0010 |
-| `flat-layout-codegen-type-strategy`    |  0010 | 0013 |
-| `runtime-shared-logic-strategy`        |   —   | 0011 |
-| `nextjs-jiti-build-time-validation`    |  0011 | 0014 |
-| `independent-versioning-strategy`      |   —   | 0012 |
-| `nextjs-conditional-exports-boundary`  |  0012 | 0015 |
-| `nuxt-vite-compile-time-boundary`      |  0013 | 0016 |
-| `cli-hosting-preset-field-metadata`    |  0014 | 0018 |
-| `env-object-canonical-surface`         |  0015 |   —  |
-| `strict-layout-complexity-budget`      |  0016 |   —  |
-| `dotenv-linter-custom-parser-strategy` |   —   | 0017 |
-| `framework-subpath-exports`            |   —   | 0019 |
 
 ## Tooling & agent skills
 


### PR DESCRIPTION
## Summary
- Remove the dual-track slug→number index from `docs/adr/README.md` (landed via #1408).
- Keep numbering policy and thematic clusters (plus Credits).

## Test plan
- [ ] Confirm README has no Index section
- [ ] Confirm numbering rules and Related clusters remain


Made with [Cursor](https://cursor.com)