### PR TITLE
feat: (v1) boot-time coercion into runtime payload + validator-free client env

### DIFF
--- a/.changeset/fix-nuxt-proxy-coercion.md
+++ b/.changeset/fix-nuxt-proxy-coercion.md
@@ -2,19 +2,20 @@
 "@arkenv/nuxt": patch
 ---
 
-#### Keep coerced number and boolean env values through the security proxy
+#### Prefer coerced env values over raw strings in the Nuxt security proxy
 
-Lock the Nuxt security proxy so schema-key reads return the coerced validation target. A key declared as `"number"` or `"boolean"` returns a number or boolean at runtime, not a raw string from Nuxt runtime config / `__NUXT__`.
+**Bug:** Validation already coerced schema keys (for example `PORT: "number"` → `3000`), but the security proxy re-read raw `process.env` / `runtimeConfig` / `__NUXT__` strings first. Those strings won, so `env` still returned the uncoerced type.
 
-```ts
-import { arkenv } from "@arkenv/nuxt";
+```diff
+  // env.ts
+  export const env = arkenv({
+    PORT: "number",
+    NUXT_PUBLIC_PORT: "number",
+  });
 
-export const env = arkenv({
-  NUXT_PUBLIC_PORT: "number",
-  PORT: "number",
-});
-
-// 3000 (number), not "3000" (string)
-env.NUXT_PUBLIC_PORT;
-env.PORT;
+  // process.env.PORT = "3000" (and the same shape in runtimeConfig / __NUXT__)
+- env.PORT; // "3000" (string) — proxy preferred the raw source
++ env.PORT; // 3000 (number) — proxy returns the coerced validation target
 ```
+
+Same import surface. Distinct from deploy-time `NUXT_PUBLIC_*` override coercion (Nitro string overrides at boot).

--- a/.changeset/nuxt-boot-gate-thin-accessors.md
+++ b/.changeset/nuxt-boot-gate-thin-accessors.md
@@ -2,19 +2,19 @@
 "@arkenv/nuxt": patch
 ---
 
-#### Keep coerced Nuxt public env types after deploy-time overrides
+#### Coerce Nuxt public env overrides instead of leaving them as strings
 
-Deploy-time `NUXT_PUBLIC_*` overrides used to leave public values as strings in the browser (for example `env.NUXT_PUBLIC_PORT === "4000"`). Those values now stay coerced on both server and client (`4000` as a `number`), and importing `@arkenv/nuxt` / `@arkenv/nuxt/client` no longer ships the validator into the client bundle.
+**Bug:** With a numeric (or boolean) public schema key, setting a deploy-time override made Nitro put a *string* into `runtimeConfig.public`. That string won, so `env` lied about the type on server and client.
 
-```ts
-// env.ts — same API as before
-import arkenv from "@arkenv/nuxt";
+```diff
+  // env.ts
+  export const env = arkenv({
+    NUXT_PUBLIC_PORT: "number",
+  });
 
-export const env = arkenv({
-  DATABASE_URL: "string",
-  NUXT_PUBLIC_PORT: "number",
-});
-
-// After NUXT_PUBLIC_PORT=4000 at Nitro boot:
-typeof env.NUXT_PUBLIC_PORT; // "number" on server and in the browser
+  // Deploy / Nitro boot: NUXT_PUBLIC_PORT=4000
+- env.NUXT_PUBLIC_PORT; // "4000" (string) — schema said number
++ env.NUXT_PUBLIC_PORT; // 4000 (number) — coerced after the override
 ```
+
+Same import surface. As a side effect, `@arkenv/nuxt` / `@arkenv/nuxt/client` no longer ship the validator into the browser bundle.

--- a/.changeset/nuxt-boot-gate-thin-accessors.md
+++ b/.changeset/nuxt-boot-gate-thin-accessors.md
@@ -2,21 +2,21 @@
 "@arkenv/nuxt": minor
 ---
 
-#### Coerce Nuxt env at Nitro boot and thin-read the payload
+#### Deliver coerced Nuxt public env on the client without shipping the validator
 
-Register a Nitro boot gate from `@arkenv/nuxt/module` that validates/coerces schema keys into `runtimeConfig` (including `public`) after `NUXT_*` / `NUXT_PUBLIC_*` string overrides. Server and client `arkenv()` entries become thin readers of that coerced payload — client package entries no longer import `@arkenv/core` / `arktype`.
-
-Usage is unchanged:
+Public/shared keys (for example `NUXT_PUBLIC_PORT: "number"`) now keep their coerced types on both server and client after deploy-time `NUXT_PUBLIC_*` overrides, and client bundles that import `@arkenv/nuxt` / `@arkenv/nuxt/client` no longer pull in `@arkenv/core` or `arktype`.
 
 ```ts
-// env.ts
+// env.ts — same import as before
 import arkenv from "@arkenv/nuxt";
 
 export const env = arkenv({
   DATABASE_URL: "string",
   NUXT_PUBLIC_PORT: "number",
-  NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });
+
+// After `NUXT_PUBLIC_PORT=4000` at Nitro boot:
+env.NUXT_PUBLIC_PORT; // 4000 (number) on server and in the browser
 ```
 
-After boot, `env.NUXT_PUBLIC_PORT` is a `number` on both server and client (including when overridden via `NUXT_PUBLIC_PORT` at Nitro start). Import `type` from `arktype` or `@arkenv/core` when you need ArkType helpers in schema files.
+Requires `@arkenv/nuxt/module` (or `@arkenv/nuxt/standard/module`) so the Nitro boot gate can validate and coerce before the payload is sent to the client. Import `type` from `arktype` or `@arkenv/core` when you need ArkType helpers in schema files.

--- a/.changeset/nuxt-boot-gate-thin-accessors.md
+++ b/.changeset/nuxt-boot-gate-thin-accessors.md
@@ -1,0 +1,22 @@
+---
+"@arkenv/nuxt": minor
+---
+
+#### Coerce Nuxt env at Nitro boot and thin-read the payload
+
+Register a Nitro boot gate from `@arkenv/nuxt/module` that validates/coerces schema keys into `runtimeConfig` (including `public`) after `NUXT_*` / `NUXT_PUBLIC_*` string overrides. Server and client `arkenv()` entries become thin readers of that coerced payload — client package entries no longer import `@arkenv/core` / `arktype`.
+
+Usage is unchanged:
+
+```ts
+// env.ts
+import arkenv from "@arkenv/nuxt";
+
+export const env = arkenv({
+  DATABASE_URL: "string",
+  NUXT_PUBLIC_PORT: "number",
+  NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+});
+```
+
+After boot, `env.NUXT_PUBLIC_PORT` is a `number` on both server and client (including when overridden via `NUXT_PUBLIC_PORT` at Nitro start). Import `type` from `arktype` or `@arkenv/core` when you need ArkType helpers in schema files.

--- a/.changeset/nuxt-boot-gate-thin-accessors.md
+++ b/.changeset/nuxt-boot-gate-thin-accessors.md
@@ -1,13 +1,13 @@
 ---
-"@arkenv/nuxt": minor
+"@arkenv/nuxt": patch
 ---
 
-#### Deliver coerced Nuxt public env on the client without shipping the validator
+#### Keep coerced Nuxt public env types after deploy-time overrides
 
-Public/shared keys (for example `NUXT_PUBLIC_PORT: "number"`) now keep their coerced types on both server and client after deploy-time `NUXT_PUBLIC_*` overrides, and client bundles that import `@arkenv/nuxt` / `@arkenv/nuxt/client` no longer pull in `@arkenv/core` or `arktype`.
+Deploy-time `NUXT_PUBLIC_*` overrides used to leave public values as strings in the browser (for example `env.NUXT_PUBLIC_PORT === "4000"`). Those values now stay coerced on both server and client (`4000` as a `number`), and importing `@arkenv/nuxt` / `@arkenv/nuxt/client` no longer ships the validator into the client bundle.
 
 ```ts
-// env.ts — same import as before
+// env.ts — same API as before
 import arkenv from "@arkenv/nuxt";
 
 export const env = arkenv({
@@ -15,8 +15,6 @@ export const env = arkenv({
   NUXT_PUBLIC_PORT: "number",
 });
 
-// After `NUXT_PUBLIC_PORT=4000` at Nitro boot:
-env.NUXT_PUBLIC_PORT; // 4000 (number) on server and in the browser
+// After NUXT_PUBLIC_PORT=4000 at Nitro boot:
+typeof env.NUXT_PUBLIC_PORT; // "number" on server and in the browser
 ```
-
-Requires `@arkenv/nuxt/module` (or `@arkenv/nuxt/standard/module`) so the Nitro boot gate can validate and coerce before the payload is sent to the client. Import `type` from `arktype` or `@arkenv/core` when you need ArkType helpers in schema files.

--- a/apps/playgrounds/nuxt-strict/app/app.vue
+++ b/apps/playgrounds/nuxt-strict/app/app.vue
@@ -20,6 +20,16 @@ const { data: health } = await useFetch("/api/health");
         <strong>API URL:</strong> <code>{{ clientEnv.NUXT_PUBLIC_API_URL }}</code>
       </p>
       <p>
+        <strong>Public port (coerced number):</strong>
+        <code>{{ clientEnv.NUXT_PUBLIC_PORT }}</code>
+        <span>(typeof {{ typeof clientEnv.NUXT_PUBLIC_PORT }})</span>
+      </p>
+      <p>
+        <strong>Feature flag (coerced boolean):</strong>
+        <code>{{ clientEnv.NUXT_PUBLIC_FEATURE_FLAG }}</code>
+        <span>(typeof {{ typeof clientEnv.NUXT_PUBLIC_FEATURE_FLAG }})</span>
+      </p>
+      <p>
         <strong>Node Env:</strong> <code>{{ clientEnv.NODE_ENV }}</code>
       </p>
     </div>

--- a/apps/playgrounds/nuxt-strict/env/client.ts
+++ b/apps/playgrounds/nuxt-strict/env/client.ts
@@ -2,4 +2,6 @@ import arkenv from "@arkenv/nuxt/client";
 
 export const env = arkenv({
 	NUXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
+	NUXT_PUBLIC_PORT: "number = 3000",
+	NUXT_PUBLIC_FEATURE_FLAG: "boolean = false",
 });

--- a/apps/playgrounds/nuxt/app/app.vue
+++ b/apps/playgrounds/nuxt/app/app.vue
@@ -36,6 +36,16 @@ const tryAccessSecret = () => {
         <strong>API URL:</strong> <code>{{ env.NUXT_PUBLIC_API_URL }}</code>
       </p>
       <p>
+        <strong>Public port (coerced number):</strong>
+        <code>{{ env.NUXT_PUBLIC_PORT }}</code>
+        <span>(typeof {{ typeof env.NUXT_PUBLIC_PORT }})</span>
+      </p>
+      <p>
+        <strong>Feature flag (coerced boolean):</strong>
+        <code>{{ env.NUXT_PUBLIC_FEATURE_FLAG }}</code>
+        <span>(typeof {{ typeof env.NUXT_PUBLIC_FEATURE_FLAG }})</span>
+      </p>
+      <p>
         <strong>Node Env:</strong> <code>{{ env.NODE_ENV }}</code>
       </p>
     </div>

--- a/apps/playgrounds/nuxt/env.ts
+++ b/apps/playgrounds/nuxt/env.ts
@@ -3,5 +3,7 @@ import arkenv from "@arkenv/nuxt";
 export const env = arkenv({
 	DATABASE_URL: "string = 'postgres://localhost:5432/mydb'",
 	NUXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
+	NUXT_PUBLIC_PORT: "number = 3000",
+	NUXT_PUBLIC_FEATURE_FLAG: "boolean = false",
 	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });

--- a/apps/www/content/docs/nuxt/index.mdx
+++ b/apps/www/content/docs/nuxt/index.mdx
@@ -4,7 +4,7 @@ icon: Album
 description: Validate and secure environment variables in Nuxt applications.
 ---
 
-The `@arkenv/nuxt` integration provides end-to-end environment validation for both the server and the browser. A Nitro boot gate coerces schema values into Nuxt's `runtimeConfig` after deploy-time `NUXT_*` / `NUXT_PUBLIC_*` overrides, and thin `env` accessors read that payload on both sides — without shipping the validator to the client. A Vite plugin still blocks server-only schema imports from the browser.
+The `@arkenv/nuxt` integration validates environment variables for both the server and the browser, keeps public values correctly typed after deploy-time overrides, and blocks server-only secrets from reaching the client.
 
 The fastest way to get started is with the [ArkEnv CLI](/docs/cli). It automatically configures `@arkenv/nuxt` for your existing Nuxt project:
 

--- a/apps/www/content/docs/nuxt/index.mdx
+++ b/apps/www/content/docs/nuxt/index.mdx
@@ -4,7 +4,7 @@ icon: Album
 description: Validate and secure environment variables in Nuxt applications.
 ---
 
-The `@arkenv/nuxt` integration provides end-to-end environment validation for both the server and the browser. It automatically injects your configuration into Nuxt's `runtimeConfig`, catching configuration bugs early and preventing sensitive server-side variables from ever reaching the client via a custom Vite plugin.
+The `@arkenv/nuxt` integration provides end-to-end environment validation for both the server and the browser. A Nitro boot gate coerces schema values into Nuxt's `runtimeConfig` after deploy-time `NUXT_*` / `NUXT_PUBLIC_*` overrides, and thin `env` accessors read that payload on both sides — without shipping the validator to the client. A Vite plugin still blocks server-only schema imports from the browser.
 
 The fastest way to get started is with the [ArkEnv CLI](/docs/cli). It automatically configures `@arkenv/nuxt` for your existing Nuxt project:
 

--- a/examples/with-nuxt-strict/app/app.vue
+++ b/examples/with-nuxt-strict/app/app.vue
@@ -20,6 +20,16 @@ const { data: health } = await useFetch("/api/health");
         <strong>API URL:</strong> <code>{{ clientEnv.NUXT_PUBLIC_API_URL }}</code>
       </p>
       <p>
+        <strong>Public port (coerced number):</strong>
+        <code>{{ clientEnv.NUXT_PUBLIC_PORT }}</code>
+        <span>(typeof {{ typeof clientEnv.NUXT_PUBLIC_PORT }})</span>
+      </p>
+      <p>
+        <strong>Feature flag (coerced boolean):</strong>
+        <code>{{ clientEnv.NUXT_PUBLIC_FEATURE_FLAG }}</code>
+        <span>(typeof {{ typeof clientEnv.NUXT_PUBLIC_FEATURE_FLAG }})</span>
+      </p>
+      <p>
         <strong>Node Env:</strong> <code>{{ clientEnv.NODE_ENV }}</code>
       </p>
     </div>

--- a/examples/with-nuxt-strict/env/client.ts
+++ b/examples/with-nuxt-strict/env/client.ts
@@ -2,4 +2,6 @@ import arkenv from "@arkenv/nuxt/client";
 
 export const env = arkenv({
 	NUXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
+	NUXT_PUBLIC_PORT: "number = 3000",
+	NUXT_PUBLIC_FEATURE_FLAG: "boolean = false",
 });

--- a/examples/with-nuxt/app/app.vue
+++ b/examples/with-nuxt/app/app.vue
@@ -36,6 +36,16 @@ const tryAccessSecret = () => {
         <strong>API URL:</strong> <code>{{ env.NUXT_PUBLIC_API_URL }}</code>
       </p>
       <p>
+        <strong>Public port (coerced number):</strong>
+        <code>{{ env.NUXT_PUBLIC_PORT }}</code>
+        <span>(typeof {{ typeof env.NUXT_PUBLIC_PORT }})</span>
+      </p>
+      <p>
+        <strong>Feature flag (coerced boolean):</strong>
+        <code>{{ env.NUXT_PUBLIC_FEATURE_FLAG }}</code>
+        <span>(typeof {{ typeof env.NUXT_PUBLIC_FEATURE_FLAG }})</span>
+      </p>
+      <p>
         <strong>Node Env:</strong> <code>{{ env.NODE_ENV }}</code>
       </p>
     </div>

--- a/examples/with-nuxt/env.ts
+++ b/examples/with-nuxt/env.ts
@@ -3,5 +3,7 @@ import arkenv from "@arkenv/nuxt";
 export const env = arkenv({
 	DATABASE_URL: "string = 'postgres://localhost:5432/mydb'",
 	NUXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
+	NUXT_PUBLIC_PORT: "number = 3000",
+	NUXT_PUBLIC_FEATURE_FLAG: "boolean = false",
 	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -1,6 +1,6 @@
 # @arkenv/nuxt
 
-ArkEnv integration for Nuxt. Provides a typesafe, minimal-dependency environment variable parser and validator for Nuxt applications. It injects your schema into Nuxt's `runtimeConfig`, coerces values at Nitro boot (including `NUXT_PUBLIC_*` overrides), exposes thin server/client `env` accessors without shipping the validator to the browser, and blocks server secrets from leaking to the client via a Vite plugin.
+ArkEnv integration for Nuxt. Provides a typesafe environment variable parser and validator for Nuxt applications. It keeps public values correctly typed after deploy-time overrides, integrates with Nuxt's `runtimeConfig`, and blocks server-only secrets from reaching the client.
 
 ## Installation
 

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -1,6 +1,6 @@
 # @arkenv/nuxt
 
-ArkEnv integration for Nuxt. Provides a typesafe, minimal-dependency environment variable parser and validator for Nuxt applications. It automatically injects your schema into Nuxt's `runtimeConfig` and prevents server secrets from leaking to the client via a custom Vite plugin.
+ArkEnv integration for Nuxt. Provides a typesafe, minimal-dependency environment variable parser and validator for Nuxt applications. It injects your schema into Nuxt's `runtimeConfig`, coerces values at Nitro boot (including `NUXT_PUBLIC_*` overrides), exposes thin server/client `env` accessors without shipping the validator to the browser, and blocks server secrets from leaking to the client via a Vite plugin.
 
 ## Installation
 

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -23,6 +23,7 @@
 		"@repo/utils": "workspace:*",
 		"@size-limit/preset-small-lib": "catalog:",
 		"arktype": "catalog:",
+		"nitropack": "^2.13.1",
 		"nuxt": "^4.4.8",
 		"rimraf": "catalog:",
 		"size-limit": "catalog:",
@@ -145,6 +146,11 @@
 			"types": "./dist/empty-shared-schema.d.ts",
 			"import": "./dist/empty-shared-schema.js",
 			"require": "./dist/empty-shared-schema.cjs"
+		},
+		"#arkenv/server-boot": {
+			"types": "./dist/empty-server-boot.d.ts",
+			"import": "./dist/empty-server-boot.js",
+			"require": "./dist/empty-server-boot.cjs"
 		}
 	}
 }

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -35,6 +35,7 @@
 		"@arkenv/core": "^1.0.0",
 		"@arkenv/standard": "^1.0.0",
 		"arktype": "^2.1.22",
+		"nitropack": "^2.0.0",
 		"nuxt": "^3.0.0 || ^4.0.0-0"
 	},
 	"peerDependenciesMeta": {
@@ -45,6 +46,9 @@
 			"optional": true
 		},
 		"arktype": {
+			"optional": true
+		},
+		"nitropack": {
 			"optional": true
 		}
 	},

--- a/packages/nuxt/src/arkenv-internal.ts
+++ b/packages/nuxt/src/arkenv-internal.ts
@@ -241,6 +241,20 @@ function readThinSourceEnv(isServer: boolean): Record<string, unknown> {
 		return gated;
 	}
 
+	if (
+		typeof process !== "undefined" &&
+		process.env.NODE_ENV !== "production" &&
+		!(globalThis as { __ARKENV_BOOT_GATE_FALLBACK_WARNED__?: boolean })
+			.__ARKENV_BOOT_GATE_FALLBACK_WARNED__
+	) {
+		(
+			globalThis as { __ARKENV_BOOT_GATE_FALLBACK_WARNED__?: boolean }
+		).__ARKENV_BOOT_GATE_FALLBACK_WARNED__ = true;
+		console.warn(
+			"[arkenv] Nuxt boot gate has not run; falling back to raw process.env. Register `@arkenv/nuxt/module` (or `@arkenv/nuxt/standard/module`) so values are validated and coerced at Nitro boot.",
+		);
+	}
+
 	return (typeof process !== "undefined" ? process.env : undefined) || {};
 }
 

