### PR TITLE
fix: security proxy prefers raw runtimeConfig/process.env strings over coerced values

### DIFF
--- a/.changeset/fix-nuxt-proxy-coercion.md
+++ b/.changeset/fix-nuxt-proxy-coercion.md
@@ -2,9 +2,9 @@
 "@arkenv/nuxt": patch
 ---
 
-#### Fix security proxy returning raw strings instead of coerced values
+#### Fix number and boolean env values returning as strings
 
-Prefer the coerced validation target for schema-key reads instead of re-reading raw `useRuntimeConfig()`, `process.env`, or `__NUXT__.config.public` strings. Those sources still feed validation at create time, but serving them again on get silently undid coercion (for example a `number` key returning a `string`).
+Keep coerced types when reading from `env`. A key declared as `"number"` or `"boolean"` now returns a number or boolean at runtime, not the raw string from Nuxt runtime config.
 
 ```ts
 import { createEnv } from "@arkenv/nuxt";
@@ -14,5 +14,6 @@ export const env = createEnv({
   PORT: "number",
 });
 
-// env.NUXT_PUBLIC_PORT and env.PORT are numbers, not "3000"
-```
+// Was "3000" (string) — now 3000 (number)
+env.NUXT_PUBLIC_PORT;
+env.PORT;

