### PR TITLE
Add AGENTS.md with Cursor Cloud setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,14 @@
 ArkEnv is a pnpm + Turborepo monorepo for a TypeScript env-var validation library. There are no databases or external services; the only long-running process is the `www` docs site (Next.js). Standard commands live in `package.json`, `docs/CONTRIBUTING.md`, and `docs/TESTING.md` — prefer those.
 
 ### Services / apps
+
 - `packages/*` — the publishable library packages (`arkenv`, `@arkenv/cli`, `nextjs`, `nuxt`, `vite-plugin`, `bun-plugin`, `build`, `fumadocs-ui`) plus internal helpers under `packages/internal/*`. These are the core product.
 - `apps/www` — the documentation website (Next.js 16 + Fumadocs). This is the only runnable app.
 - `apps/playwright-www` — Playwright e2e suite targeting `www`.
 - `apps/playgrounds/*` and `examples/*` — framework sandboxes / fixtures (optional).
 
 ### Common commands (run from repo root)
+
 - Build everything: `pnpm build` · packages only: `pnpm build:packages`
 - Run docs site (dev): `pnpm www` (serves on `http://localhost:3000`)
 - Lint/format + workspace validation: `pnpm check`
@@ -19,6 +21,7 @@ ArkEnv is a pnpm + Turborepo monorepo for a TypeScript env-var validation librar
 - E2E: see caveat below.
 
 ### Non-obvious caveats
+
 - Bun is required for `@arkenv/bun-plugin` and some bun playground/example flows, and CI installs Bun 1.3.13. It is installed globally at `~/.bun/bin` (on `PATH` via `~/.bashrc` for login shells); if a session's shell can't find `bun`, run `export PATH="$HOME/.bun/bin:$PATH"`. Bun is not needed for the core build / `pnpm test` / running `www`.
 - Node 22 (current VM LTS) works for build/lint/test/run. Some `examples/*` and playgrounds declare `"engines": { "node": "24" }`, which only produces a harmless `Unsupported engine` warning under Node 22. CI runs the typecheck job on Node 24.
 - E2E must be run the CI way (against a production server), not against `pnpm www`. The Playwright config uses `next start` when `CI` is set and `next dev` otherwise; the dev server emits console errors that the smoke test forbids and can be overwhelmed by parallel workers (`ERR_CONNECTION_REFUSED`). Build `www` first (`pnpm build --filter=www...`), then run e.g. `CI=1 pnpm exec playwright test --project=chromium` from `apps/playwright-www`. Playwright browsers must be installed once per VM: `pnpm exec playwright install --with-deps chromium firefox` (webkit is macOS-only).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ ArkEnv is a pnpm + Turborepo monorepo for a TypeScript env-var validation librar
 
 ### Services / apps
 
-- `packages/*` — the publishable library packages (`arkenv`, `@arkenv/cli`, `nextjs`, `nuxt`, `vite-plugin`, `bun-plugin`, `build`, `fumadocs-ui`) plus internal helpers under `packages/internal/*`. These are the core product.
+- `packages/*` — the publishable library packages (`arkenv`, plus `@arkenv/cli`, `@arkenv/nextjs`, `@arkenv/nuxt`, `@arkenv/vite-plugin`, `@arkenv/bun-plugin`, `@arkenv/build`, and `@arkenv/fumadocs-ui`, which live in the `cli/`, `nextjs/`, `nuxt/`, `vite-plugin/`, `bun-plugin/`, `build/`, and `fumadocs-ui/` directories) plus internal helpers under `packages/internal/*`. These are the core product.
 - `apps/www` — the documentation website (Next.js 16 + Fumadocs). This is the only runnable app.
 - `apps/playwright-www` — Playwright e2e suite targeting `www`.
 - `apps/playgrounds/*` and `examples/*` — framework sandboxes / fixtures (optional).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+ArkEnv is a pnpm + Turborepo monorepo for a TypeScript env-var validation library. There are no databases or external services; the only long-running process is the `www` docs site (Next.js). Standard commands live in `package.json`, `docs/CONTRIBUTING.md`, and `docs/TESTING.md` — prefer those.
