### PR TITLE
Support arkenv add host for strict layouts (Phase 3)

### DIFF
--- a/.changeset/add-host-preset-strict-layouts.md
+++ b/.changeset/add-host-preset-strict-layouts.md
@@ -1,0 +1,5 @@
+---
+"@arkenv/cli": patch
+---
+
+Support `arkenv add host [provider]` for strict multi-file layouts (`client.ts` and `server.ts`) by partitioning client-prefixed vs server-only variables.

--- a/.changeset/add-host-preset-strict-layouts.md
+++ b/.changeset/add-host-preset-strict-layouts.md
@@ -2,4 +2,12 @@
 "@arkenv/cli": patch
 ---
 
-Support `arkenv add host [provider]` for strict multi-file layouts (`client.ts` and `server.ts`) by partitioning client-prefixed vs server-only variables.
+#### Support `arkenv add host` for strict multi-file layouts
+
+Support `arkenv add host [provider]` in projects with strict multi-file layouts (`client.ts` and `server.ts`). Automatically partition preset variables into client-prefixed keys for `client.ts` and server-only keys for `server.ts`.
+
+Usage:
+
+```bash
+npx @arkenv/cli@latest add host [provider]
+```

--- a/packages/cli/src/cli/commands/add.test.ts
+++ b/packages/cli/src/cli/commands/add.test.ts
@@ -1,5 +1,7 @@
+import path from "node:path";
 import dedent from "dedent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { partitionPresetKeys } from "@/features/scaffold";
 import type {
 	LoggerPort,
 	ProjectScannerPort,
@@ -35,7 +37,12 @@ describe("AddUseCase", () => {
 		} as unknown as LoggerPort;
 
 		workspace = {
-			exists: vi.fn().mockResolvedValue(true),
+			exists: vi.fn().mockImplementation(async (p: string) => {
+				if (p.endsWith("client.ts") || p.endsWith("server.ts")) {
+					return false;
+				}
+				return true;
+			}),
 			readFile: vi.fn(),
 			writeFile: vi.fn(),
 			mkdir: vi.fn(),
@@ -86,7 +93,7 @@ describe("AddUseCase", () => {
 	});
 
 	it("defaults provider to vercel when isYes is true and provider is omitted", async () => {
-		vi.mocked(workspace.exists).mockResolvedValue(true);
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) => p.endsWith("env.ts"));
 		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
 			import { type } from "arkenv";
 			export const Env = type({
@@ -107,7 +114,7 @@ describe("AddUseCase", () => {
 	});
 
 	it("mutates env.ts with preset keys", async () => {
-		vi.mocked(workspace.exists).mockResolvedValue(true);
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) => p.endsWith("env.ts"));
 		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
 			import { type } from "arkenv";
 			export const Env = type({
@@ -149,7 +156,7 @@ describe("AddUseCase", () => {
 	});
 
 	it("does not mutate if keys are already present", async () => {
-		vi.mocked(workspace.exists).mockResolvedValue(true);
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) => p.endsWith("env.ts"));
 		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
 			import { type } from "arkenv";
 			export const Env = type({
@@ -180,7 +187,7 @@ describe("AddUseCase", () => {
 	});
 
 	it("logs proposed keys to stdout if env.ts is not parseable", async () => {
-		vi.mocked(workspace.exists).mockResolvedValue(true);
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) => p.endsWith("env.ts"));
 		vi.mocked(workspace.readFile).mockResolvedValue("export const x = 123;");
 
 		const result = await useCase.execute({ provider: "vercel" });
@@ -231,6 +238,89 @@ describe("AddUseCase", () => {
 			const code =
 				'/*\n import * as v from "valibot"\n*/\nimport arkenv from "./generated/env.gen";\nexport const env = arkenv({});';
 			expect(detectValidator(code)).toBe("arktype");
+		});
+	});
+
+	it("detects strict layout (env/client.ts and env/server.ts) and merges client/server keys", async () => {
+		const clientPath = path.resolve(process.cwd(), "env/client.ts");
+		const serverPath = path.resolve(process.cwd(), "env/server.ts");
+
+		vi.mocked(workspace.exists).mockImplementation(async (p) => {
+			return p === clientPath || p === serverPath;
+		});
+
+		vi.mocked(workspace.readFile).mockImplementation(async (p) => {
+			if (p === clientPath) {
+				return dedent`
+					import arkenv from "./generated/env.gen";
+					export const env = arkenv({});
+				`;
+			}
+			if (p === serverPath) {
+				return dedent`
+					import arkenv from "./generated/env.gen";
+					export const env = arkenv({});
+				`;
+			}
+			return "";
+		});
+
+		scanner.detectFramework = vi.fn().mockResolvedValue("nextjs");
+
+		const result = await useCase.execute({ provider: "vercel" });
+		expect(result).toBe(true);
+
+		expect(workspace.writeFile).toHaveBeenCalledWith(
+			clientPath,
+			expect.stringContaining("NEXT_PUBLIC_VERCEL_ENV"),
+		);
+		expect(workspace.writeFile).toHaveBeenCalledWith(
+			serverPath,
+			expect.stringContaining("VERCEL:"),
+		);
+		expect(logger.success).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"Added Vercel environment variables to env/client.ts and env/server.ts",
+			),
+		);
+	});
+
+	it("logs partitioned manual instructions if strict layout mutation fails", async () => {
+		const clientPath = path.resolve(process.cwd(), "env/client.ts");
+		const serverPath = path.resolve(process.cwd(), "env/server.ts");
+
+		vi.mocked(workspace.exists).mockImplementation(async (p) => {
+			return p === clientPath || p === serverPath;
+		});
+
+		vi.mocked(workspace.readFile).mockResolvedValue("export const invalid = 123;");
+		scanner.detectFramework = vi.fn().mockResolvedValue("nextjs");
+
+		const result = await useCase.execute({ provider: "vercel" });
+		expect(result).toBe(true);
+		expect(logger.error).toHaveBeenCalledWith(
+			"Failed to mutate strict layout schema files.",
+		);
+		expect(logger.log).toHaveBeenCalledWith(
+			expect.stringContaining("NEXT_PUBLIC_VERCEL_ENV"),
+		);
+		expect(logger.log).toHaveBeenCalledWith(expect.stringContaining("VERCEL:"));
+	});
+
+	describe("partitionPresetKeys", () => {
+		it("partitions vercel keys for nextjs framework", () => {
+			const { clientKeys, serverKeys } = partitionPresetKeys("vercel", "nextjs");
+			expect(clientKeys).toEqual([
+				"NEXT_PUBLIC_VERCEL_ENV",
+				"NEXT_PUBLIC_VERCEL_URL",
+			]);
+			expect(serverKeys).toEqual(["VERCEL", "VERCEL_ENV", "VERCEL_URL"]);
+		});
+
+		it("partitions netlify keys for nuxt framework", () => {
+			const { clientKeys, serverKeys } = partitionPresetKeys("netlify", "nuxt");
+			expect(clientKeys).toEqual(["NUXT_PUBLIC_CONTEXT", "NUXT_PUBLIC_URL"]);
+			expect(serverKeys).toEqual(["NETLIFY", "DEPLOY_URL", "CONTEXT", "URL"]);
 		});
 	});
 });

--- a/packages/cli/src/cli/commands/add.test.ts
+++ b/packages/cli/src/cli/commands/add.test.ts
@@ -93,7 +93,9 @@ describe("AddUseCase", () => {
 	});
 
 	it("defaults provider to vercel when isYes is true and provider is omitted", async () => {
-		vi.mocked(workspace.exists).mockImplementation(async (p: string) => p.endsWith("env.ts"));
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) =>
+			p.endsWith("env.ts"),
+		);
 		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
 			import { type } from "arkenv";
 			export const Env = type({
@@ -114,7 +116,9 @@ describe("AddUseCase", () => {
 	});
 
 	it("mutates env.ts with preset keys", async () => {
-		vi.mocked(workspace.exists).mockImplementation(async (p: string) => p.endsWith("env.ts"));
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) =>
+			p.endsWith("env.ts"),
+		);
 		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
 			import { type } from "arkenv";
 			export const Env = type({
@@ -156,7 +160,9 @@ describe("AddUseCase", () => {
 	});
 
 	it("does not mutate if keys are already present", async () => {
-		vi.mocked(workspace.exists).mockImplementation(async (p: string) => p.endsWith("env.ts"));
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) =>
+			p.endsWith("env.ts"),
+		);
 		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
 			import { type } from "arkenv";
 			export const Env = type({
@@ -187,7 +193,9 @@ describe("AddUseCase", () => {
 	});
 
 	it("logs proposed keys to stdout if env.ts is not parseable", async () => {
-		vi.mocked(workspace.exists).mockImplementation(async (p: string) => p.endsWith("env.ts"));
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) =>
+			p.endsWith("env.ts"),
+		);
 		vi.mocked(workspace.readFile).mockResolvedValue("export const x = 123;");
 
 		const result = await useCase.execute({ provider: "vercel" });
@@ -293,7 +301,9 @@ describe("AddUseCase", () => {
 			return p === clientPath || p === serverPath;
 		});
 
-		vi.mocked(workspace.readFile).mockResolvedValue("export const invalid = 123;");
+		vi.mocked(workspace.readFile).mockResolvedValue(
+			"export const invalid = 123;",
+		);
 		scanner.detectFramework = vi.fn().mockResolvedValue("nextjs");
 
 		const result = await useCase.execute({ provider: "vercel" });
@@ -309,7 +319,10 @@ describe("AddUseCase", () => {
 
 	describe("partitionPresetKeys", () => {
 		it("partitions vercel keys for nextjs framework", () => {
-			const { clientKeys, serverKeys } = partitionPresetKeys("vercel", "nextjs");
+			const { clientKeys, serverKeys } = partitionPresetKeys(
+				"vercel",
+				"nextjs",
+			);
 			expect(clientKeys).toEqual([
 				"NEXT_PUBLIC_VERCEL_ENV",
 				"NEXT_PUBLIC_VERCEL_URL",

--- a/packages/cli/src/cli/commands/add.ts
+++ b/packages/cli/src/cli/commands/add.ts
@@ -4,7 +4,8 @@ import {
 	getFieldDefinition,
 	getFrameworkPrefix,
 	getPresetKeys,
-} from "@/features/scaffold/templates/presets";
+	partitionPresetKeys,
+} from "@/features/scaffold";
 import type {
 	LoggerPort,
 	ProjectScannerPort,
@@ -70,6 +71,112 @@ export class AddUseCase {
 			const tsConfig = tsConfigResult.parsed || null;
 			const framework = await this.scanner.detectFramework(cwd, tsConfig);
 
+			const strictDirCandidates = [
+				path.resolve(cwd, "env"),
+				path.resolve(cwd, "src/env"),
+			];
+
+			let strictDir: string | null = null;
+			for (const dir of strictDirCandidates) {
+				const clientFile = path.join(dir, "client.ts");
+				const serverFile = path.join(dir, "server.ts");
+				if (
+					(await this.workspace.exists(clientFile)) &&
+					(await this.workspace.exists(serverFile))
+				) {
+					strictDir = dir;
+					break;
+				}
+			}
+
+			const prefix = getFrameworkPrefix(framework);
+
+			if (strictDir) {
+				const clientPath = path.join(strictDir, "client.ts");
+				const serverPath = path.join(strictDir, "server.ts");
+				const relClientPath = path.relative(cwd, clientPath);
+				const relServerPath = path.relative(cwd, serverPath);
+
+				const { clientKeys, serverKeys } = partitionPresetKeys(
+					provider,
+					framework,
+				);
+
+				const clientCode = await this.workspace.readFile(clientPath);
+				const serverCode = await this.workspace.readFile(serverPath);
+
+				const clientValidator = detectValidator(clientCode);
+				const serverValidator = detectValidator(serverCode);
+
+				const clientResult = mutateEnvConfig(
+					clientCode,
+					provider,
+					framework,
+					clientValidator,
+					clientKeys,
+				);
+				const serverResult = mutateEnvConfig(
+					serverCode,
+					provider,
+					framework,
+					serverValidator,
+					serverKeys,
+				);
+
+				const getStrictManualText = (): string => {
+					const clientText = clientKeys
+						.map(
+							(key) =>
+								`\t${key}: ${getFieldDefinition(key, clientValidator, prefix)},`,
+						)
+						.join("\n");
+					const serverText = serverKeys
+						.map(
+							(key) =>
+								`\t${key}: ${getFieldDefinition(key, serverValidator, prefix)},`,
+						)
+						.join("\n");
+					return `// ${relClientPath}\n{\n${clientText}\n}\n\n// ${relServerPath}\n{\n${serverText}\n}`;
+				};
+
+				if (
+					!clientResult.success ||
+					!clientResult.code ||
+					!serverResult.success ||
+					!serverResult.code
+				) {
+					this.logger.error("Failed to mutate strict layout schema files.");
+					this.logger.log(
+						"\nPlease add the following environment variables to your schemas manually:\n",
+					);
+					this.logger.log(getStrictManualText());
+					return true;
+				}
+
+				let anyUpdated = false;
+				if (clientResult.updated) {
+					await this.workspace.writeFile(clientPath, clientResult.code);
+					anyUpdated = true;
+				}
+				if (serverResult.updated) {
+					await this.workspace.writeFile(serverPath, serverResult.code);
+					anyUpdated = true;
+				}
+
+				const providerName = provider === "vercel" ? "Vercel" : "Netlify";
+				if (anyUpdated) {
+					this.logger.success(
+						`Added ${providerName} environment variables to ${relClientPath} and ${relServerPath}`,
+					);
+				} else {
+					this.logger.info(
+						`All ${providerName} environment variables are already present in ${relClientPath} and ${relServerPath}`,
+					);
+				}
+
+				return true;
+			}
+
 			const suggestedPath = await this.scanner.suggestDefaultEnvPath(
 				cwd,
 				tsConfig,
@@ -87,8 +194,6 @@ export class AddUseCase {
 					break;
 				}
 			}
-
-			const prefix = getFrameworkPrefix(framework);
 			const keys = getPresetKeys(provider, prefix);
 
 			const getManualFieldsText = (

--- a/packages/cli/src/features/config-mutation/config-mutation.test.ts
+++ b/packages/cli/src/features/config-mutation/config-mutation.test.ts
@@ -363,5 +363,30 @@ describe("config-mutation", () => {
 			expect(result.proposedFields).toHaveProperty("VERCEL");
 			expect(result.proposedFields).toHaveProperty("VERCEL_ENV");
 		});
+
+		it("mutates env schema with specific targetKeys subset", () => {
+			const initialContent = dedent`
+				import arkenv from "./generated/env.gen";
+
+				export const env = arkenv({
+					DATABASE_URL: "string",
+				});
+			`;
+
+			const result = mutateEnvConfig(
+				initialContent,
+				"vercel",
+				"nextjs",
+				"arktype",
+				["NEXT_PUBLIC_VERCEL_ENV", "NEXT_PUBLIC_VERCEL_URL"],
+			);
+			expect(result.success).toBe(true);
+			expect(result.updated).toBe(true);
+			expect(result.code).toContain(
+				'NEXT_PUBLIC_VERCEL_ENV: "\'production\' | \'preview\' | \'development\'?"',
+			);
+			expect(result.code).toContain('NEXT_PUBLIC_VERCEL_URL: "string?"');
+			expect(result.code).not.toContain('VERCEL: "string?"');
+		});
 	});
 });

--- a/packages/cli/src/features/config-mutation/config-mutation.test.ts
+++ b/packages/cli/src/features/config-mutation/config-mutation.test.ts
@@ -383,7 +383,7 @@ describe("config-mutation", () => {
 			expect(result.success).toBe(true);
 			expect(result.updated).toBe(true);
 			expect(result.code).toContain(
-				'NEXT_PUBLIC_VERCEL_ENV: "\'production\' | \'preview\' | \'development\'?"',
+				"NEXT_PUBLIC_VERCEL_ENV: \"'production' | 'preview' | 'development'?\"",
 			);
 			expect(result.code).toContain('NEXT_PUBLIC_VERCEL_URL: "string?"');
 			expect(result.code).not.toContain('VERCEL: "string?"');

--- a/packages/cli/src/features/config-mutation/config-mutation.ts
+++ b/packages/cli/src/features/config-mutation/config-mutation.ts
@@ -329,6 +329,7 @@ export function transformNuxtConfig(
  * @param preset The selected hosting provider preset.
  * @param framework The active framework.
  * @param validator The active validator.
+ * @param targetKeys Optional specific keys to mutate (defaults to all preset keys).
  * @returns The result of the mutation operation.
  */
 export function mutateEnvConfig(
@@ -336,6 +337,7 @@ export function mutateEnvConfig(
 	preset: HostPreset,
 	framework: Framework,
 	validator: Validator,
+	targetKeys?: string[],
 ): {
 	success: boolean;
 	updated: boolean;
@@ -344,20 +346,24 @@ export function mutateEnvConfig(
 	proposedFields: Record<string, string>;
 } {
 	const prefix = getFrameworkPrefix(framework);
-	const presetKeys = getPresetKeys(preset, prefix);
+	const keysToMutate = targetKeys ?? getPresetKeys(preset, prefix);
 	const proposedFields: Record<string, string> = {};
 
-	for (const key of presetKeys) {
+	for (const key of keysToMutate) {
 		proposedFields[key] = getFieldDefinition(key, validator, prefix);
 	}
 
 	try {
 		const mod = parseModule(code);
-		const envExport = mod.exports.env || mod.exports.Env;
+		const envExport =
+			mod.exports.env || mod.exports.Env || mod.exports.SharedSchema;
 		if (
 			!envExport ||
 			envExport.$type !== "function-call" ||
-			(envExport.$callee !== "arkenv" && envExport.$callee !== "type")
+			(envExport.$callee !== "arkenv" &&
+				envExport.$callee !== "type" &&
+				envExport.$callee !== "z.object" &&
+				envExport.$callee !== "v.object")
 		) {
 			return {
 				success: false,
@@ -380,7 +386,7 @@ export function mutateEnvConfig(
 		let updated = false;
 		const replacements: Record<string, string> = {};
 
-		for (const key of presetKeys) {
+		for (const key of keysToMutate) {
 			// Only add if the key doesn't already exist in the schema
 			if (!(key in obj)) {
 				const placeholder = `__ARK_PRESET_PLACEHOLDER_${key}__`;

--- a/packages/cli/src/features/scaffold/templates/presets.ts
+++ b/packages/cli/src/features/scaffold/templates/presets.ts
@@ -81,6 +81,38 @@ export function getPresetKeys(preset: HostPreset, prefix: string): string[] {
 }
 
 /**
+ * Partitions hosting preset keys into client-facing (prefixed) vs server-only keys for strict layouts.
+ */
+export function partitionPresetKeys(
+	preset: HostPreset,
+	frameworkOrPrefix: Framework | string,
+): { clientKeys: string[]; serverKeys: string[] } {
+	if (preset === "none") {
+		return { clientKeys: [], serverKeys: [] };
+	}
+	const def = PRESETS[preset];
+	if (!def) {
+		return { clientKeys: [], serverKeys: [] };
+	}
+
+	const prefix =
+		frameworkOrPrefix.endsWith("_") || frameworkOrPrefix === ""
+			? frameworkOrPrefix
+			: getFrameworkPrefix(frameworkOrPrefix as Framework);
+
+	const serverKeys: string[] = [...def.serverOnlyKeys, ...def.clientExposedKeys];
+	const clientKeys: string[] = [];
+
+	if (prefix) {
+		for (const key of def.clientExposedKeys) {
+			clientKeys.push(`${prefix}${key}`);
+		}
+	}
+
+	return { clientKeys, serverKeys };
+}
+
+/**
  * Returns validator-specific schema fields for preset keys, falling back to a default optional string.
  */
 export function getFieldDefinition(

--- a/packages/cli/src/features/scaffold/templates/presets.ts
+++ b/packages/cli/src/features/scaffold/templates/presets.ts
@@ -100,7 +100,10 @@ export function partitionPresetKeys(
 			? frameworkOrPrefix
 			: getFrameworkPrefix(frameworkOrPrefix as Framework);
 
-	const serverKeys: string[] = [...def.serverOnlyKeys, ...def.clientExposedKeys];
+	const serverKeys: string[] = [
+		...def.serverOnlyKeys,
+		...def.clientExposedKeys,
+	];
 	const clientKeys: string[] = [];
 
 	if (prefix) {


### PR DESCRIPTION
## Description
Support `arkenv add host [provider]` for multi-file strict layouts (`client.ts` and `server.ts`).

- Detect strict layout files pairs (client.ts + server.ts)
- Added `partitionPresetKeys` in preset.ts to partition hosting preset keys into client-prefixed keys and server only keys.
- Add unit test for key partitioning and strict layout AST mutations

Fixes #1268 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x] My code follows the code style of this project (double quotes, tabs, no parameter reassignment).
- [x] I have written sentence-case imperative commits / PR title (e.g. `Add support for custom error messages` - no `feat:`, no trailing period, capitalized).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have created a changeset using `pnpm changeset` (if this affects a published package).

### For v0 (dev) PRs:
- [ ] **Forward-Porting**: (For maintainers) Has this change been manually forward-ported to the `v1` branch?