### PR TITLE
feat: Forward-port add host command from #1324

### DIFF
--- a/.changeset/add-host-preset-add-command.md
+++ b/.changeset/add-host-preset-add-command.md
@@ -1,0 +1,15 @@
+---
+"arkenv": minor
+---
+
+#### Add `add host` command to CLI for adding hosting presets to existing schemas
+
+Support adding a hosting provider preset (Vercel or Netlify) to an existing `env.ts` configuration file:
+
+```bash
+npx arkenv@next add host [provider]
+```
+
+- Prompts interactively to select Vercel or Netlify if the provider is omitted.
+- Auto-detects the framework (Next.js, Nuxt, Vite, Bun) and the validator engine (Zod, Valibot, or ArkType) to inject the preset fields with the correct syntax.
+- Fallback to logging the generated variable schemas to stdout with manual configuration instructions if `env.ts` is missing or unparseable.

--- a/.changeset/add-host-preset-add-command.md
+++ b/.changeset/add-host-preset-add-command.md
@@ -7,7 +7,7 @@
 Support adding a hosting provider preset (Vercel or Netlify) to an existing `env.ts` configuration file:
 
 ```bash
-npx arkenv@next add host [provider]
+npx arkenv@alpha add host [provider]
 ```
 
 - Prompts interactively to select Vercel or Netlify if the provider is omitted.

--- a/apps/www/content/docs/cli/hosting-presets.mdx
+++ b/apps/www/content/docs/cli/hosting-presets.mdx
@@ -1,16 +1,16 @@
 ---
 title: Hosting presets
 icon: Cloud
-description: Pre-populate your schema with Vercel or Netlify system environment variables during arkenv init.
+description: Pre-populate your schema with Vercel or Netlify system environment variables during arkenv init, or add them later with arkenv add host.
 ---
 