--- a/packages/nuxt/src/arkenv-internal.ts
+++ b/packages/nuxt/src/arkenv-internal.ts
@@ -4,10 +4,16 @@ import { getBootGateResult } from "./boot-gate-state";
 import { createCaptureStub, isCapturing, recordCapture } from "./capture";
 import { isForceServer } from "./validate-context";
 
+/** Symbol key for the raw extended env values object on an env proxy. */
 export const EXTENDED_ENV = Symbol.for("arkenv.extended_env");
+/** Symbol key for the set of declared schema keys on an env proxy. */
 export const ENV_KEYS = Symbol.for("arkenv.keys");
+/** Symbol key for server-only keys that must not be readable on the client. */
 export const SERVER_ONLY_KEYS = Symbol.for("arkenv.server_only_keys");
 
+/**
+ * Legacy nested schema shape (`server` / `client` / `shared` buckets).
+ */
 export type LegacyNestedSchema = {
 	server?: SchemaShape;
 	client?: SchemaShape;
@@ -16,6 +22,9 @@ export type LegacyNestedSchema = {
 	runtimeEnv?: Dict<string>;
 };
 
+/**
+ * Options for the flat (unified) schema form of {@link arkenvInternal}.
+ */
 export type FlatSchemaOptions = {
 	extends?: readonly unknown[];
 	runtimeEnv?: Dict<string>;
@@ -26,6 +35,9 @@ export type FlatSchemaOptions = {
 	exposeToClient?: readonly string[];
 };
 
+/**
+ * Optional server hooks for the thin Nuxt accessor path.
+ */
 export type ArkenvInternalHooks = {
 	/**
 	 * Run the Nuxt boot gate before reading values (server thin path only).

--- a/packages/nuxt/src/arkenv-internal.ts
+++ b/packages/nuxt/src/arkenv-internal.ts
@@ -1,4 +1,7 @@
 import type { Dict, SchemaShape } from "@repo/types";
+import { getSchemaKeys } from "@repo/utils";
+import { getBootGateResult } from "./boot-gate-state";
+import { createCaptureStub, isCapturing, recordCapture } from "./capture";
 import { isForceServer } from "./validate-context";
 
 export const EXTENDED_ENV = Symbol.for("arkenv.extended_env");
@@ -23,16 +26,27 @@ export type FlatSchemaOptions = {
 	exposeToClient?: readonly string[];
 };
 
+export type ArkenvInternalHooks = {
+	/**
+	 * Run the Nuxt boot gate before reading values (server thin path only).
+	 */
+	ensureBootGate?: () => void;
+};
+
 /**
- * Validate and wrap environment variables in a security proxy.
+ * Partition a schema into server/client/shared buckets and wrap coerced values
+ * in a security proxy — without running core validation.
+ *
+ * On Nuxt, `createEnv` / core validation runs in the Nitro boot gate. This
+ * function is the symmetric thin accessor: server and client both read the
+ * already-coerced `runtimeConfig` / `__NUXT__` payload.
  *
  * @param schemaOrOptions The schema definition or the unified options object
  * @param optionsOrIsServer The options object or a boolean indicating if running on the server
  * @param context The optional execution context containing server and entrypoint flags
- * @param coreArkenv The arkenv function to use for validation
- * @param getSchemaKeys The getSchemaKeys function to extract schema keys
- * @returns The wrapped and validated environment proxy object
- * @throws An error if a required key is missing or invalid
+ * @param hooks Optional server hooks (boot gate)
+ * @returns The wrapped environment proxy object
+ * @throws An error if a required key is missing from the payload or a server key is read on the client
  * @internal
  */
 export function arkenvInternal(
@@ -45,11 +59,18 @@ export function arkenvInternal(
 				strictLayout?: "client" | "server";
 		  }
 		| undefined,
-	/** The core arkenv validation function (either `@arkenv/core` or `@arkenv/standard`). */
-	coreArkenv: (schema: any, config?: any) => Record<string, unknown>,
-	/** Extracts the declared key names from a schema object. */
-	getSchemaKeys: (schema: SchemaShape) => string[],
+	hooks?: ArkenvInternalHooks,
 ): unknown {
+	if (isCapturing()) {
+		recordCapture(schemaOrOptions, optionsOrIsServer, context);
+		const keys = collectDeclaredKeys(
+			schemaOrOptions,
+			optionsOrIsServer,
+			context,
+		);
+		return createCaptureStub(keys);
+	}
+
 	let server: SchemaShape = {};
 	let client: Record<string, unknown> = {};
 	let shared: SchemaShape = {};
@@ -57,13 +78,7 @@ export function arkenvInternal(
 	let runtimeEnv: Dict<string> = {};
 	let isServer = false;
 
-	const globalConfig =
-		typeof window !== "undefined"
-			? (window as any).__NUXT__?.config?.public
-			: undefined;
-
 	if (typeof optionsOrIsServer === "boolean") {
-		// Old nested schema behavior (backward compatible)
 		const legacySchema = schemaOrOptions as
 			| LegacyNestedSchema
 			| null
@@ -75,9 +90,8 @@ export function arkenvInternal(
 		runtimeEnv = (legacySchema?.runtimeEnv || {}) as Dict<string>;
 		isServer = optionsOrIsServer;
 	} else {
-		// New flat schema behavior
 		const flatSchema = (schemaOrOptions || {}) as SchemaShape;
-		const options = (optionsOrIsServer || {}) as FlatSchemaOptions;
+		const options = optionsOrIsServer || {};
 		extendsList = options.extends || [];
 		runtimeEnv = (options.runtimeEnv || {}) as Dict<string>;
 		isServer = isForceServer() || !!context?.isServer;
@@ -92,7 +106,6 @@ export function arkenvInternal(
 			const exposedKeys =
 				options.exposeToClient || options.expose || options.shared || [];
 			for (const key of Object.keys(flatSchema)) {
-				// NODE_ENV is implicitly shared
 				if (exposedKeys.includes(key) || key === "NODE_ENV") {
 					shared[key] = flatSchema[key];
 				} else if (key.startsWith("NUXT_PUBLIC_")) {
@@ -104,17 +117,16 @@ export function arkenvInternal(
 		}
 	}
 
-	const sourceEnv: Record<string, unknown> = isServer
-		? (typeof process !== "undefined" ? process.env : undefined) || {}
-		: globalConfig ||
-			(typeof process !== "undefined" ? process.env : undefined) ||
-			{};
+	if (isServer) {
+		hooks?.ensureBootGate?.();
+	}
+
+	const sourceEnv = readThinSourceEnv(isServer);
 
 	let extendedEnvValues: Record<string, unknown> = {};
 	const allKeys = new Set<string>();
 	const serverOnlyKeys = new Set<string>();
 
-	// Add local keys
 	for (const key of Object.keys(server)) {
 		allKeys.add(key);
 		if (!(key in client) && !(key in shared)) {
@@ -128,10 +140,6 @@ export function arkenvInternal(
 		allKeys.add(key);
 	}
 
-	// Prepare combined environment for core validation
-	const combinedEnv: Record<string, unknown> = {};
-
-	// Process extended environments
 	if (extendsList && Array.isArray(extendsList)) {
 		for (const ext of extendsList) {
 			if (ext && (typeof ext === "object" || typeof ext === "function")) {
@@ -153,39 +161,15 @@ export function arkenvInternal(
 					if (extServerOnly instanceof Set) {
 						for (const key of extServerOnly) serverOnlyKeys.add(key);
 					}
-				} else {
-					// Prepare what we have so far for validating the extended schema
-					for (const key of Object.keys(extendedEnvValues)) {
-						if (extendedEnvValues[key] !== undefined) {
-							combinedEnv[key] = extendedEnvValues[key];
-						}
-					}
-					for (const key of Object.keys(sourceEnv)) {
-						if (sourceEnv[key] !== undefined) {
-							combinedEnv[key] = sourceEnv[key];
-						}
-					}
-					if (isServer) {
-						for (const key of Object.keys(server)) {
-							if (
-								combinedEnv[key] === undefined &&
-								process.env[key] !== undefined
-							) {
-								combinedEnv[key] = process.env[key];
-							}
-						}
-					}
-
-					const validated = coreArkenv(ext as SchemaShape, {
-						env: combinedEnv as Dict<string>,
-						safe: false,
-					});
-					extendedEnvValues = { ...extendedEnvValues, ...validated };
-
-					const extKeys = getSchemaKeys(ext);
+				} else if (
+					typeof ext === "object" &&
+					ext !== null &&
+					!Array.isArray(ext)
+				) {
+					// Raw schema in extends (e.g. SharedSchema) — keys only; values from source
+					const extKeys = getSchemaKeys(ext as SchemaShape);
 					for (const key of extKeys) {
 						allKeys.add(key);
-						// Only classify as server-only when running on the server and the key is not public.
 						if (
 							isServer &&
 							!key.startsWith("NUXT_PUBLIC_") &&
@@ -199,7 +183,6 @@ export function arkenvInternal(
 		}
 	}
 
-	// Remove keys from serverOnlyKeys if they are defined as client or shared locally
 	for (const key of Object.keys(client)) {
 		serverOnlyKeys.delete(key);
 	}
@@ -207,8 +190,6 @@ export function arkenvInternal(
 		serverOnlyKeys.delete(key);
 	}
 
-	// Validate options
-	// For client keys, check prefix
 	for (const key of Object.keys(client)) {
 		if (!key.startsWith("NUXT_PUBLIC_")) {
 			throw new Error(
@@ -217,73 +198,108 @@ export function arkenvInternal(
 		}
 	}
 
-	// Build final combinedEnv
-	for (const key of Object.keys(extendedEnvValues)) {
-		if (extendedEnvValues[key] !== undefined) {
-			combinedEnv[key] = extendedEnvValues[key];
-		}
-	}
+	const values: Record<string, unknown> = {};
 
-	for (const key of Object.keys(sourceEnv)) {
-		if (sourceEnv[key] !== undefined) {
-			combinedEnv[key] = sourceEnv[key];
-		}
-	}
-
-	for (const key of Object.keys(runtimeEnv)) {
+	for (const key of allKeys) {
 		if (runtimeEnv[key] !== undefined) {
-			combinedEnv[key] = runtimeEnv[key];
+			values[key] = runtimeEnv[key];
+		} else if (extendedEnvValues[key] !== undefined) {
+			values[key] = extendedEnvValues[key];
+		} else if (sourceEnv[key] !== undefined) {
+			values[key] = sourceEnv[key];
 		}
 	}
 
-	if (isServer) {
-		// Fallback server keys to process.env if omitted or undefined
-		for (const key of Object.keys(server)) {
-			if (combinedEnv[key] === undefined && process.env[key] !== undefined) {
-				combinedEnv[key] = process.env[key];
-			}
-		}
-	}
-
-	// Select schema based on environment
-	const schema = isServer
-		? { ...server, ...client, ...shared }
-		: { ...client, ...shared };
-
-	// Run core validation
-	const validated = coreArkenv(schema as SchemaShape, {
-		env: combinedEnv as Dict<string>,
-		safe: false,
-	});
-
-	const mergedValidated = { ...extendedEnvValues, ...validated } as Record<
-		string,
-		unknown
-	>;
-
-	// Return a Proxy wrapper with strict access rules to prevent server variable leakage on the client.
-	// Always serve the coerced validation target — never re-read raw runtimeConfig / process.env /
-	// __NUXT__ strings, which would silently undo ADR 0002 coercion.
-	return createSecurityProxy(
-		mergedValidated,
-		allKeys,
-		serverOnlyKeys,
-		isServer,
-	);
+	return createSecurityProxy(values, allKeys, serverOnlyKeys, isServer);
 }
 
 /**
- * Wrap the validated environment object in a Proxy to enforce client/server security access rules.
+ * Read the thin env source: boot-gate result / process.env on server, `__NUXT__` on client.
  *
- * Schema-key reads always return the coerced validation target. Raw `useRuntimeConfig()` /
- * `process.env` / `__NUXT__.config.public` strings are intentionally not preferred on get —
- * those sources feed validation at create time, but serving them again would bypass coercion.
+ * @param isServer Whether this accessor is on the server
+ * @returns Flat key→value map of already-coerced (or raw test) values
+ */
+function readThinSourceEnv(isServer: boolean): Record<string, unknown> {
+	if (!isServer) {
+		const globalConfig =
+			typeof window !== "undefined"
+				? (
+						window as {
+							__NUXT__?: { config?: { public?: Record<string, unknown> } };
+						}
+					).__NUXT__?.config?.public
+				: undefined;
+		return (
+			globalConfig ||
+			(typeof process !== "undefined" ? process.env : undefined) ||
+			{}
+		);
+	}
+
+	const gated = getBootGateResult();
+	if (gated) {
+		return gated;
+	}
+
+	return (typeof process !== "undefined" ? process.env : undefined) || {};
+}
+
+/**
+ * Collect declared schema key names for capture stubs.
  *
- * @param target The validated and coerced environment object
- * @param allKeys The set of all keys defined in the schema (including extended schemas)
- * @param serverOnlyKeys The set of keys that must not be accessed on the client
- * @param isServer Whether the proxy is running in a server context
- * @returns A Proxy that enforces access rules while preserving coerced value types
+ * @param schemaOrOptions Schema or nested options
+ * @param optionsOrIsServer Flat options or legacy boolean
+ * @param context Optional layout context
+ * @returns Declared key names
+ */
+function collectDeclaredKeys(
+	schemaOrOptions: SchemaShape | LegacyNestedSchema | null | undefined,
+	optionsOrIsServer: FlatSchemaOptions | boolean | null | undefined,
+	_context:
+		| {
+				isServer: boolean;
+				isShared?: boolean;
+				strictLayout?: "client" | "server";
+		  }
+		| undefined,
+): string[] {
+	if (typeof optionsOrIsServer === "boolean") {
+		const legacy = schemaOrOptions as LegacyNestedSchema;
+		return [
+			...Object.keys(legacy?.server || {}),
+			...Object.keys(legacy?.client || {}),
+			...Object.keys(legacy?.shared || {}),
+		];
+	}
+
+	const isLegacy =
+		schemaOrOptions &&
+		typeof schemaOrOptions === "object" &&
+		("runtimeEnv" in schemaOrOptions ||
+			"server" in schemaOrOptions ||
+			"client" in schemaOrOptions ||
+			"shared" in schemaOrOptions);
+
+	if (isLegacy) {
+		const legacy = schemaOrOptions as LegacyNestedSchema;
+		return [
+			...Object.keys(legacy.server || {}),
+			...Object.keys(legacy.client || {}),
+			...Object.keys(legacy.shared || {}),
+		];
+	}
+
+	return Object.keys((schemaOrOptions || {}) as SchemaShape);
+}
+
+/**
+ * Wrap the env object in a Proxy to enforce client/server security access rules.
+ *
+ * @param target Coerced env values
+ * @param allKeys All schema keys
+ * @param serverOnlyKeys Keys that must not be readable on the client
+ * @param isServer Whether this proxy is on the server
+ * @returns The security proxy
  */
 function createSecurityProxy(
 	target: Record<string, unknown>,
@@ -303,7 +319,6 @@ function createSecurityProxy(
 				return serverOnlyKeys;
 			}
 
-			// Always allow symbol properties (Symbol.iterator, Symbol.toStringTag, etc.)
 			if (typeof prop === "symbol") {
 				return Reflect.get(target, prop, receiver);
 			}
@@ -315,9 +330,7 @@ function createSecurityProxy(
 					);
 				}
 
-				// Allow schema keys and standard Object prototype properties
 				if (!allKeys.has(prop) && !(prop in Object.prototype)) {
-					// Fallback for bundler/framework-specific properties that bypass the prototype
 					const isCommonKey =
 						prop === "__esModule" ||
 						prop === "$$typeof" ||
@@ -334,8 +347,6 @@ function createSecurityProxy(
 			}
 			return Reflect.get(target, prop, receiver);
 		},
-		// Intercept Object.keys(), Object.getOwnPropertyNames(), Reflect.ownKeys()
-		// to prevent enumerating server-only keys on the client
 		ownKeys(target) {
 			const keys = Reflect.ownKeys(target);
 			if (!isServer) {
@@ -345,14 +356,12 @@ function createSecurityProxy(
 			}
 			return keys;
 		},
-		// Intercept Object.getOwnPropertyDescriptor() to hide server-only properties on the client
 		getOwnPropertyDescriptor(target, prop) {
 			if (!isServer && typeof prop === "string" && serverOnlyKeys.has(prop)) {
 				return undefined;
 			}
 			return Reflect.getOwnPropertyDescriptor(target, prop);
 		},
-		// Intercept "key in obj" existence checks to hide server-only keys on the client
 		has(target, prop) {
 			if (!isServer && typeof prop === "string" && serverOnlyKeys.has(prop)) {
 				return false;

--- a/packages/nuxt/src/arkenv-server-boot.d.ts
+++ b/packages/nuxt/src/arkenv-server-boot.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Ambient fallback for the `#arkenv/server-boot` virtual module.
+ *
+ * `@arkenv/nuxt/module` aliases this to the real boot-gate ensure on server/Nitro
+ * graphs and to a no-op stub on the client, so client bundles never import core.
+ */
+declare module "#arkenv/server-boot" {
+	/**
+	 * Ensure the Nitro boot gate has run (no-op on the client stub).
+	 */
+	export function ensureBootGate(): void;
+}

--- a/packages/nuxt/src/auto-extend.ts
+++ b/packages/nuxt/src/auto-extend.ts
@@ -1,0 +1,34 @@
+import type { FlatSchemaOptions } from "./arkenv-internal";
+import { isStrictLayoutActive } from "./strict-client-env";
+
+/**
+ * Apply strict-layout auto-extend when `extends` is omitted.
+ *
+ * Pass the extend target via `resolveExtendTarget` so client entries never
+ * import the server-only `#arkenv/client-env` graph (and vice versa).
+ *
+ * @param optionsOrIsServer Flat options, legacy boolean, or undefined
+ * @param resolveExtendTarget Lazy resolver for the default extend target
+ * @returns Options with auto-extend applied when appropriate
+ */
+export function withAutoExtend(
+	optionsOrIsServer: FlatSchemaOptions | boolean | null | undefined,
+	resolveExtendTarget: () => unknown,
+): FlatSchemaOptions | boolean | null | undefined {
+	if (typeof optionsOrIsServer === "boolean") {
+		return optionsOrIsServer;
+	}
+
+	if (optionsOrIsServer != null && "extends" in optionsOrIsServer) {
+		return optionsOrIsServer;
+	}
+
+	if (!isStrictLayoutActive()) {
+		return optionsOrIsServer;
+	}
+
+	return {
+		...(optionsOrIsServer ?? {}),
+		extends: [resolveExtendTarget()],
+	};
+}

--- a/packages/nuxt/src/boot-gate-state.ts
+++ b/packages/nuxt/src/boot-gate-state.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared boot-gate result state.
+ *
+ * Kept free of `@arkenv/core` / `@arkenv/standard` imports so client entries can
+ * read coerced values without pulling the validator into the browser bundle.
+ */
+
+let gateResult: Record<string, unknown> | null = null;
+let gateDone = false;
+
+/**
+ * Store the flattened coerced values from a successful boot-gate run.
+ *
+ * @param values Coerced env values
+ */
+export function setBootGateResult(values: Record<string, unknown>): void {
+	gateResult = values;
+	gateDone = true;
+}
+
+/**
+ * Return coerced values produced by the last successful boot gate run.
+ *
+ * @returns Flattened coerced env values, or `null` if the gate has not run
+ */
+export function getBootGateResult(): Record<string, unknown> | null {
+	return gateResult;
+}
+
+/**
+ * Report whether the boot gate has completed.
+ *
+ * @returns `true` when the gate has already run successfully
+ */
+export function isBootGateDone(): boolean {
+	return gateDone;
+}
+
+/**
+ * Reset boot-gate result state (tests only).
+ */
+export function resetBootGateResultForTests(): void {
+	gateResult = null;
+	gateDone = false;
+}

--- a/packages/nuxt/src/boot-gate.test.ts
+++ b/packages/nuxt/src/boot-gate.test.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetBootGateForTests, runBootGate } from "./boot-gate";
+import {
+	getBootGateResult,
+	resetBootGateResultForTests,
+} from "./boot-gate-state";
+
+afterEach(() => {
+	resetBootGateForTests();
+	resetBootGateResultForTests();
+});
+
+describe("Nuxt boot gate", () => {
+	it("coerces NUXT_PUBLIC_* string overrides into runtimeConfig.public", () => {
+		const tempDir = path.resolve(__dirname, "temp-boot-gate-coerce");
+		fs.mkdirSync(tempDir, { recursive: true });
+		const schemaPath = path.join(tempDir, "env.ts");
+
+		fs.writeFileSync(
+			schemaPath,
+			`
+			import arkenv from "@arkenv/nuxt";
+			export const env = arkenv({
+				DATABASE_URL: "string",
+				NUXT_PUBLIC_PORT: "number",
+				NUXT_PUBLIC_ENABLED: "boolean",
+				NODE_ENV: "'development' | 'production' | 'test' = 'test'",
+			});
+			`,
+		);
+
+		const runtimeConfig: {
+			public: Record<string, unknown>;
+			DATABASE_URL?: unknown;
+			[key: string]: unknown;
+		} = {
+			public: {
+				NUXT_PUBLIC_PORT: "4000",
+				NUXT_PUBLIC_ENABLED: "false",
+				NODE_ENV: "test",
+			},
+			DATABASE_URL: "postgres://localhost/db",
+		};
+
+		try {
+			runBootGate(
+				{
+					schemaPath,
+					layout: "simple",
+					baseDir: "",
+					engine: "arktype",
+				},
+				runtimeConfig,
+			);
+
+			expect(runtimeConfig.public.NUXT_PUBLIC_PORT).toBe(4000);
+			expect(typeof runtimeConfig.public.NUXT_PUBLIC_PORT).toBe("number");
+			expect(runtimeConfig.public.NUXT_PUBLIC_ENABLED).toBe(false);
+			expect(runtimeConfig.DATABASE_URL).toBe("postgres://localhost/db");
+
+			const gated = getBootGateResult();
+			expect(gated?.NUXT_PUBLIC_PORT).toBe(4000);
+			expect(gated?.NUXT_PUBLIC_ENABLED).toBe(false);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("fails fast on invalid NUXT_PUBLIC_* boot overrides", () => {
+		const tempDir = path.resolve(__dirname, "temp-boot-gate-invalid");
+		fs.mkdirSync(tempDir, { recursive: true });
+		const schemaPath = path.join(tempDir, "env.ts");
+
+		fs.writeFileSync(
+			schemaPath,
+			`
+			import arkenv from "@arkenv/nuxt";
+			export const env = arkenv({
+				NUXT_PUBLIC_PORT: "number",
+			});
+			`,
+		);
+
+		const runtimeConfig = {
+			public: {
+				NUXT_PUBLIC_PORT: "not-a-number",
+			},
+		};
+
+		try {
+			expect(() =>
+				runBootGate(
+					{
+						schemaPath,
+						layout: "simple",
+						baseDir: "",
+						engine: "arktype",
+					},
+					runtimeConfig,
+				),
+			).toThrow();
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/nuxt/src/boot-gate.test.ts
+++ b/packages/nuxt/src/boot-gate.test.ts
@@ -105,4 +105,99 @@ describe("Nuxt boot gate", () => {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	it("keeps deliberate empty-string runtimeConfig overrides over process.env", () => {
+		const tempDir = path.resolve(__dirname, "temp-boot-gate-empty");
+		fs.mkdirSync(tempDir, { recursive: true });
+		const schemaPath = path.join(tempDir, "env.ts");
+
+		fs.writeFileSync(
+			schemaPath,
+			`
+			import arkenv from "@arkenv/nuxt";
+			export const env = arkenv({
+				NUXT_PUBLIC_LABEL: "string",
+			});
+			`,
+		);
+
+		process.env.NUXT_PUBLIC_LABEL = "from-process-env";
+		const runtimeConfig = {
+			public: {
+				NUXT_PUBLIC_LABEL: "",
+			},
+		};
+
+		try {
+			runBootGate(
+				{
+					schemaPath,
+					layout: "simple",
+					baseDir: "",
+					engine: "arktype",
+				},
+				runtimeConfig,
+			);
+
+			expect(runtimeConfig.public.NUXT_PUBLIC_LABEL).toBe("");
+			expect(getBootGateResult()?.NUXT_PUBLIC_LABEL).toBe("");
+		} finally {
+			delete process.env.NUXT_PUBLIC_LABEL;
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("coerces overrides with the standard engine", () => {
+		const tempDir = path.resolve(__dirname, "temp-boot-gate-standard");
+		fs.mkdirSync(tempDir, { recursive: true });
+		const schemaPath = path.join(tempDir, "env.ts");
+
+		fs.writeFileSync(
+			schemaPath,
+			`
+			import arkenv from "@arkenv/nuxt/standard";
+
+			const numberSchema = {
+				"~standard": {
+					version: 1,
+					vendor: "mock",
+					validate: (value) => {
+						const n = Number(value);
+						if (value === undefined || value === "" || Number.isNaN(n)) {
+							return { issues: [{ message: "expected number" }] };
+						}
+						return { value: n };
+					},
+				},
+			};
+
+			export const env = arkenv({
+				NUXT_PUBLIC_PORT: numberSchema,
+			});
+			`,
+		);
+
+		const runtimeConfig = {
+			public: {
+				NUXT_PUBLIC_PORT: "8080",
+			},
+		};
+
+		try {
+			runBootGate(
+				{
+					schemaPath,
+					layout: "simple",
+					baseDir: "",
+					engine: "standard",
+				},
+				runtimeConfig,
+			);
+
+			expect(runtimeConfig.public.NUXT_PUBLIC_PORT).toBe(8080);
+			expect(typeof runtimeConfig.public.NUXT_PUBLIC_PORT).toBe("number");
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/nuxt/src/boot-gate.ts
+++ b/packages/nuxt/src/boot-gate.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Dict, SchemaShape } from "@repo/types";
@@ -16,9 +15,9 @@ import {
 	endCapture,
 	publicKeysFromCaptures,
 } from "./capture";
+import { resolveCoreArkenv } from "./resolve-core-arkenv";
 import { withForceServer } from "./validate-context";
 
-const require = createRequire(import.meta.url);
 export type BootGateEngine = "arktype" | "standard";
 
 export type BootGateConfig = {
@@ -65,27 +64,6 @@ export function getBootGateConfig(): BootGateConfig | null {
 export function resetBootGateForTests(): void {
 	gateConfig = null;
 	resetBootGateResultForTests();
-}
-
-type CoreArkenv = (
-	schema: SchemaShape,
-	config?: { env?: Dict<string>; safe?: boolean },
-) => Record<string, unknown>;
-
-/**
- * Resolve the core validation function for the configured engine.
- *
- * @param engine ArkType (`@arkenv/core`) or Standard Schema (`@arkenv/standard`)
- * @returns The engine's `arkenv` function
- */
-function resolveCoreArkenv(engine: BootGateEngine): CoreArkenv {
-	if (engine === "standard") {
-		// Lazy require keeps `@arkenv/standard` out of ArkType-only graphs.
-		// eslint-disable-next-line @typescript-eslint/no-require-imports
-		return require("@arkenv/standard").arkenv as CoreArkenv;
-	}
-	// eslint-disable-next-line @typescript-eslint/no-require-imports
-	return require("@arkenv/core").arkenv as CoreArkenv;
 }
 
 /**

--- a/packages/nuxt/src/boot-gate.ts
+++ b/packages/nuxt/src/boot-gate.ts
@@ -1,0 +1,489 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Dict, SchemaShape } from "@repo/types";
+import { createJiti } from "jiti";
+import {
+	getBootGateResult,
+	isBootGateDone,
+	resetBootGateResultForTests,
+	setBootGateResult,
+} from "./boot-gate-state";
+import {
+	beginCapture,
+	combineCapturedSchemas,
+	endCapture,
+	publicKeysFromCaptures,
+} from "./capture";
+import { withForceServer } from "./validate-context";
+
+const require = createRequire(import.meta.url);
+export type BootGateEngine = "arktype" | "standard";
+
+export type BootGateConfig = {
+	schemaPath: string;
+	layout: "simple" | "strict";
+	baseDir: string;
+	engine: BootGateEngine;
+};
+
+export type BootGateRuntimeConfig = {
+	public?: Record<string, unknown>;
+	arkenvGate?: BootGateConfig;
+	[key: string]: unknown;
+};
+
+let gateConfig: BootGateConfig | null = null;
+
+export {
+	getBootGateResult,
+	isBootGateDone,
+} from "./boot-gate-state";
+
+/**
+ * Store boot-gate configuration for {@link ensureBootGate}.
+ *
+ * @param config Schema path, layout, and validation engine
+ */
+export function configureBootGate(config: BootGateConfig): void {
+	gateConfig = config;
+}
+
+/**
+ * Return the current boot-gate configuration, if any.
+ *
+ * @returns The configured gate options, or `null`
+ */
+export function getBootGateConfig(): BootGateConfig | null {
+	return gateConfig;
+}
+
+/**
+ * Reset boot-gate state (tests only).
+ */
+export function resetBootGateForTests(): void {
+	gateConfig = null;
+	resetBootGateResultForTests();
+}
+
+type CoreArkenv = (
+	schema: SchemaShape,
+	config?: { env?: Dict<string>; safe?: boolean },
+) => Record<string, unknown>;
+
+/**
+ * Resolve the core validation function for the configured engine.
+ *
+ * @param engine ArkType (`@arkenv/core`) or Standard Schema (`@arkenv/standard`)
+ * @returns The engine's `arkenv` function
+ */
+function resolveCoreArkenv(engine: BootGateEngine): CoreArkenv {
+	if (engine === "standard") {
+		// Lazy require keeps `@arkenv/standard` out of ArkType-only graphs.
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		return require("@arkenv/standard").arkenv as CoreArkenv;
+	}
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	return require("@arkenv/core").arkenv as CoreArkenv;
+}
+
+/**
+ * Build Jiti aliases that point package entry points at this package's source/dist.
+ *
+ * @param packageDir Absolute directory containing this package's entry files
+ * @param resolvedLayout Detected layout mode
+ * @param baseDir Strict-layout env directory, or empty for flat
+ * @param internalOptions Optional alias overrides for tests
+ * @returns Alias map for Jiti
+ */
+export function buildSchemaJitiAliases(
+	packageDir: string,
+	resolvedLayout: "simple" | "strict",
+	baseDir: string,
+	internalOptions?: { _jitiAliases?: Record<string, string> },
+): Record<string, string> {
+	const packageJsonPath = path.resolve(packageDir, "../package.json");
+	let pkgExports: Record<string, unknown> = {};
+	try {
+		const pkgContent = fs.readFileSync(packageJsonPath, "utf-8");
+		pkgExports = JSON.parse(pkgContent).exports || {};
+	} catch {
+		// fallback if package.json isn't adjacent/found
+	}
+
+	const resolveExportPath = (subpath: string, fallbackFile: string): string => {
+		const entry = pkgExports[subpath] as
+			| { import?: string; default?: string }
+			| string
+			| undefined;
+		if (entry) {
+			const target =
+				typeof entry === "string"
+					? entry
+					: entry.import || entry.default || entry;
+			if (typeof target === "string") {
+				const fileBasename = path.basename(target).replace(/\.m?[jt]s$/, "");
+				const tsPath = path.join(packageDir, `${fileBasename}.ts`);
+				if (fs.existsSync(tsPath)) {
+					return tsPath;
+				}
+				const jsPath = path.join(packageDir, `${fileBasename}.js`);
+				if (fs.existsSync(jsPath)) {
+					return jsPath;
+				}
+			}
+		}
+		return fallbackFile;
+	};
+
+	const sharedPath = resolveExportPath(
+		"./shared",
+		fs.existsSync(path.join(packageDir, "shared.ts"))
+			? path.join(packageDir, "shared.ts")
+			: path.join(packageDir, "shared.js"),
+	);
+	const indexPath = resolveExportPath(
+		".",
+		fs.existsSync(path.join(packageDir, "index.ts"))
+			? path.join(packageDir, "index.ts")
+			: path.join(packageDir, "index.js"),
+	);
+	const clientPath = resolveExportPath(
+		"./client",
+		fs.existsSync(path.join(packageDir, "client.ts"))
+			? path.join(packageDir, "client.ts")
+			: path.join(packageDir, "client.js"),
+	);
+	const serverPath = resolveExportPath(
+		"./server",
+		fs.existsSync(path.join(packageDir, "server.ts"))
+			? path.join(packageDir, "server.ts")
+			: path.join(packageDir, "server.js"),
+	);
+	const standardIndexPath = resolveExportPath(
+		"./standard",
+		fs.existsSync(path.join(packageDir, "standard/index.ts"))
+			? path.join(packageDir, "standard/index.ts")
+			: path.join(packageDir, "standard/index.js"),
+	);
+	const standardClientPath = resolveExportPath(
+		"./standard/client",
+		fs.existsSync(path.join(packageDir, "standard/client.ts"))
+			? path.join(packageDir, "standard/client.ts")
+			: path.join(packageDir, "standard/client.js"),
+	);
+	const standardServerPath = resolveExportPath(
+		"./standard/server",
+		fs.existsSync(path.join(packageDir, "standard/server.ts"))
+			? path.join(packageDir, "standard/server.ts")
+			: path.join(packageDir, "standard/server.js"),
+	);
+
+	const mockImportsPath = fs.existsSync(
+		path.join(packageDir, "mock-imports.ts"),
+	)
+		? path.join(packageDir, "mock-imports.ts")
+		: fs.existsSync(path.join(packageDir, "mock-imports.js"))
+			? path.join(packageDir, "mock-imports.js")
+			: path.join(packageDir, "mock-imports.cjs");
+
+	const emptyClientEnvPath = fs.existsSync(
+		path.join(packageDir, "empty-client-env.ts"),
+	)
+		? path.join(packageDir, "empty-client-env.ts")
+		: path.join(packageDir, "empty-client-env.js");
+
+	const emptySharedSchemaPath = fs.existsSync(
+		path.join(packageDir, "empty-shared-schema.ts"),
+	)
+		? path.join(packageDir, "empty-shared-schema.ts")
+		: path.join(packageDir, "empty-shared-schema.js");
+
+	const emptyServerBootPath = fs.existsSync(
+		path.join(packageDir, "empty-server-boot.ts"),
+	)
+		? path.join(packageDir, "empty-server-boot.ts")
+		: path.join(packageDir, "empty-server-boot.js");
+
+	const strictUserClientPath =
+		resolvedLayout === "strict" && baseDir
+			? path.join(baseDir, "client.ts")
+			: undefined;
+
+	const strictUserSharedPath =
+		resolvedLayout === "strict" && baseDir
+			? path.join(baseDir, "internal", "shared.ts")
+			: undefined;
+
+	return {
+		"@arkenv/nuxt/shared": sharedPath,
+		"@arkenv/nuxt": indexPath,
+		"@arkenv/nuxt/client": clientPath,
+		"@arkenv/nuxt/server": serverPath,
+		"@arkenv/nuxt/standard": standardIndexPath,
+		"@arkenv/nuxt/standard/client": standardClientPath,
+		"@arkenv/nuxt/standard/server": standardServerPath,
+		"#imports": mockImportsPath,
+		"#arkenv/server-boot": emptyServerBootPath,
+		"#arkenv/client-env":
+			strictUserClientPath && fs.existsSync(strictUserClientPath)
+				? strictUserClientPath
+				: emptyClientEnvPath,
+		"#arkenv/shared-schema":
+			strictUserSharedPath && fs.existsSync(strictUserSharedPath)
+				? strictUserSharedPath
+				: emptySharedSchemaPath,
+		...internalOptions?._jitiAliases,
+	};
+}
+
+/**
+ * Resolve the directory that contains this package's compiled or source entries.
+ *
+ * @returns Absolute package entry directory
+ */
+function resolvePackageDir(): string {
+	const filenameForJiti =
+		typeof __filename !== "undefined"
+			? __filename
+			: typeof import.meta !== "undefined" && import.meta.url
+				? fileURLToPath(import.meta.url)
+				: "";
+	return path.dirname(filenameForJiti);
+}
+
+/**
+ * Load user schema files under capture mode and return the combined schema.
+ *
+ * @param config Boot-gate schema location options
+ * @param internalOptions Optional Jiti alias overrides for tests
+ * @returns Combined schema and public key set
+ */
+export function loadSchemaViaCapture(
+	config: BootGateConfig,
+	internalOptions?: { _jitiAliases?: Record<string, string> },
+): { schema: SchemaShape; publicKeys: Set<string> } {
+	const packageDir = resolvePackageDir();
+	const fileToEvaluate =
+		config.layout === "strict" && config.baseDir
+			? path.join(config.baseDir, "server.ts")
+			: config.schemaPath;
+
+	const aliases = buildSchemaJitiAliases(
+		packageDir,
+		config.layout,
+		config.baseDir,
+		internalOptions,
+	);
+
+	const jitiOptions = {
+		moduleCache: false,
+		fsCache: false,
+		tsconfigPaths: true,
+		alias: aliases,
+	} as const;
+
+	const g = globalThis as {
+		__ARKENV_STRICT_LAYOUT__?: boolean;
+		__ARKENV_CLIENT_ENV__?: unknown;
+		__ARKENV_SHARED_SCHEMA__?: unknown;
+	};
+
+	return withForceServer(() => {
+		beginCapture();
+		try {
+			const evaluateSchema = (jiti: ReturnType<typeof createJiti>) => {
+				if (config.layout === "strict" && config.baseDir) {
+					const strictUserSharedPath = path.join(
+						config.baseDir,
+						"internal",
+						"shared.ts",
+					);
+					if (!fs.existsSync(strictUserSharedPath)) {
+						throw new Error(
+							`[arkenv] Strict layout requires "internal/shared.ts" with a usable SharedSchema export under "${config.baseDir}".`,
+						);
+					}
+
+					const sharedMod = jiti(strictUserSharedPath) as {
+						SharedSchema?: SchemaShape;
+						default?: { SharedSchema?: SchemaShape };
+					};
+					const sharedSchema =
+						sharedMod.SharedSchema ?? sharedMod.default?.SharedSchema;
+					if (sharedSchema === undefined || sharedSchema === null) {
+						throw new Error(
+							`[arkenv] Strict layout requires a usable SharedSchema export from "${strictUserSharedPath}".`,
+						);
+					}
+					g.__ARKENV_SHARED_SCHEMA__ = sharedSchema;
+
+					const strictUserClientPath = path.join(config.baseDir, "client.ts");
+					if (fs.existsSync(strictUserClientPath)) {
+						g.__ARKENV_STRICT_LAYOUT__ = true;
+						const clientMod = jiti(strictUserClientPath) as {
+							env?: unknown;
+							default?: { env?: unknown };
+						};
+						g.__ARKENV_CLIENT_ENV__ =
+							clientMod.env ?? clientMod.default?.env ?? clientMod;
+					}
+				}
+
+				jiti(fileToEvaluate);
+			};
+
+			try {
+				const jiti = createJiti(fileToEvaluate, jitiOptions);
+				evaluateSchema(jiti);
+			} catch (error: unknown) {
+				const message = error instanceof Error ? error.message : String(error);
+				const isTsconfigNotFound =
+					error instanceof Error &&
+					/tsconfig/i.test(message) &&
+					(/not found/i.test(message) ||
+						(error as NodeJS.ErrnoException).code === "ENOENT");
+
+				if (isTsconfigNotFound) {
+					const fallbackJiti = createJiti(fileToEvaluate, {
+						...jitiOptions,
+						tsconfigPaths: false,
+					});
+					evaluateSchema(fallbackJiti);
+				} else {
+					throw error;
+				}
+			}
+
+			const calls = endCapture();
+			return {
+				schema: combineCapturedSchemas(calls),
+				publicKeys: publicKeysFromCaptures(calls),
+			};
+		} finally {
+			endCapture();
+			delete g.__ARKENV_STRICT_LAYOUT__;
+			delete g.__ARKENV_CLIENT_ENV__;
+			delete g.__ARKENV_SHARED_SCHEMA__;
+		}
+	});
+}
+
+/**
+ * Flatten Nuxt `runtimeConfig` into a single key→value map for validation.
+ *
+ * @param runtimeConfig The live Nitro runtime config (after string overrides)
+ * @returns Flat env map including public keys at the top level
+ */
+export function flattenRuntimeConfig(
+	runtimeConfig: BootGateRuntimeConfig,
+): Record<string, unknown> {
+	const { public: publicConfig, arkenvGate: _gate, ...rest } = runtimeConfig;
+	const flat: Record<string, unknown> = { ...rest };
+	if (publicConfig && typeof publicConfig === "object") {
+		Object.assign(flat, publicConfig);
+	}
+	return flat;
+}
+
+/**
+ * Write coerced values back into `runtimeConfig`, including `public`.
+ *
+ * @param runtimeConfig The live Nitro runtime config to mutate
+ * @param coerced Validated/coerced values from core
+ * @param publicKeys Keys that belong under `runtimeConfig.public`
+ */
+export function applyCoercedToRuntimeConfig(
+	runtimeConfig: BootGateRuntimeConfig,
+	coerced: Record<string, unknown>,
+	publicKeys: Set<string>,
+): void {
+	runtimeConfig.public = runtimeConfig.public || {};
+
+	for (const [key, value] of Object.entries(coerced)) {
+		if (publicKeys.has(key)) {
+			runtimeConfig.public[key] = value;
+		} else {
+			runtimeConfig[key] = value;
+		}
+	}
+}
+
+/**
+ * Run the Nuxt boot gate: capture schema, validate/coerce against live config, write back.
+ *
+ * @param config Schema path and engine
+ * @param runtimeConfig Live Nitro runtime config (mutated in place)
+ * @param internalOptions Optional Jiti overrides for tests
+ * @returns Flattened coerced values
+ * @throws When validation fails (fail-fast)
+ */
+export function runBootGate(
+	config: BootGateConfig,
+	runtimeConfig: BootGateRuntimeConfig,
+	internalOptions?: { _jitiAliases?: Record<string, string> },
+): Record<string, unknown> {
+	const { schema, publicKeys } = loadSchemaViaCapture(config, internalOptions);
+
+	if (Object.keys(schema).length === 0) {
+		const flat = flattenRuntimeConfig(runtimeConfig);
+		setBootGateResult(flat);
+		return flat;
+	}
+
+	const sourceValues = flattenRuntimeConfig(runtimeConfig);
+	const processEnv =
+		typeof process !== "undefined" ? (process.env as Dict<string>) : {};
+
+	const combinedEnv: Record<string, unknown> = { ...processEnv };
+	for (const [key, value] of Object.entries(sourceValues)) {
+		if (value !== undefined && value !== "") {
+			combinedEnv[key] = value;
+		}
+	}
+
+	const coreArkenv = resolveCoreArkenv(config.engine);
+	const coerced = coreArkenv(schema, {
+		env: combinedEnv as Dict<string>,
+		safe: false,
+	});
+
+	applyCoercedToRuntimeConfig(runtimeConfig, coerced, publicKeys);
+	setBootGateResult({ ...coerced });
+	return getBootGateResult() as Record<string, unknown>;
+}
+
+/**
+ * Ensure the boot gate has run once (eager plugin + thin server accessor).
+ *
+ * Reads `arkenvGate` from `runtimeConfig` when {@link configureBootGate} was not called.
+ * No-ops when neither config nor a usable runtimeConfig gate block is available.
+ *
+ * @param runtimeConfig Optional live runtime config (from Nitro plugin / tests)
+ */
+export function ensureBootGate(runtimeConfig?: BootGateRuntimeConfig): void {
+	if (isBootGateDone()) return;
+
+	const config =
+		gateConfig ||
+		(runtimeConfig?.arkenvGate as BootGateConfig | undefined) ||
+		null;
+
+	if (!config?.schemaPath) {
+		return;
+	}
+
+	const rc =
+		runtimeConfig ||
+		({
+			public: {},
+		} as BootGateRuntimeConfig);
+
+	if (!rc.arkenvGate) {
+		rc.arkenvGate = config;
+	}
+
+	configureBootGate(config);
+	runBootGate(config, rc);
+}

--- a/packages/nuxt/src/boot-gate.ts
+++ b/packages/nuxt/src/boot-gate.ts
@@ -436,9 +436,12 @@ export function runBootGate(
 	const processEnv =
 		typeof process !== "undefined" ? (process.env as Dict<string>) : {};
 
+	// `runtimeConfig` after Nitro boot is authoritative — including deliberate empty
+	// string overrides (`NUXT_PUBLIC_FOO=""`). Spread `process.env` first as a
+	// fallback for keys Nitro has not projected into config yet.
 	const combinedEnv: Record<string, unknown> = { ...processEnv };
 	for (const [key, value] of Object.entries(sourceValues)) {
-		if (value !== undefined && value !== "") {
+		if (value !== undefined) {
 			combinedEnv[key] = value;
 		}
 	}

--- a/packages/nuxt/src/capture.ts
+++ b/packages/nuxt/src/capture.ts
@@ -136,7 +136,7 @@ export function combineCapturedSchemas(
  * @returns Schema keys contributed by that call
  */
 function schemaFromCapture(call: CapturedSchemaCall): SchemaShape {
-	const { schemaOrOptions, optionsOrIsServer, context } = call;
+	const { schemaOrOptions, optionsOrIsServer } = call;
 
 	if (typeof optionsOrIsServer === "boolean") {
 		const legacy = schemaOrOptions as CaptureLegacyNested;
@@ -164,19 +164,7 @@ function schemaFromCapture(call: CapturedSchemaCall): SchemaShape {
 		} as SchemaShape;
 	}
 
-	const flat = (schemaOrOptions || {}) as SchemaShape;
-
-	if (context?.isShared) {
-		return flat;
-	}
-	if (
-		context?.strictLayout === "client" ||
-		context?.strictLayout === "server"
-	) {
-		return flat;
-	}
-
-	return flat;
+	return (schemaOrOptions || {}) as SchemaShape;
 }
 
 /**

--- a/packages/nuxt/src/capture.ts
+++ b/packages/nuxt/src/capture.ts
@@ -1,0 +1,281 @@
+import type { Dict, SchemaShape } from "@repo/types";
+
+/** Matches {@link EXTENDED_ENV} in arkenv-internal without importing it (avoid cycles). */
+const EXTENDED_ENV = Symbol.for("arkenv.extended_env");
+/** Matches {@link ENV_KEYS} in arkenv-internal without importing it (avoid cycles). */
+const ENV_KEYS = Symbol.for("arkenv.keys");
+/** Matches {@link SERVER_ONLY_KEYS} in arkenv-internal without importing it (avoid cycles). */
+const SERVER_ONLY_KEYS = Symbol.for("arkenv.server_only_keys");
+
+const CAPTURE_STATE_KEY = "__ARKENV_SCHEMA_CAPTURE__";
+
+type CaptureState = {
+	capturing: boolean;
+	captures: CapturedSchemaCall[];
+};
+
+export type CaptureLegacyNested = {
+	server?: SchemaShape;
+	client?: SchemaShape;
+	shared?: SchemaShape;
+	extends?: readonly unknown[];
+	runtimeEnv?: Dict<string>;
+};
+
+export type CaptureFlatOptions = {
+	extends?: readonly unknown[];
+	runtimeEnv?: Dict<string>;
+	expose?: readonly string[];
+	shared?: readonly string[];
+	exposeToClient?: readonly string[];
+};
+
+export type CapturedSchemaCall = {
+	schemaOrOptions: SchemaShape | CaptureLegacyNested;
+	optionsOrIsServer: CaptureFlatOptions | boolean | null | undefined;
+	context:
+		| {
+				isServer: boolean;
+				isShared?: boolean;
+				strictLayout?: "client" | "server";
+		  }
+		| undefined;
+};
+
+/**
+ * Read the process-global capture state so Jiti-loaded copies share one flag.
+ *
+ * @returns The shared capture state bag
+ */
+function getCaptureState(): CaptureState {
+	const g = globalThis as unknown as Record<string, CaptureState | undefined>;
+	if (!g[CAPTURE_STATE_KEY]) {
+		g[CAPTURE_STATE_KEY] = { capturing: false, captures: [] };
+	}
+	return g[CAPTURE_STATE_KEY];
+}
+
+/**
+ * Start recording `arkenv()` schema arguments instead of reading runtime values.
+ */
+export function beginCapture(): void {
+	const state = getCaptureState();
+	state.capturing = true;
+	state.captures = [];
+}
+
+/**
+ * Stop recording and return the captured `arkenv()` calls.
+ *
+ * @returns The schema calls recorded since {@link beginCapture}
+ */
+export function endCapture(): CapturedSchemaCall[] {
+	const state = getCaptureState();
+	state.capturing = false;
+	return state.captures.slice();
+}
+
+/**
+ * Report whether schema capture mode is active.
+ *
+ * @returns `true` when {@link beginCapture} is in effect
+ */
+export function isCapturing(): boolean {
+	return getCaptureState().capturing;
+}
+
+/**
+ * Record an `arkenv()` call while capture mode is active.
+ *
+ * @param schemaOrOptions The schema definition or nested options object
+ * @param optionsOrIsServer Flat options, legacy boolean, or undefined
+ * @param context Optional server/client/strict-layout context
+ */
+export function recordCapture(
+	schemaOrOptions: SchemaShape | CaptureLegacyNested | null | undefined,
+	optionsOrIsServer: CaptureFlatOptions | boolean | null | undefined,
+	context:
+		| {
+				isServer: boolean;
+				isShared?: boolean;
+				strictLayout?: "client" | "server";
+		  }
+		| undefined,
+): void {
+	getCaptureState().captures.push({
+		schemaOrOptions: (schemaOrOptions || {}) as
+			| SchemaShape
+			| CaptureLegacyNested,
+		optionsOrIsServer,
+		context,
+	});
+}
+
+/**
+ * Build a combined schema shape from captured `arkenv()` calls.
+ *
+ * @param calls The captured schema calls
+ * @returns A flat schema object suitable for core validation
+ */
+export function combineCapturedSchemas(
+	calls: CapturedSchemaCall[],
+): SchemaShape {
+	const combined: SchemaShape = {};
+
+	for (const call of calls) {
+		Object.assign(combined, schemaFromCapture(call));
+	}
+
+	return combined;
+}
+
+/**
+ * Derive a flat schema shape from a single captured call.
+ *
+ * @param call The captured `arkenv()` invocation
+ * @returns Schema keys contributed by that call
+ */
+function schemaFromCapture(call: CapturedSchemaCall): SchemaShape {
+	const { schemaOrOptions, optionsOrIsServer, context } = call;
+
+	if (typeof optionsOrIsServer === "boolean") {
+		const legacy = schemaOrOptions as CaptureLegacyNested;
+		return {
+			...(legacy.server || {}),
+			...(legacy.client || {}),
+			...(legacy.shared || {}),
+		} as SchemaShape;
+	}
+
+	const isLegacy =
+		schemaOrOptions &&
+		typeof schemaOrOptions === "object" &&
+		("runtimeEnv" in schemaOrOptions ||
+			"server" in schemaOrOptions ||
+			"client" in schemaOrOptions ||
+			"shared" in schemaOrOptions);
+
+	if (isLegacy) {
+		const legacy = schemaOrOptions as CaptureLegacyNested;
+		return {
+			...(legacy.server || {}),
+			...(legacy.client || {}),
+			...(legacy.shared || {}),
+		} as SchemaShape;
+	}
+
+	const flat = (schemaOrOptions || {}) as SchemaShape;
+
+	if (context?.isShared) {
+		return flat;
+	}
+	if (
+		context?.strictLayout === "client" ||
+		context?.strictLayout === "server"
+	) {
+		return flat;
+	}
+
+	return flat;
+}
+
+/**
+ * Collect public (client + shared) key names from captured calls.
+ *
+ * @param calls The captured schema calls
+ * @returns Keys that belong in `runtimeConfig.public`
+ */
+export function publicKeysFromCaptures(
+	calls: CapturedSchemaCall[],
+): Set<string> {
+	const publicKeys = new Set<string>();
+
+	for (const call of calls) {
+		const { schemaOrOptions, optionsOrIsServer, context } = call;
+
+		if (typeof optionsOrIsServer === "boolean") {
+			const legacy = schemaOrOptions as CaptureLegacyNested;
+			for (const key of Object.keys(legacy.client || {})) publicKeys.add(key);
+			for (const key of Object.keys(legacy.shared || {})) publicKeys.add(key);
+			continue;
+		}
+
+		const isLegacy =
+			schemaOrOptions &&
+			typeof schemaOrOptions === "object" &&
+			("server" in schemaOrOptions ||
+				"client" in schemaOrOptions ||
+				"shared" in schemaOrOptions);
+
+		if (isLegacy) {
+			const legacy = schemaOrOptions as CaptureLegacyNested;
+			for (const key of Object.keys(legacy.client || {})) publicKeys.add(key);
+			for (const key of Object.keys(legacy.shared || {})) publicKeys.add(key);
+			continue;
+		}
+
+		const flat = (schemaOrOptions || {}) as SchemaShape;
+		const options = (optionsOrIsServer || {}) as CaptureFlatOptions;
+
+		if (context?.isShared || context?.strictLayout === "client") {
+			for (const key of Object.keys(flat)) publicKeys.add(key);
+			continue;
+		}
+
+		if (context?.strictLayout === "server") {
+			continue;
+		}
+
+		const exposed =
+			options.exposeToClient || options.expose || options.shared || [];
+		for (const key of Object.keys(flat)) {
+			if (
+				exposed.includes(key) ||
+				key === "NODE_ENV" ||
+				key.startsWith("NUXT_PUBLIC_")
+			) {
+				publicKeys.add(key);
+			}
+		}
+	}
+
+	return publicKeys;
+}
+
+/**
+ * Create a stub env proxy for capture-mode evaluation of user schema files.
+ *
+ * @param schemaKeys Keys declared by the captured schema
+ * @returns A security-proxy-compatible stub object
+ */
+export function createCaptureStub(schemaKeys: string[]): unknown {
+	const target: Dict<unknown> = {};
+	const keySet = new Set(schemaKeys);
+
+	return new Proxy(target, {
+		get(_t, prop) {
+			if (prop === EXTENDED_ENV) return target;
+			if (prop === ENV_KEYS) return keySet;
+			if (prop === SERVER_ONLY_KEYS) return new Set<string>();
+			if (typeof prop === "symbol") return undefined;
+			return undefined;
+		},
+		ownKeys() {
+			return [...keySet];
+		},
+		getOwnPropertyDescriptor(_t, prop) {
+			if (typeof prop === "string" && keySet.has(prop)) {
+				return {
+					configurable: true,
+					enumerable: true,
+					writable: false,
+					value: undefined,
+				};
+			}
+			return undefined;
+		},
+		has(_t, prop) {
+			return typeof prop === "string" && keySet.has(prop);
+		},
+	});
+}

--- a/packages/nuxt/src/client-bundle.test.ts
+++ b/packages/nuxt/src/client-bundle.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import path from "node:path";
+import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
+
+describe("client entry bundle isolation", () => {
+	it("does not include @arkenv/core or arktype in the client package entry", async () => {
+		const outfile = path.resolve(__dirname, "temp-client-bundle.mjs");
+
+		try {
+			await build({
+				entryPoints: [path.resolve(__dirname, "client.ts")],
+				bundle: true,
+				write: true,
+				outfile,
+				format: "esm",
+				platform: "browser",
+				packages: "bundle",
+				external: [
+					"#arkenv/shared-schema",
+					"#arkenv/client-env",
+					"#arkenv/server-boot",
+				],
+				logLevel: "silent",
+			});
+
+			const code = fs.readFileSync(outfile, "utf8");
+			expect(code).not.toMatch(/@arkenv\/core/);
+			expect(code).not.toMatch(/from\s*["']arktype["']/);
+			expect(code).not.toMatch(/require\(["']arktype["']\)/);
+			expect(code).not.toMatch(/createEnv|arktype/);
+		} finally {
+			fs.rmSync(outfile, { force: true });
+		}
+	});
+});

--- a/packages/nuxt/src/client-bundle.test.ts
+++ b/packages/nuxt/src/client-bundle.test.ts
@@ -3,34 +3,46 @@ import path from "node:path";
 import { build } from "esbuild";
 import { describe, expect, it } from "vitest";
 
+async function assertClientEntryIsValidatorFree(entryRelativePath: string) {
+	const outfile = path.resolve(
+		__dirname,
+		`temp-${path.basename(entryRelativePath, ".ts")}-bundle.mjs`,
+	);
+
+	try {
+		await build({
+			entryPoints: [path.resolve(__dirname, entryRelativePath)],
+			bundle: true,
+			write: true,
+			outfile,
+			format: "esm",
+			platform: "browser",
+			packages: "bundle",
+			external: [
+				"#arkenv/shared-schema",
+				"#arkenv/client-env",
+				"#arkenv/server-boot",
+			],
+			logLevel: "silent",
+		});
+
+		const code = fs.readFileSync(outfile, "utf8");
+		expect(code).not.toMatch(/@arkenv\/core/);
+		expect(code).not.toMatch(/@arkenv\/standard/);
+		expect(code).not.toMatch(/from\s*["']arktype["']/);
+		expect(code).not.toMatch(/require\(["']arktype["']\)/);
+		expect(code).not.toMatch(/createEnv|arktype/);
+	} finally {
+		fs.rmSync(outfile, { force: true });
+	}
+}
+
 describe("client entry bundle isolation", () => {
 	it("does not include @arkenv/core or arktype in the client package entry", async () => {
-		const outfile = path.resolve(__dirname, "temp-client-bundle.mjs");
+		await assertClientEntryIsValidatorFree("client.ts");
+	});
 
-		try {
-			await build({
-				entryPoints: [path.resolve(__dirname, "client.ts")],
-				bundle: true,
-				write: true,
-				outfile,
-				format: "esm",
-				platform: "browser",
-				packages: "bundle",
-				external: [
-					"#arkenv/shared-schema",
-					"#arkenv/client-env",
-					"#arkenv/server-boot",
-				],
-				logLevel: "silent",
-			});
-
-			const code = fs.readFileSync(outfile, "utf8");
-			expect(code).not.toMatch(/@arkenv\/core/);
-			expect(code).not.toMatch(/from\s*["']arktype["']/);
-			expect(code).not.toMatch(/require\(["']arktype["']\)/);
-			expect(code).not.toMatch(/createEnv|arktype/);
-		} finally {
-			fs.rmSync(outfile, { force: true });
-		}
+	it("does not include @arkenv/standard or arktype in the standard client entry", async () => {
+		await assertClientEntryIsValidatorFree("standard/client.ts");
 	});
 });

--- a/packages/nuxt/src/client.ts
+++ b/packages/nuxt/src/client.ts
@@ -5,9 +5,8 @@ import type { type as at, distill } from "arktype";
 // Static import so Vite/Nitro can resolve the alias at bundle time.
 // Outside strict layout the module aliases this to `empty-shared-schema.ts`.
 import { SharedSchema as importedSharedSchema } from "#arkenv/shared-schema";
-import { arkenvInternal, type FlatSchemaOptions } from "./arkenv-internal";
-import { isStrictLayoutActive } from "./strict-client-env";
 import { resolveStrictSharedSchema } from "./strict-shared-schema";
+import { dispatchStrictThinArkenv } from "./thin-accessor";
 import type { MergeExtends, ResolveExtendsElement } from "./types";
 
 /**
@@ -21,33 +20,6 @@ type AutoSharedSchema = typeof import("#arkenv/shared-schema") extends {
 }
 	? ResolveExtendsElement<S>
 	: {};
-
-/**
- * Apply strict-layout auto-extend when `extends` is omitted.
- *
- * @param optionsOrIsServer Flat options, legacy boolean, or undefined
- * @returns Options with auto-extend applied when appropriate
- */
-function withAutoExtend(
-	optionsOrIsServer: FlatSchemaOptions | boolean | null | undefined,
-): FlatSchemaOptions | boolean | null | undefined {
-	if (typeof optionsOrIsServer === "boolean") {
-		return optionsOrIsServer;
-	}
-
-	if (optionsOrIsServer != null && "extends" in optionsOrIsServer) {
-		return optionsOrIsServer;
-	}
-
-	if (!isStrictLayoutActive()) {
-		return optionsOrIsServer;
-	}
-
-	return {
-		...(optionsOrIsServer ?? {}),
-		extends: [resolveStrictSharedSchema(importedSharedSchema)],
-	};
-}
 
 /**
  * Create a typesafe environment configuration for Nuxt (client entry).
@@ -104,23 +76,10 @@ export function arkenv<
 >;
 
 export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
-	const isLegacy =
-		schemaOrOptions &&
-		typeof schemaOrOptions === "object" &&
-		("client" in schemaOrOptions || "shared" in schemaOrOptions);
-
-	if (isLegacy) {
-		if ("server" in schemaOrOptions) {
-			throw new Error(
-				"client entry point only accepts 'client' and 'shared' schemas.",
-			);
-		}
-		return arkenvInternal(schemaOrOptions, false, undefined);
-	}
-
-	return arkenvInternal(schemaOrOptions, withAutoExtend(optionsOrIsServer), {
-		isServer: false,
+	return dispatchStrictThinArkenv(schemaOrOptions, optionsOrIsServer, {
 		strictLayout: "client",
+		resolveAutoExtendTarget: () =>
+			resolveStrictSharedSchema(importedSharedSchema),
 	});
 }
 

--- a/packages/nuxt/src/client.ts
+++ b/packages/nuxt/src/client.ts
@@ -1,5 +1,4 @@
 import type { EnvSchema } from "@arkenv/core";
-import { arkenv as coreArkenv, getSchemaKeys } from "@arkenv/core";
 import type { $ } from "@repo/scope";
 import type { SchemaShape } from "@repo/types";
 import type { type as at, distill } from "arktype";
@@ -51,32 +50,17 @@ function withAutoExtend(
 }
 
 /**
- * Create a validated, type-safe environment configuration for Nuxt applications (Client entry point).
+ * Create a type-safe environment configuration for Nuxt (client entry).
+ *
+ * Reads the already-coerced public payload — does not import or run the validator.
  *
  * With `@arkenv/nuxt/module` in strict layout, omitting `extends` includes the
  * shared schema by default. Any explicit `extends` is used as-is and opts out
  * of that default; pass `extends: []` to include no extended env.
  *
- * @example Default strict-layout behavior
- * ```ts
- * import arkenv from "@arkenv/nuxt/client";
- *
- * export const env = arkenv({
- *   NUXT_PUBLIC_API_URL: "string",
- * });
- * ```
- *
- * @example Opt out of the default shared merge
- * ```ts
- * export const env = arkenv(
- *   { NUXT_PUBLIC_API_URL: "string" },
- *   { extends: [] },
- * );
- * ```
- *
  * @param schemaOrOptions The schema definition or configuration options containing client/shared schemas
  * @param optionsOrIsServer Optional configuration paths or a boolean indicating server status
- * @returns A validated, readonly environment variables object wrapped in a security proxy
+ * @returns A readonly environment variables object wrapped in a security proxy
  * @throws An error if any client-side variable is not prefixed with `NUXT_PUBLIC_`
  * @throws An error if a server-only variable is accessed on the client side
  */
@@ -131,24 +115,13 @@ export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
 				"client entry point only accepts 'client' and 'shared' schemas.",
 			);
 		}
-		return arkenvInternal(
-			schemaOrOptions,
-			false,
-			undefined,
-			coreArkenv,
-			getSchemaKeys,
-		);
+		return arkenvInternal(schemaOrOptions, false, undefined);
 	}
 
-	return arkenvInternal(
-		schemaOrOptions,
-		withAutoExtend(optionsOrIsServer),
-		{ isServer: false, strictLayout: "client" },
-		coreArkenv,
-		getSchemaKeys,
-	);
+	return arkenvInternal(schemaOrOptions, withAutoExtend(optionsOrIsServer), {
+		isServer: false,
+		strictLayout: "client",
+	});
 }
-
-export { type } from "@arkenv/core";
 
 export default arkenv;

--- a/packages/nuxt/src/client.ts
+++ b/packages/nuxt/src/client.ts
@@ -50,7 +50,7 @@ function withAutoExtend(
 }
 
 /**
- * Create a type-safe environment configuration for Nuxt (client entry).
+ * Create a typesafe environment configuration for Nuxt (client entry).
  *
  * Reads the already-coerced public payload — does not import or run the validator.
  *

--- a/packages/nuxt/src/coercion-regression.test.ts
+++ b/packages/nuxt/src/coercion-regression.test.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetBootGateForTests, runBootGate } from "./boot-gate";
+import {
+	resetBootGateResultForTests,
+	setBootGateResult,
+} from "./boot-gate-state";
+import { arkenv } from "./index";
+
+afterEach(() => {
+	resetBootGateForTests();
+	resetBootGateResultForTests();
+	delete (globalThis as { window?: unknown }).window;
+	delete process.env.PORT;
+	delete process.env.DEBUG;
+	delete process.env.NUXT_PUBLIC_PORT;
+	delete process.env.NUXT_PUBLIC_ENABLED;
+	delete process.env.DATABASE_URL;
+});
+
+/**
+ * Regressions for the two Nuxt coercion honesty bugs:
+ *
+ * 1. Security proxy preferred raw `process.env` / `__NUXT__` strings over the
+ *    coerced validation target (#1327).
+ * 2. Nitro boot `NUXT_PUBLIC_*` overrides stayed as strings in `runtimeConfig`
+ *    (#1424).
+ *
+ * Under thin accessors, (1) is "prefer boot-gate result over raw process.env";
+ * (2) is "runBootGate coerces string overrides, then thin `arkenv()` reads them".
+ */
+describe("Nuxt coercion honesty regressions", () => {
+	it("prefers the boot-gate coerced result over raw process.env strings", () => {
+		// Gate already produced numbers; process.env still has the raw strings
+		// Nitro / the shell would leave behind. Thin reads must not undo coercion.
+		process.env.PORT = "9090";
+		process.env.DEBUG = "true";
+		setBootGateResult({
+			PORT: 7777,
+			DEBUG: false,
+		});
+
+		const env = arkenv({
+			PORT: "number",
+			DEBUG: "boolean",
+		});
+
+		expect(env.PORT).toBe(7777);
+		expect(typeof env.PORT).toBe("number");
+		expect(env.DEBUG).toBe(false);
+		expect(typeof env.DEBUG).toBe("boolean");
+	});
+
+	it("coerces Nitro string overrides at the boot gate, then thin arkenv() returns numbers/booleans", () => {
+		const tempDir = path.resolve(__dirname, "temp-coercion-regression-gate");
+		fs.mkdirSync(tempDir, { recursive: true });
+		const schemaPath = path.join(tempDir, "env.ts");
+
+		fs.writeFileSync(
+			schemaPath,
+			`
+			import arkenv from "@arkenv/nuxt";
+			export const env = arkenv({
+				DATABASE_URL: "string",
+				PORT: "number",
+				DEBUG: "boolean",
+				NUXT_PUBLIC_PORT: "number",
+				NUXT_PUBLIC_ENABLED: "boolean",
+				NODE_ENV: "'development' | 'production' | 'test' = 'test'",
+			});
+			`,
+		);
+
+		// Raw string sources — the pre-fix shape for both bugs.
+		process.env.DATABASE_URL = "postgres://localhost/db";
+		process.env.PORT = "9090";
+		process.env.DEBUG = "true";
+		process.env.NUXT_PUBLIC_PORT = "4000";
+		process.env.NUXT_PUBLIC_ENABLED = "false";
+
+		const runtimeConfig: {
+			public: Record<string, unknown>;
+			DATABASE_URL?: unknown;
+			PORT?: unknown;
+			DEBUG?: unknown;
+			[key: string]: unknown;
+		} = {
+			public: {
+				NUXT_PUBLIC_PORT: "4000",
+				NUXT_PUBLIC_ENABLED: "false",
+				NODE_ENV: "test",
+			},
+			DATABASE_URL: "postgres://localhost/db",
+			PORT: "9090",
+			DEBUG: "true",
+		};
+
+		try {
+			runBootGate(
+				{
+					schemaPath,
+					layout: "simple",
+					baseDir: "",
+					engine: "arktype",
+				},
+				runtimeConfig,
+			);
+
+			// Bug 2: payload itself is coerced after the string overrides.
+			expect(runtimeConfig.PORT).toBe(9090);
+			expect(runtimeConfig.DEBUG).toBe(true);
+			expect(runtimeConfig.public.NUXT_PUBLIC_PORT).toBe(4000);
+			expect(runtimeConfig.public.NUXT_PUBLIC_ENABLED).toBe(false);
+
+			// Bug 1 (thin era): even with process.env still holding strings,
+			// arkenv() reads the coerced boot-gate result.
+			const env = arkenv({
+				DATABASE_URL: "string",
+				PORT: "number",
+				DEBUG: "boolean",
+				NUXT_PUBLIC_PORT: "number",
+				NUXT_PUBLIC_ENABLED: "boolean",
+				NODE_ENV: "'development' | 'production' | 'test' = 'test'",
+			});
+
+			expect(env.PORT).toBe(9090);
+			expect(typeof env.PORT).toBe("number");
+			expect(env.DEBUG).toBe(true);
+			expect(typeof env.DEBUG).toBe("boolean");
+			expect(env.NUXT_PUBLIC_PORT).toBe(4000);
+			expect(typeof env.NUXT_PUBLIC_PORT).toBe("number");
+			expect(env.NUXT_PUBLIC_ENABLED).toBe(false);
+			expect(typeof env.NUXT_PUBLIC_ENABLED).toBe("boolean");
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("exposes coerced public values on the client via __NUXT__ (post-boot payload)", () => {
+		const originalWindow = globalThis.window;
+		// What the client receives after a successful boot gate + Nitro serialize.
+		(globalThis as { window?: unknown }).window = {
+			__NUXT__: {
+				config: {
+					public: {
+						NUXT_PUBLIC_PORT: 4000,
+						NUXT_PUBLIC_ENABLED: false,
+					},
+				},
+			},
+		};
+
+		try {
+			const env = arkenv({
+				NUXT_PUBLIC_PORT: "number",
+				NUXT_PUBLIC_ENABLED: "boolean",
+			});
+
+			expect(env.NUXT_PUBLIC_PORT).toBe(4000);
+			expect(typeof env.NUXT_PUBLIC_PORT).toBe("number");
+			expect(env.NUXT_PUBLIC_ENABLED).toBe(false);
+			expect(typeof env.NUXT_PUBLIC_ENABLED).toBe("boolean");
+		} finally {
+			(globalThis as { window?: unknown }).window = originalWindow;
+		}
+	});
+
+	it("does not re-coerce raw strings on the client (coercion is boot-gate only)", () => {
+		const originalWindow = globalThis.window;
+		// If the boot gate never wrote coerced values, thin client reads stay strings.
+		(globalThis as { window?: unknown }).window = {
+			__NUXT__: {
+				config: {
+					public: {
+						NUXT_PUBLIC_PORT: "4000",
+						NUXT_PUBLIC_ENABLED: "false",
+					},
+				},
+			},
+		};
+
+		try {
+			const env = arkenv({
+				NUXT_PUBLIC_PORT: "number",
+				NUXT_PUBLIC_ENABLED: "boolean",
+			});
+
+			expect(env.NUXT_PUBLIC_PORT).toBe("4000");
+			expect(typeof env.NUXT_PUBLIC_PORT).toBe("string");
+			expect(env.NUXT_PUBLIC_ENABLED).toBe("false");
+			expect(typeof env.NUXT_PUBLIC_ENABLED).toBe("string");
+		} finally {
+			(globalThis as { window?: unknown }).window = originalWindow;
+		}
+	});
+});

--- a/packages/nuxt/src/empty-server-boot.ts
+++ b/packages/nuxt/src/empty-server-boot.ts
@@ -1,0 +1,7 @@
+/**
+ * Client / default stub for `#arkenv/server-boot`.
+ *
+ * The Nuxt module aliases this specifier to the real boot-gate ensure on the
+ * server and Nitro graphs only, so client bundles never import `@arkenv/core`.
+ */
+export function ensureBootGate(): void {}

--- a/packages/nuxt/src/index.test.ts
+++ b/packages/nuxt/src/index.test.ts
@@ -1,9 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetBootGateForTests } from "./boot-gate";
+import {
+	resetBootGateResultForTests,
+	setBootGateResult,
+} from "./boot-gate-state";
 import { arkenv } from "./index";
+
+afterEach(() => {
+	resetBootGateForTests();
+	resetBootGateResultForTests();
+	delete (globalThis as { window?: unknown }).window;
+});
 
 describe("arkenv (Nuxt runtime)", () => {
 	it("should parse a basic environment variable", () => {
 		process.env.DATABASE_URL = "postgres://localhost:5432/db";
+		setBootGateResult({
+			DATABASE_URL: "postgres://localhost:5432/db",
+		});
 
 		const env = arkenv({
 			server: {
@@ -28,9 +42,11 @@ describe("arkenv (Nuxt runtime)", () => {
 	});
 
 	it("should allow accessing server-side, client, and shared variables on the server", () => {
-		process.env.DATABASE_URL = "postgres://localhost:5432/db";
-		process.env.NUXT_PUBLIC_API_URL = "https://api.example.com";
-		process.env.NODE_ENV = "test";
+		setBootGateResult({
+			DATABASE_URL: "postgres://localhost:5432/db",
+			NUXT_PUBLIC_API_URL: "https://api.example.com",
+			NODE_ENV: "test",
+		});
 
 		const env = arkenv({
 			server: {
@@ -47,14 +63,9 @@ describe("arkenv (Nuxt runtime)", () => {
 		expect(env.DATABASE_URL).toBe("postgres://localhost:5432/db");
 		expect(env.NUXT_PUBLIC_API_URL).toBe("https://api.example.com");
 		expect(env.NODE_ENV).toBe("test");
-
-		delete process.env.DATABASE_URL;
-		delete process.env.NUXT_PUBLIC_API_URL;
-		delete process.env.NODE_ENV;
 	});
 
 	it("should throw an error when accessing a server-side variable on the client", () => {
-		// Mock window to simulate browser client
 		const originalWindow = globalThis.window;
 		(globalThis as any).window = {
 			__NUXT__: {
@@ -89,23 +100,18 @@ describe("arkenv (Nuxt runtime)", () => {
 				"Accessing server-side environment variable 'DATABASE_URL' on the client is not allowed.",
 			);
 
-			// Enumerate keys
 			const keys = Object.keys(env);
 			expect(keys).toContain("NUXT_PUBLIC_API_URL");
 			expect(keys).toContain("NODE_ENV");
 			expect(keys).not.toContain("DATABASE_URL");
 
-			// ownKeys
 			const ownKeys = Reflect.ownKeys(env);
 			expect(ownKeys).toContain("NUXT_PUBLIC_API_URL");
-			expect(ownKeys).toContain("NODE_ENV");
 			expect(ownKeys).not.toContain("DATABASE_URL");
 
-			// in operator
 			expect("NUXT_PUBLIC_API_URL" in env).toBe(true);
 			expect("DATABASE_URL" in env).toBe(false);
 
-			// getOwnPropertyDescriptor
 			expect(
 				Object.getOwnPropertyDescriptor(env, "NUXT_PUBLIC_API_URL"),
 			).toBeDefined();
@@ -146,24 +152,21 @@ describe("arkenv (Nuxt runtime)", () => {
 		}
 	});
 
-	it("should keep coerced server types when values are sourced from process.env", () => {
-		process.env.PORT = "9090";
-		process.env.DEBUG = "true";
+	it("should keep coerced server types from the boot-gate result", () => {
+		setBootGateResult({
+			PORT: 9090,
+			DEBUG: true,
+		});
 
-		try {
-			const env = arkenv({
-				PORT: "number",
-				DEBUG: "boolean",
-			});
+		const env = arkenv({
+			PORT: "number",
+			DEBUG: "boolean",
+		});
 
-			expect(env.PORT).toBe(9090);
-			expect(typeof env.PORT).toBe("number");
-			expect(env.DEBUG).toBe(true);
-			expect(typeof env.DEBUG).toBe("boolean");
-		} finally {
-			delete process.env.PORT;
-			delete process.env.DEBUG;
-		}
+		expect(env.PORT).toBe(9090);
+		expect(typeof env.PORT).toBe("number");
+		expect(env.DEBUG).toBe(true);
+		expect(typeof env.DEBUG).toBe("boolean");
 	});
 
 	it("should keep coerced client types when values are sourced from __NUXT__.config.public", () => {
@@ -172,8 +175,8 @@ describe("arkenv (Nuxt runtime)", () => {
 			__NUXT__: {
 				config: {
 					public: {
-						NUXT_PUBLIC_PORT: "4000",
-						NUXT_PUBLIC_ENABLED: "false",
+						NUXT_PUBLIC_PORT: 4000,
+						NUXT_PUBLIC_ENABLED: false,
 					},
 				},
 			},

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -5,7 +5,7 @@ import { ensureBootGate } from "#arkenv/server-boot";
 import { arkenvInternal, type FlatSchemaOptions } from "./arkenv-internal";
 
 /**
- * Create a type-safe environment configuration for Nuxt (flat / unified entry).
+ * Create a typesafe environment configuration for Nuxt (flat / unified entry).
  *
  * Values are read from the Nitro boot-gate coerced `runtimeConfig` / `__NUXT__`
  * payload — this entry does not run core validation.
@@ -27,7 +27,7 @@ export function arkenv<
 }): Readonly<Infer<TServer & TClient & TShared>>;
 
 /**
- * Create a type-safe environment configuration for Nuxt (flat schema).
+ * Create a typesafe environment configuration for Nuxt (flat schema).
  *
  * @param schema Flat schema definition
  * @param options Optional extends / exposeToClient / runtimeEnv

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -1,8 +1,18 @@
 import type { EnvSchema, Infer } from "@arkenv/core";
-import { arkenv as coreArkenv, getSchemaKeys } from "@arkenv/core";
 import type { SchemaShape } from "@repo/types";
+// Virtual: empty on client, real ensureBootGate on server (see module aliases).
+import { ensureBootGate } from "#arkenv/server-boot";
 import { arkenvInternal, type FlatSchemaOptions } from "./arkenv-internal";
 
+/**
+ * Create a type-safe environment configuration for Nuxt (flat / unified entry).
+ *
+ * Values are read from the Nitro boot-gate coerced `runtimeConfig` / `__NUXT__`
+ * payload — this entry does not run core validation.
+ *
+ * @param options Nested server/client/shared schema options
+ * @returns A readonly environment proxy
+ */
 export function arkenv<
 	const TServer extends SchemaShape = {},
 	const TClient extends SchemaShape = {},
@@ -16,6 +26,13 @@ export function arkenv<
 	runtimeEnv?: Record<string, unknown>;
 }): Readonly<Infer<TServer & TClient & TShared>>;
 
+/**
+ * Create a type-safe environment configuration for Nuxt (flat schema).
+ *
+ * @param schema Flat schema definition
+ * @param options Optional extends / exposeToClient / runtimeEnv
+ * @returns A readonly environment proxy
+ */
 export function arkenv<const TSchema extends SchemaShape = {}>(
 	schema: EnvSchema<TSchema>,
 	options?: FlatSchemaOptions,
@@ -35,26 +52,20 @@ export function arkenv(
 
 	const isServer = typeof window === "undefined";
 
+	const hooks = isServer ? { ensureBootGate } : undefined;
+
 	if (isLegacy) {
-		return arkenvInternal(
-			schemaOrOptions,
-			isServer,
-			undefined,
-			coreArkenv,
-			getSchemaKeys,
-		);
+		return arkenvInternal(schemaOrOptions, isServer, undefined, hooks);
 	}
 
 	return arkenvInternal(
 		schemaOrOptions,
 		optionsOrIsServer as FlatSchemaOptions | undefined,
 		{ isServer },
-		coreArkenv,
-		getSchemaKeys,
+		hooks,
 	);
 }
 
-export type { Infer } from "@arkenv/core";
-export { type } from "@arkenv/core";
+export type { EnvSchema, Infer } from "@arkenv/core";
 
 export default arkenv;

--- a/packages/nuxt/src/module-engine.ts
+++ b/packages/nuxt/src/module-engine.ts
@@ -1,0 +1,21 @@
+import type { BootGateEngine } from "./boot-gate";
+
+let defaultEngine: BootGateEngine = "arktype";
+
+/**
+ * Set the default boot-gate engine for the next module setup (Standard module).
+ *
+ * @param engine ArkType or Standard Schema engine
+ */
+export function setDefaultBootGateEngine(engine: BootGateEngine): void {
+	defaultEngine = engine;
+}
+
+/**
+ * Return the default boot-gate engine for module setup.
+ *
+ * @returns The configured engine
+ */
+export function getDefaultBootGateEngine(): BootGateEngine {
+	return defaultEngine;
+}

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -12,6 +12,10 @@ vi.mock("@nuxt/kit", () => {
 				setup: config.setup,
 			};
 		},
+		createResolver: () => ({
+			resolve: (p: string) => path.resolve(__dirname, p),
+		}),
+		addServerPlugin: vi.fn(),
 		useLogger: () => {
 			return {
 				info: vi.fn(),
@@ -22,6 +26,25 @@ vi.mock("@nuxt/kit", () => {
 		},
 	};
 });
+
+/**
+ * Invoke every Nuxt hook registered under `name` (module may register several).
+ *
+ * @param mockNuxt The mock Nuxt instance with a vi.fn hook
+ * @param name Hook name
+ * @param args Arguments forwarded to each handler
+ */
+function runHooks(
+	mockNuxt: { hook: { mock: { calls: unknown[][] } } },
+	name: string,
+	...args: unknown[]
+) {
+	for (const [hookName, handler] of mockNuxt.hook.mock.calls) {
+		if (hookName === name && typeof handler === "function") {
+			(handler as (...a: unknown[]) => void)(...args);
+		}
+	}
+}
 
 describe("Nuxt module integration", () => {
 	it("should parse and register variables to nuxt.options.runtimeConfig", async () => {
@@ -67,6 +90,10 @@ describe("Nuxt module integration", () => {
 				mockNuxt.options.runtimeConfig.public.NUXT_PUBLIC_API_URL,
 			).toBeDefined();
 			expect(mockNuxt.options.runtimeConfig.public.NODE_ENV).toBeDefined();
+			expect(mockNuxt.options.runtimeConfig.arkenvGate).toMatchObject({
+				layout: "simple",
+				engine: "arktype",
+			});
 
 			// Check if vite hook was registered
 			expect(mockNuxt.hook).toHaveBeenCalledWith(
@@ -223,23 +250,21 @@ describe("Nuxt module integration", () => {
 				sharedPath,
 			]);
 
-			const nitroHook = mockNuxt.hook.mock.calls.find(
-				([name]: [string, ...any[]]) => name === "nitro:config",
-			)?.[1];
-			expect(nitroHook).toBeDefined();
 			const nitroConfig: any = {};
-			nitroHook(nitroConfig);
+			runHooks(mockNuxt, "nitro:config", nitroConfig);
 			expect(nitroConfig.alias["#arkenv/client-env"]).toBe(clientPath);
 			expect(nitroConfig.alias["#arkenv/shared-schema"]).toBe(sharedPath);
 			expect(nitroConfig.replace.__ARKENV_STRICT_LAYOUT__).toBe("true");
+			expect(nitroConfig.alias["#arkenv/server-boot"]).toBeDefined();
 
-			const viteHook = mockNuxt.hook.mock.calls.find(
-				([name]: [string, ...any[]]) => name === "vite:extendConfig",
-			)?.[1];
-			expect(viteHook).toBeDefined();
-
-			const serverConfig: any = { plugins: [] };
-			viteHook(serverConfig, { isClient: false });
+			const serverConfig: any = {
+				plugins: [],
+				resolve: { alias: {} },
+				define: {},
+			};
+			runHooks(mockNuxt, "vite:extendConfig", serverConfig, {
+				isClient: false,
+			});
 
 			expect(serverConfig.define.__ARKENV_STRICT_LAYOUT__).toBe("true");
 			expect(serverConfig.resolve.alias["#arkenv/client-env"]).toBe(clientPath);
@@ -261,8 +286,12 @@ describe("Nuxt module integration", () => {
 				sharedPath,
 			);
 
-			const clientConfig: any = { plugins: [] };
-			viteHook(clientConfig, { isClient: true });
+			const clientConfig: any = {
+				plugins: [],
+				resolve: { alias: {} },
+				define: {},
+			};
+			runHooks(mockNuxt, "vite:extendConfig", clientConfig, { isClient: true });
 			expect(clientConfig.define.__ARKENV_STRICT_LAYOUT__).toBe("true");
 			expect(
 				clientConfig.plugins.find(
@@ -372,23 +401,22 @@ describe("Nuxt module integration", () => {
 
 			expect(mockNuxt.options.alias["#arkenv/client-env"]).toBeUndefined();
 			expect(mockNuxt.options.alias["#arkenv/shared-schema"]).toBeUndefined();
+			expect(mockNuxt.options.alias["#arkenv/server-boot"]).toBeDefined();
 
 			expect(
 				mockNuxt.hook.mock.calls.find(
 					([name]: [string, ...any[]]) => name === "prepare:types",
 				),
 			).toBeUndefined();
-			expect(
-				mockNuxt.hook.mock.calls.find(
-					([name]: [string, ...any[]]) => name === "nitro:config",
-				),
-			).toBeUndefined();
 
-			const viteHook = mockNuxt.hook.mock.calls.find(
-				([name]: [string, ...any[]]) => name === "vite:extendConfig",
-			)?.[1];
-			const config: any = { plugins: [] };
-			viteHook(config, { isClient: false });
+			const nitroConfig: any = { alias: {} };
+			runHooks(mockNuxt, "nitro:config", nitroConfig);
+			expect(nitroConfig.alias["#arkenv/client-env"]).toBeUndefined();
+			expect(nitroConfig.alias["#arkenv/shared-schema"]).toBeUndefined();
+			expect(nitroConfig.alias["#arkenv/server-boot"]).toBeDefined();
+
+			const config: any = { plugins: [], resolve: { alias: {} } };
+			runHooks(mockNuxt, "vite:extendConfig", config, { isClient: false });
 
 			expect(config.define?.__ARKENV_STRICT_LAYOUT__).toBeUndefined();
 			expect(
@@ -436,11 +464,8 @@ describe("Nuxt module integration", () => {
 				mockNuxt,
 			);
 
-			const viteHook = mockNuxt.hook.mock.calls.find(
-				([name]: [string, ...any[]]) => name === "vite:extendConfig",
-			)?.[1];
-			const config: any = { plugins: [] };
-			viteHook(config, { isClient: false });
+			const config: any = { plugins: [], resolve: { alias: {} } };
+			runHooks(mockNuxt, "vite:extendConfig", config, { isClient: false });
 
 			const plugin = config.plugins.find(
 				(p: any) => p.name === "arkenv-nuxt-client-env",
@@ -487,11 +512,8 @@ describe("Nuxt module integration", () => {
 				mockNuxt,
 			);
 
-			const viteHook = mockNuxt.hook.mock.calls.find(
-				([name]: [string, ...any[]]) => name === "vite:extendConfig",
-			)?.[1];
-			const config: any = { plugins: [] };
-			viteHook(config, { isClient: false });
+			const config: any = { plugins: [], resolve: { alias: {} } };
+			runHooks(mockNuxt, "vite:extendConfig", config, { isClient: false });
 
 			const plugin = config.plugins.find(
 				(p: any) => p.name === "arkenv-nuxt-shared-schema",

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import { defineNuxtModule } from "@nuxt/kit";
+import { addServerPlugin, createResolver, defineNuxtModule } from "@nuxt/kit";
 import type { NuxtModule } from "@nuxt/schema";
 import { formatBuildError, resolveBuildLog } from "@repo/log";
 import { name, peerDependencies, version } from "../package.json";
+import type { BootGateEngine } from "./boot-gate";
 import {
 	type ArkEnvConfigOptions,
 	extractClientKeys,
@@ -15,6 +16,7 @@ import {
 	resolveLayout,
 	validateSchema,
 } from "./config";
+import { getDefaultBootGateEngine } from "./module-engine";
 import { missingClientTsError } from "./strict-client-env";
 import {
 	registerStrictLayoutHooks,
@@ -71,6 +73,36 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 	},
 	setup(options, nuxt) {
 		const buildLog = resolveBuildLog(options);
+		const resolver = createResolver(import.meta.url);
+		const engine: BootGateEngine = getDefaultBootGateEngine();
+
+		const emptyServerBoot = resolver.resolve("./empty-server-boot");
+		const realServerBoot = resolver.resolve("./server-boot");
+
+		// Default to the empty stub; Vite SSR + Nitro overwrite with the real gate.
+		nuxt.options.alias = nuxt.options.alias || {};
+		nuxt.options.alias["#arkenv/server-boot"] = emptyServerBoot;
+
+		nuxt.hook("vite:extendConfig", (config, { isClient }) => {
+			// biome-ignore lint/suspicious/noExplicitAny: Nuxt's Vite config type is overly restrictive
+			const anyConfig = config as any;
+			anyConfig.resolve = anyConfig.resolve || {};
+			anyConfig.resolve.alias = anyConfig.resolve.alias || {};
+			const aliasTarget = isClient ? emptyServerBoot : realServerBoot;
+			if (Array.isArray(anyConfig.resolve.alias)) {
+				anyConfig.resolve.alias.push({
+					find: "#arkenv/server-boot",
+					replacement: aliasTarget,
+				});
+			} else {
+				anyConfig.resolve.alias["#arkenv/server-boot"] = aliasTarget;
+			}
+		});
+
+		nuxt.hook("nitro:config", (nitroConfig) => {
+			nitroConfig.alias = nitroConfig.alias || {};
+			nitroConfig.alias["#arkenv/server-boot"] = realServerBoot;
+		});
 
 		const schemaPath = options.schemaPath
 			? path.resolve(nuxt.options.rootDir, options.schemaPath)
@@ -127,7 +159,9 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 
 		if (validate) {
 			try {
-				validateSchema(schemaPath, resolvedLayout, baseDir ?? "");
+				validateSchema(schemaPath, resolvedLayout, baseDir ?? "", {
+					engine,
+				});
 			} catch (error: unknown) {
 				const message = error instanceof Error ? error.message : String(error);
 				throw new Error(
@@ -183,6 +217,15 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 				nuxt.options.runtimeConfig.public[key] = process.env[key] || "";
 			}
 		}
+
+		(nuxt.options.runtimeConfig as { arkenvGate?: unknown }).arkenvGate = {
+			schemaPath,
+			layout: resolvedLayout,
+			baseDir: baseDir ?? "",
+			engine,
+		};
+
+		addServerPlugin(resolver.resolve("./runtime/nitro-boot-plugin"));
 
 		registerViteExtendHook(nuxt, {
 			resolvedLayout,

--- a/packages/nuxt/src/resolve-core-arkenv.ts
+++ b/packages/nuxt/src/resolve-core-arkenv.ts
@@ -15,9 +15,7 @@ type CoreArkenv = (
  * @param engine ArkType (`@arkenv/core`) or Standard Schema (`@arkenv/standard`)
  * @returns The engine's `arkenv` function
  */
-export function resolveCoreArkenv(
-	engine: "arktype" | "standard",
-): CoreArkenv {
+export function resolveCoreArkenv(engine: "arktype" | "standard"): CoreArkenv {
 	const jiti = createJiti(import.meta.url);
 	if (engine === "standard") {
 		return (jiti("@arkenv/standard") as { arkenv: CoreArkenv }).arkenv;

--- a/packages/nuxt/src/resolve-core-arkenv.ts
+++ b/packages/nuxt/src/resolve-core-arkenv.ts
@@ -1,0 +1,26 @@
+import type { Dict, SchemaShape } from "@repo/types";
+import { createJiti } from "jiti";
+
+type CoreArkenv = (
+	schema: SchemaShape,
+	config?: { env?: Dict<string>; safe?: boolean },
+) => Record<string, unknown>;
+
+/**
+ * Resolve the core validation function for the configured engine.
+ *
+ * Uses Jiti so optional peers (`@arkenv/core` / `@arkenv/standard`) load
+ * synchronously without a static import that would force both packages.
+ *
+ * @param engine ArkType (`@arkenv/core`) or Standard Schema (`@arkenv/standard`)
+ * @returns The engine's `arkenv` function
+ */
+export function resolveCoreArkenv(
+	engine: "arktype" | "standard",
+): CoreArkenv {
+	const jiti = createJiti(import.meta.url);
+	if (engine === "standard") {
+		return (jiti("@arkenv/standard") as { arkenv: CoreArkenv }).arkenv;
+	}
+	return (jiti("@arkenv/core") as { arkenv: CoreArkenv }).arkenv;
+}

--- a/packages/nuxt/src/runtime/nitro-boot-plugin.ts
+++ b/packages/nuxt/src/runtime/nitro-boot-plugin.ts
@@ -1,0 +1,23 @@
+import { defineNitroPlugin, useRuntimeConfig } from "nitropack/runtime";
+import {
+	type BootGateConfig,
+	type BootGateRuntimeConfig,
+	configureBootGate,
+	ensureBootGate,
+} from "../boot-gate";
+
+/**
+ * Nitro boot plugin: coerce schema keys into `runtimeConfig` after string overrides.
+ *
+ * Registered by `@arkenv/nuxt/module`. This is the single `createEnv` moment for
+ * Nuxt — thin `arkenv()` accessors only read the coerced payload afterward.
+ */
+export default defineNitroPlugin(() => {
+	const runtimeConfig = useRuntimeConfig() as BootGateRuntimeConfig;
+	const gate = runtimeConfig.arkenvGate as BootGateConfig | undefined;
+
+	if (gate?.schemaPath) {
+		configureBootGate(gate);
+		ensureBootGate(runtimeConfig);
+	}
+});

--- a/packages/nuxt/src/server-boot.ts
+++ b/packages/nuxt/src/server-boot.ts
@@ -1,0 +1,6 @@
+/**
+ * Server-side `#arkenv/server-boot` implementation.
+ *
+ * Re-exports {@link ensureBootGate} from the Nitro boot-gate module (core-backed).
+ */
+export { ensureBootGate } from "./boot-gate";

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -6,11 +6,8 @@ import type { type as at, distill } from "arktype";
 // Outside strict layout the module aliases this to `empty-client-env.ts`.
 import { env as importedClientEnv } from "#arkenv/client-env";
 import { ensureBootGate } from "#arkenv/server-boot";
-import { arkenvInternal, type FlatSchemaOptions } from "./arkenv-internal";
-import {
-	isStrictLayoutActive,
-	resolveStrictClientEnv,
-} from "./strict-client-env";
+import { resolveStrictClientEnv } from "./strict-client-env";
+import { dispatchStrictThinArkenv } from "./thin-accessor";
 import type { MergeExtends } from "./types";
 
 /**
@@ -24,35 +21,6 @@ type AutoClientEnv = typeof import("#arkenv/client-env") extends {
 }
 	? E
 	: {};
-
-/**
- * Apply strict-layout auto-extend when `extends` is omitted.
- *
- * Kept in the server entry so client bundles never import this module graph.
- *
- * @param optionsOrIsServer Flat options, legacy boolean, or undefined
- * @returns Options with auto-extend applied when appropriate
- */
-function withAutoExtend(
-	optionsOrIsServer: FlatSchemaOptions | boolean | null | undefined,
-): FlatSchemaOptions | boolean | null | undefined {
-	if (typeof optionsOrIsServer === "boolean") {
-		return optionsOrIsServer;
-	}
-
-	if (optionsOrIsServer != null && "extends" in optionsOrIsServer) {
-		return optionsOrIsServer;
-	}
-
-	if (!isStrictLayoutActive()) {
-		return optionsOrIsServer;
-	}
-
-	return {
-		...(optionsOrIsServer ?? {}),
-		extends: [resolveStrictClientEnv(importedClientEnv)],
-	};
-}
 
 /**
  * Create a typesafe environment configuration for Nuxt (server entry).
@@ -102,30 +70,11 @@ export function arkenv<
 >;
 
 export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
-	const isLegacy =
-		schemaOrOptions &&
-		typeof schemaOrOptions === "object" &&
-		("runtimeEnv" in schemaOrOptions ||
-			"server" in schemaOrOptions ||
-			"shared" in schemaOrOptions);
-
-	const hooks = { ensureBootGate };
-
-	if (isLegacy) {
-		if ("client" in schemaOrOptions) {
-			throw new Error(
-				"server entry point only accepts 'server' and 'shared' schemas.",
-			);
-		}
-		return arkenvInternal(schemaOrOptions, true, undefined, hooks);
-	}
-
-	return arkenvInternal(
-		schemaOrOptions,
-		withAutoExtend(optionsOrIsServer),
-		{ isServer: true, strictLayout: "server" },
-		hooks,
-	);
+	return dispatchStrictThinArkenv(schemaOrOptions, optionsOrIsServer, {
+		strictLayout: "server",
+		resolveAutoExtendTarget: () => resolveStrictClientEnv(importedClientEnv),
+		ensureBootGate,
+	});
 }
 
 export default arkenv;

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -55,7 +55,7 @@ function withAutoExtend(
 }
 
 /**
- * Create a type-safe environment configuration for Nuxt (server entry).
+ * Create a typesafe environment configuration for Nuxt (server entry).
  *
  * Calls {@link ensureBootGate} then reads coerced `runtimeConfig` values —
  * does not re-validate with core in this entry.

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -1,11 +1,11 @@
 import type { EnvSchema } from "@arkenv/core";
-import { arkenv as coreArkenv, getSchemaKeys } from "@arkenv/core";
 import type { $ } from "@repo/scope";
 import type { SchemaShape } from "@repo/types";
 import type { type as at, distill } from "arktype";
 // Static import so Vite/Nitro can resolve the alias at bundle time.
 // Outside strict layout the module aliases this to `empty-client-env.ts`.
 import { env as importedClientEnv } from "#arkenv/client-env";
+import { ensureBootGate } from "#arkenv/server-boot";
 import { arkenvInternal, type FlatSchemaOptions } from "./arkenv-internal";
 import {
 	isStrictLayoutActive,
@@ -55,33 +55,18 @@ function withAutoExtend(
 }
 
 /**
- * Create a validated, type-safe environment configuration for Nuxt applications (Server entry point).
+ * Create a type-safe environment configuration for Nuxt (server entry).
+ *
+ * Calls {@link ensureBootGate} then reads coerced `runtimeConfig` values —
+ * does not re-validate with core in this entry.
  *
  * With `@arkenv/nuxt/module` in strict layout, omitting `extends` includes the
  * client and shared env by default. Any explicit `extends` is used as-is and
  * opts out of that default; pass `extends: []` to include no extended env.
  *
- * @example Default strict-layout behavior
- * ```ts
- * import arkenv from "@arkenv/nuxt/server";
- *
- * export const env = arkenv({
- *   DATABASE_URL: "string",
- * });
- * ```
- *
- * @example Opt out of the default client merge
- * ```ts
- * export const env = arkenv(
- *   { DATABASE_URL: "string" },
- *   { extends: [] },
- * );
- * ```
- *
  * @param schemaOrOptions The schema definition or configuration options containing server/shared schemas
  * @param optionsOrIsServer Optional configuration paths or a boolean indicating server status
- * @returns A validated, readonly environment variables object wrapped in a security proxy
- * @throws An error if a client-side variable is missing from `runtimeEnv`
+ * @returns A readonly environment variables object wrapped in a security proxy
  */
 export function arkenv<
 	const TSchema extends SchemaShape = {},
@@ -124,30 +109,23 @@ export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
 			"server" in schemaOrOptions ||
 			"shared" in schemaOrOptions);
 
+	const hooks = { ensureBootGate };
+
 	if (isLegacy) {
 		if ("client" in schemaOrOptions) {
 			throw new Error(
 				"server entry point only accepts 'server' and 'shared' schemas.",
 			);
 		}
-		return arkenvInternal(
-			schemaOrOptions,
-			true,
-			undefined,
-			coreArkenv,
-			getSchemaKeys,
-		);
+		return arkenvInternal(schemaOrOptions, true, undefined, hooks);
 	}
 
 	return arkenvInternal(
 		schemaOrOptions,
 		withAutoExtend(optionsOrIsServer),
 		{ isServer: true, strictLayout: "server" },
-		coreArkenv,
-		getSchemaKeys,
+		hooks,
 	);
 }
-
-export { type } from "@arkenv/core";
 
 export default arkenv;

--- a/packages/nuxt/src/standard/client.ts
+++ b/packages/nuxt/src/standard/client.ts
@@ -47,7 +47,7 @@ function withAutoExtend(
 }
 
 /**
- * Create a type-safe environment configuration for Nuxt (client entry, Standard Mode).
+ * Create a typesafe environment configuration for Nuxt (client entry, Standard Mode).
  *
  * Reads the already-coerced public payload — does not import or run the validator.
  *

--- a/packages/nuxt/src/standard/client.ts
+++ b/packages/nuxt/src/standard/client.ts
@@ -2,9 +2,8 @@ import type { StandardSchemaV1 } from "@repo/types";
 // Static import so Vite/Nitro can resolve the alias at bundle time.
 // Outside strict layout the module aliases this to `empty-shared-schema.ts`.
 import { SharedSchema as importedSharedSchema } from "#arkenv/shared-schema";
-import { arkenvInternal, type FlatSchemaOptions } from "@/arkenv-internal";
-import { isStrictLayoutActive } from "@/strict-client-env";
 import { resolveStrictSharedSchema } from "@/strict-shared-schema";
+import { dispatchStrictThinArkenv } from "@/thin-accessor";
 import type { MergeExtends, ResolveExtendsElement } from "@/types";
 
 /**
@@ -18,33 +17,6 @@ type AutoSharedSchema = typeof import("#arkenv/shared-schema") extends {
 }
 	? ResolveExtendsElement<S>
 	: {};
-
-/**
- * Apply strict-layout auto-extend when `extends` is omitted.
- *
- * @param optionsOrIsServer Flat options, legacy boolean, or undefined
- * @returns Options with auto-extend applied when appropriate
- */
-function withAutoExtend(
-	optionsOrIsServer: FlatSchemaOptions | boolean | null | undefined,
-): FlatSchemaOptions | boolean | null | undefined {
-	if (typeof optionsOrIsServer === "boolean") {
-		return optionsOrIsServer;
-	}
-
-	if (optionsOrIsServer != null && "extends" in optionsOrIsServer) {
-		return optionsOrIsServer;
-	}
-
-	if (!isStrictLayoutActive()) {
-		return optionsOrIsServer;
-	}
-
-	return {
-		...(optionsOrIsServer ?? {}),
-		extends: [resolveStrictSharedSchema(importedSharedSchema)],
-	};
-}
 
 /**
  * Create a typesafe environment configuration for Nuxt (client entry, Standard Mode).
@@ -115,23 +87,10 @@ export function arkenv<
 >;
 
 export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
-	const isLegacy =
-		schemaOrOptions &&
-		typeof schemaOrOptions === "object" &&
-		("client" in schemaOrOptions || "shared" in schemaOrOptions);
-
-	if (isLegacy) {
-		if ("server" in schemaOrOptions) {
-			throw new Error(
-				"client entry point only accepts 'client' and 'shared' schemas.",
-			);
-		}
-		return arkenvInternal(schemaOrOptions, false, undefined);
-	}
-
-	return arkenvInternal(schemaOrOptions, withAutoExtend(optionsOrIsServer), {
-		isServer: false,
+	return dispatchStrictThinArkenv(schemaOrOptions, optionsOrIsServer, {
 		strictLayout: "client",
+		resolveAutoExtendTarget: () =>
+			resolveStrictSharedSchema(importedSharedSchema),
 	});
 }
 

--- a/packages/nuxt/src/standard/client.ts
+++ b/packages/nuxt/src/standard/client.ts
@@ -1,4 +1,3 @@
-import { arkenv as coreArkenv, getSchemaKeys } from "@arkenv/standard";
 import type { StandardSchemaV1 } from "@repo/types";
 // Static import so Vite/Nitro can resolve the alias at bundle time.
 // Outside strict layout the module aliases this to `empty-shared-schema.ts`.
@@ -48,32 +47,17 @@ function withAutoExtend(
 }
 
 /**
- * Create a validated, type-safe environment configuration for Nuxt applications (Client entry point, Standard Mode).
+ * Create a type-safe environment configuration for Nuxt (client entry, Standard Mode).
+ *
+ * Reads the already-coerced public payload — does not import or run the validator.
  *
  * With `@arkenv/nuxt/module` in strict layout, omitting `extends` includes the
  * shared schema by default. Any explicit `extends` is used as-is and opts out
  * of that default; pass `extends: []` to include no extended env.
  *
- * @example Default strict-layout behavior
- * ```ts
- * import arkenv from "@arkenv/nuxt/standard/client";
- *
- * export const env = arkenv({
- *   NUXT_PUBLIC_API_URL: apiUrlSchema,
- * });
- * ```
- *
- * @example Opt out of the default shared merge
- * ```ts
- * export const env = arkenv(
- *   { NUXT_PUBLIC_API_URL: apiUrlSchema },
- *   { extends: [] },
- * );
- * ```
- *
  * @param schemaOrOptions The schema definition or configuration options containing client/shared schemas
  * @param optionsOrIsServer Optional configuration paths or a boolean indicating server status
- * @returns A validated, readonly environment variables object wrapped in a security proxy
+ * @returns A readonly environment variables object wrapped in a security proxy
  * @throws An error if any client-side variable is not prefixed with `NUXT_PUBLIC_`
  * @throws An error if a server-only variable is accessed on the client side
  */
@@ -142,22 +126,13 @@ export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
 				"client entry point only accepts 'client' and 'shared' schemas.",
 			);
 		}
-		return arkenvInternal(
-			schemaOrOptions,
-			false,
-			undefined,
-			coreArkenv,
-			getSchemaKeys,
-		);
+		return arkenvInternal(schemaOrOptions, false, undefined);
 	}
 
-	return arkenvInternal(
-		schemaOrOptions,
-		withAutoExtend(optionsOrIsServer),
-		{ isServer: false, strictLayout: "client" },
-		coreArkenv,
-		getSchemaKeys,
-	);
+	return arkenvInternal(schemaOrOptions, withAutoExtend(optionsOrIsServer), {
+		isServer: false,
+		strictLayout: "client",
+	});
 }
 
 export default arkenv;

--- a/packages/nuxt/src/standard/index.ts
+++ b/packages/nuxt/src/standard/index.ts
@@ -1,5 +1,5 @@
-import { arkenv as coreArkenv, getSchemaKeys } from "@arkenv/standard";
 import type { StandardSchemaV1 } from "@repo/types";
+import { ensureBootGate } from "#arkenv/server-boot";
 import { arkenvInternal } from "@/arkenv-internal";
 import type { MergeExtends } from "../types";
 
@@ -17,11 +17,14 @@ type ClientVisibleKeys<
 }[keyof TSchema];
 
 /**
- * Create a validated, type-safe environment configuration for Nuxt applications (Standard Mode).
+ * Create a type-safe environment configuration for Nuxt (Standard Mode).
+ *
+ * Values are read from the Nitro boot-gate coerced payload — this entry does
+ * not run core validation.
  *
  * @param schema A flat schema of environment variable Standard Schema validators
  * @param options Optional configuration including client-side variables and extends
- * @returns A validated, readonly environment variables object wrapped in a security proxy
+ * @returns A readonly environment variables object wrapped in a security proxy
  */
 export function arkenv<
 	const TSchema extends Record<string, StandardSchemaV1> = {},
@@ -45,11 +48,11 @@ export function arkenv<
 >;
 
 /**
- * Create a validated, type-safe environment configuration for Nuxt applications (Standard Mode).
+ * Create a type-safe environment configuration for Nuxt (Standard Mode).
  *
  * @deprecated Use the unified flat layout signature instead: `arkenv(schema, options)`
  * @param options The environment validation configuration options
- * @returns A validated, readonly environment variables object wrapped in a security proxy
+ * @returns A readonly environment variables object wrapped in a security proxy
  * @throws An error if any client-side variable is not prefixed with `NUXT_PUBLIC_`
  */
 export function arkenv<
@@ -79,23 +82,17 @@ export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
 			"shared" in schemaOrOptions);
 
 	const isServer = typeof window === "undefined";
+	const hooks = isServer ? { ensureBootGate } : undefined;
 
 	if (isLegacy) {
-		return arkenvInternal(
-			schemaOrOptions,
-			isServer,
-			undefined,
-			coreArkenv,
-			getSchemaKeys,
-		);
+		return arkenvInternal(schemaOrOptions, isServer, undefined, hooks);
 	}
 
 	return arkenvInternal(
 		schemaOrOptions,
 		optionsOrIsServer,
 		{ isServer },
-		coreArkenv,
-		getSchemaKeys,
+		hooks,
 	);
 }
 

--- a/packages/nuxt/src/standard/index.ts
+++ b/packages/nuxt/src/standard/index.ts
@@ -17,7 +17,7 @@ type ClientVisibleKeys<
 }[keyof TSchema];
 
 /**
- * Create a type-safe environment configuration for Nuxt (Standard Mode).
+ * Create a typesafe environment configuration for Nuxt (Standard Mode).
  *
  * Values are read from the Nitro boot-gate coerced payload — this entry does
  * not run core validation.
@@ -48,7 +48,7 @@ export function arkenv<
 >;
 
 /**
- * Create a type-safe environment configuration for Nuxt (Standard Mode).
+ * Create a typesafe environment configuration for Nuxt (Standard Mode).
  *
  * @deprecated Use the unified flat layout signature instead: `arkenv(schema, options)`
  * @param options The environment validation configuration options

--- a/packages/nuxt/src/standard/module.ts
+++ b/packages/nuxt/src/standard/module.ts
@@ -1,4 +1,7 @@
-import module from "@/module";
+import { setDefaultBootGateEngine } from "@/module-engine";
+
+// Pin the Standard engine before re-exporting the shared module implementation.
+setDefaultBootGateEngine("standard");
 
 export * from "@/module";
-export default module;
+export { default } from "@/module";

--- a/packages/nuxt/src/standard/server.ts
+++ b/packages/nuxt/src/standard/server.ts
@@ -52,7 +52,7 @@ function withAutoExtend(
 }
 
 /**
- * Create a validated, type-safe environment configuration for Nuxt applications (Server entry point, Standard Mode).
+ * Create a validated, typesafe environment configuration for Nuxt applications (Server entry point, Standard Mode).
  *
  * With `@arkenv/nuxt/module` in strict layout, omitting `extends` includes the
  * client and shared env by default. Any explicit `extends` is used as-is and

--- a/packages/nuxt/src/standard/server.ts
+++ b/packages/nuxt/src/standard/server.ts
@@ -1,8 +1,8 @@
-import { arkenv as coreArkenv, getSchemaKeys } from "@arkenv/standard";
 import type { StandardSchemaV1 } from "@repo/types";
 // Static import so Vite/Nitro can resolve the alias at bundle time.
 // Outside strict layout the module aliases this to `empty-client-env.ts`.
 import { env as importedClientEnv } from "#arkenv/client-env";
+import { ensureBootGate } from "#arkenv/server-boot";
 import { arkenvInternal, type FlatSchemaOptions } from "@/arkenv-internal";
 import {
 	isStrictLayoutActive,
@@ -135,27 +135,22 @@ export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
 			"server" in schemaOrOptions ||
 			"shared" in schemaOrOptions);
 
+	const hooks = { ensureBootGate };
+
 	if (isLegacy) {
 		if ("client" in schemaOrOptions) {
 			throw new Error(
 				"server entry point only accepts 'server' and 'shared' schemas.",
 			);
 		}
-		return arkenvInternal(
-			schemaOrOptions,
-			true,
-			undefined,
-			coreArkenv,
-			getSchemaKeys,
-		);
+		return arkenvInternal(schemaOrOptions, true, undefined, hooks);
 	}
 
 	return arkenvInternal(
 		schemaOrOptions,
 		withAutoExtend(optionsOrIsServer),
 		{ isServer: true, strictLayout: "server" },
-		coreArkenv,
-		getSchemaKeys,
+		hooks,
 	);
 }
 

--- a/packages/nuxt/src/standard/server.ts
+++ b/packages/nuxt/src/standard/server.ts
@@ -3,11 +3,8 @@ import type { StandardSchemaV1 } from "@repo/types";
 // Outside strict layout the module aliases this to `empty-client-env.ts`.
 import { env as importedClientEnv } from "#arkenv/client-env";
 import { ensureBootGate } from "#arkenv/server-boot";
-import { arkenvInternal, type FlatSchemaOptions } from "@/arkenv-internal";
-import {
-	isStrictLayoutActive,
-	resolveStrictClientEnv,
-} from "@/strict-client-env";
+import { resolveStrictClientEnv } from "@/strict-client-env";
+import { dispatchStrictThinArkenv } from "@/thin-accessor";
 import type { MergeExtends } from "@/types";
 
 /**
@@ -21,35 +18,6 @@ type AutoClientEnv = typeof import("#arkenv/client-env") extends {
 }
 	? E
 	: {};
-
-/**
- * Apply strict-layout auto-extend when `extends` is omitted.
- *
- * Kept in the server entry so client bundles never import this module graph.
- *
- * @param optionsOrIsServer Flat options, legacy boolean, or undefined
- * @returns Options with auto-extend applied when appropriate
- */
-function withAutoExtend(
-	optionsOrIsServer: FlatSchemaOptions | boolean | null | undefined,
-): FlatSchemaOptions | boolean | null | undefined {
-	if (typeof optionsOrIsServer === "boolean") {
-		return optionsOrIsServer;
-	}
-
-	if (optionsOrIsServer != null && "extends" in optionsOrIsServer) {
-		return optionsOrIsServer;
-	}
-
-	if (!isStrictLayoutActive()) {
-		return optionsOrIsServer;
-	}
-
-	return {
-		...(optionsOrIsServer ?? {}),
-		extends: [resolveStrictClientEnv(importedClientEnv)],
-	};
-}
 
 /**
  * Create a validated, typesafe environment configuration for Nuxt applications (Server entry point, Standard Mode).
@@ -128,30 +96,11 @@ export function arkenv<
 >;
 
 export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
-	const isLegacy =
-		schemaOrOptions &&
-		typeof schemaOrOptions === "object" &&
-		("runtimeEnv" in schemaOrOptions ||
-			"server" in schemaOrOptions ||
-			"shared" in schemaOrOptions);
-
-	const hooks = { ensureBootGate };
-
-	if (isLegacy) {
-		if ("client" in schemaOrOptions) {
-			throw new Error(
-				"server entry point only accepts 'server' and 'shared' schemas.",
-			);
-		}
-		return arkenvInternal(schemaOrOptions, true, undefined, hooks);
-	}
-
-	return arkenvInternal(
-		schemaOrOptions,
-		withAutoExtend(optionsOrIsServer),
-		{ isServer: true, strictLayout: "server" },
-		hooks,
-	);
+	return dispatchStrictThinArkenv(schemaOrOptions, optionsOrIsServer, {
+		strictLayout: "server",
+		resolveAutoExtendTarget: () => resolveStrictClientEnv(importedClientEnv),
+		ensureBootGate,
+	});
 }
 
 export default arkenv;

--- a/packages/nuxt/src/standard/shared.ts
+++ b/packages/nuxt/src/standard/shared.ts
@@ -1,14 +1,14 @@
-import { arkenv as coreArkenv, getSchemaKeys } from "@arkenv/standard";
 import type { StandardSchemaV1 } from "@repo/types";
+import { ensureBootGate } from "#arkenv/server-boot";
 import { arkenvInternal } from "@/arkenv-internal";
 import type { MergeExtends } from "@/types";
 
 /**
- * Create a validated, type-safe environment configuration for Nuxt applications (Shared entry point, Standard Mode).
+ * Create a type-safe shared environment configuration for Nuxt (Standard Mode).
  *
  * @param schema The schema definition containing the shared variables
  * @param options Optional configuration options
- * @returns A validated, readonly environment variables object wrapped in a security proxy
+ * @returns A readonly environment variables object wrapped in a security proxy
  */
 export function arkenv<
 	const TSchema extends Record<string, StandardSchemaV1> = {},
@@ -31,8 +31,7 @@ export function arkenv<
 			isServer,
 			isShared: true,
 		},
-		coreArkenv,
-		getSchemaKeys,
+		isServer ? { ensureBootGate } : undefined,
 	) as any;
 }
 

--- a/packages/nuxt/src/standard/shared.ts
+++ b/packages/nuxt/src/standard/shared.ts
@@ -4,7 +4,7 @@ import { arkenvInternal } from "@/arkenv-internal";
 import type { MergeExtends } from "@/types";
 
 /**
- * Create a type-safe shared environment configuration for Nuxt (Standard Mode).
+ * Create a typesafe shared environment configuration for Nuxt (Standard Mode).
  *
  * @param schema The schema definition containing the shared variables
  * @param options Optional configuration options

--- a/packages/nuxt/src/thin-accessor.ts
+++ b/packages/nuxt/src/thin-accessor.ts
@@ -1,0 +1,68 @@
+import {
+	arkenvInternal,
+	type ArkenvInternalHooks,
+} from "./arkenv-internal";
+import { withAutoExtend } from "./auto-extend";
+
+export type ThinStrictLayout = "client" | "server";
+
+/**
+ * Dispatch a strict-layout thin `arkenv()` call into {@link arkenvInternal}.
+ *
+ * Shared by ArkType and Standard client/server entries so legacy detection,
+ * entry guards, auto-extend, and boot-gate hooks stay in one place. Callers
+ * keep their own type overloads and virtual-module imports.
+ *
+ * @param schemaOrOptions Schema or nested options object
+ * @param optionsOrIsServer Flat options, legacy boolean, or undefined
+ * @param options Layout, auto-extend target, and optional boot-gate hook
+ * @returns The thin env proxy from {@link arkenvInternal}
+ * @throws When a legacy nested schema uses the wrong entry buckets
+ */
+export function dispatchStrictThinArkenv(
+	schemaOrOptions: unknown,
+	optionsOrIsServer: unknown,
+	options: {
+		strictLayout: ThinStrictLayout;
+		resolveAutoExtendTarget: () => unknown;
+		ensureBootGate?: () => void;
+	},
+): unknown {
+	const isServer = options.strictLayout === "server";
+	const hooks: ArkenvInternalHooks | undefined = options.ensureBootGate
+		? { ensureBootGate: options.ensureBootGate }
+		: undefined;
+
+	const isLegacy =
+		schemaOrOptions &&
+		typeof schemaOrOptions === "object" &&
+		(isServer
+			? "runtimeEnv" in schemaOrOptions ||
+				"server" in schemaOrOptions ||
+				"shared" in schemaOrOptions
+			: "client" in schemaOrOptions || "shared" in schemaOrOptions);
+
+	if (isLegacy) {
+		if (isServer && "client" in schemaOrOptions) {
+			throw new Error(
+				"server entry point only accepts 'server' and 'shared' schemas.",
+			);
+		}
+		if (!isServer && "server" in schemaOrOptions) {
+			throw new Error(
+				"client entry point only accepts 'client' and 'shared' schemas.",
+			);
+		}
+		return arkenvInternal(schemaOrOptions, isServer, undefined, hooks);
+	}
+
+	return arkenvInternal(
+		schemaOrOptions as never,
+		withAutoExtend(
+			optionsOrIsServer as never,
+			options.resolveAutoExtendTarget,
+		),
+		{ isServer, strictLayout: options.strictLayout },
+		hooks,
+	);
+}

--- a/packages/nuxt/src/thin-accessor.ts
+++ b/packages/nuxt/src/thin-accessor.ts
@@ -1,7 +1,4 @@
-import {
-	arkenvInternal,
-	type ArkenvInternalHooks,
-} from "./arkenv-internal";
+import { type ArkenvInternalHooks, arkenvInternal } from "./arkenv-internal";
 import { withAutoExtend } from "./auto-extend";
 
 export type ThinStrictLayout = "client" | "server";
@@ -58,10 +55,7 @@ export function dispatchStrictThinArkenv(
 
 	return arkenvInternal(
 		schemaOrOptions as never,
-		withAutoExtend(
-			optionsOrIsServer as never,
-			options.resolveAutoExtendTarget,
-		),
+		withAutoExtend(optionsOrIsServer as never, options.resolveAutoExtendTarget),
 		{ isServer, strictLayout: options.strictLayout },
 		hooks,
 	);

--- a/packages/nuxt/src/validate-schema.ts
+++ b/packages/nuxt/src/validate-schema.ts
@@ -1,28 +1,7 @@
-import { createRequire } from "node:module";
-import type { Dict, SchemaShape } from "@repo/types";
+import type { Dict } from "@repo/types";
 import type { BootGateEngine } from "./boot-gate";
 import { loadSchemaViaCapture } from "./boot-gate";
-
-const require = createRequire(import.meta.url);
-type CoreArkenv = (
-	schema: SchemaShape,
-	config?: { env?: Dict<string>; safe?: boolean },
-) => Record<string, unknown>;
-
-/**
- * Resolve the core validation function for the configured engine.
- *
- * @param engine ArkType (`@arkenv/core`) or Standard Schema (`@arkenv/standard`)
- * @returns The engine's `arkenv` function
- */
-function resolveCoreArkenv(engine: BootGateEngine): CoreArkenv {
-	if (engine === "standard") {
-		// eslint-disable-next-line @typescript-eslint/no-require-imports
-		return require("@arkenv/standard").arkenv as CoreArkenv;
-	}
-	// eslint-disable-next-line @typescript-eslint/no-require-imports
-	return require("@arkenv/core").arkenv as CoreArkenv;
-}
+import { resolveCoreArkenv } from "./resolve-core-arkenv";
 
 /**
  * Validate the project schema at build/dev time by loading schema via capture

--- a/packages/nuxt/src/validate-schema.ts
+++ b/packages/nuxt/src/validate-schema.ts
@@ -1,228 +1,65 @@
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { createJiti } from "jiti";
-import { withForceServer } from "./validate-context";
+import { createRequire } from "node:module";
+import type { Dict, SchemaShape } from "@repo/types";
+import type { BootGateEngine } from "./boot-gate";
+import { loadSchemaViaCapture } from "./boot-gate";
+
+const require = createRequire(import.meta.url);
+type CoreArkenv = (
+	schema: SchemaShape,
+	config?: { env?: Dict<string>; safe?: boolean },
+) => Record<string, unknown>;
 
 /**
- * Evaluate the project schema under Jiti so validation runs at build/dev time.
+ * Resolve the core validation function for the configured engine.
  *
- * In strict layout this loads `server.ts` with `#arkenv/client-env` aliased to
- * the project's `client.ts` and `#arkenv/shared-schema` aliased to
- * `internal/shared.ts`, mirroring the Nuxt module's auto-extend wiring.
+ * @param engine ArkType (`@arkenv/core`) or Standard Schema (`@arkenv/standard`)
+ * @returns The engine's `arkenv` function
+ */
+function resolveCoreArkenv(engine: BootGateEngine): CoreArkenv {
+	if (engine === "standard") {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		return require("@arkenv/standard").arkenv as CoreArkenv;
+	}
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	return require("@arkenv/core").arkenv as CoreArkenv;
+}
+
+/**
+ * Validate the project schema at build/dev time by loading schema via capture
+ * and calling core directly against the build environment.
  *
  * @param schemaPath Absolute path to the schema file or directory
  * @param resolvedLayout Detected or configured layout mode
  * @param baseDir Strict-layout env directory, or empty for flat layout
- * @param internalOptions Optional Jiti alias overrides for tests
+ * @param internalOptions Optional engine / Jiti alias overrides
  */
 export function validateSchema(
 	schemaPath: string,
 	resolvedLayout: "simple" | "strict",
 	baseDir: string,
-	internalOptions?: { _jitiAliases?: Record<string, string> },
+	internalOptions?: {
+		_jitiAliases?: Record<string, string>;
+		engine?: BootGateEngine;
+	},
 ): void {
-	withForceServer(() => {
-		const g = globalThis as {
-			__ARKENV_STRICT_LAYOUT__?: boolean;
-			__ARKENV_CLIENT_ENV__?: unknown;
-			__ARKENV_SHARED_SCHEMA__?: unknown;
-		};
+	const engine = internalOptions?.engine ?? "arktype";
+	const { schema } = loadSchemaViaCapture(
+		{
+			schemaPath,
+			layout: resolvedLayout,
+			baseDir,
+			engine,
+		},
+		internalOptions,
+	);
 
-		try {
-			const fileToEvaluate =
-				resolvedLayout === "strict" && baseDir
-					? path.join(baseDir, "server.ts")
-					: schemaPath;
+	if (Object.keys(schema).length === 0) {
+		return;
+	}
 
-			const filenameForJiti =
-				typeof __filename !== "undefined"
-					? __filename
-					: typeof import.meta !== "undefined" && import.meta.url
-						? fileURLToPath(import.meta.url)
-						: "";
-			const dir = path.dirname(filenameForJiti);
-
-			const packageJsonPath = path.resolve(dir, "../package.json");
-			let pkgExports: Record<string, unknown> = {};
-			try {
-				const pkgContent = fs.readFileSync(packageJsonPath, "utf-8");
-				pkgExports = JSON.parse(pkgContent).exports || {};
-			} catch {
-				// fallback if package.json isn't adjacent/found
-			}
-
-			const resolveExportPath = (
-				subpath: string,
-				fallbackFile: string,
-			): string => {
-				const entry = pkgExports[subpath] as
-					| { import?: string; default?: string }
-					| string
-					| undefined;
-				if (entry) {
-					const target =
-						typeof entry === "string"
-							? entry
-							: entry.import || entry.default || entry;
-					if (typeof target === "string") {
-						const fileBasename = path
-							.basename(target)
-							.replace(/\.m?[jt]s$/, "");
-						const tsPath = path.join(dir, `${fileBasename}.ts`);
-						if (fs.existsSync(tsPath)) {
-							return tsPath;
-						}
-						const jsPath = path.join(dir, `${fileBasename}.js`);
-						if (fs.existsSync(jsPath)) {
-							return jsPath;
-						}
-					}
-				}
-				return fallbackFile;
-			};
-
-			const sharedPath = resolveExportPath(
-				"./shared",
-				fs.existsSync(path.join(dir, "shared.ts"))
-					? path.join(dir, "shared.ts")
-					: path.join(dir, "shared.js"),
-			);
-			const indexPath = resolveExportPath(
-				".",
-				fs.existsSync(path.join(dir, "index.ts"))
-					? path.join(dir, "index.ts")
-					: path.join(dir, "index.js"),
-			);
-			const clientPath = resolveExportPath(
-				"./client",
-				fs.existsSync(path.join(dir, "client.ts"))
-					? path.join(dir, "client.ts")
-					: path.join(dir, "client.js"),
-			);
-			const serverPath = resolveExportPath(
-				"./server",
-				fs.existsSync(path.join(dir, "server.ts"))
-					? path.join(dir, "server.ts")
-					: path.join(dir, "server.js"),
-			);
-
-			const mockImportsPath = fs.existsSync(path.join(dir, "mock-imports.ts"))
-				? path.join(dir, "mock-imports.ts")
-				: fs.existsSync(path.join(dir, "mock-imports.js"))
-					? path.join(dir, "mock-imports.js")
-					: path.join(dir, "mock-imports.cjs");
-
-			const emptyClientEnvPath = fs.existsSync(
-				path.join(dir, "empty-client-env.ts"),
-			)
-				? path.join(dir, "empty-client-env.ts")
-				: path.join(dir, "empty-client-env.js");
-
-			const emptySharedSchemaPath = fs.existsSync(
-				path.join(dir, "empty-shared-schema.ts"),
-			)
-				? path.join(dir, "empty-shared-schema.ts")
-				: path.join(dir, "empty-shared-schema.js");
-
-			const strictUserClientPath =
-				resolvedLayout === "strict" && baseDir
-					? path.join(baseDir, "client.ts")
-					: undefined;
-
-			const strictUserSharedPath =
-				resolvedLayout === "strict" && baseDir
-					? path.join(baseDir, "internal", "shared.ts")
-					: undefined;
-
-			const aliases: Record<string, string> = {
-				"@arkenv/nuxt/shared": sharedPath,
-				"@arkenv/nuxt": indexPath,
-				"@arkenv/nuxt/client": clientPath,
-				"@arkenv/nuxt/server": serverPath,
-				"#imports": mockImportsPath,
-				"#arkenv/client-env":
-					strictUserClientPath && fs.existsSync(strictUserClientPath)
-						? strictUserClientPath
-						: emptyClientEnvPath,
-				"#arkenv/shared-schema":
-					strictUserSharedPath && fs.existsSync(strictUserSharedPath)
-						? strictUserSharedPath
-						: emptySharedSchemaPath,
-				...internalOptions?._jitiAliases,
-			};
-
-			const jitiOptions = {
-				moduleCache: false,
-				fsCache: false,
-				tsconfigPaths: true,
-				alias: aliases,
-			} as const;
-
-			/**
-			 * Evaluate the schema file, injecting strict-layout auto-extend state for Jiti.
-			 *
-			 * @param jiti The configured Jiti loader instance
-			 */
-			const evaluateSchema = (jiti: ReturnType<typeof createJiti>) => {
-				if (resolvedLayout === "strict" && baseDir) {
-					if (!strictUserSharedPath || !fs.existsSync(strictUserSharedPath)) {
-						throw new Error(
-							`[arkenv] Strict layout requires "internal/shared.ts" with a usable SharedSchema export under "${baseDir}".`,
-						);
-					}
-
-					const sharedMod = jiti(strictUserSharedPath) as {
-						SharedSchema?: unknown;
-						default?: { SharedSchema?: unknown };
-					};
-					const sharedSchema =
-						sharedMod.SharedSchema ?? sharedMod.default?.SharedSchema;
-					if (sharedSchema === undefined || sharedSchema === null) {
-						throw new Error(
-							`[arkenv] Strict layout requires a usable SharedSchema export from "${strictUserSharedPath}".`,
-						);
-					}
-					g.__ARKENV_SHARED_SCHEMA__ = sharedSchema;
-				}
-
-				if (strictUserClientPath && fs.existsSync(strictUserClientPath)) {
-					g.__ARKENV_STRICT_LAYOUT__ = true;
-					const clientMod = jiti(strictUserClientPath) as {
-						env?: unknown;
-						default?: { env?: unknown };
-					};
-					g.__ARKENV_CLIENT_ENV__ =
-						clientMod.env ?? clientMod.default?.env ?? clientMod;
-				}
-				jiti(fileToEvaluate);
-			};
-
-			try {
-				const jiti = createJiti(fileToEvaluate, jitiOptions);
-				evaluateSchema(jiti);
-			} catch (error: unknown) {
-				const message = error instanceof Error ? error.message : String(error);
-				const isTsconfigNotFound =
-					error instanceof Error &&
-					/tsconfig/i.test(message) &&
-					(/not found/i.test(message) ||
-						(error as NodeJS.ErrnoException).code === "ENOENT");
-
-				if (isTsconfigNotFound) {
-					const fallbackJiti = createJiti(fileToEvaluate, {
-						...jitiOptions,
-						tsconfigPaths: false,
-					});
-					evaluateSchema(fallbackJiti);
-					return;
-				}
-				throw error;
-			}
-		} finally {
-			delete g.__ARKENV_STRICT_LAYOUT__;
-			delete g.__ARKENV_CLIENT_ENV__;
-			delete g.__ARKENV_SHARED_SCHEMA__;
-		}
+	const coreArkenv = resolveCoreArkenv(engine);
+	coreArkenv(schema, {
+		env: (typeof process !== "undefined" ? process.env : {}) as Dict<string>,
+		safe: false,
 	});
 }

--- a/packages/nuxt/tsdown.config.ts
+++ b/packages/nuxt/tsdown.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
 		"src/client.ts",
 		"src/empty-client-env.ts",
 		"src/empty-shared-schema.ts",
+		"src/empty-server-boot.ts",
+		"src/server-boot.ts",
+		"src/boot-gate.ts",
+		"src/runtime/nitro-boot-plugin.ts",
 		"src/standard/index.ts",
 		"src/standard/module.ts",
 		"src/standard/server.ts",
@@ -25,8 +29,10 @@ export default defineConfig({
 		neverBundle: [
 			"@nuxt/kit",
 			"@nuxt/schema",
+			"nitropack",
 			"#arkenv/client-env",
 			"#arkenv/shared-schema",
+			"#arkenv/server-boot",
 		],
 	},
 });

--- a/packages/nuxt/vitest.config.ts
+++ b/packages/nuxt/vitest.config.ts
@@ -27,6 +27,10 @@ export default defineProject({
 				find: "#arkenv/shared-schema",
 				replacement: path.resolve(__dirname, "./src/empty-shared-schema.ts"),
 			},
+			{
+				find: "#arkenv/server-boot",
+				replacement: path.resolve(__dirname, "./src/server-boot.ts"),
+			},
 		],
 	},
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,7 +456,7 @@ importers:
         version: link:../../../packages/vite-plugin
       '@solidjs/start':
         specifier: 1.3.2
-        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
       arktype:
         specifier: 'catalog:'
         version: 2.2.0
@@ -465,7 +465,7 @@ importers:
         version: 1.9.12
       vinxi:
         specifier: 0.5.11
-        version: 0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+        version: 0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
 
   apps/playgrounds/standard-schema:
     dependencies:
@@ -1199,6 +1199,9 @@ importers:
       arktype:
         specifier: 'catalog:'
         version: 2.2.0
+      nitropack:
+        specifier: ^2.13.1
+        version: 2.13.4(@vercel/blob@2.3.3)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)
       nuxt:
         specifier: ^4.4.8
         version: 4.4.8(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@biomejs/biome@2.4.14)(@parcel/watcher@2.5.6)(@types/node@25.6.0)(@vercel/blob@2.3.3)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.2))(rollup@4.60.2)(terser@5.47.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
@@ -10318,11 +10321,6 @@ packages:
       uglify-js:
         optional: true
 
-  terser@5.46.2:
-    resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   terser@5.47.1:
     resolution: {integrity: sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==}
     engines: {node: '>=10'}
@@ -10596,15 +10594,6 @@ packages:
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
-
-  unimport@6.2.0:
-    resolution: {integrity: sha512-4NcqaphAHQff4eBWQ3pjVOCYNLlmVGGMoLDmboobh8+OQe9yP7UyeoMP043M1bG0YNc3CqtukD2VuINxOqm4rQ==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      oxc-parser: '*'
-    peerDependenciesMeta:
-      oxc-parser:
-        optional: true
 
   unimport@6.3.0:
     resolution: {integrity: sha512-M+Dxk5W9WRd+8j56W9tp8lGW/dmMc7g5zj7BWQnEjKQhryBstqsi1V0izb0zHwSkEN8cSYV7K75/bykairV2tA==}
@@ -15263,13 +15252,13 @@ snapshots:
     dependencies:
       serialize-javascript: 7.0.5
       smob: 1.6.1
-      terser: 5.46.2
+      terser: 5.47.1
     optionalDependencies:
       rollup: 4.60.2
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
@@ -15986,11 +15975,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@solidjs/start@1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@solidjs/start@1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tanstack/server-functions-plugin': 1.121.21(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
-      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
       cookie-es: 2.0.1
       defu: 6.1.7
       error-stack-parser: 2.1.4
@@ -16002,7 +15991,7 @@ snapshots:
       source-map-js: 1.2.1
       terracotta: 1.1.0(solid-js@1.9.12)
       tinyglobby: 0.2.16
-      vinxi: 0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vinxi: 0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
       vite-plugin-solid: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
@@ -16574,7 +16563,7 @@ snapshots:
       untun: 0.1.3
       uqr: 0.1.3
 
-  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@babel/parser': 7.29.3
       acorn: 8.16.0
@@ -16585,18 +16574,18 @@ snapshots:
       magicast: 0.2.11
       recast: 0.23.11
       tslib: 2.8.1
-      vinxi: 0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vinxi: 0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
 
-  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
       acorn: 8.16.0
       acorn-loose: 8.5.2
       acorn-typescript: 1.4.13(acorn@8.16.0)
       astring: 1.9.0
       magicast: 0.2.11
       recast: 0.23.11
-      vinxi: 0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vinxi: 0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
@@ -16662,7 +16651,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -16724,7 +16713,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -18122,7 +18111,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -19078,7 +19067,7 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   is-stream@2.0.1: {}
 
@@ -20194,7 +20183,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.2.0(oxc-parser@0.133.0)
+      unimport: 6.3.0(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)
       untyped: 2.0.0
@@ -22257,13 +22246,6 @@ snapshots:
       lightningcss: 1.32.0
       postcss: 8.5.14
 
-  terser@5.46.2:
-    dependencies:
-      '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
-      commander: 2.20.3
-      source-map-support: 0.5.21
-
   terser@5.47.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -22552,25 +22534,6 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unimport@6.2.0(oxc-parser@0.133.0):
-    dependencies:
-      acorn: 8.16.0
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      pkg-types: 2.3.1
-      scule: 1.3.0
-      strip-literal: 3.1.0
-      tinyglobby: 0.2.17
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-    optionalDependencies:
-      oxc-parser: 0.133.0
-
   unimport@6.3.0(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17):
     dependencies:
       acorn: 8.16.0
@@ -22774,7 +22737,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.133.0)(rolldown@1.0.0-rc.17)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
+  vinxi@0.5.11(@types/node@25.6.0)(@vercel/blob@2.3.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)


### PR DESCRIPTION
Fixes #1424

## Summary
- Add a Nitro boot gate (registered by `@arkenv/nuxt/module`) that validates/coerces schema keys into `runtimeConfig` (including `public`) after `NUXT_*` / `NUXT_PUBLIC_*` string overrides
- Make server and client `arkenv()` entries thin readers of that coerced payload; client package entries no longer import `@arkenv/core` / `arktype`
- Keep build-time `validate: true` as a core call via schema capture (not thin `arkenv()` side effects)
- Update docs/example to show coerced public number/boolean values

## Test plan
- [x] `pnpm --filter @arkenv/nuxt typecheck`
- [x] `pnpm --filter @arkenv/nuxt exec vitest run` (49 tests, including boot-gate coercion + client bundle isolation)
- [ ] Override `NUXT_PUBLIC_PORT` at Nitro boot in `examples/with-nuxt` and confirm coerced `number` on server and client
- [ ] Confirm invalid `NUXT_PUBLIC_*` overrides fail fast on the server
- [ ] Confirm server-only keys remain unreadable on the client


Made with [Cursor](https://cursor.com)