--- a/.changeset/fix-nuxt-proxy-coercion.md
+++ b/.changeset/fix-nuxt-proxy-coercion.md
@@ -16,4 +16,5 @@ export const env = createEnv({
 
 // Was "3000" (string) — now 3000 (number)
 env.NUXT_PUBLIC_PORT;
+env.NUXT_PUBLIC_PORT;
 env.PORT;

--- a/.changeset/fix-nuxt-proxy-coercion.md
+++ b/.changeset/fix-nuxt-proxy-coercion.md
@@ -17,3 +17,4 @@ export const env = createEnv({
 // Was "3000" (string) — now 3000 (number)
 env.NUXT_PUBLIC_PORT;
 env.PORT;
+```

--- a/.changeset/fix-nuxt-proxy-coercion.md
+++ b/.changeset/fix-nuxt-proxy-coercion.md
@@ -16,5 +16,4 @@ export const env = createEnv({
 
 // Was "3000" (string) — now 3000 (number)
 env.NUXT_PUBLIC_PORT;
-env.NUXT_PUBLIC_PORT;
 env.PORT;

--- a/.changeset/fix-nuxt-proxy-coercion.md
+++ b/.changeset/fix-nuxt-proxy-coercion.md
@@ -1,0 +1,18 @@
+---
+"@arkenv/nuxt": patch
+---
+
+#### Fix security proxy returning raw strings instead of coerced values
+
+Prefer the coerced validation target for schema-key reads instead of re-reading raw `useRuntimeConfig()`, `process.env`, or `__NUXT__.config.public` strings. Those sources still feed validation at create time, but serving them again on get silently undid coercion (for example a `number` key returning a `string`).
+
+```ts
+import { createEnv } from "@arkenv/nuxt";
+
+export const env = createEnv({
+  NUXT_PUBLIC_PORT: "number",
+  PORT: "number",
+});
+
+// env.NUXT_PUBLIC_PORT and env.PORT are numbers, not "3000"
+```

--- a/packages/nuxt/src/create-env.ts
+++ b/packages/nuxt/src/create-env.ts
@@ -263,25 +263,35 @@ export function createEnvInternal(
 		unknown
 	>;
 
-	// Return a Proxy wrapper with strict access rules to prevent server variable leakage on the client
+	// Return a Proxy wrapper with strict access rules to prevent server variable leakage on the client.
+	// Always serve the coerced validation target — never re-read raw runtimeConfig / process.env /
+	// __NUXT__ strings, which would silently undo ADR 0002 coercion (see ADR 0015).
 	return createSecurityProxy(
 		mergedValidated,
 		allKeys,
 		serverOnlyKeys,
 		isServer,
-		runtimeEnv,
 	);
 }
 
 /**
- * Wraps the validated environment object in a Proxy to enforce client/server security access rules.
+ * Wrap the validated environment object in a Proxy to enforce client/server security access rules.
+ *
+ * Schema-key reads always return the coerced validation target. Raw `useRuntimeConfig()` /
+ * `process.env` / `__NUXT__.config.public` strings are intentionally not preferred on get —
+ * those sources feed validation at create time, but serving them again would bypass coercion.
+ *
+ * @param target The validated and coerced environment object
+ * @param allKeys The set of all keys defined in the schema (including extended schemas)
+ * @param serverOnlyKeys The set of keys that must not be accessed on the client
+ * @param isServer Whether the proxy is running in a server context
+ * @returns A Proxy that enforces access rules while preserving coerced value types
  */
 function createSecurityProxy(
 	target: Record<string, unknown>,
 	allKeys: Set<string>,
 	serverOnlyKeys: Set<string>,
 	isServer: boolean,
-	runtimeEnv: Record<string, unknown> = {},
 ): unknown {
 	return new Proxy(target, {
 		get(target, prop, receiver) {
@@ -321,54 +331,6 @@ function createSecurityProxy(
 						throw new Error(
 							`Environment variable '${prop}' is not defined in the schema.`,
 						);
-					}
-				}
-
-				if (allKeys.has(prop)) {
-					if (typeof window !== "undefined") {
-						if (runtimeEnv && prop in runtimeEnv) {
-							return Reflect.get(target, prop, receiver);
-						}
-						try {
-							const runtimeConfig = useRuntimeConfig();
-							if (runtimeConfig?.public && prop in runtimeConfig.public) {
-								return runtimeConfig.public[prop];
-							}
-						} catch {
-							// fallback if useRuntimeConfig is not available yet
-						}
-						const globalPublic = (window as any).__NUXT__?.config?.public;
-						if (globalPublic && prop in globalPublic) {
-							return globalPublic[prop];
-						}
-					} else {
-						if (runtimeEnv && prop in runtimeEnv) {
-							return Reflect.get(target, prop, receiver);
-						}
-						try {
-							const runtimeConfig = useRuntimeConfig();
-							if (runtimeConfig) {
-								if (prop in runtimeConfig && runtimeConfig[prop] !== "") {
-									return runtimeConfig[prop];
-								}
-								if (
-									runtimeConfig.public &&
-									prop in runtimeConfig.public &&
-									runtimeConfig.public[prop] !== ""
-								) {
-									return runtimeConfig.public[prop];
-								}
-							}
-						} catch {
-							// fallback
-						}
-						if (
-							typeof process !== "undefined" &&
-							process.env &&
-							prop in process.env
-						) {
-							return process.env[prop];
-						}
 					}
 				}
 			}

--- a/packages/nuxt/src/index.test.ts
+++ b/packages/nuxt/src/index.test.ts
@@ -1,16 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
-
-vi.mock("#imports", () => {
-	return {
-		useRuntimeConfig: () => {
-			if ((globalThis as any).__mockRuntimeConfig) {
-				return (globalThis as any).__mockRuntimeConfig;
-			}
-			throw new Error("Nuxt instance not found");
-		},
-	};
-});
-
+import { describe, expect, it } from "vitest";
 import { createEnv } from "./index";
 
 describe("createEnv (Nuxt runtime)", () => {
@@ -276,15 +264,24 @@ describe("createEnv (Nuxt runtime)", () => {
 		(globalThis as any).__mockRuntimeConfig = {
 			public: {
 				NUXT_PUBLIC_API_URL: "https://dynamic-config.api.com",
+				NUXT_PUBLIC_PORT: "3000",
+				NUXT_PUBLIC_FEATURE_FLAG: "true",
 			},
 		};
 
 		try {
 			const env = createEnv({
 				NUXT_PUBLIC_API_URL: "string",
+				NUXT_PUBLIC_PORT: "number",
+				NUXT_PUBLIC_FEATURE_FLAG: "boolean",
 			});
 
 			expect(env.NUXT_PUBLIC_API_URL).toBe("https://dynamic-config.api.com");
+			// Coercion must survive the security proxy (raw runtimeConfig strings are not preferred)
+			expect(env.NUXT_PUBLIC_PORT).toBe(3000);
+			expect(typeof env.NUXT_PUBLIC_PORT).toBe("number");
+			expect(env.NUXT_PUBLIC_FEATURE_FLAG).toBe(true);
+			expect(typeof env.NUXT_PUBLIC_FEATURE_FLAG).toBe("boolean");
 		} finally {
 			(globalThis as any).window = originalWindow;
 			delete (globalThis as any).__mockRuntimeConfig;
@@ -294,17 +291,71 @@ describe("createEnv (Nuxt runtime)", () => {
 	it("should dynamically resolve server keys from useRuntimeConfig on the server", () => {
 		(globalThis as any).__mockRuntimeConfig = {
 			DATABASE_URL: "postgres://dynamic-server/db",
+			PORT: "8080",
 			public: {},
 		};
 
 		try {
 			const env = createEnv({
 				DATABASE_URL: "string",
+				PORT: "number",
 			});
 
 			expect(env.DATABASE_URL).toBe("postgres://dynamic-server/db");
+			expect(env.PORT).toBe(8080);
+			expect(typeof env.PORT).toBe("number");
 		} finally {
 			delete (globalThis as any).__mockRuntimeConfig;
+		}
+	});
+
+	it("should return coerced values from the process.env fallback path on the server", () => {
+		// No runtimeConfig mock — forces the former process.env preference path
+		delete (globalThis as any).__mockRuntimeConfig;
+		process.env.PORT = "9090";
+		process.env.DEBUG = "true";
+
+		try {
+			const env = createEnv({
+				PORT: "number",
+				DEBUG: "boolean",
+			});
+
+			expect(env.PORT).toBe(9090);
+			expect(typeof env.PORT).toBe("number");
+			expect(env.DEBUG).toBe(true);
+			expect(typeof env.DEBUG).toBe("boolean");
+		} finally {
+			delete process.env.PORT;
+			delete process.env.DEBUG;
+		}
+	});
+
+	it("should return coerced client values from __NUXT__.config.public without preferring raw strings", () => {
+		const originalWindow = globalThis.window;
+		(globalThis as any).window = {
+			__NUXT__: {
+				config: {
+					public: {
+						NUXT_PUBLIC_PORT: "4000",
+						NUXT_PUBLIC_ENABLED: "false",
+					},
+				},
+			},
+		};
+
+		try {
+			const env = createEnv({
+				NUXT_PUBLIC_PORT: "number",
+				NUXT_PUBLIC_ENABLED: "boolean",
+			});
+
+			expect(env.NUXT_PUBLIC_PORT).toBe(4000);
+			expect(typeof env.NUXT_PUBLIC_PORT).toBe("number");
+			expect(env.NUXT_PUBLIC_ENABLED).toBe(false);
+			expect(typeof env.NUXT_PUBLIC_ENABLED).toBe("boolean");
+		} finally {
+			(globalThis as any).window = originalWindow;
 		}
 	});
 });

--- a/packages/nuxt/src/index.test.ts
+++ b/packages/nuxt/src/index.test.ts
@@ -257,7 +257,7 @@ describe("createEnv (Nuxt runtime)", () => {
 		}
 	});
 
-	it("should dynamically resolve client keys from useRuntimeConfig on the client", () => {
+	it("should keep coerced client types when values are sourced from useRuntimeConfig", () => {
 		const originalWindow = globalThis.window;
 		(globalThis as any).window = {};
 
@@ -288,7 +288,7 @@ describe("createEnv (Nuxt runtime)", () => {
 		}
 	});
 
-	it("should dynamically resolve server keys from useRuntimeConfig on the server", () => {
+	it("should keep coerced server types when values are sourced from useRuntimeConfig", () => {
 		(globalThis as any).__mockRuntimeConfig = {
 			DATABASE_URL: "postgres://dynamic-server/db",
 			PORT: "8080",
@@ -309,8 +309,8 @@ describe("createEnv (Nuxt runtime)", () => {
 		}
 	});
 
-	it("should return coerced values from the process.env fallback path on the server", () => {
-		// No runtimeConfig mock — forces the former process.env preference path
+	it("should keep coerced server types when values are sourced from process.env", () => {
+		// No runtimeConfig mock — values come from process.env at create time
 		delete (globalThis as any).__mockRuntimeConfig;
 		process.env.PORT = "9090";
 		process.env.DEBUG = "true";
@@ -331,7 +331,7 @@ describe("createEnv (Nuxt runtime)", () => {
 		}
 	});
 
-	it("should return coerced client values from __NUXT__.config.public without preferring raw strings", () => {
+	it("should keep coerced client types when values are sourced from __NUXT__.config.public", () => {
 		const originalWindow = globalThis.window;
 		(globalThis as any).window = {
 			__NUXT__: {

--- a/packages/nuxt/src/mock-imports.ts
+++ b/packages/nuxt/src/mock-imports.ts
@@ -1,4 +1,15 @@
+/**
+ * Resolve Nuxt runtime config in tests.
+ *
+ * Prefer `globalThis.__mockRuntimeConfig` when set by a test; otherwise return
+ * an empty public config so schema validation can fall through to `process.env`.
+ *
+ * @returns The mocked Nuxt runtime config object
+ */
 export function useRuntimeConfig(): any {
+	if ((globalThis as any).__mockRuntimeConfig) {
+		return (globalThis as any).__mockRuntimeConfig;
+	}
 	return {
 		public: {},
 	};

--- a/packages/nuxt/vitest.config.ts
+++ b/packages/nuxt/vitest.config.ts
@@ -1,0 +1,28 @@
+import path from "node:path";
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+	test: {
+		name: "@arkenv/nuxt",
+		unstubEnvs: true,
+		restoreMocks: true,
+		unstubGlobals: true,
+	},
+	resolve: {
+		tsconfigPaths: true,
+		alias: [
+			{
+				find: /^arkenv\/arktype$/,
+				replacement: path.resolve(__dirname, "../arkenv/src/arktype/index.ts"),
+			},
+			{
+				find: /^arkenv$/,
+				replacement: path.resolve(__dirname, "../arkenv/src/index.ts"),
+			},
+			{
+				find: "#imports",
+				replacement: path.resolve(__dirname, "./src/mock-imports.ts"),
+			},
+		],
+	},
+});


### PR DESCRIPTION
Fixes #1327

## Summary
- Prefer the coerced validation target in the Nuxt security proxy instead of re-reading raw `useRuntimeConfig()` / `process.env` / `__NUXT__.config.public` strings (which silently undid ADR 0002 coercion).
- Update dynamic `useRuntimeConfig` tests to assert coerced `number`/`boolean` values, and add regression coverage for the server `process.env` and client `__NUXT__` paths.
- Add a missing `@arkenv/nuxt` Vitest project config so the package tests run in CI.

## Test plan
- [x] `pnpm exec vitest run --project @arkenv/nuxt`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run fix`


Made with [Cursor](https://cursor.com)