### PR TITLE
docs: convert remaining GitHub callouts to Fumadocs syntax

### DIFF
--- a/apps/www/content/docs/nextjs/configuration.mdx
+++ b/apps/www/content/docs/nextjs/configuration.mdx
@@ -136,6 +136,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {};
 export default withArkEnv(nextConfig, { codegen: false });
 ```
+
 :::
 
 See the [FAQ](/docs/nextjs/faq#can-i-disable-code-generation) for the full manual setup pattern.

--- a/apps/www/content/docs/nextjs/configuration.mdx
+++ b/apps/www/content/docs/nextjs/configuration.mdx
@@ -126,17 +126,17 @@ npx @arkenv/cli@latest init --no-codegen
 
 Or set it up manually by passing the `{ codegen: false }` option to `withArkEnv` in `next.config.ts`, and importing `arkenv` directly from `@arkenv/nextjs` in your schema file. You then become responsible for keeping `runtimeEnv` in sync with your schema.
 
-> [!TIP]
-> **Build-time validation without codegen:**
-> When using `{ codegen: false }`, `withArkEnv` will skip compiling and generating `env.gen.ts` but will still execute build-time environment variable validation, ensuring invalid variables fail the build:
->
-> ```ts title="next.config.ts"
-> import { withArkEnv } from "@arkenv/nextjs/config";
-> import type { NextConfig } from "next";
->
-> const nextConfig: NextConfig = {};
-> export default withArkEnv(nextConfig, { codegen: false });
-> ```
+:::tip[Build-time validation without codegen]
+When using `{ codegen: false }`, `withArkEnv` will skip compiling and generating `env.gen.ts` but will still execute build-time environment variable validation, ensuring invalid variables fail the build:
+
+```ts title="next.config.ts"
+import { withArkEnv } from "@arkenv/nextjs/config";
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+export default withArkEnv(nextConfig, { codegen: false });
+```
+:::
 
 See the [FAQ](/docs/nextjs/faq#can-i-disable-code-generation) for the full manual setup pattern.
 

--- a/apps/www/content/docs/nextjs/layouts/strict.mdx
+++ b/apps/www/content/docs/nextjs/layouts/strict.mdx
@@ -24,7 +24,7 @@ By importing `@arkenv/core` from `@/env/client` in client-side code and `@/env/s
 - **Internal schema modules** (`env/internal/shared.ts`): `import { type } from "@arkenv/core"`.
 - **Standalone server scripts** (outside the env module graph): `import { arkenv } from "@arkenv/core"`.
 
-:::note Migration
+:::note[Migration]
 If you previously used `@arkenv/nextjs/shared` in `env/internal/shared.ts`, replace it with `import { type } from "@arkenv/core"`. The `/client` and `/server` subpath exports are unchanged.
 :::
 

--- a/apps/www/content/docs/nextjs/using-other-validators.mdx
+++ b/apps/www/content/docs/nextjs/using-other-validators.mdx
@@ -132,5 +132,6 @@ export const env = arkenv({
 Legacy nested layout `arkenv({ server, client, shared, runtimeEnv })` is still supported but deprecated.
 :::
 
-> [!NOTE]
-> If you are using the default Simple layout with codegen, the CLI will automatically generate `generated/env.gen.ts` importing from `@arkenv/nextjs/standard` if your schema file imports from `@arkenv/standard` or `@arkenv/nextjs/standard`.
+:::note
+If you are using the default Simple layout with codegen, the CLI will automatically generate `generated/env.gen.ts` importing from `@arkenv/nextjs/standard` if your schema file imports from `@arkenv/standard` or `@arkenv/nextjs/standard`.
+:::

--- a/apps/www/content/docs/nuxt/layouts/strict.mdx
+++ b/apps/www/content/docs/nuxt/layouts/strict.mdx
@@ -23,7 +23,7 @@ By importing `env` from `~/env/client` in client-side code and `~/env/server` in
 - **Internal schema modules** (`env/internal/shared.ts`): `import { type } from "@arkenv/core"`.
 - **Standalone server scripts** (outside the env module graph): `import { arkenv } from "@arkenv/core"`.
 
-:::note Migration
+:::note[Migration]
 If you previously used `@arkenv/nuxt/shared` in `env/internal/shared.ts`, replace it with `import { type } from "@arkenv/core"`. The `/client` and `/server` subpath exports are unchanged.
 :::
 


### PR DESCRIPTION
## Summary
- Replace leftover GitHub-style `> [!NOTE]` / `> [!TIP]` callouts in www MDX with native Fumadocs `:::note` / `:::tip` syntax
- Fix malformed titled callouts (`:::note Migration` → `:::note[Migration]`) on Next.js and Nuxt strict layout docs

## Test plan
- [ ] Open affected pages locally (`/docs/nextjs/configuration`, `/docs/nextjs/using-other-validators`, `/docs/nextjs/layouts/strict`, `/docs/nuxt/layouts/strict`) and confirm callouts render with Fumadocs styling
- [ ] Confirm the tip titled “Build-time validation without codegen” still shows its nested code sample
- [ ] Confirm Migration note titles appear correctly on both strict layout pages


Made with [Cursor](https://cursor.com)