### PR TITLE
docs: park schema/define stance language (gates #1333)

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -17,11 +17,11 @@ The main goal is to provide a developer-friendly way to validate and type-check 
 
 **Env object**:
 The imported validated environment object (`import { env } from "./env"`). This is the **canonical surface** across Next, Nuxt, Vite, and Bun — client and server.
-_Avoid_: treating `import.meta.env` / `process.env` as the recommended ArkEnv API
+*Avoid*: treating `import.meta.env` / `process.env` as the recommended ArkEnv API
 
 **Schema/define path**:
 The Vite plugin call shape `arkenv(schema)` that validates at build time and inlines via Vite `define` into `import.meta.env.*`, with types from `ImportMetaEnvAugmented`. Still supported so existing apps keep working (#1328 acceptance). Lasting product stance is the open call on **#1333** (gates CLI #1332 and related SPA-mode work).
-_Avoid_: **SPA mode** as the product name in examples, changelogs, or new docs for this path until #1333 decides
+*Avoid*: **SPA mode** as the product name in examples, changelogs, or new docs for this path until #1333 decides
 
 ## Flagged ambiguities
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -13,6 +13,20 @@ ArkEnv is a typesafe environment variable parser powered by [ArkType](https://ar
 
 The main goal is to provide a developer-friendly way to validate and type-check environment variables using familiar TypeScript-like syntax, ensuring applications fail fast with clear error messages when environment variables are missing or invalid.
 
+## Language
+
+**Env object**:
+The imported validated environment object (`import { env } from "./env"`). This is the **canonical surface** across Next, Nuxt, Vite, and Bun — client and server.
+_Avoid_: treating `import.meta.env` / `process.env` as the recommended ArkEnv API
+
+**Schema/define path**:
+The Vite plugin call shape `arkenv(schema)` that validates at build time and inlines via Vite `define` into `import.meta.env.*`, with types from `ImportMetaEnvAugmented`. Still supported so existing apps keep working (#1328 acceptance). Lasting product stance is the open call on **#1333** (gates CLI #1332 and related SPA-mode work).
+_Avoid_: **SPA mode** as the product name in examples, changelogs, or new docs for this path until #1333 decides
+
+## Flagged ambiguities
+
+- **"SPA mode"** (ADR 0015 / #1105): previously named the schema/define path as a permanent documented mode. Continuity-alone justification is rejected. Lasting stance (documented escape hatch vs time-boxed deprecate/remove) is **deferred** to **#1333** pending hands-on play with the transform DX. Current lean: teach **env object** only in docs/CLI defaults; keep schema/define working but unbranded until the call. ADR 0015's "SPA mode forever" / soft-landing rationale may need an amendment after that decision.
+
 ## Tech stack
 
 ### Core technologies

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -25,7 +25,7 @@ The Vite plugin call shape `arkenv(schema)` that validates at build time and inl
 
 ## Flagged ambiguities
 
-- **"SPA mode"** (ADR 0015 / #1105): previously named the schema/define path as a permanent documented mode. Continuity-alone justification is rejected. Lasting stance (documented escape hatch vs time-boxed deprecate/remove) is **deferred** to **#1333** pending hands-on play with the transform DX. Current lean: teach **env object** only in docs/CLI defaults; keep schema/define working but unbranded until the call. ADR 0015's "SPA mode forever" / soft-landing rationale may need an amendment after that decision.
+- **"SPA mode"** (#1105 / canonical env-object ADR): previously named the schema/define path as a permanent documented mode. Continuity-alone justification is rejected. Lasting stance (documented escape hatch vs time-boxed deprecate/remove) is **deferred** to **#1333** pending hands-on play with the transform DX. Current lean: teach **env object** only in docs/CLI defaults; keep schema/define working but unbranded until the call. The env-object ADR's soft-landing / "SPA mode" framing may need an amendment after that decision. (On `dev` that ADR is `0015-env-object-canonical-surface`; on `v1` ADR **0015** is a different document — Next.js conditional exports.)
 
 ## Tech stack
 


### PR DESCRIPTION
## Summary
- Adds Language / Flagged ambiguities to `docs/CONTEXT.md` for the **env object** (canonical) vs **schema/define path** (stance open).
- Points the deferred product call at **#1333** (gates CLI #1332 / #1440); epic #1105 already updated on GitHub.

## Test plan
- [ ] Skim Language section for accuracy against #1105 / #1333
- [ ] No need to run package tests (docs-only)


Made with [Cursor](https://cursor.com)