-Most hosting providers inject their own **system environment variables** at build and runtime (for example, Vercel sets `VERCEL_ENV` and `VERCEL_URL`, Netlify sets `CONTEXT` and `URL`). Hosting presets let `arkenv init` pre-populate your generated schema with the correct variables for your provider, already typed and marked optional, so you don't have to look them up by hand.
+Most hosting providers inject their own **system environment variables** at build and runtime (for example, Vercel sets `VERCEL_ENV` and `VERCEL_URL`, Netlify sets `CONTEXT` and `URL`). Hosting presets let `arkenv init` pre-populate your generated schema with the correct variables for your provider, already typed and marked optional, so you don't have to look them up by hand. If you already have an `env.ts`, use [`arkenv add host`](#add-host-to-an-existing-schema) to inject the same fields later.
 
 Presets work with every validator (ArkType, Zod, Valibot) and both the [flat](#layouts) and [strict](#layouts) layouts.
 
-## Selecting a preset
+## Selecting a preset during init
 
-There are two ways to pick a preset.
+There are two ways to pick a preset when scaffolding a new project.
 
 ### Interactive prompt
 
@@ -38,6 +38,24 @@ The flag accepts `none`, `vercel`, or `netlify`. The following is equivalent:
 ```npm
 npx arkenv@latest init -H vercel
 ```
+
+## Add host to an existing schema
+
+If you already ran `init` (or hand-wrote an `env.ts`) and want to add a hosting preset later, use `add host`:
+
+```npm
+npx arkenv@latest add host vercel
+```
+
+Omit the provider to pick interactively:
+
+```npm
+npx arkenv@latest add host
+```
+
+The command auto-detects your framework prefix and validator (ArkType, Zod, or Valibot), then merges the preset fields into a flat `env.ts` (or `src/env.ts`). If the file is missing or unparseable, it prints the proposed fields so you can paste them in manually. Keys that are already present are left unchanged.
+
+With `--yes` or `--agent`, an omitted provider defaults to `vercel`.
 
 ## What each preset adds
 
@@ -215,7 +233,7 @@ Presets only add variables; they never remove or overwrite variables scanned fro
 ## Next steps
 
 <Cards>
-  <Card title="CLI Introduction" href="/docs/cli" description="See every init flag, including --host-preset." />
+  <Card title="CLI Introduction" href="/docs/cli" description="See every command and flag, including init --host-preset and add host." />
 
   <Card title="Zod, Valibot, and other validators" href="/docs/nextjs/using-other-validators" description="Mix and match Standard Schema validators with ArkEnv." />
 </Cards>

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -21,6 +21,7 @@ npx arkenv@latest add host [provider]
 ```
 
 See [Hosting presets](/docs/cli/hosting-presets#add-host-to-an-existing-schema) for details.
+
 ## Behavior
 
 The CLI automatically adjusts its workflow depending on where it is executed:

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -14,6 +14,13 @@ Run the CLI using your package manager of choice. The CLI will guide you through
 npx arkenv@latest init [project-name] [options]
 ```
 
+To add a hosting preset to an existing flat `env.ts` later:
+
+```npm
+npx arkenv@latest add host [provider]
+```
+
+See [Hosting presets](/docs/cli/hosting-presets#add-host-to-an-existing-schema) for details.
 ## Behavior
 
 The CLI automatically adjusts its workflow depending on where it is executed:

--- a/packages/arkenv/src/adapters/prompt.adapter.ts
+++ b/packages/arkenv/src/adapters/prompt.adapter.ts
@@ -73,7 +73,11 @@ export class ClackPromptAdapter implements PromptPort {
 	): Promise<T | null> {
 		const result = await clackSelect({
 			message,
-			options: options as any,
+			// Clack's Option<T> is a conditional type incompatible with our port
+			// shape under exactOptionalPropertyTypes; cast via unknown.
+			options: options as unknown as Parameters<
+				typeof clackSelect
+			>[0]["options"],
 			initialValue,
 		});
 		if (isCancel(result)) return null;

--- a/packages/arkenv/src/adapters/prompt.adapter.ts
+++ b/packages/arkenv/src/adapters/prompt.adapter.ts
@@ -1,4 +1,8 @@
-import { confirm as clackConfirm, isCancel } from "@clack/prompts";
+import {
+	confirm as clackConfirm,
+	select as clackSelect,
+	isCancel,
+} from "@clack/prompts";
 import { shake } from "radashi";
 import { runPromptWizard } from "@/cli/ui";
 import type { ProjectOptions } from "@/features/scaffold";
@@ -57,5 +61,22 @@ export class ClackPromptAdapter implements PromptPort {
 		isYes = false,
 	): Promise<ProjectOptions | null> {
 		return runPromptWizard(defaults, isYes);
+	}
+
+	/**
+	 * Prompt the user to select one option from a list.
+	 */
+	async select<T extends string>(
+		message: string,
+		options: { value: T; label: string; hint?: string }[],
+		initialValue?: T,
+	): Promise<T | null> {
+		const result = await clackSelect({
+			message,
+			options: options as any,
+			initialValue,
+		});
+		if (isCancel(result)) return null;
+		return result as T;
 	}
 }

--- a/packages/arkenv/src/cli/cli.test.ts
+++ b/packages/arkenv/src/cli/cli.test.ts
@@ -330,6 +330,11 @@ describe("CLI parser", () => {
 				expect(cli.validationError).toBe("Invalid host preset: vercle");
 			});
 
+			it("should reject bare add without a subcommand", () => {
+				const cli = new CLI(["node", "arkenv", "add"]);
+				expect(cli.validationError).toBe("Missing subcommand");
+			});
+
 			it("should reject non-host subcommand", () => {
 				const cli = new CLI(["node", "arkenv", "add", "client"]);
 				expect(cli.validationError).toBe("Unknown argument: client");

--- a/packages/arkenv/src/cli/cli.test.ts
+++ b/packages/arkenv/src/cli/cli.test.ts
@@ -292,5 +292,60 @@ describe("CLI parser", () => {
 			const invalid = new CLI(["node", "arkenv", "init", "-H", "vercle"]);
 			expect(invalid.validationError).toBe("Invalid host preset: vercle");
 		});
+
+		describe("add command", () => {
+			it("should parse valid add host vercel command", () => {
+				const cli = new CLI(["node", "arkenv", "add", "host", "vercel"]);
+				expect(cli.command).toBe("add");
+				expect(cli.addInput.provider).toBe("vercel");
+				expect(cli.validationError).toBeUndefined();
+			});
+
+			it("should parse valid add host netlify command", () => {
+				const cli = new CLI(["node", "arkenv", "add", "host", "netlify"]);
+				expect(cli.command).toBe("add");
+				expect(cli.addInput.provider).toBe("netlify");
+				expect(cli.validationError).toBeUndefined();
+			});
+
+			it("should parse valid add host command with omitted provider", () => {
+				const cli = new CLI(["node", "arkenv", "add", "host"]);
+				expect(cli.command).toBe("add");
+				expect(cli.addInput.provider).toBeUndefined();
+				expect(cli.validationError).toBeUndefined();
+			});
+
+			it("should parse isYes in addInput when --yes or --agent flag is passed", () => {
+				const cli1 = new CLI(["node", "arkenv", "add", "host", "--yes"]);
+				expect(cli1.command).toBe("add");
+				expect(cli1.addInput.isYes).toBe(true);
+
+				const cli2 = new CLI(["node", "arkenv", "add", "host", "--agent"]);
+				expect(cli2.command).toBe("add");
+				expect(cli2.addInput.isYes).toBe(true);
+			});
+
+			it("should reject invalid provider", () => {
+				const cli = new CLI(["node", "arkenv", "add", "host", "vercle"]);
+				expect(cli.validationError).toBe("Invalid host preset: vercle");
+			});
+
+			it("should reject non-host subcommand", () => {
+				const cli = new CLI(["node", "arkenv", "add", "client"]);
+				expect(cli.validationError).toBe("Unknown argument: client");
+			});
+
+			it("should reject extra positional arguments", () => {
+				const cli = new CLI([
+					"node",
+					"arkenv",
+					"add",
+					"host",
+					"vercel",
+					"extra",
+				]);
+				expect(cli.validationError).toBe("Unknown argument: extra");
+			});
+		});
 	});
 });

