### PR TITLE
Forward-port AGENTS.md from dev to v1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ArkEnv is a pnpm + Turborepo monorepo for a TypeScript env-var validation library. There are no databases or external services; the only long-running process is the `www` docs site (Next.js). Standard commands live in `package.json`, `docs/CONTRIBUTING.md`, and `docs/TESTING.md` — prefer those.
 
-> This is the `v1` branch. Its package layout differs from `dev` (v0): here `packages/arkenv` is the **CLI** (published as `arkenv`) and the **core runtime** lives in `packages/core` (published as `@arkenv/core`). There is no `packages/cli` on `v1`. `v1` publishes pre-release versions (`1.0.0-alpha.x`) under the `next` npm tag.
+> This is the `v1` branch. Its package layout differs from `dev` (v0): here `packages/arkenv` is the **CLI** (published as `arkenv`) and the **core runtime** lives in `packages/core` (published as `@arkenv/core`). There is no `packages/cli` on `v1`. `v1` publishes pre-release versions (`1.0.0-alpha.x`) under the `alpha` npm tag.
 
 ### Services / apps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+ArkEnv is a pnpm + Turborepo monorepo for a TypeScript env-var validation library. There are no databases or external services; the only long-running process is the `www` docs site (Next.js). Standard commands live in `package.json`, `docs/CONTRIBUTING.md`, and `docs/TESTING.md` — prefer those.
+
+> This is the `v1` branch. Its package layout differs from `dev` (v0): here `packages/arkenv` is the **CLI** (published as `arkenv`) and the **core runtime** lives in `packages/core` (published as `@arkenv/core`). There is no `packages/cli` on `v1`. `v1` publishes pre-release versions (`1.0.0-alpha.x`) under the `next` npm tag.
+
+### Services / apps
+
+- `packages/*` — the publishable library packages: `arkenv` (the CLI, in `packages/arkenv/`), `@arkenv/core` (core runtime, in `packages/core/`), `@arkenv/standard` (in `packages/standard/`), plus `@arkenv/nextjs`, `@arkenv/nuxt`, `@arkenv/vite-plugin`, `@arkenv/bun-plugin`, `@arkenv/build`, and `@arkenv/fumadocs-ui` (which live in the `nextjs/`, `nuxt/`, `vite-plugin/`, `bun-plugin/`, `build/`, and `fumadocs-ui/` directories), plus internal helpers under `packages/internal/*`. These are the core product.
+- `apps/www` — the documentation website (Next.js 16 + Fumadocs). This is the only runnable app.
+- `apps/playwright-www` — Playwright e2e suite targeting `www`.
+- `apps/playgrounds/*` and `examples/*` — framework sandboxes / fixtures (optional).
+
+### Common commands (run from repo root)
+
+- Build everything: `pnpm build` · packages only: `pnpm build:packages`
+- Run docs site (dev): `pnpm www` (serves on `http://localhost:3000`)
+- Lint/format + workspace validation: `pnpm check`
+- Typecheck: `pnpm typecheck`
+- Unit/integration tests: `pnpm test -- --run` (Vitest)
+- E2E: see caveat below.
+
+### Non-obvious caveats
+
+- Bun is required for `@arkenv/bun-plugin` and some bun playground/example flows, and CI installs Bun 1.3.13. It is installed globally at `~/.bun/bin` (on `PATH` via `~/.bashrc` for login shells); if a session's shell can't find `bun`, run `export PATH="$HOME/.bun/bin:$PATH"`. Bun is not needed for the core build / `pnpm test` / running `www`.
+- Node 22 (current VM LTS) works for build/lint/test/run. Some `examples/*` and playgrounds declare `"engines": { "node": "24" }`, which only produces a harmless `Unsupported engine` warning under Node 22. CI runs the typecheck job on Node 24.
+- E2E must be run the CI way (against a production server), not against `pnpm www`. The Playwright config uses `next start` when `CI` is set and `next dev` otherwise; the dev server emits console errors that the smoke test forbids and can be overwhelmed by parallel workers (`ERR_CONNECTION_REFUSED`). Build `www` first (`pnpm build --filter=www...`), then run e.g. `CI=1 pnpm exec playwright test --project=chromium` from `apps/playwright-www`. Playwright browsers must be installed once per VM: `pnpm exec playwright install --with-deps chromium firefox` (webkit is macOS-only).
+- The CLI tests print `fatal: not a git repository` / `Using 'master' as the name...` git hints while running — this is expected (they scaffold temp git repos) and does not indicate failure.
+- To run a package that consumes the local (workspace) build, use a workspace playground (e.g. `apps/playgrounds/node`, which depends on `@arkenv/core: workspace:*`). Copy `.env.example` to `.env` first, then `pnpm start`. The `examples/*` projects are standalone npm projects that resolve the published packages (e.g. `@arkenv/core`) from npm, not the local build.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Forward-ports the merged dev PR #1421 ("Add AGENTS.md with Cursor Cloud setup instructions") to the `v1` branch, adapting it to v1's package layout.

`AGENTS.md` was absent on `v1`; this adds it with the `## Cursor Cloud specific instructions` section (services layout, common commands, and non-obvious caveats).

## v1 adaptations

- Added a note that this is the `v1` branch and its layout differs from `dev`.
- `packages/arkenv` is documented as the **CLI** (`arkenv`); the **core runtime** is `@arkenv/core` in `packages/core` (no `packages/cli` on v1). Also lists `@arkenv/standard`.
- Workspace-playground hint updated: `apps/playgrounds/node` depends on `@arkenv/core: workspace:*` (not `arkenv`), and `examples/*` resolve published packages such as `@arkenv/core` from npm.
- Common commands, and the Bun / Node-24-warning / E2E-in-production-mode / CLI git-hint caveats were verified against the v1 tree (root `package.json` scripts and `apps/playwright-www/playwright.config.ts` match dev's behavior).

## Notes

- No changeset: the dev PR was docs/infra only (root `AGENTS.md`), so there is nothing to version.
- Verified `AGENTS.md` passes markdown lint on v1 (`pnpm check:mdx` → "no issues found").

Ports dev PR #1421.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8ee71d8-5096-47e5-b31f-118e3e9ae7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8ee71d8-5096-47e5-b31f-118e3e9ae7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

