### PR TITLE
Restructure CLI docs for multi-command (add host)

### DIFF
--- a/apps/www/content/docs/cli/hosting-presets.mdx
+++ b/apps/www/content/docs/cli/hosting-presets.mdx
@@ -1,16 +1,16 @@
 ---
 title: Hosting presets
 icon: Cloud
-description: Pre-populate your schema with Vercel or Netlify system environment variables during arkenv init.
+description: Pre-populate your schema with Vercel or Netlify system environment variables during arkenv init, or add them later with arkenv add host.
 ---
 
-Most hosting providers inject their own **system environment variables** at build and runtime (for example, Vercel sets `VERCEL_ENV` and `VERCEL_URL`, Netlify sets `CONTEXT` and `URL`). Hosting presets let `arkenv init` pre-populate your generated schema with the correct variables for your provider, already typed and marked optional, so you don't have to look them up by hand.
+Most hosting providers inject their own **system environment variables** at build and runtime (for example, Vercel sets `VERCEL_ENV` and `VERCEL_URL`, Netlify sets `CONTEXT` and `URL`). Hosting presets let `arkenv init` pre-populate your generated schema with the correct variables for your provider, already typed and marked optional, so you don't have to look them up by hand. If you already have an `env.ts`, use [`arkenv add host`](#add-host-to-an-existing-schema) to inject the same fields later.
 
 Presets work with every validator (ArkType, Zod, Valibot) and both the [flat](#layouts) and [strict](#layouts) layouts.
 
-## Selecting a preset
+## Selecting a preset during init
 
-There are two ways to pick a preset.
+There are two ways to pick a preset when scaffolding a new project.
 
 ### Interactive prompt
 
@@ -38,6 +38,24 @@ The flag accepts `none`, `vercel`, or `netlify`. The following is equivalent:
 ```npm
 npx @arkenv/cli@latest init -H vercel
 ```
+
+## Add host to an existing schema
+
+If you already ran `init` (or hand-wrote an `env.ts`) and want to add a hosting preset later, use `add host`:
+
+```npm
+npx @arkenv/cli@latest add host vercel
+```
+
+Omit the provider to pick interactively:
+
+```npm
+npx @arkenv/cli@latest add host
+```
+
+The command auto-detects your framework prefix and validator (ArkType, Zod, or Valibot), then merges the preset fields into a flat `env.ts` (or `src/env.ts`). If the file is missing or unparseable, it prints the proposed fields so you can paste them in manually. Keys that are already present are left unchanged.
+
+With `--yes` or `--agent`, an omitted provider defaults to `vercel`.
 
 ## What each preset adds
 
@@ -215,7 +233,7 @@ Presets only add variables; they never remove or overwrite variables scanned fro
 ## Next steps
 
 <Cards>
-  <Card title="CLI Introduction" href="/docs/cli" description="See every init flag, including --host-preset." />
+  <Card title="CLI Introduction" href="/docs/cli" description="See every command and flag, including init --host-preset and add host." />
 
   <Card title="Zod, Valibot, and other validators" href="/docs/nextjs/using-other-validators" description="Mix and match Standard Schema validators with ArkEnv." />
 </Cards>

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -37,13 +37,13 @@ See [Hosting presets](/docs/cli/hosting-presets#add-host-to-an-existing-schema) 
 
 These flags apply across commands:
 
-| Flag      | Alias | Description                                                                                                                                      |
-| --------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--yes`   | `-y`  | Skip prompts and use defaults (also passed to subprocesses). For `add host`, an omitted provider defaults to `vercel`.                            |
-| `--quiet` | `-q`  | Suppress output logs unless an error occurs.                                                                                                      |
-| `--json`  | `-j`  | Print a structured JSON summary to `stdout` upon completion.                                                                                     |
-| `--agent` |       | Enable non-interactive, machine-readable mode for AI agents. Bypasses prompts and outputs structured JSON. Macro for `--yes --quiet --json`.     |
-| `--help`  | `-h`  | Display the CLI help information.                                                                                                                |
+| Flag      | Alias | Description                                                                                                                                  |
+| --------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--yes`   | `-y`  | Skip prompts and use defaults (also passed to subprocesses). For `add host`, an omitted provider defaults to `vercel`.                       |
+| `--quiet` | `-q`  | Suppress output logs unless an error occurs.                                                                                                 |
+| `--json`  | `-j`  | Print a structured JSON summary to `stdout` upon completion.                                                                                 |
+| `--agent` |       | Enable non-interactive, machine-readable mode for AI agents. Bypasses prompts and outputs structured JSON. Macro for `--yes --quiet --json`. |
+| `--help`  | `-h`  | Display the CLI help information.                                                                                                            |
 
 When running with `--json` or `--agent`, the CLI emits a structured JSON summary you can parse programmatically. See [Machine-readable output](/docs/cli/machine-readable-output) for the full schema and error codes.
 

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -23,6 +23,15 @@ The command adjusts its workflow depending on where it is executed:
 - **Existing project**: If a `package.json` exists in the target directory, the CLI configures ArkEnv directly in the project. It scans for any `.env` or `.env.example` files to automatically pre-populate the schema fields, installs the selected validator dependencies, and generates the `env.ts` file.
 - **New project**: If the target directory does not contain a `package.json` and is empty, the CLI guides you through creating a new project from an ArkEnv starter template. See our [official examples](/docs/arkenv/examples#examples) for a list of available templates.
 
+#### Options
+
+| Flag            | Alias | Description                                                                                                                                        |
+| --------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--example`     |       | Specify an example name when creating a new project.                                                                                               |
+| `--force`       | `-f`  | Bypass checks and force initialization.                                                                                                            |
+| `--no-codegen`  |       | Disable automatic env.gen.ts code generation for Next.js (falls back to manual runtimeEnv destructuring).                                          |
+| `--host-preset` | `-H`  | Pre-populate the schema with a hosting provider's system env vars (`none`, `vercel`, `netlify`). See [Hosting presets](/docs/cli/hosting-presets). |
+
 ### `add host`
 
 Add a hosting provider preset (Vercel or Netlify) to an existing flat `env.ts`.
@@ -46,14 +55,3 @@ These flags apply across commands:
 | `--help`  | `-h`  | Display the CLI help information.                                                                                                            |
 
 When running with `--json` or `--agent`, the CLI emits a structured JSON summary you can parse programmatically. See [Machine-readable output](/docs/cli/machine-readable-output) for the full schema and error codes.
-
-## `init` options
-
-These flags only affect `init`:
-
-| Flag            | Alias | Description                                                                                                                                        |
-| --------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--example`     |       | Specify an example name when creating a new project.                                                                                               |
-| `--force`       | `-f`  | Bypass checks and force initialization.                                                                                                            |
-| `--no-codegen`  |       | Disable automatic env.gen.ts code generation for Next.js (falls back to manual runtimeEnv destructuring).                                          |
-| `--host-preset` | `-H`  | Pre-populate the schema with a hosting provider's system env vars (`none`, `vercel`, `netlify`). See [Hosting presets](/docs/cli/hosting-presets). |

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -21,7 +21,7 @@ The command adjusts its workflow depending on where it is executed:
 - **Existing project**: If a `package.json` exists in the target directory, the CLI configures ArkEnv directly in the project. It scans for any `.env` or `.env.example` files to automatically pre-populate the schema fields, installs the selected validator dependencies, and generates the `env.ts` file.
 - **New project**: If the target directory does not contain a `package.json` and is empty, the CLI guides you through creating a new project from an ArkEnv starter template. See our [official examples](/docs/arkenv/examples#examples) for a list of available templates.
 
-#### Options
+#### Options [!toc]
 
 | Flag            | Alias | Description                                                                                                                                        |
 | --------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -16,8 +16,6 @@ Set up ArkEnv in a project (or create a new one from an example).
 npx @arkenv/cli@latest init [project-name] [options]
 ```
 
-#### How `init` chooses a workflow
-
 The command adjusts its workflow depending on where it is executed:
 
 - **Existing project**: If a `package.json` exists in the target directory, the CLI configures ArkEnv directly in the project. It scans for any `.env` or `.env.example` files to automatically pre-populate the schema fields, installs the selected validator dependencies, and generates the `env.ts` file.

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -14,6 +14,14 @@ Run the CLI using your package manager of choice. The CLI will guide you through
 npx @arkenv/cli@latest init [project-name] [options]
 ```
 
+To add a hosting preset to an existing flat `env.ts` later:
+
+```npm
+npx @arkenv/cli@latest add host [provider]
+```
+
+See [Hosting presets](/docs/cli/hosting-presets#add-host-to-an-existing-schema) for details.
+
 ## Behavior
 
 The CLI automatically adjusts its workflow depending on where it is executed:

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -1,48 +1,59 @@
 ---
 title: Introduction
 icon: Album
-description: Quickly scaffold ArkEnv projects with an interactive CLI.
+description: Commands for scaffolding and mutating ArkEnv setup with an interactive CLI.
 ---
 
-The ArkEnv CLI is the command-line interface used to initialize and configure ArkEnv in your project.
+The ArkEnv CLI provides commands to scaffold a new ArkEnv setup and to mutate an existing one (for example, adding a hosting preset to `env.ts`).
 
-## Usage
+## Commands
 
-Run the CLI using your package manager of choice. The CLI will guide you through the setup process interactively.
+### `init`
+
+Set up ArkEnv in a project (or create a new one from an example).
 
 ```npm
 npx @arkenv/cli@latest init [project-name] [options]
 ```
 
-To add a hosting preset to an existing flat `env.ts` later:
+#### How `init` chooses a workflow
+
+The command adjusts its workflow depending on where it is executed:
+
+- **Existing project**: If a `package.json` exists in the target directory, the CLI configures ArkEnv directly in the project. It scans for any `.env` or `.env.example` files to automatically pre-populate the schema fields, installs the selected validator dependencies, and generates the `env.ts` file.
+- **New project**: If the target directory does not contain a `package.json` and is empty, the CLI guides you through creating a new project from an ArkEnv starter template. See our [official examples](/docs/arkenv/examples#examples) for a list of available templates.
+
+### `add host`
+
+Add a hosting provider preset (Vercel or Netlify) to an existing flat `env.ts`.
 
 ```npm
 npx @arkenv/cli@latest add host [provider]
 ```
 
-See [Hosting presets](/docs/cli/hosting-presets#add-host-to-an-existing-schema) for details.
+See [Hosting presets](/docs/cli/hosting-presets#add-host-to-an-existing-schema) for behavior, interactive selection, and fallbacks when `env.ts` is missing or unparseable.
 
-## Behavior
+## Global options
 
-The CLI automatically adjusts its workflow depending on where it is executed:
+These flags apply across commands:
 
-- **Existing project**: If a `package.json` exists in the target directory, the CLI configures ArkEnv directly in the project. It scans for any `.env` or `.env.example` files to automatically pre-populate the schema fields, installs the selected validator dependencies, and generates the `env.ts` file.
-- **New project**: If the target directory does not contain a `package.json` and is empty, the CLI guides you through creating a new project from an ArkEnv starter template. See our [official examples](/docs/arkenv/examples#examples) for a list of available templates.
+| Flag      | Alias | Description                                                                                                                                      |
+| --------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--yes`   | `-y`  | Skip prompts and use defaults (also passed to subprocesses). For `add host`, an omitted provider defaults to `vercel`.                            |
+| `--quiet` | `-q`  | Suppress output logs unless an error occurs.                                                                                                      |
+| `--json`  | `-j`  | Print a structured JSON summary to `stdout` upon completion.                                                                                     |
+| `--agent` |       | Enable non-interactive, machine-readable mode for AI agents. Bypasses prompts and outputs structured JSON. Macro for `--yes --quiet --json`.     |
+| `--help`  | `-h`  | Display the CLI help information.                                                                                                                |
 
-## Options
+When running with `--json` or `--agent`, the CLI emits a structured JSON summary you can parse programmatically. See [Machine-readable output](/docs/cli/machine-readable-output) for the full schema and error codes.
 
-Configure the CLI behavior using the following command-line flags:
+## `init` options
+
+These flags only affect `init`:
 
 | Flag            | Alias | Description                                                                                                                                        |
 | --------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--yes`         | `-y`  | Skip all prompts and use the default configuration.                                                                                                |
-| `--quiet`       | `-q`  | Suppress all output logs unless an error occurs.                                                                                                   |
-| `--json`        | `-j`  | Print a structured JSON summary to `stdout` upon completion.                                                                                       |
-| `--agent`       |       | Enable non-interactive, machine-readable mode for AI agents. Bypasses all prompts and outputs structured JSON. Macro for `--yes --quiet --json`.   |
 | `--example`     |       | Specify an example name when creating a new project.                                                                                               |
 | `--force`       | `-f`  | Bypass checks and force initialization.                                                                                                            |
 | `--no-codegen`  |       | Disable automatic env.gen.ts code generation for Next.js (falls back to manual runtimeEnv destructuring).                                          |
 | `--host-preset` | `-H`  | Pre-populate the schema with a hosting provider's system env vars (`none`, `vercel`, `netlify`). See [Hosting presets](/docs/cli/hosting-presets). |
-| `--help`        | `-h`  | Display the CLI help information.                                                                                                                  |
-
-When running with `--json` or `--agent`, the CLI emits a structured JSON summary you can parse programmatically. See [Machine-readable output](/docs/cli/machine-readable-output) for the full schema and error codes.


### PR DESCRIPTION
## Summary
- Restructures `/docs/cli` as a multi-command hub: **Commands** (`init`, `add host`) with hub-style entries
- Nests the existing-project / new-project **Behavior** under `init`
- Splits flags into **Global options** and **`init` options**
- Rewrites the page description and lede for scaffolding + mutation (keeps title “Introduction”)
- Documents `add host` on [Hosting presets](https://arkenv.js.org/docs/cli/hosting-presets) (deep dive) with the index linking there

Follow-up for matching `arkenv --help` layout: #1428 (blocked on this landing).

## Test plan
- [ ] Preview `/docs/cli` — Commands first, no page-level Behavior/flat Options
- [ ] Confirm Global vs `init` option tables and `--yes` note for `add host`
- [ ] Confirm `add host` links to hosting-presets deep dive
- [ ] Preview hosting-presets “Add host to an existing schema” section