--- a/packages/arkenv/src/cli/cli.ts
+++ b/packages/arkenv/src/cli/cli.ts
@@ -39,6 +39,7 @@ export class CLI {
 	public name: string | undefined;
 	public validationError: string | undefined;
 	public logger: Logger;
+	public positionalArgs: string[];
 
 	/**
 	 * Creates a CLI context from process arguments and optional adapters.
@@ -112,11 +113,30 @@ export class CLI {
 			}
 		}
 
+		this.positionalArgs = positionalArgs;
+
 		if (!this.validationError) {
-			if (positionalArgs.length > 1) {
-				this.validationError = `Unknown argument: ${positionalArgs[1]}`;
+			if (this.command === "add") {
+				if (positionalArgs[0] !== "host") {
+					this.validationError = `Unknown argument: ${positionalArgs[0] || ""}`;
+				} else if (positionalArgs.length > 2) {
+					this.validationError = `Unknown argument: ${positionalArgs[2]}`;
+				} else {
+					const provider = positionalArgs[1];
+					if (
+						provider !== undefined &&
+						provider !== "vercel" &&
+						provider !== "netlify"
+					) {
+						this.validationError = `Invalid host preset: ${provider}`;
+					}
+				}
 			} else {
-				this.name = positionalArgs[0];
+				if (positionalArgs.length > 1) {
+					this.validationError = `Unknown argument: ${positionalArgs[1]}`;
+				} else {
+					this.name = positionalArgs[0];
+				}
 			}
 		}
 
@@ -217,6 +237,18 @@ export class CLI {
 			input.hostPreset = this.hostPreset;
 		}
 		return input;
+	}
+
+	/**
+	 * Returns the parsed input consumed by the add command.
+	 */
+	get addInput(): { provider?: "vercel" | "netlify"; isYes?: boolean } {
+		const provider = this.positionalArgs[1];
+		const isYes = this.isYes;
+		if (provider === "vercel" || provider === "netlify") {
+			return { provider, isYes };
+		}
+		return { isYes };
 	}
 
 	/**

--- a/packages/arkenv/src/cli/cli.ts
+++ b/packages/arkenv/src/cli/cli.ts
@@ -117,8 +117,10 @@ export class CLI {
 
 		if (!this.validationError) {
 			if (this.command === "add") {
-				if (positionalArgs[0] !== "host") {
-					this.validationError = `Unknown argument: ${positionalArgs[0] || ""}`;
+				if (!positionalArgs[0]) {
+					this.validationError = "Missing subcommand";
+				} else if (positionalArgs[0] !== "host") {
+					this.validationError = `Unknown argument: ${positionalArgs[0]}`;
 				} else if (positionalArgs.length > 2) {
 					this.validationError = `Unknown argument: ${positionalArgs[2]}`;
 				} else {

--- a/packages/arkenv/src/cli/commands/add.test.ts
+++ b/packages/arkenv/src/cli/commands/add.test.ts
@@ -1,0 +1,236 @@
+import dedent from "dedent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+	LoggerPort,
+	ProjectScannerPort,
+	PromptPort,
+	WorkspacePort,
+} from "@/shared/ports";
+import { AddUseCase, detectValidator } from "./add";
+
+describe("AddUseCase", () => {
+	let logger: LoggerPort;
+	let workspace: WorkspacePort;
+	let prompt: PromptPort;
+	let scanner: ProjectScannerPort;
+	let useCase: AddUseCase;
+
+	beforeEach(() => {
+		logger = {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			fatal: vi.fn(),
+			step: vi.fn(),
+			success: vi.fn(),
+			cancel: vi.fn(),
+			note: vi.fn(),
+			finish: vi.fn(),
+			log: vi.fn(),
+			spinner: vi.fn().mockReturnValue({
+				start: vi.fn(),
+				stop: vi.fn(),
+			}),
+			interactiveStdout: vi.fn(),
+		} as unknown as LoggerPort;
+
+		workspace = {
+			exists: vi.fn().mockResolvedValue(true),
+			readFile: vi.fn(),
+			writeFile: vi.fn(),
+			mkdir: vi.fn(),
+			execute: vi.fn(),
+		} as unknown as WorkspacePort;
+
+		prompt = {
+			confirm: vi.fn(),
+			runWizard: vi.fn(),
+			select: vi.fn(),
+		} as unknown as PromptPort;
+
+		scanner = {
+			hasPackageJson: vi.fn().mockResolvedValue(true),
+			isEmptyDirectory: vi.fn().mockResolvedValue(false),
+			checkRequirements: vi.fn().mockResolvedValue([]),
+			checkTsConfig: vi
+				.fn()
+				.mockResolvedValue({ status: "strict", parsed: null }),
+			detectFramework: vi.fn().mockResolvedValue("vanilla"),
+			suggestDefaultEnvPath: vi.fn().mockResolvedValue("./env.ts"),
+			getEnvExampleKeys: vi.fn().mockResolvedValue(null),
+			detectPackageManager: vi.fn().mockResolvedValue("pnpm"),
+			hasSkill: vi.fn().mockResolvedValue(false),
+			checkGitStatus: vi.fn().mockResolvedValue({ status: "clean" }),
+		} as unknown as ProjectScannerPort;
+
+		useCase = new AddUseCase(logger, workspace, prompt, scanner);
+	});
+
+	it("prompts for provider if omitted", async () => {
+		vi.mocked(prompt.select).mockResolvedValue("vercel");
+		vi.mocked(workspace.exists).mockResolvedValue(true);
+		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
+			import { type } from "@arkenv/core";
+			export const Env = type({
+				DATABASE_URL: "string",
+			});
+		`);
+
+		const result = await useCase.execute({});
+		expect(result).toBe(true);
+		expect(prompt.select).toHaveBeenCalled();
+		expect(workspace.writeFile).toHaveBeenCalled();
+		expect(logger.success).toHaveBeenCalledWith(
+			expect.stringContaining("Added Vercel"),
+		);
+	});
+
+	it("defaults provider to vercel when isYes is true and provider is omitted", async () => {
+		vi.mocked(workspace.exists).mockResolvedValue(true);
+		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
+			import { type } from "@arkenv/core";
+			export const Env = type({
+				DATABASE_URL: "string",
+			});
+		`);
+
+		const result = await useCase.execute({ isYes: true });
+		expect(result).toBe(true);
+		expect(prompt.select).not.toHaveBeenCalled();
+		expect(workspace.writeFile).toHaveBeenCalledWith(
+			expect.stringContaining("env.ts"),
+			expect.stringContaining('VERCEL: "string?"'),
+		);
+		expect(logger.success).toHaveBeenCalledWith(
+			expect.stringContaining("Added Vercel"),
+		);
+	});
+
+	it("mutates env.ts with preset keys", async () => {
+		vi.mocked(workspace.exists).mockResolvedValue(true);
+		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
+			import { type } from "@arkenv/core";
+			export const Env = type({
+				DATABASE_URL: "string",
+			});
+		`);
+
+		const result = await useCase.execute({ provider: "vercel" });
+		expect(result).toBe(true);
+		expect(workspace.writeFile).toHaveBeenCalledWith(
+			expect.stringContaining("env.ts"),
+			expect.stringContaining('VERCEL: "string?"'),
+		);
+		expect(logger.success).toHaveBeenCalledWith(
+			expect.stringContaining("Added Vercel"),
+		);
+	});
+
+	it("locates and mutates src/env.ts in nested layouts", async () => {
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) => {
+			return p.endsWith("src/env.ts");
+		});
+		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
+			import { type } from "@arkenv/core";
+			export const Env = type({
+				DATABASE_URL: "string",
+			});
+		`);
+
+		const result = await useCase.execute({ provider: "vercel" });
+		expect(result).toBe(true);
+		expect(workspace.writeFile).toHaveBeenCalledWith(
+			expect.stringContaining("src/env.ts"),
+			expect.stringContaining('VERCEL: "string?"'),
+		);
+		expect(logger.success).toHaveBeenCalledWith(
+			expect.stringContaining("src/env.ts"),
+		);
+	});
+
+	it("does not mutate if keys are already present", async () => {
+		vi.mocked(workspace.exists).mockResolvedValue(true);
+		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
+			import { type } from "@arkenv/core";
+			export const Env = type({
+				DATABASE_URL: "string",
+				VERCEL: "string?",
+				VERCEL_ENV: "'production' | 'preview' | 'development'?",
+				VERCEL_URL: "string?",
+			});
+		`);
+
+		const result = await useCase.execute({ provider: "vercel" });
+		expect(result).toBe(true);
+		expect(workspace.writeFile).not.toHaveBeenCalled();
+		expect(logger.info).toHaveBeenCalledWith(
+			expect.stringContaining("already present"),
+		);
+	});
+
+	it("logs proposed keys to stdout if env.ts does not exist", async () => {
+		vi.mocked(workspace.exists).mockResolvedValue(false);
+
+		const result = await useCase.execute({ provider: "vercel" });
+		expect(result).toBe(true);
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.stringContaining("Could not locate"),
+		);
+		expect(logger.log).toHaveBeenCalledWith(expect.stringContaining("VERCEL:"));
+	});
+
+	it("logs proposed keys to stdout if env.ts is not parseable", async () => {
+		vi.mocked(workspace.exists).mockResolvedValue(true);
+		vi.mocked(workspace.readFile).mockResolvedValue("export const x = 123;");
+
+		const result = await useCase.execute({ provider: "vercel" });
+		expect(result).toBe(true);
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.stringContaining("Could not find arkenv or type schema call"),
+		);
+		expect(logger.log).toHaveBeenCalledWith(expect.stringContaining("VERCEL:"));
+	});
+
+	describe("detectValidator", () => {
+		it("detects zod from import statements", () => {
+			const code = 'import { z } from "zod";\nexport const env = arkenv({});';
+			expect(detectValidator(code)).toBe("zod");
+		});
+
+		it("detects valibot from import statements", () => {
+			const code =
+				'import * as v from "valibot";\nexport const env = arkenv({});';
+			expect(detectValidator(code)).toBe("valibot");
+		});
+
+		it("defaults to arktype when no zod or valibot import is present", () => {
+			const code =
+				'import arkenv from "./generated/env.gen";\nexport const env = arkenv({});';
+			expect(detectValidator(code)).toBe("arktype");
+		});
+
+		it("ignores commented-out zod imports", () => {
+			const code =
+				'// import { z } from "zod"\nimport arkenv from "./generated/env.gen";\nexport const env = arkenv({});';
+			expect(detectValidator(code)).toBe("arktype");
+		});
+
+		it("detects zod from multi-line import statements", () => {
+			const code =
+				'import {\n  z,\n} from "zod";\nexport const env = arkenv({});';
+			expect(detectValidator(code)).toBe("zod");
+		});
+
+		it("detects valibot from multi-line import statements", () => {
+			const code =
+				'import {\n  string,\n  optional,\n} from "valibot";\nexport const env = arkenv({});';
+			expect(detectValidator(code)).toBe("valibot");
+		});
+
+		it("ignores multi-line commented-out valibot imports", () => {
+			const code =
+				'/*\n import * as v from "valibot"\n*/\nimport arkenv from "./generated/env.gen";\nexport const env = arkenv({});';
+			expect(detectValidator(code)).toBe("arktype");
+		});
+	});
+});

