### PR TITLE
docs: convert remaining GitHub callouts to Fumadocs syntax

### DIFF
--- a/apps/www/content/docs/nextjs/configuration.mdx
+++ b/apps/www/content/docs/nextjs/configuration.mdx
@@ -87,17 +87,17 @@ npx @arkenv/cli@latest init --no-codegen
 
 Or set it up manually by passing the `{ codegen: false }` option to `withArkEnv` in `next.config.ts`, and importing `createEnv` directly from `@arkenv/nextjs` in your schema file. You then become responsible for keeping `runtimeEnv` in sync with your schema.
 
-> [!TIP]
-> **Build-time validation without codegen:**
-> When using `{ codegen: false }`, `withArkEnv` will skip compiling and generating `env.gen.ts` but will still execute build-time environment variable validation, ensuring invalid variables fail the build:
->
-> ```ts title="next.config.ts" twoslash
-> import { withArkEnv } from "@arkenv/nextjs/config";
-> import type { NextConfig } from "next";
->
-> const nextConfig: NextConfig = {};
-> export default withArkEnv(nextConfig, { codegen: false });
-> ```
+:::tip[Build-time validation without codegen]
+When using `{ codegen: false }`, `withArkEnv` will skip compiling and generating `env.gen.ts` but will still execute build-time environment variable validation, ensuring invalid variables fail the build:
+
+```ts title="next.config.ts" twoslash
+import { withArkEnv } from "@arkenv/nextjs/config";
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+export default withArkEnv(nextConfig, { codegen: false });
+```
+:::
 
 See the [FAQ](/docs/nextjs/faq#can-i-disable-code-generation) for the full manual setup pattern.
 

--- a/apps/www/content/docs/nextjs/configuration.mdx
+++ b/apps/www/content/docs/nextjs/configuration.mdx
@@ -97,6 +97,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {};
 export default withArkEnv(nextConfig, { codegen: false });
 ```
+
 :::
 
 See the [FAQ](/docs/nextjs/faq#can-i-disable-code-generation) for the full manual setup pattern.

--- a/apps/www/content/docs/nuxt/security.mdx
+++ b/apps/www/content/docs/nuxt/security.mdx
@@ -10,8 +10,11 @@ In Nuxt, environment variables are dynamic. Instead of statically inlining value
 
 1. **Integration with `runtimeConfig`.** ArkEnv registers client-side and shared variables in `runtimeConfig.public` (making them accessible everywhere) and server-only variables in the private `runtimeConfig` (ensuring they remain strictly on the server). During production builds, server-only keys are registered with empty defaults (`""`) so that sensitive build-time environment values are never serialized or baked into the Nitro server bundle output.
 2. **Runtime misuse guard.** In the flat layout, if a client component tries to access a server-only environment variable, the ArkEnv runtime proxy intercepts the access and throws a loud error before returning any values.
-   > [!WARNING]
-   > **SSR Runtime Guard Caveat**: The flat layout's runtime proxy only throws errors in the browser. During Server-Side Rendering (SSR), client-shared code executes on the server first. During this server execution, `createEnv` treats the context as the server and will return the server-only values. If you need compile-time protection against server variables being accessed in shared code during SSR, use the **Strict layout**.
+
+:::warning[SSR Runtime Guard Caveat]
+The flat layout's runtime proxy only throws errors in the browser. During Server-Side Rendering (SSR), client-shared code executes on the server first. During this server execution, `createEnv` treats the context as the server and will return the server-only values. If you need compile-time protection against server variables being accessed in shared code during SSR, use the **Strict layout**.
+:::
+
 3. **Compile-time boundary.** In the strict layout, a custom Vite compiler plugin automatically blocks any client-side imports of server environment files (like `~/env/server.ts` or `@arkenv/nuxt/server`), failing the build immediately before a bundle is produced.
 
 ---


### PR DESCRIPTION
## Summary
- Replace leftover GitHub-style `> [!TIP]` / `> [!WARNING]` callouts in www MDX with native Fumadocs `:::tip` / `:::warning` syntax
- Preserve titled callouts via `:::tip[…]` / `:::warning[…]`

Companion to #1441 (same cleanup on `v1`).

## Test plan
- [ ] Open `/docs/nextjs/configuration` and confirm the “Build-time validation without codegen” tip renders with its nested code sample
- [ ] Open `/docs/nuxt/security` and confirm the “SSR Runtime Guard Caveat” warning renders correctly between list items 2 and 3
- [ ] Confirm no remaining `> [!…]` callouts under `apps/www/**/*.mdx`


Made with [Cursor](https://cursor.com)