+
+### Services / apps
+- `packages/*` — the publishable library packages (`arkenv`, `@arkenv/cli`, `nextjs`, `nuxt`, `vite-plugin`, `bun-plugin`, `build`, `fumadocs-ui`) plus internal helpers under `packages/internal/*`. These are the core product.
+- `apps/www` — the documentation website (Next.js 16 + Fumadocs). This is the only runnable app.
+- `apps/playwright-www` — Playwright e2e suite targeting `www`.
+- `apps/playgrounds/*` and `examples/*` — framework sandboxes / fixtures (optional).
+
+### Common commands (run from repo root)
+- Build everything: `pnpm build` · packages only: `pnpm build:packages`
+- Run docs site (dev): `pnpm www` (serves on `http://localhost:3000`)
+- Lint/format + workspace validation: `pnpm check`
+- Typecheck: `pnpm typecheck`
+- Unit/integration tests: `pnpm test -- --run` (Vitest; 76 files / 819 tests)
+- E2E: see caveat below.
+
+### Non-obvious caveats
+- Bun is required for `@arkenv/bun-plugin` and some bun playground/example flows, and CI installs Bun 1.3.13. It is installed globally at `~/.bun/bin` (on `PATH` via `~/.bashrc` for login shells); if a session's shell can't find `bun`, run `export PATH="$HOME/.bun/bin:$PATH"`. Bun is not needed for the core build / `pnpm test` / running `www`.
+- Node 22 (current VM LTS) works for build/lint/test/run. Some `examples/*` and playgrounds declare `"engines": { "node": "24" }`, which only produces a harmless `Unsupported engine` warning under Node 22. CI runs the typecheck job on Node 24.
+- E2E must be run the CI way (against a production server), not against `pnpm www`. The Playwright config uses `next start` when `CI` is set and `next dev` otherwise; the dev server emits console errors that the smoke test forbids and can be overwhelmed by parallel workers (`ERR_CONNECTION_REFUSED`). Build `www` first (`pnpm build --filter=www...`), then run e.g. `CI=1 pnpm exec playwright test --project=chromium` from `apps/playwright-www`. Playwright browsers must be installed once per VM: `pnpm exec playwright install --with-deps chromium firefox` (webkit is macOS-only).
+- The CLI tests print `fatal: not a git repository` / `Using 'master' as the name...` git hints while running — this is expected (they scaffold temp git repos) and does not indicate failure.
+- To run a package that consumes the local (workspace) build, use a workspace playground (e.g. `apps/playgrounds/node`, which depends on `arkenv: workspace:*`). Copy `.env.example` to `.env` first, then `pnpm start`. The `examples/*` projects are standalone npm projects that resolve the published `arkenv` from npm, not the local build.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the ArkEnv development environment for Cursor Cloud agents, and documents non-obvious startup/run caveats in a new `AGENTS.md`.

ArkEnv is a pnpm + Turborepo monorepo for a TypeScript env-var validation library. No databases or external services are required; the only long-running app is the `www` docs site (Next.js).

## What was verified

| Step | Command | Result |
|------|---------|--------|
| Install | `pnpm install` | OK |
| Build | `pnpm build` | 24/24 tasks |
| Lint | `pnpm check` | OK |
| Typecheck | `pnpm typecheck` | 23/23 |
| Unit/integration tests | `pnpm test -- --run` | 76 files, 819 tests passed |
| Run app (dev) | `pnpm www` | Serves `http://localhost:3000` (HTTP 200) |
| E2E (CI/prod mode) | `CI=1 pnpm exec playwright test --project=chromium` | 5/5 passed |

## Hello-world (core functionality)

Ran the `node-playground` (consumes local `arkenv` via `workspace:*`) against a valid `.env` — parsing, coercion (string→number/boolean/array), defaults and undeclared-key stripping all worked. An invalid `.env` correctly produced aggregated `ArkEnvError` messages, proving validation fires.

## Changes

- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering services, common commands, and non-obvious caveats (Bun requirement + location, Node 22 vs `engines: node 24` warnings, running e2e in production mode, CLI test git-hint noise, using workspace playgrounds to exercise the local build).

## Demo

[arkenv_www_docs_dev_demo.mp4](https://cursor.com/agents/bc-c8ee71d8-5096-47e5-b31f-118e3e9ae7ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farkenv_www_docs_dev_demo.mp4)

[ArkEnv homepage (dev)](https://cursor.com/agents/bc-c8ee71d8-5096-47e5-b31f-118e3e9ae7ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwww_homepage.webp)
[ArkEnv docs page (dev)](https://cursor.com/agents/bc-c8ee71d8-5096-47e5-b31f-118e3e9ae7ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwww_docs_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8ee71d8-5096-47e5-b31f-118e3e9ae7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8ee71d8-5096-47e5-b31f-118e3e9ae7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