--- a/packages/arkenv/src/cli/commands/add.ts
+++ b/packages/arkenv/src/cli/commands/add.ts
@@ -1,0 +1,187 @@
+import path from "node:path";
+import { mutateEnvConfig } from "@/features/config-mutation";
+import { FRAMEWORK_CLIENT_PREFIXES } from "@/features/scaffold/frameworks";
+import type { Validator } from "@/features/scaffold/plan";
+import { getPresetKeys } from "@/features/scaffold/presets";
+import {
+	DIALECTS,
+	tryFormatPresetFieldValue,
+} from "@/features/scaffold/validators/dialects";
+import type {
+	LoggerPort,
+	ProjectScannerPort,
+	PromptPort,
+	WorkspacePort,
+} from "@/shared/ports";
+
+export type AddInput = {
+	provider?: "vercel" | "netlify";
+	isYes?: boolean;
+};
+
+/**
+ * Resolve a hosting-preset key to a validator-specific schema fragment.
+ *
+ * Uses v1 dialect renderers (same as scaffold codegen) so add-host output
+ * stays aligned with `arkenv init` field syntax.
+ */
+function getFieldDefinition(
+	key: string,
+	validator: Validator,
+	prefix: string,
+	provider: "vercel" | "netlify",
+): string {
+	const dialect = DIALECTS[validator];
+	return (
+		tryFormatPresetFieldValue(dialect, key, prefix, provider) ??
+		dialect.formatOptionalString()
+	);
+}
+
+/**
+ * Use case for adding a hosting preset (Vercel/Netlify) to an existing env.ts schema.
+ */
+export class AddUseCase {
+	constructor(
+		private readonly logger: LoggerPort,
+		private readonly workspace: WorkspacePort,
+		private readonly prompt: PromptPort,
+		private readonly scanner: ProjectScannerPort,
+	) {}
+
+	/**
+	 * Executes the add command by finding/mutating env.ts.
+	 */
+	async execute(input: AddInput): Promise<boolean> {
+		this.logger.interactiveStdout(true);
+
+		try {
+			let provider = input.provider;
+
+			if (!provider) {
+				if (input.isYes) {
+					provider = "vercel";
+				} else {
+					const selected = await this.prompt.select(
+						"Select a hosting provider preset:",
+						[
+							{
+								value: "vercel",
+								label: "Vercel",
+								hint: "Add VERCEL, VERCEL_ENV, VERCEL_URL, etc.",
+							},
+							{
+								value: "netlify",
+								label: "Netlify",
+								hint: "Add NETLIFY, CONTEXT, URL, DEPLOY_URL, etc.",
+							},
+						],
+						"vercel",
+					);
+					if (selected === "vercel" || selected === "netlify") {
+						provider = selected;
+					} else {
+						return false;
+					}
+				}
+			}
+
+			const cwd = process.cwd();
+			const tsConfigResult = await this.scanner.checkTsConfig(cwd);
+			const tsConfig = tsConfigResult.parsed || null;
+			const framework = await this.scanner.detectFramework(cwd, tsConfig);
+
+			const suggestedPath = await this.scanner.suggestDefaultEnvPath(
+				cwd,
+				tsConfig,
+			);
+			const candidatePaths = [
+				path.resolve(cwd, "env.ts"),
+				path.resolve(cwd, "src/env.ts"),
+				path.resolve(cwd, suggestedPath),
+			];
+
+			let envPath: string | null = null;
+			for (const candidate of candidatePaths) {
+				if (await this.workspace.exists(candidate)) {
+					envPath = candidate;
+					break;
+				}
+			}
+
+			const prefix = FRAMEWORK_CLIENT_PREFIXES[framework];
+			const keys = getPresetKeys(provider, prefix);
+
+			const getManualFieldsText = (validator: Validator): string => {
+				return keys
+					.map(
+						(key) =>
+							`\t${key}: ${getFieldDefinition(key, validator, prefix, provider)},`,
+					)
+					.join("\n");
+			};
+
+			if (!envPath) {
+				this.logger.error("Could not locate your env.ts file.");
+				this.logger.log(
+					"\nPlease add the following environment variables to your schema manually:\n",
+				);
+				this.logger.log(`{\n${getManualFieldsText("arktype")}\n}`);
+				return true;
+			}
+
+			const code = await this.workspace.readFile(envPath);
+			const validator = detectValidator(code);
+			const result = mutateEnvConfig(code, provider, framework, validator);
+
+			const relativeEnvPath = path.relative(cwd, envPath);
+
+			if (!result.success || !result.code) {
+				this.logger.error(
+					result.error || `Failed to mutate ${relativeEnvPath}.`,
+				);
+				this.logger.log(
+					"\nPlease add the following environment variables to your schema manually:\n",
+				);
+				this.logger.log(`{\n${getManualFieldsText(validator)}\n}`);
+				return true;
+			}
+
+			if (result.updated) {
+				await this.workspace.writeFile(envPath, result.code);
+				this.logger.success(
+					`Added ${provider === "vercel" ? "Vercel" : "Netlify"} environment variables to ${relativeEnvPath}`,
+				);
+			} else {
+				this.logger.info(
+					`All ${provider === "vercel" ? "Vercel" : "Netlify"} environment variables are already present in ${relativeEnvPath}`,
+				);
+			}
+
+			return true;
+		} finally {
+			this.logger.interactiveStdout(false);
+		}
+	}
+}
+
+/**
+ * Detects the validator engine (Zod, Valibot, or ArkType) used in an env.ts schema file.
+ * Strips single-line and multi-line comments to avoid misclassifying commented-out code or string literals.
+ *
+ * @param code The source code of env.ts.
+ * @returns The detected validator engine.
+ */
+export function detectValidator(code: string): Validator {
+	const cleanedCode = code
+		.replace(/\/\/.*/g, "")
+		.replace(/\/\*[\s\S]*?\*\//g, "");
+
+	if (/(?:^|\n)\s*import\s+[\s\S]*?from\s+['"]zod['"]/.test(cleanedCode)) {
+		return "zod";
+	}
+	if (/(?:^|\n)\s*import\s+[\s\S]*?from\s+['"]valibot['"]/.test(cleanedCode)) {
+		return "valibot";
+	}
+	return "arktype";
+}

--- a/packages/arkenv/src/cli/commands/add.ts
+++ b/packages/arkenv/src/cli/commands/add.ts
@@ -1,12 +1,11 @@
 import path from "node:path";
-import { mutateEnvConfig } from "@/features/config-mutation";
+import {
+	getFieldDefinition,
+	mutateEnvConfig,
+} from "@/features/config-mutation";
 import { FRAMEWORK_CLIENT_PREFIXES } from "@/features/scaffold/frameworks";
 import type { Validator } from "@/features/scaffold/plan";
 import { getPresetKeys } from "@/features/scaffold/presets";
-import {
-	DIALECTS,
-	tryFormatPresetFieldValue,
-} from "@/features/scaffold/validators/dialects";
 import type {
 	LoggerPort,
 	ProjectScannerPort,
@@ -18,25 +17,6 @@ export type AddInput = {
 	provider?: "vercel" | "netlify";
 	isYes?: boolean;
 };
-
-/**
- * Resolve a hosting-preset key to a validator-specific schema fragment.
- *
- * Uses v1 dialect renderers (same as scaffold codegen) so add-host output
- * stays aligned with `arkenv init` field syntax.
- */
-function getFieldDefinition(
-	key: string,
-	validator: Validator,
-	prefix: string,
-	provider: "vercel" | "netlify",
-): string {
-	const dialect = DIALECTS[validator];
-	return (
-		tryFormatPresetFieldValue(dialect, key, prefix, provider) ??
-		dialect.formatOptionalString()
-	);
-}
 
 /**
  * Use case for adding a hosting preset (Vercel/Netlify) to an existing env.ts schema.

--- a/packages/arkenv/src/cli/commands/help.test.ts
+++ b/packages/arkenv/src/cli/commands/help.test.ts
@@ -29,6 +29,14 @@ describe("HelpUseCase", () => {
 			"  arkenv init [project-name]    Set up ArkEnv in your project",
 		);
 
+		const addCommandLog = logs.find((l) =>
+			l.includes("arkenv add host [provider]"),
+		);
+		expect(addCommandLog).toBeDefined();
+		expect(addCommandLog).toBe(
+			"  arkenv add host [provider]    Add hosting provider preset (vercel, netlify) to env.ts",
+		);
+
 		// Options should be aligned based on the longest option (--host-preset, -H <preset>) which is 26 chars
 		// leftPad (2) + longest flag (26) + colGap (4) = 32 characters start index for descriptions.
 		const yesOptionLog = logs.find((l) => l.includes("--yes, -y"));

--- a/packages/arkenv/src/cli/commands/help.ts
+++ b/packages/arkenv/src/cli/commands/help.ts
@@ -38,6 +38,10 @@ export class HelpUseCase {
 				left: "arkenv init [project-name]",
 				right: "Set up ArkEnv in your project",
 			},
+			{
+				left: "arkenv add host [provider]",
+				right: "Add hosting provider preset (vercel, netlify) to env.ts",
+			},
 		];
 
 		const options: HelpItem[] = [

--- a/packages/arkenv/src/cli/commands/index.ts
+++ b/packages/arkenv/src/cli/commands/index.ts
@@ -1,2 +1,3 @@
+export * from "./add";
 export * from "./help";
 export * from "./init";

--- a/packages/arkenv/src/cli/composition.ts
+++ b/packages/arkenv/src/cli/composition.ts
@@ -4,7 +4,7 @@ import {
 	NodeWorkspace,
 } from "@/adapters";
 import { CLI } from "./cli";
-import { HelpUseCase, InitUseCase } from "./commands";
+import { AddUseCase, HelpUseCase, InitUseCase } from "./commands";
 
 /**
  * Bootstraps the application's dependency graph by composing
@@ -21,6 +21,7 @@ export function compose(argv: string[]) {
 	const scanner = new NodeProjectScannerAdapter(logger);
 
 	const initUseCase = new InitUseCase(logger, workspace, prompt, scanner);
+	const addUseCase = new AddUseCase(logger, workspace, prompt, scanner);
 	const helpUseCase = new HelpUseCase(logger);
 
 	return {
@@ -29,6 +30,7 @@ export function compose(argv: string[]) {
 		workspace,
 		prompt,
 		initUseCase,
+		addUseCase,
 		helpUseCase,
 	};
 }

--- a/packages/arkenv/src/features/config-mutation/config-mutation.test.ts
+++ b/packages/arkenv/src/features/config-mutation/config-mutation.test.ts
@@ -1,6 +1,10 @@
 import dedent from "dedent";
 import { describe, expect, it } from "vitest";
-import { transformNextjsConfig, transformViteConfig } from "./config-mutation";
+import {
+	mutateEnvConfig,
+	transformNextjsConfig,
+	transformViteConfig,
+} from "./config-mutation";
 
 describe("config-mutation", () => {
 	describe("transformViteConfig", () => {
@@ -249,6 +253,115 @@ describe("config-mutation", () => {
 			expect(result.code).toContain('from "@arkenv/nextjs/config"');
 			expect(result.code).toContain("withArkEnv({");
 			expect(result.code).toContain("codegen: false");
+		});
+	});
+
+	describe("mutateEnvConfig", () => {
+		it("mutates flat env.ts with ArkType correctly", () => {
+			const initialContent = dedent`
+				import arkenv from "./generated/env.gen";
+
+				export const env = arkenv({
+					DATABASE_URL: "string",
+				});
+			`;
+
+			const result = mutateEnvConfig(
+				initialContent,
+				"vercel",
+				"nextjs",
+				"arktype",
+			);
+			expect(result.success).toBe(true);
+			expect(result.updated).toBe(true);
+			expect(result.code).toContain('VERCEL: "string?"');
+			expect(result.code).toContain(
+				"VERCEL_ENV: \"'production' | 'preview' | 'development'?\"",
+			);
+			expect(result.code).toContain(
+				"NEXT_PUBLIC_VERCEL_ENV: \"'production' | 'preview' | 'development'?\"",
+			);
+		});
+
+		it("mutates flat env.ts with Zod correctly", () => {
+			const initialContent = dedent`
+				import arkenv from "./generated/env.gen";
+				import { z } from "zod";
+
+				export const env = arkenv({
+					DATABASE_URL: z.string(),
+				});
+			`;
+
+			const result = mutateEnvConfig(initialContent, "vercel", "nextjs", "zod");
+			expect(result.success).toBe(true);
+			expect(result.updated).toBe(true);
+			expect(result.code).toContain("VERCEL: z.string().optional()");
+			expect(result.code).toContain(
+				'VERCEL_ENV: z.enum(["production", "preview", "development"]).optional()',
+			);
+		});
+
+		it("mutates flat env.ts with Valibot correctly", () => {
+			const initialContent = dedent`
+				import arkenv from "./generated/env.gen";
+				import * as v from "valibot";
+
+				export const env = arkenv({
+					DATABASE_URL: v.string(),
+				});
+			`;
+
+			const result = mutateEnvConfig(
+				initialContent,
+				"vercel",
+				"nextjs",
+				"valibot",
+			);
+			expect(result.success).toBe(true);
+			expect(result.updated).toBe(true);
+			expect(result.code).toContain("VERCEL: v.optional(v.string())");
+			expect(result.code).toContain(
+				'VERCEL_ENV: v.optional(v.picklist(["production", "preview", "development"]))',
+			);
+		});
+
+		it("returns updated: false if keys are already present", () => {
+			const initialContent = dedent`
+				import arkenv from "./generated/env.gen";
+
+				export const env = arkenv({
+					DATABASE_URL: "string",
+					VERCEL: "string?",
+					VERCEL_ENV: "'production' | 'preview' | 'development'?",
+					VERCEL_URL: "string?",
+					NEXT_PUBLIC_VERCEL_ENV: "'production' | 'preview' | 'development'?",
+					NEXT_PUBLIC_VERCEL_URL: "string?",
+				});
+			`;
+
+			const result = mutateEnvConfig(
+				initialContent,
+				"vercel",
+				"nextjs",
+				"arktype",
+			);
+			expect(result.success).toBe(true);
+			expect(result.updated).toBe(false);
+		});
+
+		it("returns success: false and proposedFields when schema is not found", () => {
+			const initialContent = "export const x = 123;";
+			const result = mutateEnvConfig(
+				initialContent,
+				"vercel",
+				"nextjs",
+				"arktype",
+			);
+			expect(result.success).toBe(false);
+			expect(result.updated).toBe(false);
+			expect(result.proposedFields).toHaveProperty("VERCEL");
+			expect(result.proposedFields).toHaveProperty("VERCEL_ENV");
 		});
 	});
 });

--- a/packages/arkenv/src/features/config-mutation/config-mutation.ts
+++ b/packages/arkenv/src/features/config-mutation/config-mutation.ts
@@ -323,8 +323,11 @@ export function transformNuxtConfig(
 
 /**
  * Resolve a hosting-preset key to a validator-specific schema fragment.
+ *
+ * Uses v1 dialect renderers (same as scaffold codegen) so add-host and
+ * mutateEnvConfig output stay aligned with `arkenv init` field syntax.
  */
-function getFieldDefinition(
+export function getFieldDefinition(
 	key: string,
 	validator: Validator,
 	prefix: string,

--- a/packages/arkenv/src/features/config-mutation/config-mutation.ts
+++ b/packages/arkenv/src/features/config-mutation/config-mutation.ts
@@ -4,6 +4,13 @@ import {
 	generateCode,
 	parseModule,
 } from "magicast";
+import { FRAMEWORK_CLIENT_PREFIXES } from "@/features/scaffold/frameworks";
+import type { Framework, Validator } from "@/features/scaffold/plan";
+import { getPresetKeys, type HostPreset } from "@/features/scaffold/presets";
+import {
+	DIALECTS,
+	tryFormatPresetFieldValue,
+} from "@/features/scaffold/validators/dialects";
 import type { BootstrapResult } from "@/shared/ports";
 
 /**
@@ -310,6 +317,126 @@ export function transformNuxtConfig(
 			success: false,
 			updated: false,
 			error: `Failed to parse Nuxt config: ${error}`,
+		};
+	}
+}
+
+/**
+ * Resolve a hosting-preset key to a validator-specific schema fragment.
+ */
+function getFieldDefinition(
+	key: string,
+	validator: Validator,
+	prefix: string,
+	preset: HostPreset,
+): string {
+	const dialect = DIALECTS[validator];
+	return (
+		tryFormatPresetFieldValue(dialect, key, prefix, preset) ??
+		dialect.formatOptionalString()
+	);
+}
+
+/**
+ * Transform an env.ts schema file by merging host preset keys.
+ *
+ * @param code The environment configuration code.
+ * @param preset The selected hosting provider preset.
+ * @param framework The active framework.
+ * @param validator The active validator.
+ * @returns The result of the mutation operation.
+ */
+export function mutateEnvConfig(
+	code: string,
+	preset: HostPreset,
+	framework: Framework,
+	validator: Validator,
+): {
+	success: boolean;
+	updated: boolean;
+	code?: string;
+	error?: string;
+	proposedFields: Record<string, string>;
+} {
+	const prefix = FRAMEWORK_CLIENT_PREFIXES[framework];
+	const presetKeys = getPresetKeys(preset, prefix);
+	const proposedFields: Record<string, string> = {};
+
+	for (const key of presetKeys) {
+		proposedFields[key] = getFieldDefinition(key, validator, prefix, preset);
+	}
+
+	try {
+		const mod = parseModule(code);
+		const envExport = mod.exports.env || mod.exports.Env;
+		if (
+			!envExport ||
+			envExport.$type !== "function-call" ||
+			(envExport.$callee !== "arkenv" && envExport.$callee !== "type")
+		) {
+			return {
+				success: false,
+				updated: false,
+				error: "Could not find arkenv or type schema call in env.ts",
+				proposedFields,
+			};
+		}
+
+		const obj = envExport.$args[0];
+		if (!obj || typeof obj !== "object" || "$type" in obj) {
+			return {
+				success: false,
+				updated: false,
+				error: "Could not find schema object literal inside arkenv/type call",
+				proposedFields,
+			};
+		}
+
+		let updated = false;
+		const replacements: Record<string, string> = {};
+
+		for (const key of presetKeys) {
+			// Only add if the key doesn't already exist in the schema
+			if (!(key in obj)) {
+				const placeholder = `__ARK_PRESET_PLACEHOLDER_${key}__`;
+				obj[key] = placeholder;
+				replacements[placeholder] = proposedFields[key];
+				updated = true;
+			}
+		}
+
+		if (!updated) {
+			return { success: true, updated: false, code, proposedFields };
+		}
+
+		let generatedCode = generateCode(mod, {
+			format: detectCodeFormat(code),
+		}).code;
+
+		// Replace placeholders
+		for (const [placeholder, rawVal] of Object.entries(replacements)) {
+			generatedCode = generatedCode.replace(
+				new RegExp(`['"]${placeholder}['"]`, "g"),
+				rawVal,
+			);
+		}
+
+		generatedCode = normalizeImportSpacing(generatedCode);
+		generatedCode = preserveTrailingNewline(generatedCode, code);
+
+		return {
+			success: true,
+			updated: true,
+			code: generatedCode,
+			proposedFields,
+		};
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e.message : String(e);
+		return {
+			success: false,
+			updated: false,
+			error: `Failed to parse env.ts: ${error}`,
+			proposedFields,
 		};
 	}
 }

--- a/packages/arkenv/src/index.ts
+++ b/packages/arkenv/src/index.ts
@@ -32,7 +32,9 @@ async function main() {
 		}
 	}
 
-	const { cli, logger, initUseCase, helpUseCase } = compose(process.argv);
+	const { cli, logger, initUseCase, addUseCase, helpUseCase } = compose(
+		process.argv,
+	);
 	globalLogger = logger;
 
 	setupGracefulShutdown(logger);
@@ -50,7 +52,16 @@ async function main() {
 		process.exit(0);
 	}
 
-	if (cli.command !== "init") {
+	const commands = {
+		init: () => initUseCase.execute(shake(cli.initInput)),
+		add: () => addUseCase.execute(cli.addInput),
+	} as const;
+
+	const handler = cli.command
+		? commands[cli.command as keyof typeof commands]
+		: undefined;
+
+	if (!handler) {
 		if (cli.command) {
 			logger.error(`Unknown command: ${cli.command}`);
 		} else {
@@ -60,8 +71,9 @@ async function main() {
 		await logger.flush();
 		process.exit(1);
 	}
+
 	try {
-		const success = await initUseCase.execute(shake(cli.initInput));
+		const success = await handler();
 		if (!success) {
 			await logger.flush();
 			process.exit(1);

--- a/packages/arkenv/src/shared/ports/prompt.port.ts
+++ b/packages/arkenv/src/shared/ports/prompt.port.ts
@@ -41,4 +41,12 @@ export type PromptPort = {
 		},
 		isYes?: boolean,
 	): Promise<ProjectOptions | null>;
+	/**
+	 * Prompt the user to select one option from a list.
+	 */
+	select<T extends string>(
+		message: string,
+		options: { value: T; label: string; hint?: string }[],
+		initialValue?: T,
+	): Promise<T | null>;
 };


### PR DESCRIPTION
## Summary
- Forward-ports [#1324](https://github.com/yamcodes/arkenv/pull/1324) (`arkenv add host [provider]`) from `dev` onto `v1`
- Re-implements under `packages/arkenv/` (v1 CLI) with dialect-based field rendering via `DIALECTS` / `tryFormatPresetFieldValue` and `FRAMEWORK_CLIENT_PREFIXES`
- Adds `mutateEnvConfig`, prompt `select`, help/parser coverage, and a `minor` changeset for `arkenv`

Fixes #1267 (v1 parity)

## Test plan
- [x] `pnpm --filter arkenv exec vitest run` (342 tests)
- [x] `pnpm --filter arkenv typecheck`
- [ ] Manually: `arkenv add host vercel` against a flat `env.ts`
- [ ] Manually: `arkenv add host` interactive prompt and missing-`env.ts` fallback


Made with [Cursor](https://cursor.com)