### PR TITLE
Document that add host works for flat and strict layouts

### DIFF
--- a/.changeset/add-host-help-schema-wording.md
+++ b/.changeset/add-host-help-schema-wording.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/cli": patch
+---
+
+#### Clarify `add host` help text for flat and strict layouts
+
+Update the `arkenv --help` description for `add host` so it refers to the schema generally, matching support for both flat and strict layouts.

--- a/.changeset/add-host-help-schema-wording.md
+++ b/.changeset/add-host-help-schema-wording.md
@@ -1,7 +1,0 @@
----
-"@arkenv/cli": patch
----
-
-#### Clarify `add host` help text for flat and strict layouts
-
-Update the `arkenv --help` description for `add host` so it refers to the schema generally, matching support for both flat and strict layouts.

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -26,8 +26,8 @@ export default function HomePage() {
 			<div className="flex flex-col lg:flex-row items-center justify-center px-4 sm:px-6 lg:pl-20 lg:pr-6 max-w-screen-2xl mx-auto w-full gap-4 md:gap-8 lg:gap-12 lg:mt-20">
 				<div className="flex flex-col items-center lg:items-start text-center lg:text-left lg:flex-[1.4] relative z-20 mt-12 w-full max-w-full">
 					<div className="lg:mb-6 mb-0">
-						<AnnouncementBadge href="docs/nextjs/layouts/flat" new>
-							Flat layout for Next.js
+						<AnnouncementBadge href="docs/cli/hosting-presets" new>
+							Next.js, Netlify presets
 						</AnnouncementBadge>
 					</div>
 					<h1 className="mb-4 mt-6 lg:mt-0 w-full max-w-2xl">

--- a/apps/www/content/docs/cli/hosting-presets.mdx
+++ b/apps/www/content/docs/cli/hosting-presets.mdx
@@ -4,7 +4,7 @@ icon: Cloud
 description: Pre-populate your schema with Vercel or Netlify system environment variables during arkenv init, or add them later with arkenv add host.
 ---
 
-Most hosting providers inject their own **system environment variables** at build and runtime (for example, Vercel sets `VERCEL_ENV` and `VERCEL_URL`, Netlify sets `CONTEXT` and `URL`). Hosting presets let `arkenv init` pre-populate your generated schema with the correct variables for your provider, already typed and marked optional, so you don't have to look them up by hand. If you already have an `env.ts`, use [`arkenv add host`](#add-host-to-an-existing-schema) to inject the same fields later.
+Most hosting providers inject their own **system environment variables** at build and runtime (for example, Vercel sets `VERCEL_ENV` and `VERCEL_URL`, Netlify sets `CONTEXT` and `URL`). Hosting presets let `arkenv init` pre-populate your generated schema with the correct variables for your provider, already typed and marked optional, so you don't have to look them up by hand. If you already have a schema, use [`arkenv add host`](#add-host-to-an-existing-schema) to inject the same fields later.
 
 Presets work with every validator (ArkType, Zod, Valibot) and both the [flat](#layouts) and [strict](#layouts) layouts.
 
@@ -41,7 +41,7 @@ npx @arkenv/cli@latest init -H vercel
 
 ## Add host to an existing schema
 
-If you already ran `init` (or hand-wrote an `env.ts`) and want to add a hosting preset later, use `add host`:
+If you already ran `init` (or hand-wrote a schema) and want to add a hosting preset later, use `add host`:
 
 ```npm
 npx @arkenv/cli@latest add host vercel
@@ -53,7 +53,7 @@ Omit the provider to pick interactively:
 npx @arkenv/cli@latest add host
 ```
 
-The command auto-detects your framework prefix and validator (ArkType, Zod, or Valibot), then merges the preset fields into a flat `env.ts` (or `src/env.ts`). If the file is missing or unparseable, it prints the proposed fields so you can paste them in manually. Keys that are already present are left unchanged.
+The command auto-detects your layout ([flat](#layouts) or [strict](#layouts)), framework prefix, and validator (ArkType, Zod, or Valibot), then merges the preset fields into your schema. If the schema is missing or unparseable, it prints the proposed fields so you can paste them in manually. Keys that are already present are left unchanged.
 
 With `--yes` or `--agent`, an omitted provider defaults to `vercel`.
 
@@ -221,9 +221,9 @@ The examples below show the schema generated for a plain Node.js project (no fra
 
 ## Layouts
 
-Presets adapt to whichever layout you scaffold:
+Presets adapt to whichever layout you use — both during `init` and when you run `add host`:
 
-- **Flat / simple layout** - all preset variables land in your single schema, alongside your own variables.
+- **Flat / simple layout** - all preset variables land in your single schema (`env.ts` or `src/env.ts`), alongside your own variables.
 - **Strict layout** - server-only variables (e.g. `VERCEL`, `NETLIFY`, `DEPLOY_URL`) go into the server schema. The **unprefixed** client-exposed variables (e.g. `VERCEL_ENV`, `URL`) also go into the server schema, since they're only readable server-side; it's their **framework-prefixed copies** (e.g. `NEXT_PUBLIC_VERCEL_ENV`, `VITE_URL`) that go into the client schema.
 
 :::note

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -4,7 +4,7 @@ icon: Album
 description: Commands for scaffolding and mutating ArkEnv setup with an interactive CLI.
 ---
 
-The ArkEnv CLI provides commands to scaffold a new ArkEnv setup and to mutate an existing one (for example, adding a hosting preset to `env.ts`).
+The ArkEnv CLI provides commands to scaffold a new ArkEnv setup and to mutate an existing one (for example, adding a hosting preset to your schema).
 
 ## Commands
 
@@ -32,13 +32,13 @@ The command adjusts its workflow depending on where it is executed:
 
 ### `add host`
 
-Add a hosting provider preset (Vercel or Netlify) to an existing flat `env.ts`.
+Add a hosting provider preset (Vercel or Netlify) to an existing schema (flat or strict).
 
 ```npm
 npx @arkenv/cli@latest add host [provider]
 ```
 
-See [Hosting presets](/docs/cli/hosting-presets#add-host-to-an-existing-schema) for behavior, interactive selection, and fallbacks when `env.ts` is missing or unparseable.
+See [Hosting presets](/docs/cli/hosting-presets#add-host-to-an-existing-schema) for behavior, interactive selection, and fallbacks when the schema is missing or unparseable.
 
 ## Global options
 

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -32,7 +32,7 @@ The command adjusts its workflow depending on where it is executed:
 
 ### `add host`
 
-Add a hosting provider preset (Vercel or Netlify) to an existing schema (flat or strict).
+Add a hosting provider preset (Vercel or Netlify) to an existing schema.
 
 ```npm
 npx @arkenv/cli@latest add host [provider]

--- a/packages/cli/src/cli/commands/add.ts
+++ b/packages/cli/src/cli/commands/add.ts
@@ -19,7 +19,7 @@ export type AddInput = {
 };
 
 /**
- * Use case for adding a hosting preset (Vercel/Netlify) to an existing env.ts schema.
+ * Use case for adding a hosting preset (Vercel/Netlify) to an existing schema.
  */
 export class AddUseCase {
 	constructor(

--- a/packages/cli/src/cli/commands/help.test.ts
+++ b/packages/cli/src/cli/commands/help.test.ts
@@ -34,7 +34,7 @@ describe("HelpUseCase", () => {
 		);
 		expect(addCommandLog).toBeDefined();
 		expect(addCommandLog).toBe(
-			"  arkenv add host [provider]    Add hosting provider preset (vercel, netlify) to env.ts",
+			"  arkenv add host [provider]    Add hosting provider preset (vercel, netlify) to schema",
 		);
 
 		// Options should be aligned based on the longest option (--host-preset, -H <preset>) which is 26 chars

--- a/packages/cli/src/cli/commands/help.ts
+++ b/packages/cli/src/cli/commands/help.ts
@@ -40,7 +40,7 @@ export class HelpUseCase {
 			},
 			{
 				left: "arkenv add host [provider]",
-				right: "Add hosting provider preset (vercel, netlify) to env.ts",
+				right: "Add hosting provider preset (vercel, netlify) to schema",
 			},
 		];
 


### PR DESCRIPTION
## Summary
- Updates CLI docs so `arkenv add host` is no longer described as flat-`env.ts`-only
- Reflects Phase 3 (#1430): `add host` auto-detects flat or strict layout and merges presets accordingly

## Test plan
- [ ] Preview `/docs/cli` — `add host` blurb mentions flat or strict
- [ ] Preview `/docs/cli/hosting-presets` — Add host section describes layout auto-detection; Layouts section covers `init` and `add host`


Made with [Cursor](https://cursor.com)