### PR TITLE
fix: Forward-port Nuxt proxy coercion lock from #1420

### DIFF
--- a/.changeset/fix-nuxt-proxy-coercion.md
+++ b/.changeset/fix-nuxt-proxy-coercion.md
@@ -1,0 +1,20 @@
+---
+"@arkenv/nuxt": patch
+---
+
+#### Keep coerced number and boolean env values through the security proxy
+
+Lock the Nuxt security proxy so schema-key reads return the coerced validation target. A key declared as `"number"` or `"boolean"` returns a number or boolean at runtime, not a raw string from Nuxt runtime config / `__NUXT__`.
+
+```ts
+import { arkenv } from "@arkenv/nuxt";
+
+export const env = arkenv({
+  NUXT_PUBLIC_PORT: "number",
+  PORT: "number",
+});
+
+// 3000 (number), not "3000" (string)
+env.NUXT_PUBLIC_PORT;
+env.PORT;
+```

--- a/packages/nuxt/src/arkenv-internal.ts
+++ b/packages/nuxt/src/arkenv-internal.ts
@@ -263,7 +263,7 @@ export function arkenvInternal(
 
 	// Return a Proxy wrapper with strict access rules to prevent server variable leakage on the client.
 	// Always serve the coerced validation target — never re-read raw runtimeConfig / process.env /
-	// __NUXT__ strings, which would silently undo ADR 0002 coercion (see ADR 0015).
+	// __NUXT__ strings, which would silently undo ADR 0002 coercion.
 	return createSecurityProxy(
 		mergedValidated,
 		allKeys,

--- a/packages/nuxt/src/arkenv-internal.ts
+++ b/packages/nuxt/src/arkenv-internal.ts
@@ -261,7 +261,9 @@ export function arkenvInternal(
 		unknown
 	>;
 
-	// Return a Proxy wrapper with strict access rules to prevent server variable leakage on the client
+	// Return a Proxy wrapper with strict access rules to prevent server variable leakage on the client.
+	// Always serve the coerced validation target — never re-read raw runtimeConfig / process.env /
+	// __NUXT__ strings, which would silently undo ADR 0002 coercion (see ADR 0015).
 	return createSecurityProxy(
 		mergedValidated,
 		allKeys,
@@ -271,7 +273,17 @@ export function arkenvInternal(
 }
 
 /**
- * Wraps the validated environment object in a Proxy to enforce client/server security access rules.
+ * Wrap the validated environment object in a Proxy to enforce client/server security access rules.
+ *
+ * Schema-key reads always return the coerced validation target. Raw `useRuntimeConfig()` /
+ * `process.env` / `__NUXT__.config.public` strings are intentionally not preferred on get —
+ * those sources feed validation at create time, but serving them again would bypass coercion.
+ *
+ * @param target The validated and coerced environment object
+ * @param allKeys The set of all keys defined in the schema (including extended schemas)
+ * @param serverOnlyKeys The set of keys that must not be accessed on the client
+ * @param isServer Whether the proxy is running in a server context
+ * @returns A Proxy that enforces access rules while preserving coerced value types
  */
 function createSecurityProxy(
 	target: Record<string, unknown>,

--- a/packages/nuxt/src/index.test.ts
+++ b/packages/nuxt/src/index.test.ts
@@ -145,4 +145,52 @@ describe("arkenv (Nuxt runtime)", () => {
 			(globalThis as any).window = originalWindow;
 		}
 	});
+
+	it("should keep coerced server types when values are sourced from process.env", () => {
+		process.env.PORT = "9090";
+		process.env.DEBUG = "true";
+
+		try {
+			const env = arkenv({
+				PORT: "number",
+				DEBUG: "boolean",
+			});
+
+			expect(env.PORT).toBe(9090);
+			expect(typeof env.PORT).toBe("number");
+			expect(env.DEBUG).toBe(true);
+			expect(typeof env.DEBUG).toBe("boolean");
+		} finally {
+			delete process.env.PORT;
+			delete process.env.DEBUG;
+		}
+	});
+
+	it("should keep coerced client types when values are sourced from __NUXT__.config.public", () => {
+		const originalWindow = globalThis.window;
+		(globalThis as any).window = {
+			__NUXT__: {
+				config: {
+					public: {
+						NUXT_PUBLIC_PORT: "4000",
+						NUXT_PUBLIC_ENABLED: "false",
+					},
+				},
+			},
+		};
+
+		try {
+			const env = arkenv({
+				NUXT_PUBLIC_PORT: "number",
+				NUXT_PUBLIC_ENABLED: "boolean",
+			});
+
+			expect(env.NUXT_PUBLIC_PORT).toBe(4000);
+			expect(typeof env.NUXT_PUBLIC_PORT).toBe("number");
+			expect(env.NUXT_PUBLIC_ENABLED).toBe(false);
+			expect(typeof env.NUXT_PUBLIC_ENABLED).toBe("boolean");
+		} finally {
+			(globalThis as any).window = originalWindow;
+		}
+	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Forward-ports [#1420](https://github.com/yamcodes/arkenv/pull/1420) / [#1327](https://github.com/yamcodes/arkenv/issues/1327) from `dev` onto `v1`
- On `v1`, `createSecurityProxy` in `arkenv-internal.ts` already preferred the coerced validation target (the get-time `runtimeConfig` / `process.env` / `__NUXT__` preference bug never landed here). This port locks that invariant with ADR 0015 docs comments and coercion regression tests.
- Adds a `patch` changeset for `@arkenv/nuxt` (v1+ bump rules)

## Notes
- Skipped the `useRuntimeConfig` create-time tests from #1420: `v1` `arkenvInternal` does not merge `useRuntimeConfig()` into `sourceEnv` (server uses `process.env`; client uses `__NUXT__` / `process.env`).
- Boot-time `NUXT_PUBLIC_*` payload honesty / validator-free client remain #1424.

## Test plan
- [x] `pnpm --filter @arkenv/nuxt exec vitest run src/index.test.ts` (7 passed)
- [x] `pnpm --filter @arkenv/nuxt typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0623c244-7bc7-41d8-8d5f-7445513461e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0623c244-7bc7-41d8-8d5f-7445513461e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

