### PR TITLE
feat: (v1) env-module transform — canonical env object surface

### DIFF
--- a/.changeset/bun-env-module-transform.md
+++ b/.changeset/bun-env-module-transform.md
@@ -16,12 +16,12 @@ Usage:
 // plugins = ["@arkenv/bun-plugin"]
 
 // or explicitly in Bun.build:
-import { arkenv } from "@arkenv/bun-plugin";
+import arkenv from "@arkenv/bun-plugin";
 
 await Bun.build({
   entrypoints: ["./src/index.html"],
   target: "browser",
-  plugins: [arkenv()], // finds src/env.ts or env.ts
+  plugins: [arkenv], // finds src/env.ts or env.ts
   // or: arkenv({ schemaPath: "src/env.ts", clientPrefix: "BUN_PUBLIC_" })
 });
 ```

--- a/.changeset/bun-env-module-transform.md
+++ b/.changeset/bun-env-module-transform.md
@@ -1,0 +1,46 @@
+---
+"@arkenv/bun-plugin": minor
+---
+
+#### Add `env.ts` transform for Bun fullstack apps
+
+Let the Bun plugin discover your `env.ts` and expose a shared `env` object that works in both client and server code. On the client (`Bun.build` / `[serve.static]`), public (`BUN_PUBLIC_*`) values are inlined at build time and server-only keys throw if read; on the server (`bun run` / `Bun.serve`), `env.ts` still runs normally and validates against the real environment at boot. The plugin does not rewrite your `env.ts` file on disk.
+
+Works with `@arkenv/bun-plugin` and `@arkenv/bun-plugin/standard`.
+
+Usage:
+
+```ts
+// bunfig.toml — zero-config browser transform
+// [serve.static]
+// plugins = ["@arkenv/bun-plugin"]
+
+// or explicitly in Bun.build:
+import { arkenv } from "@arkenv/bun-plugin";
+
+await Bun.build({
+  entrypoints: ["./src/index.html"],
+  target: "browser",
+  plugins: [arkenv()], // finds src/env.ts or env.ts
+  // or: arkenv({ schemaPath: "src/env.ts", clientPrefix: "BUN_PUBLIC_" })
+});
+```
+
+```ts
+// src/env.ts
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+  DATABASE_URL: "string",
+  BUN_PUBLIC_API_URL: "string",
+});
+```
+
+```ts
+import { env } from "./env";
+
+env.BUN_PUBLIC_API_URL; // available on client and server
+env.DATABASE_URL; // server only — throws if read in the browser
+```
+
+Passing a schema to `arkenv(schema)` (the previous `process.env` rewrite API) continues to work unchanged as SPA mode.

--- a/apps/playgrounds/bun-react/README.md
+++ b/apps/playgrounds/bun-react/README.md
@@ -18,4 +18,4 @@ To run for production:
 bun start
 ```
 
-This project was created using `bun init` in bun v1.2.22. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.
+This example uses the canonical `env` object surface: one `import { env } from "./env"` serves both the `Bun.build` client bundle (inlined `BUN_PUBLIC_*` values + server-key guards) and `Bun.serve` server code (boot-time validation against the real environment).

--- a/apps/playgrounds/bun-react/bin/build.ts
+++ b/apps/playgrounds/bun-react/bin/build.ts
@@ -1,11 +1,11 @@
-import { arkenv } from "@arkenv/bun-plugin";
+import arkenv from "@arkenv/bun-plugin";
 
 const result = await Bun.build({
 	entrypoints: ["./src/index.html"],
 	outdir: "./dist",
 	target: "browser",
 	minify: true,
-	plugins: [arkenv()],
+	plugins: [arkenv],
 });
 
 if (!result.success) {

--- a/apps/playgrounds/bun-react/bin/build.ts
+++ b/apps/playgrounds/bun-react/bin/build.ts
@@ -1,11 +1,11 @@
-import arkenv from "@arkenv/bun-plugin";
+import { arkenv } from "@arkenv/bun-plugin";
 
 const result = await Bun.build({
 	entrypoints: ["./src/index.html"],
 	outdir: "./dist",
 	target: "browser",
 	minify: true,
-	plugins: [arkenv],
+	plugins: [arkenv()],
 });
 
 if (!result.success) {

--- a/apps/playgrounds/bun-react/bun-env.d.ts
+++ b/apps/playgrounds/bun-react/bun-env.d.ts
@@ -1,14 +1,5 @@
 /// <reference types="bun-types" />
 
-// Import the Env schema type from env.ts
-type ProcessEnvAugmented = import("@arkenv/bun-plugin").ProcessEnvAugmented<
-	typeof import("./src/env").default
->;
-
-declare namespace NodeJS {
-	interface ProcessEnv extends ProcessEnvAugmented {}
-}
-
 declare module "*.svg" {
 	const content: string;
 	export default content;

--- a/apps/playgrounds/bun-react/src/app.tsx
+++ b/apps/playgrounds/bun-react/src/app.tsx
@@ -1,5 +1,5 @@
-import { APITester } from "./api-tester";
 import { env } from "@/env";
+import { APITester } from "./api-tester";
 import "./index.css";
 
 import logo from "./logo.svg";

--- a/apps/playgrounds/bun-react/src/app.tsx
+++ b/apps/playgrounds/bun-react/src/app.tsx
@@ -1,5 +1,5 @@
 import { APITester } from "./api-tester";
-import { env } from "./env";
+import { env } from "@/env";
 import "./index.css";
 
 import logo from "./logo.svg";

--- a/apps/playgrounds/bun-react/src/app.tsx
+++ b/apps/playgrounds/bun-react/src/app.tsx
@@ -1,4 +1,5 @@
 import { APITester } from "./api-tester";
+import { env } from "./env";
 import "./index.css";
 
 import logo from "./logo.svg";
@@ -28,18 +29,18 @@ export function App() {
 				<tbody>
 					<tr>
 						<td>BUN_PUBLIC_API_URL</td>
-						<td>{process.env.BUN_PUBLIC_API_URL}</td>
-						<td>{typeof process.env.BUN_PUBLIC_API_URL}</td>
+						<td>{env.BUN_PUBLIC_API_URL}</td>
+						<td>{typeof env.BUN_PUBLIC_API_URL}</td>
 					</tr>
 					<tr>
 						<td>BUN_PUBLIC_DEBUG</td>
-						<td>{String(process.env.BUN_PUBLIC_DEBUG)}</td>
-						<td>{typeof process.env.BUN_PUBLIC_DEBUG}</td>
+						<td>{String(env.BUN_PUBLIC_DEBUG)}</td>
+						<td>{typeof env.BUN_PUBLIC_DEBUG}</td>
 					</tr>
 				</tbody>
 			</table>
 			{/* Print whether we are in "build" or in the dev server */}
-			<p>Mode: {process.env.NODE_ENV}</p>
+			<p>Mode: {env.NODE_ENV}</p>
 		</div>
 	);
 }

--- a/apps/playgrounds/bun-react/src/env.ts
+++ b/apps/playgrounds/bun-react/src/env.ts
@@ -1,7 +1,13 @@
-import { type } from "@arkenv/core";
+import arkenv from "@arkenv/core";
 
-export default type({
-	BUN_PUBLIC_API_URL: "string.url",
-	BUN_PUBLIC_DEBUG: "boolean",
-	NODE_ENV: "'development' | 'production' | 'test'",
+/**
+ * Canonical env object for the Bun + React example.
+ * Client (`BUN_PUBLIC_*`) keys are inlined by `@arkenv/bun-plugin` in browser bundles;
+ * server-only keys validate at boot when `env.ts` is imported from `Bun.serve` code.
+ */
+export const env = arkenv({
+	DATABASE_URL: "string = 'postgres://localhost:5432/bun-react'",
+	BUN_PUBLIC_API_URL: "string.url = 'https://api.example.com'",
+	BUN_PUBLIC_DEBUG: "boolean = true",
+	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });

--- a/apps/playgrounds/bun-react/src/env.ts
+++ b/apps/playgrounds/bun-react/src/env.ts
@@ -1,10 +1,6 @@
 import arkenv from "@arkenv/core";
 
-/**
- * Canonical env object for the Bun + React example.
- * Client (`BUN_PUBLIC_*`) keys are inlined by `@arkenv/bun-plugin` in browser bundles;
- * server-only keys validate at boot when `env.ts` is imported from `Bun.serve` code.
- */
+/** Validated environment for this app. */
 export const env = arkenv({
 	DATABASE_URL: "string = 'postgres://localhost:5432/bun-react'",
 	BUN_PUBLIC_API_URL: "string.url = 'https://api.example.com'",

--- a/apps/playgrounds/bun-react/src/index.tsx
+++ b/apps/playgrounds/bun-react/src/index.tsx
@@ -1,4 +1,5 @@
 import { serve } from "bun";
+import { env } from "./env";
 import index from "./index.html";
 
 const server = serve({
@@ -11,6 +12,8 @@ const server = serve({
 				return Response.json({
 					message: "Hello, world!",
 					method: "GET",
+					// Server-only key — validated at boot against the real environment.
+					databaseConfigured: Boolean(env.DATABASE_URL),
 				});
 			},
 			async PUT() {
@@ -29,7 +32,7 @@ const server = serve({
 		},
 	},
 
-	development: process.env.NODE_ENV !== "production" && {
+	development: env.NODE_ENV !== "production" && {
 		// Enable browser hot reloading in development
 		hmr: true,
 
@@ -39,3 +42,4 @@ const server = serve({
 });
 
 console.log(`🚀 Server running at ${server.url}`);
+console.log(`🗄️  DATABASE_URL configured (${env.DATABASE_URL.length} chars)`);

--- a/apps/playgrounds/bun-react/src/index.tsx
+++ b/apps/playgrounds/bun-react/src/index.tsx
@@ -1,5 +1,5 @@
 import { serve } from "bun";
-import { env } from "./env";
+import { env } from "@/env";
 import index from "./index.html";
 
 const server = serve({

--- a/apps/playgrounds/solid-start/src/env.ts
+++ b/apps/playgrounds/solid-start/src/env.ts
@@ -1,10 +1,6 @@
 import arkenv from "@arkenv/core";
 
-/**
- * Canonical env object for the SolidStart example.
- * Client (`VITE_*`) keys are inlined by `@arkenv/vite-plugin` in the browser graph;
- * server-only keys validate at boot in the SSR graph.
- */
+/** Validated environment for this app. */
 export const env = arkenv({
 	DATABASE_URL: "string = 'postgres://localhost:5432/solidstart'",
 	VITE_TEST: "string = 'Hello from SolidStart'",

--- a/examples/with-bun-react/README.md
+++ b/examples/with-bun-react/README.md
@@ -18,4 +18,4 @@ To run for production:
 bun start
 ```
 
-This project was created using `bun init` in bun v1.2.22. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.
+This example uses the canonical `env` object surface: one `import { env } from "./env"` serves both the `Bun.build` client bundle (inlined `BUN_PUBLIC_*` values + server-key guards) and `Bun.serve` server code (boot-time validation against the real environment).

--- a/examples/with-bun-react/bin/build.ts
+++ b/examples/with-bun-react/bin/build.ts
@@ -1,11 +1,11 @@
-import { arkenv } from "@arkenv/bun-plugin";
+import arkenv from "@arkenv/bun-plugin";
 
 const result = await Bun.build({
 	entrypoints: ["./src/index.html"],
 	outdir: "./dist",
 	target: "browser",
 	minify: true,
-	plugins: [arkenv()],
+	plugins: [arkenv],
 });
 
 if (!result.success) {

--- a/examples/with-bun-react/bin/build.ts
+++ b/examples/with-bun-react/bin/build.ts
@@ -1,11 +1,11 @@
-import arkenv from "@arkenv/bun-plugin";
+import { arkenv } from "@arkenv/bun-plugin";
 
 const result = await Bun.build({
 	entrypoints: ["./src/index.html"],
 	outdir: "./dist",
 	target: "browser",
 	minify: true,
-	plugins: [arkenv],
+	plugins: [arkenv()],
 });
 
 if (!result.success) {

--- a/examples/with-bun-react/bun-env.d.ts
+++ b/examples/with-bun-react/bun-env.d.ts
@@ -1,14 +1,5 @@
 /// <reference types="bun-types" />
 
-// Import the Env schema type from env.ts
-type ProcessEnvAugmented = import("@arkenv/bun-plugin").ProcessEnvAugmented<
-	typeof import("./src/env").default
->;
-
-declare namespace NodeJS {
-	interface ProcessEnv extends ProcessEnvAugmented {}
-}
-
 declare module "*.svg" {
 	const content: string;
 	export default content;

--- a/examples/with-bun-react/src/app.tsx
+++ b/examples/with-bun-react/src/app.tsx
@@ -1,5 +1,5 @@
-import { APITester } from "./api-tester";
 import { env } from "@/env";
+import { APITester } from "./api-tester";
 import "./index.css";
 
 import logo from "./logo.svg";

--- a/examples/with-bun-react/src/app.tsx
+++ b/examples/with-bun-react/src/app.tsx
@@ -1,5 +1,5 @@
 import { APITester } from "./api-tester";
-import { env } from "./env";
+import { env } from "@/env";
 import "./index.css";
 
 import logo from "./logo.svg";

--- a/examples/with-bun-react/src/app.tsx
+++ b/examples/with-bun-react/src/app.tsx
@@ -1,4 +1,5 @@
 import { APITester } from "./api-tester";
+import { env } from "./env";
 import "./index.css";
 
 import logo from "./logo.svg";
@@ -28,18 +29,18 @@ export function App() {
 				<tbody>
 					<tr>
 						<td>BUN_PUBLIC_API_URL</td>
-						<td>{process.env.BUN_PUBLIC_API_URL}</td>
-						<td>{typeof process.env.BUN_PUBLIC_API_URL}</td>
+						<td>{env.BUN_PUBLIC_API_URL}</td>
+						<td>{typeof env.BUN_PUBLIC_API_URL}</td>
 					</tr>
 					<tr>
 						<td>BUN_PUBLIC_DEBUG</td>
-						<td>{String(process.env.BUN_PUBLIC_DEBUG)}</td>
-						<td>{typeof process.env.BUN_PUBLIC_DEBUG}</td>
+						<td>{String(env.BUN_PUBLIC_DEBUG)}</td>
+						<td>{typeof env.BUN_PUBLIC_DEBUG}</td>
 					</tr>
 				</tbody>
 			</table>
 			{/* Print whether we are in "build" or in the dev server */}
-			<p>Mode: {process.env.NODE_ENV}</p>
+			<p>Mode: {env.NODE_ENV}</p>
 		</div>
 	);
 }

--- a/examples/with-bun-react/src/env.ts
+++ b/examples/with-bun-react/src/env.ts
@@ -1,7 +1,13 @@
-import { type } from "@arkenv/core";
+import arkenv from "@arkenv/core";
 
-export default type({
-	BUN_PUBLIC_API_URL: "string.url",
-	BUN_PUBLIC_DEBUG: "boolean",
-	NODE_ENV: "'development' | 'production' | 'test'",
+/**
+ * Canonical env object for the Bun + React example.
+ * Client (`BUN_PUBLIC_*`) keys are inlined by `@arkenv/bun-plugin` in browser bundles;
+ * server-only keys validate at boot when `env.ts` is imported from `Bun.serve` code.
+ */
+export const env = arkenv({
+	DATABASE_URL: "string = 'postgres://localhost:5432/bun-react'",
+	BUN_PUBLIC_API_URL: "string.url = 'https://api.example.com'",
+	BUN_PUBLIC_DEBUG: "boolean = true",
+	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });

--- a/examples/with-bun-react/src/env.ts
+++ b/examples/with-bun-react/src/env.ts
@@ -1,10 +1,6 @@
 import arkenv from "@arkenv/core";
 
-/**
- * Canonical env object for the Bun + React example.
- * Client (`BUN_PUBLIC_*`) keys are inlined by `@arkenv/bun-plugin` in browser bundles;
- * server-only keys validate at boot when `env.ts` is imported from `Bun.serve` code.
- */
+/** Validated environment for this app. */
 export const env = arkenv({
 	DATABASE_URL: "string = 'postgres://localhost:5432/bun-react'",
 	BUN_PUBLIC_API_URL: "string.url = 'https://api.example.com'",

--- a/examples/with-bun-react/src/index.tsx
+++ b/examples/with-bun-react/src/index.tsx
@@ -1,4 +1,5 @@
 import { serve } from "bun";
+import { env } from "./env";
 import index from "./index.html";
 
 const server = serve({
@@ -11,6 +12,8 @@ const server = serve({
 				return Response.json({
 					message: "Hello, world!",
 					method: "GET",
+					// Server-only key — validated at boot against the real environment.
+					databaseConfigured: Boolean(env.DATABASE_URL),
 				});
 			},
 			async PUT() {
@@ -29,7 +32,7 @@ const server = serve({
 		},
 	},
 
-	development: process.env.NODE_ENV !== "production" && {
+	development: env.NODE_ENV !== "production" && {
 		// Enable browser hot reloading in development
 		hmr: true,
 
@@ -39,3 +42,4 @@ const server = serve({
 });
 
 console.log(`🚀 Server running at ${server.url}`);
+console.log(`🗄️  DATABASE_URL configured (${env.DATABASE_URL.length} chars)`);

--- a/examples/with-bun-react/src/index.tsx
+++ b/examples/with-bun-react/src/index.tsx
@@ -1,5 +1,5 @@
 import { serve } from "bun";
-import { env } from "./env";
+import { env } from "@/env";
 import index from "./index.html";
 
 const server = serve({

--- a/examples/with-solid-start/src/env.ts
+++ b/examples/with-solid-start/src/env.ts
@@ -1,10 +1,6 @@
 import arkenv from "@arkenv/core";
 
-/**
- * Canonical env object for the SolidStart example.
- * Client (`VITE_*`) keys are inlined by `@arkenv/vite-plugin` in the browser graph;
- * server-only keys validate at boot in the SSR graph.
- */
+/** Validated environment for this app. */
 export const env = arkenv({
 	DATABASE_URL: "string = 'postgres://localhost:5432/solidstart'",
 	VITE_TEST: "string = 'Hello from SolidStart'",

--- a/packages/bun-plugin/package.json
+++ b/packages/bun-plugin/package.json
@@ -8,6 +8,10 @@
 	},
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",
+	"dependencies": {
+		"@arkenv/build": "workspace:*",
+		"jiti": "catalog:"
+	},
 	"devDependencies": {
 		"@arkenv/core": "workspace:*",
 		"@arkenv/standard": "workspace:*",
@@ -89,11 +93,13 @@
 	"size-limit": [
 		{
 			"path": "dist/index.js",
-			"limit": "3.2 kB",
+			"limit": "8 kB",
 			"import": "*",
 			"ignore": [
 				"bun",
 				"arktype",
+				"jiti",
+				"@arkenv/build",
 				"node:path",
 				"node:fs",
 				"node:process"

--- a/packages/bun-plugin/src/__fixtures__/transform-env/.env.test
+++ b/packages/bun-plugin/src/__fixtures__/transform-env/.env.test
@@ -1,0 +1,5 @@
+BUN_PUBLIC_API_URL=https://fixture.example.com
+BUN_PUBLIC_DEBUG=true
+BUN_PUBLIC_PORT=8080
+DATABASE_URL=postgres://fixture:5432/db
+NODE_ENV=test

--- a/packages/bun-plugin/src/__fixtures__/transform-env/env.ts
+++ b/packages/bun-plugin/src/__fixtures__/transform-env/env.ts
@@ -1,0 +1,11 @@
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+	DATABASE_URL: "string = 'postgres://localhost:5432/mydb'",
+	BUN_PUBLIC_API_URL: "string = 'https://api.example.com'",
+	BUN_PUBLIC_DEBUG: "boolean = false",
+	BUN_PUBLIC_PORT: "number = 3000",
+	NODE_ENV: "'development' | 'production' | 'test' = 'test'",
+});
+
+export default env;

--- a/packages/bun-plugin/src/__fixtures__/transform-env/index.ts
+++ b/packages/bun-plugin/src/__fixtures__/transform-env/index.ts
@@ -1,0 +1,17 @@
+import { env } from "./env";
+
+export const config = {
+	apiUrl: env.BUN_PUBLIC_API_URL,
+	debug: env.BUN_PUBLIC_DEBUG,
+	port: env.BUN_PUBLIC_PORT,
+	nodeEnv: env.NODE_ENV,
+};
+
+/**
+ * Read a server-only key (throws in the transformed client module).
+ *
+ * @returns The database URL from the env object
+ */
+export function readServerSecret() {
+	return env.DATABASE_URL;
+}

--- a/packages/bun-plugin/src/bun-plugin-generic.ts
+++ b/packages/bun-plugin/src/bun-plugin-generic.ts
@@ -54,7 +54,7 @@ export function createBunPlugin(
 		return createDefinePlugin(
 			coreArkenv,
 			pluginName,
-			schemaOrOptions as CompiledEnvSchema | SchemaShape,
+			schemaOrOptions as Record<string, unknown>,
 			config,
 			factoryLogOptions,
 		);

--- a/packages/bun-plugin/src/bun-plugin-generic.ts
+++ b/packages/bun-plugin/src/bun-plugin-generic.ts
@@ -1,111 +1,82 @@
-import { join } from "node:path";
-import {
-	type ArkEnvLogOptions,
-	resolveBuildLog,
-	splitPluginConfig,
-} from "@repo/log";
+import type { ArkEnvLogOptions } from "@repo/log";
+import type { CompiledEnvSchema, SchemaShape } from "@repo/types";
+import type { ParseStandardConfig as ArkEnvConfig } from "@repo/utils";
 import type { BunPlugin } from "bun";
-import { processEnvSchema, registerLoader } from "./utils";
+import { createDefinePlugin } from "./define-plugin";
+import { type BunTransformOptions, isTransformModeCall } from "./env-module";
+import type { BunPluginFactoryConfig } from "./plugin-config";
+import { createTransformPlugin } from "./transform-plugin";
+
+export type { BunPluginFactoryConfig } from "./plugin-config";
+export type { BunTransformOptions };
 
 /**
- * Create a generic Bun plugin instance parameterized with a validator and name.
+ * Create a Bun plugin factory bound to a specific ArkEnv runtime (`core` or `standard`).
  *
- * @param coreArkenv The arkenv validation function to use
- * @param pluginName The display name of the plugin
- * @param factoryLogOptions Optional logger configuration for build-time messages
- * @returns An object containing the configured arkenv plugin creator and the hybrid plugin instance
+ * - **Transform** — `arkenv()` / `arkenv({ schemaPath, clientPrefix })`: rewrite the user's
+ *   `env.ts` in browser bundles (ADR 0021). Server graphs execute `env.ts` as-is.
+ * - **Schema/SPA** — `arkenv(schema, config?)`: build-time validation + `process.env`
+ *   rewriting (existing API, unchanged).
+ *
+ * The returned `hybrid` is the factory with transform `setup`/`target` attached so
+ * `bunfig.toml` / default-import usage (`plugins = ["@arkenv/bun-plugin"]`) enables
+ * zero-config transform mode.
+ *
+ * @param coreArkenv The ArkEnv runtime function used for schema/SPA validation
+ * @param pluginName The Bun plugin name
+ * @param factoryLogOptions Optional default logging options for the factory
+ * @returns An object containing the configured arkenv factory and the hybrid plugin
  */
 export function createBunPlugin(
 	coreArkenv: any,
 	pluginName: string,
 	factoryLogOptions?: ArkEnvLogOptions,
 ) {
-	function arkenv(options: any, config?: any): BunPlugin {
-		const { pluginConfig, logOptions } = splitPluginConfig(config);
-		const buildLog = resolveBuildLog({
-			...factoryLogOptions,
-			...logOptions,
-		});
-		let envMap: Map<string, string>;
-		try {
-			envMap = processEnvSchema(options, pluginConfig, coreArkenv);
-		} catch (error: unknown) {
-			buildLog.logBuildErrorWithCause("Environment validation failed", error);
-			throw error;
+	/**
+	 * Create a Bun plugin in transform or SPA mode based on the call shape.
+	 *
+	 * @param schemaOrOptions Transform options, or a schema for SPA mode
+	 * @param config Optional ArkEnv config (SPA mode only)
+	 * @returns A configured Bun plugin
+	 */
+	function arkenv(
+		schemaOrOptions?: CompiledEnvSchema | SchemaShape | BunPluginFactoryConfig,
+		config?: Omit<ArkEnvConfig, "safe"> & ArkEnvLogOptions,
+	): BunPlugin {
+		if (isTransformModeCall(schemaOrOptions, config)) {
+			return createTransformPlugin(
+				pluginName,
+				(schemaOrOptions ?? {}) as BunPluginFactoryConfig,
+				factoryLogOptions,
+			);
 		}
 
-		return {
-			name: pluginName,
-			setup(build) {
-				registerLoader(build, envMap);
-			},
-		} satisfies BunPlugin;
+		return createDefinePlugin(
+			coreArkenv,
+			pluginName,
+			schemaOrOptions as CompiledEnvSchema | SchemaShape,
+			config,
+			factoryLogOptions,
+		);
 	}
 
-	const hybrid = arkenv as any & BunPlugin;
+	const zeroConfigTransform = createTransformPlugin(
+		pluginName,
+		{},
+		factoryLogOptions,
+	);
+
+	const hybrid = arkenv as typeof arkenv & BunPlugin;
 
 	Object.defineProperty(hybrid, "name", {
 		value: pluginName,
 		writable: false,
 	});
-
-	hybrid.setup = (build: any) => {
-		const buildLog = resolveBuildLog(factoryLogOptions);
-		const envMap = new Map<string, string>();
-
-		build.onStart(async () => {
-			const cwd = process.cwd();
-			let schema: any;
-
-			const possiblePaths = [join(cwd, "src", "env.ts"), join(cwd, "env.ts")];
-
-			for (const p of possiblePaths) {
-				if (await Bun.file(p).exists()) {
-					try {
-						const mod = await import(p);
-						if (mod.default) {
-							schema = mod.default;
-							break;
-						}
-						if (mod.env) {
-							schema = mod.env;
-							break;
-						}
-					} catch (e) {
-						buildLog.logBuildErrorWithCause(
-							`Failed to load env schema from ${p}`,
-							e,
-						);
-					}
-				}
-			}
-
-			if (!schema) {
-				const pathsList = possiblePaths.map((p) => ` - ${p}`).join("\n");
-				const example = `
-Example \`src/env.ts\`:
-\`\`\`ts
-import { type } from "@arkenv/core"; // or "@arkenv/standard" / "@arkenv/core"
-export default type({
-  BUN_PUBLIC_API_URL: "string",
-  BUN_PUBLIC_DEBUG: "boolean"
-});
-\`\`\`
-`;
-				throw new Error(
-					`${pluginName}: No environment schema found.\n\nChecked paths:\n${pathsList}\n\nPlease create a schema file at one of these locations exporting your environment definition.\n${example}`,
-				);
-			}
-
-			const newEnvMap = processEnvSchema(schema, undefined, coreArkenv);
-			envMap.clear();
-			for (const [k, v] of newEnvMap) {
-				envMap.set(k, v);
-			}
-		});
-
-		registerLoader(build, envMap);
-	};
+	Object.defineProperty(hybrid, "target", {
+		value: "browser",
+		writable: false,
+	});
+	hybrid.setup = zeroConfigTransform.setup;
 
 	return { arkenv, hybrid };
 }

--- a/packages/bun-plugin/src/classify-env-keys.ts
+++ b/packages/bun-plugin/src/classify-env-keys.ts
@@ -1,0 +1,40 @@
+import { extractKeys } from "@arkenv/build";
+
+/**
+ * Classify schema keys into client, shared, and server-only sets.
+ *
+ * @param content The source of the env module
+ * @param prefixes Client-exposed prefixes (e.g. `["BUN_PUBLIC_"]`)
+ * @returns Key classification for the transform
+ */
+export function classifyEnvKeys(
+	content: string,
+	prefixes: string[],
+): {
+	clientKeys: string[];
+	sharedKeys: string[];
+	serverKeys: string[];
+} {
+	const primary = prefixes[0] ?? "BUN_PUBLIC_";
+	const { clientKeys, sharedKeys, serverKeys } = extractKeys(content, primary);
+
+	if (prefixes.length <= 1) {
+		return { clientKeys, sharedKeys, serverKeys };
+	}
+
+	const clientSet = new Set(clientKeys);
+	const remainingServer: string[] = [];
+	for (const key of serverKeys) {
+		if (prefixes.some((prefix) => key.startsWith(prefix))) {
+			clientSet.add(key);
+		} else {
+			remainingServer.push(key);
+		}
+	}
+
+	return {
+		clientKeys: [...clientSet] as string[],
+		sharedKeys,
+		serverKeys: remainingServer,
+	};
+}

--- a/packages/bun-plugin/src/define-plugin.ts
+++ b/packages/bun-plugin/src/define-plugin.ts
@@ -1,0 +1,50 @@
+import {
+	type ArkEnvLogOptions,
+	resolveBuildLog,
+	splitPluginConfig,
+} from "@repo/log";
+import type { ParseStandardConfig as ArkEnvConfig } from "@repo/utils";
+import type { BunPlugin } from "bun";
+import { processEnvSchema, registerLoader } from "./utils";
+
+/**
+ * Build the SPA-mode plugin: validate at creation and rewrite `process.env` reads.
+ *
+ * @param coreArkenv The ArkEnv runtime function used for schema validation
+ * @param pluginName The Bun plugin name
+ * @param schema The environment variable schema definition
+ * @param config Optional ArkEnv configuration and build-time logging options
+ * @param factoryLogOptions Default logging options from the factory
+ * @returns A Bun plugin that rewrites `process.env.BUN_PUBLIC_*` accessors
+ */
+export function createDefinePlugin(
+	coreArkenv: (
+		def: any,
+		config?: Omit<ArkEnvConfig, "safe">,
+	) => Record<string, unknown>,
+	pluginName: string,
+	schema: Record<string, unknown>,
+	config?: Omit<ArkEnvConfig, "safe"> & ArkEnvLogOptions,
+	factoryLogOptions?: ArkEnvLogOptions,
+): BunPlugin {
+	const { pluginConfig, logOptions } = splitPluginConfig(config);
+	const buildLog = resolveBuildLog({
+		...factoryLogOptions,
+		...logOptions,
+	});
+
+	let envMap: Map<string, string>;
+	try {
+		envMap = processEnvSchema(schema as any, pluginConfig, coreArkenv);
+	} catch (error: unknown) {
+		buildLog.logBuildErrorWithCause("Environment validation failed", error);
+		throw error;
+	}
+
+	return {
+		name: pluginName,
+		setup(build) {
+			registerLoader(build, envMap);
+		},
+	} satisfies BunPlugin;
+}

--- a/packages/bun-plugin/src/env-module-path.ts
+++ b/packages/bun-plugin/src/env-module-path.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import path from "node:path";
+import { findSchemaPath } from "@arkenv/build";
+
+/**
+ * Strip query suffixes from a module path.
+ *
+ * @param id The raw module path
+ * @returns A filesystem path suitable for comparison
+ */
+export function normalizeModuleId(id: string): string {
+	let normalized = id;
+	const queryIndex = normalized.indexOf("?");
+	if (queryIndex !== -1) {
+		normalized = normalized.slice(0, queryIndex);
+	}
+	return path.normalize(normalized);
+}
+
+/**
+ * Check whether a module path refers to the resolved env module.
+ *
+ * @param id The module path (may include query strings)
+ * @param schemaPath The absolute path to the env module
+ * @returns Whether `id` identifies the same module as `schemaPath`
+ */
+export function isEnvModuleId(id: string, schemaPath: string): boolean {
+	const normalizedId = path.resolve(normalizeModuleId(id));
+	const normalizedSchema = path.resolve(schemaPath);
+	if (normalizedId === normalizedSchema) return true;
+
+	const stripExt = (filePath: string) =>
+		filePath.replace(/\.(m|c)?[jt]sx?$/, "");
+	return stripExt(normalizedId) === stripExt(normalizedSchema);
+}
+
+/**
+ * Resolve the absolute env-module path from plugin options and the project root.
+ *
+ * @param root The project root (typically `process.cwd()`)
+ * @param schemaPath An optional relative or absolute schema path from plugin config
+ * @returns The absolute path to the env module
+ * @throws If no env module can be found
+ */
+export function resolveEnvModulePath(
+	root: string,
+	schemaPath?: string,
+): string {
+	if (schemaPath) {
+		const resolved = path.isAbsolute(schemaPath)
+			? schemaPath
+			: path.resolve(root, schemaPath);
+		if (!fs.existsSync(resolved)) {
+			throw new Error(
+				`ArkEnv Bun plugin: schemaPath "${schemaPath}" does not exist (resolved to "${resolved}").`,
+			);
+		}
+		return resolved;
+	}
+
+	const discovered = findSchemaPath(root);
+	if (!discovered) {
+		throw new Error(
+			`ArkEnv Bun plugin: could not find an env module. Expected "src/env.ts" or "env.ts" under "${root}", or pass schemaPath.`,
+		);
+	}
+	return discovered;
+}
+
+/**
+ * Normalize a `clientPrefix` value to a string array.
+ *
+ * @param prefix A string prefix, list of prefixes, or undefined
+ * @returns A non-empty list of prefixes (defaults to `["BUN_PUBLIC_"]`)
+ */
+export function normalizePrefixes(
+	prefix: string | string[] | undefined,
+): string[] {
+	if (prefix === undefined) return ["BUN_PUBLIC_"];
+	return Array.isArray(prefix) ? prefix : [prefix];
+}

--- a/packages/bun-plugin/src/env-module.test.ts
+++ b/packages/bun-plugin/src/env-module.test.ts
@@ -1,0 +1,299 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	classifyEnvKeys,
+	generateClientEnvModule,
+	isEnvModuleId,
+	isTransformModeCall,
+} from "./env-module.js";
+import { arkenv, hybrid } from "./plugin.js";
+
+describe("transform mode helpers", () => {
+	it("detects transform-mode calls", () => {
+		expect(isTransformModeCall(undefined, undefined)).toBe(true);
+		expect(isTransformModeCall({ schemaPath: "src/env.ts" }, undefined)).toBe(
+			true,
+		);
+		expect(
+			isTransformModeCall({ clientPrefix: "BUN_PUBLIC_" }, undefined),
+		).toBe(true);
+		expect(isTransformModeCall({}, undefined)).toBe(false);
+		expect(isTransformModeCall({ BUN_PUBLIC_FOO: "string" }, undefined)).toBe(
+			false,
+		);
+		expect(
+			isTransformModeCall({ BUN_PUBLIC_FOO: "string" }, { coerce: true }),
+		).toBe(false);
+	});
+
+	it("classifies flat-layout keys by client prefix", () => {
+		const content = `
+			export const env = arkenv({
+				DATABASE_URL: "string",
+				BUN_PUBLIC_API_URL: "string",
+				NODE_ENV: "'development' | 'production'",
+			});
+		`;
+		const keys = classifyEnvKeys(content, ["BUN_PUBLIC_"]);
+		expect(keys.clientKeys).toContain("BUN_PUBLIC_API_URL");
+		expect(keys.sharedKeys).toContain("NODE_ENV");
+		expect(keys.serverKeys).toContain("DATABASE_URL");
+	});
+
+	it("generates inlined literals and throwing server-key getters", () => {
+		const code = generateClientEnvModule(
+			{ BUN_PUBLIC_API_URL: "https://api.example.com", BUN_PUBLIC_PORT: 8080 },
+			["DATABASE_URL"],
+		);
+
+		expect(code).toContain('"BUN_PUBLIC_API_URL": "https://api.example.com"');
+		expect(code).toContain('"BUN_PUBLIC_PORT": 8080');
+		expect(code).toContain('get ["DATABASE_URL"]()');
+		expect(code).toContain(
+			"Attempted to access server environment variable 'DATABASE_URL' on the client",
+		);
+		expect(code).not.toContain("arkenv");
+		expect(code).not.toContain("arktype");
+	});
+
+	it("matches env module ids with query suffixes", () => {
+		const schemaPath = "/proj/src/env.ts";
+		expect(isEnvModuleId("/proj/src/env.ts", schemaPath)).toBe(true);
+		expect(isEnvModuleId("/proj/src/env.ts?t=123", schemaPath)).toBe(true);
+		expect(isEnvModuleId("/proj/src/other.ts", schemaPath)).toBe(false);
+	});
+});
+
+describe("transform mode plugin", () => {
+	const temps: string[] = [];
+
+	afterEach(() => {
+		for (const dir of temps.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("returns a browser-targeted plugin for transform calls", () => {
+		const plugin = arkenv();
+		expect(plugin).toHaveProperty("name", "@arkenv/bun-plugin");
+		expect(plugin).toHaveProperty("target", "browser");
+		expect(plugin).toHaveProperty("setup");
+		expect(typeof plugin.setup).toBe("function");
+	});
+
+	it("exposes hybrid as a zero-config browser transform plugin", () => {
+		expect(hybrid).toHaveProperty("name", "@arkenv/bun-plugin");
+		expect(hybrid).toHaveProperty("target", "browser");
+		expect(hybrid).toHaveProperty("setup");
+	});
+
+	it("keeps schema/SPA path working alongside transform helpers", () => {
+		process.env.BUN_PUBLIC_TEST = "test-value";
+		const plugin = arkenv({ BUN_PUBLIC_TEST: "string" });
+		expect(plugin).toHaveProperty("name", "@arkenv/bun-plugin");
+		expect(plugin).not.toHaveProperty("target");
+		expect(plugin).toHaveProperty("setup");
+		delete process.env.BUN_PUBLIC_TEST;
+	});
+
+	it("rewrites the env module via onLoad with coerced literals", async () => {
+		const fixtureDir = join(__dirname, "__fixtures__", "transform-env");
+		const previous = { ...process.env };
+		Object.assign(process.env, {
+			BUN_PUBLIC_API_URL: "https://fixture.example.com",
+			BUN_PUBLIC_DEBUG: "true",
+			BUN_PUBLIC_PORT: "8080",
+			DATABASE_URL: "postgres://fixture:5432/db",
+			NODE_ENV: "test",
+		});
+
+		try {
+			const plugin = arkenv({ schemaPath: join(fixtureDir, "env.ts") });
+
+			let onStart: (() => void | Promise<void>) | undefined;
+			let onLoad:
+				| ((args: {
+						path: string;
+				  }) =>
+						| { contents?: string; loader?: string }
+						| undefined
+						| Promise<{ contents?: string; loader?: string } | undefined>)
+				| undefined;
+
+			const mockBuild = {
+				onStart(cb: () => void | Promise<void>) {
+					onStart = cb;
+				},
+				onLoad(
+					_opts: { filter: RegExp },
+					cb: typeof onLoad extends infer T ? T : never,
+				) {
+					onLoad = cb;
+				},
+			};
+
+			plugin.setup(mockBuild as any);
+			await onStart?.();
+
+			const result = await onLoad?.({
+				path: join(fixtureDir, "env.ts"),
+			});
+			expect(result?.contents).toBeDefined();
+			const code = result?.contents ?? "";
+
+			expect(code).toContain("https://fixture.example.com");
+			expect(code).toContain("8080");
+			expect(code).toContain("BUN_PUBLIC_DEBUG");
+			expect(code).toContain(
+				"Attempted to access server environment variable 'DATABASE_URL' on the client",
+			);
+			expect(code).not.toContain("@arkenv/core");
+			expect(code).not.toContain("arktype");
+			expect(code).not.toContain("postgres://fixture:5432/db");
+		} finally {
+			process.env = previous;
+		}
+	});
+
+	it("does not rewrite non-env modules", async () => {
+		const fixtureDir = join(__dirname, "__fixtures__", "transform-env");
+		const previous = { ...process.env };
+		Object.assign(process.env, {
+			BUN_PUBLIC_API_URL: "https://fixture.example.com",
+			BUN_PUBLIC_DEBUG: "true",
+			BUN_PUBLIC_PORT: "8080",
+			DATABASE_URL: "postgres://fixture:5432/db",
+			NODE_ENV: "test",
+		});
+
+		try {
+			const plugin = arkenv({ schemaPath: join(fixtureDir, "env.ts") });
+			let onStart: (() => void | Promise<void>) | undefined;
+			let onLoad:
+				| ((args: {
+						path: string;
+				  }) =>
+						| { contents?: string }
+						| undefined
+						| Promise<{ contents?: string } | undefined>)
+				| undefined;
+
+			plugin.setup({
+				onStart(cb: () => void | Promise<void>) {
+					onStart = cb;
+				},
+				onLoad(_opts: { filter: RegExp }, cb: NonNullable<typeof onLoad>) {
+					onLoad = cb;
+				},
+			} as any);
+
+			await onStart?.();
+			const result = await onLoad?.({
+				path: join(fixtureDir, "index.ts"),
+			});
+			expect(result).toBeUndefined();
+		} finally {
+			process.env = previous;
+		}
+	});
+
+	it("throws when a server-only key is read from the transformed module", async () => {
+		const fixtureDir = join(__dirname, "__fixtures__", "transform-env");
+		const previous = { ...process.env };
+		Object.assign(process.env, {
+			BUN_PUBLIC_API_URL: "https://fixture.example.com",
+			BUN_PUBLIC_DEBUG: "true",
+			BUN_PUBLIC_PORT: "8080",
+			DATABASE_URL: "postgres://fixture:5432/db",
+			NODE_ENV: "test",
+		});
+
+		try {
+			const plugin = arkenv({ schemaPath: join(fixtureDir, "env.ts") });
+			let onStart: (() => void | Promise<void>) | undefined;
+			let onLoad:
+				| ((args: {
+						path: string;
+				  }) =>
+						| { contents?: string }
+						| undefined
+						| Promise<{ contents?: string } | undefined>)
+				| undefined;
+
+			plugin.setup({
+				onStart(cb: () => void | Promise<void>) {
+					onStart = cb;
+				},
+				onLoad(_opts: { filter: RegExp }, cb: NonNullable<typeof onLoad>) {
+					onLoad = cb;
+				},
+			} as any);
+
+			await onStart?.();
+			const result = await onLoad?.({
+				path: join(fixtureDir, "env.ts"),
+			});
+			expect(result?.contents).toBeDefined();
+
+			const outDir = mkdtempSync(join(tmpdir(), "arkenv-bun-transform-"));
+			temps.push(outDir);
+			const outFile = join(outDir, "env.mjs");
+			writeFileSync(outFile, result?.contents ?? "");
+
+			const mod = await import(`${outFile}?t=${Date.now()}`);
+			expect(mod.env.BUN_PUBLIC_API_URL).toBe("https://fixture.example.com");
+			expect(mod.env.BUN_PUBLIC_DEBUG).toBe(true);
+			expect(mod.env.BUN_PUBLIC_PORT).toBe(8080);
+			expect(() => mod.env.DATABASE_URL).toThrow(
+				/Attempted to access server environment variable 'DATABASE_URL' on the client/,
+			);
+		} finally {
+			process.env = previous;
+		}
+	});
+
+	it("fails fast when required env is missing at transform setup", async () => {
+		const previous = { ...process.env };
+		delete process.env.BUN_PUBLIC_API_URL;
+		delete process.env.DATABASE_URL;
+
+		const strictDir = mkdtempSync(join(tmpdir(), "arkenv-bun-strict-"));
+		temps.push(strictDir);
+		writeFileSync(
+			join(strictDir, "env.ts"),
+			`import arkenv from "@arkenv/core";
+export const env = arkenv({
+  DATABASE_URL: "string",
+  BUN_PUBLIC_API_URL: "string",
+});
+export default env;
+`,
+		);
+
+		try {
+			const plugin = arkenv({ schemaPath: join(strictDir, "env.ts") });
+			let onStart: (() => void | Promise<void>) | undefined;
+			plugin.setup({
+				onStart(cb: () => void | Promise<void>) {
+					onStart = cb;
+				},
+				onLoad() {},
+			} as any);
+
+			await expect(Promise.resolve().then(() => onStart?.())).rejects.toThrow();
+		} finally {
+			process.env = previous;
+		}
+	});
+});
+
+describe("SPA mode regression", () => {
+	it("still rewrites process.env for schema calls", () => {
+		process.env.BUN_PUBLIC_TEST = "test-value";
+		const plugin = arkenv({ BUN_PUBLIC_TEST: "string" });
+		expect(plugin.target).toBeUndefined();
+		delete process.env.BUN_PUBLIC_TEST;
+	});
+});

--- a/packages/bun-plugin/src/env-module.ts
+++ b/packages/bun-plugin/src/env-module.ts
@@ -1,0 +1,13 @@
+export { classifyEnvKeys } from "./classify-env-keys";
+export {
+	isEnvModuleId,
+	normalizeModuleId,
+	normalizePrefixes,
+	resolveEnvModulePath,
+} from "./env-module-path";
+export { generateClientEnvModule } from "./generate-client-env-module";
+export { loadValidatedEnv } from "./load-validated-env";
+export {
+	type BunTransformOptions,
+	isTransformModeCall,
+} from "./transform-options";

--- a/packages/bun-plugin/src/generate-client-env-module.ts
+++ b/packages/bun-plugin/src/generate-client-env-module.ts
@@ -1,0 +1,33 @@
+/**
+ * Build the client-graph replacement module: inlined coerced literals + server-key guards.
+ *
+ * No validator import is emitted. See ADR 0021 (env-object canonical surface) —
+ * contributors must not reintroduce `env.gen.ts`, client-side re-validation, or
+ * `runtimeEnv` wiring on hosts that own their transform.
+ *
+ * @param clientValues Coerced values for client and shared keys
+ * @param serverKeys Server-only keys that must throw when read on the client
+ * @returns The transformed module source
+ */
+export function generateClientEnvModule(
+	clientValues: Record<string, unknown>,
+	serverKeys: string[],
+): string {
+	const lines: string[] = ["const env = {"];
+
+	for (const [key, value] of Object.entries(clientValues)) {
+		lines.push(`  ${JSON.stringify(key)}: ${JSON.stringify(value)},`);
+	}
+
+	for (const key of serverKeys) {
+		const message = `ArkEnv Error: Attempted to access server environment variable '${key}' on the client.`;
+		lines.push(
+			`  get [${JSON.stringify(key)}]() {`,
+			`    throw new Error(${JSON.stringify(message)});`,
+			"  },",
+		);
+	}
+
+	lines.push("};", "export { env };", "export default env;", "");
+	return lines.join("\n");
+}

--- a/packages/bun-plugin/src/index.ts
+++ b/packages/bun-plugin/src/index.ts
@@ -1,5 +1,6 @@
 import { hybrid } from "./plugin";
 
+export type { BunTransformOptions } from "./plugin";
 export { arkenv, hybrid } from "./plugin";
 export type { ProcessEnvAugmented } from "./types";
 export default hybrid;

--- a/packages/bun-plugin/src/load-validated-env.ts
+++ b/packages/bun-plugin/src/load-validated-env.ts
@@ -1,0 +1,78 @@
+import { createJiti } from "jiti";
+
+/**
+ * Load the env module via Jiti with `process.env` seeded from the build environment.
+ *
+ * @param schemaPath Absolute path to the env module
+ * @param loadedEnv Env values from `process.env` (and optional plugin overrides)
+ * @returns The validated `env` export (named or default)
+ * @throws If the module cannot be loaded or does not export `env`
+ */
+export function loadValidatedEnv(
+	schemaPath: string,
+	loadedEnv: Record<string, string | undefined>,
+): Record<string, unknown> {
+	const previousEnv = { ...process.env };
+	Object.assign(process.env, loadedEnv);
+
+	try {
+		const jitiOptions = {
+			moduleCache: false,
+			fsCache: false,
+			tsconfigPaths: true,
+		} as const;
+
+		/**
+		 * Evaluate the env module with the given Jiti instance.
+		 *
+		 * @param jiti The configured Jiti loader
+		 * @returns The module namespace
+		 */
+		const evaluate = (jiti: ReturnType<typeof createJiti>) =>
+			jiti(schemaPath) as {
+				env?: Record<string, unknown>;
+				default?: Record<string, unknown> | { env?: Record<string, unknown> };
+			};
+
+		let mod: ReturnType<typeof evaluate>;
+		try {
+			mod = evaluate(createJiti(schemaPath, jitiOptions));
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			const isTsconfigNotFound =
+				error instanceof Error &&
+				/tsconfig/i.test(message) &&
+				(/not found/i.test(message) ||
+					(error as NodeJS.ErrnoException).code === "ENOENT");
+
+			if (!isTsconfigNotFound) throw error;
+			mod = evaluate(
+				createJiti(schemaPath, { ...jitiOptions, tsconfigPaths: false }),
+			);
+		}
+
+		const exported =
+			mod.env ??
+			(mod.default &&
+			typeof mod.default === "object" &&
+			"env" in mod.default &&
+			mod.default.env
+				? mod.default.env
+				: mod.default);
+
+		if (!exported || typeof exported !== "object") {
+			throw new Error(
+				`ArkEnv Bun plugin: "${schemaPath}" must export an \`env\` object (named or default).`,
+			);
+		}
+
+		return exported as Record<string, unknown>;
+	} finally {
+		for (const key of Object.keys(process.env)) {
+			if (!(key in previousEnv)) {
+				delete process.env[key];
+			}
+		}
+		Object.assign(process.env, previousEnv);
+	}
+}

--- a/packages/bun-plugin/src/plugin-config.ts
+++ b/packages/bun-plugin/src/plugin-config.ts
@@ -1,0 +1,8 @@
+import type { ArkEnvLogOptions } from "@repo/log";
+import type { ParseStandardConfig as ArkEnvConfig } from "@repo/utils";
+import type { BunTransformOptions } from "./transform-options";
+
+/** Combined config accepted by the Bun plugin factory (transform + ArkEnv + logging). */
+export type BunPluginFactoryConfig = Omit<ArkEnvConfig, "safe"> &
+	ArkEnvLogOptions &
+	BunTransformOptions;

--- a/packages/bun-plugin/src/plugin.ts
+++ b/packages/bun-plugin/src/plugin.ts
@@ -3,7 +3,13 @@ import { arkenv as coreArkenv } from "@arkenv/core";
 import type { ArkEnvLogOptions } from "@repo/log";
 import type { CompiledEnvSchema, SchemaShape } from "@repo/types";
 import type { BunPlugin } from "bun";
-import { createBunPlugin } from "./bun-plugin-generic";
+import {
+	type BunPluginFactoryConfig,
+	createBunPlugin,
+} from "./bun-plugin-generic";
+import type { BunTransformOptions } from "./env-module";
+
+export type { BunTransformOptions };
 
 type BunPluginConfig = Omit<ArkEnvConfig, "safe"> & ArkEnvLogOptions;
 
@@ -12,16 +18,41 @@ const { arkenv: arkenvFn, hybrid: hybridObj } = createBunPlugin(
 	"@arkenv/bun-plugin",
 );
 
+/**
+ * Bun plugin — transform path: rewrite `env.ts` in browser bundles.
+ *
+ * @param options Transform options (`schemaPath`, `clientPrefix`) plus ArkEnv/logging config
+ * @returns The Bun plugin instance
+ *
+ * @remarks
+ * ADR 0021: env.ts is the canonical surface. Do not add `env.gen.ts` codegen or
+ * client-side re-validation on this host.
+ */
+export function arkenv(options?: BunPluginFactoryConfig): BunPlugin;
+/**
+ * Bun plugin — schema/SPA path: validate and rewrite `process.env` accessors.
+ *
+ * @param options The environment variable schema definition
+ * @param config Optional ArkEnv configuration and build-time logging options
+ * @returns The Bun plugin instance
+ */
 export function arkenv(
 	options: CompiledEnvSchema,
 	config?: BunPluginConfig,
 ): BunPlugin;
+/**
+ * Bun plugin — schema/SPA path: validate and rewrite `process.env` accessors.
+ *
+ * @param options The environment variable schema definition
+ * @param config Optional ArkEnv configuration and build-time logging options
+ * @returns The Bun plugin instance
+ */
 export function arkenv<const T extends SchemaShape>(
 	options: EnvSchema<T>,
 	config?: BunPluginConfig,
 ): BunPlugin;
 export function arkenv<const T extends SchemaShape>(
-	options: EnvSchema<T> | CompiledEnvSchema,
+	options?: EnvSchema<T> | CompiledEnvSchema | BunPluginFactoryConfig,
 	config?: BunPluginConfig,
 ): BunPlugin {
 	return arkenvFn(options, config);

--- a/packages/bun-plugin/src/standard.ts
+++ b/packages/bun-plugin/src/standard.ts
@@ -3,7 +3,13 @@ import { arkenv as coreArkenv } from "@arkenv/standard";
 import type { ArkEnvLogOptions } from "@repo/log";
 import type { StandardSchemaV1 } from "@repo/types";
 import type { BunPlugin } from "bun";
-import { createBunPlugin } from "./bun-plugin-generic";
+import {
+	type BunPluginFactoryConfig,
+	createBunPlugin,
+} from "./bun-plugin-generic";
+import type { BunTransformOptions } from "./env-module";
+
+export type { BunTransformOptions };
 
 type BunPluginConfig = Omit<StandardEnvConfig, "safe"> & ArkEnvLogOptions;
 
@@ -13,10 +19,29 @@ const { arkenv: arkenvFn, hybrid: hybridObj } = createBunPlugin(
 );
 
 /**
- * Bun plugin to validate environment variables using Standard Schema.
+ * Bun plugin (Standard Schema) — transform path: rewrite `env.ts` in browser bundles.
+ *
+ * @param options Transform options (`schemaPath`, `clientPrefix`) plus ArkEnv/logging config
+ * @returns The Bun plugin instance
+ *
+ * @remarks
+ * ADR 0021: env.ts is the canonical surface. Do not add `env.gen.ts` codegen or
+ * client-side re-validation on this host.
+ */
+export function arkenv(options?: BunPluginFactoryConfig): BunPlugin;
+/**
+ * Bun plugin (Standard Schema) — schema/SPA path: validate and rewrite `process.env`.
+ *
+ * @param options The environment variable schema definition map
+ * @param config Optional ArkEnv configuration and build-time logging options
+ * @returns The Bun plugin instance
  */
 export function arkenv<const T extends Record<string, StandardSchemaV1>>(
 	options: T,
+	config?: BunPluginConfig,
+): BunPlugin;
+export function arkenv<const T extends Record<string, StandardSchemaV1>>(
+	options?: T | BunPluginFactoryConfig,
 	config?: BunPluginConfig,
 ): BunPlugin {
 	return arkenvFn(options, config);

--- a/packages/bun-plugin/src/transform-options.ts
+++ b/packages/bun-plugin/src/transform-options.ts
@@ -1,0 +1,55 @@
+/** Known plugin option keys used to discriminate transform-mode calls from schemas. */
+const TRANSFORM_OPTION_KEYS = new Set([
+	"schemaPath",
+	"clientPrefix",
+	"logger",
+	"logLevel",
+	"env",
+	"coerce",
+	"onUndeclaredKey",
+	"arrayFormat",
+	"debugSecrets",
+	"emptyAsUndefined",
+]);
+
+/**
+ * Options for the Bun plugin's env-module transform mode.
+ *
+ * @see docs/adr/0021-env-object-canonical-surface.md — transform design
+ */
+export type BunTransformOptions = {
+	/**
+	 * Path to the env module (`env.ts`), relative to `process.cwd()`.
+	 *
+	 * When omitted, ArkEnv auto-discovers `src/env.ts` or `env.ts`.
+	 */
+	schemaPath?: string;
+	/**
+	 * Prefix(es) that mark client-exposed environment variables.
+	 *
+	 * Defaults to `"BUN_PUBLIC_"`.
+	 */
+	clientPrefix?: string | string[];
+};
+
+/**
+ * Decide whether the first plugin argument selects transform mode.
+ *
+ * Transform mode: `arkenv()`, `arkenv({ schemaPath })`, or options-only bags.
+ * Schema/SPA path: `arkenv(schema)` / `arkenv(schema, config)` — including `arkenv({})`.
+ *
+ * @param first The first argument passed to the plugin factory
+ * @param second The optional second (schema-path config) argument
+ * @returns Whether the call should enable env-module transform mode
+ */
+export function isTransformModeCall(
+	first: unknown,
+	second: unknown,
+): first is BunTransformOptions | undefined {
+	if (second !== undefined) return false;
+	if (first === undefined) return true;
+	if (typeof first !== "object" || first === null) return false;
+	const keys = Object.keys(first);
+	if (keys.length === 0) return false;
+	return keys.every((key) => TRANSFORM_OPTION_KEYS.has(key));
+}

--- a/packages/bun-plugin/src/transform-plugin.ts
+++ b/packages/bun-plugin/src/transform-plugin.ts
@@ -1,0 +1,131 @@
+import fs from "node:fs";
+import {
+	type ArkEnvLogOptions,
+	resolveBuildLog,
+	splitPluginConfig,
+} from "@repo/log";
+import type { BunPlugin } from "bun";
+import { classifyEnvKeys } from "./classify-env-keys";
+import {
+	isEnvModuleId,
+	normalizePrefixes,
+	resolveEnvModulePath,
+} from "./env-module-path";
+import { generateClientEnvModule } from "./generate-client-env-module";
+import { loadValidatedEnv } from "./load-validated-env";
+import type { BunPluginFactoryConfig } from "./plugin-config";
+
+/**
+ * Build the env-module transform plugin (browser rewrite; server passthrough).
+ *
+ * Scoped to `target: "browser"` so `bun run` / `Bun.serve` server code executes
+ * `env.ts` as-is against the real deployment environment.
+ *
+ * @param pluginName The Bun plugin name
+ * @param transformOptions Plugin options including `schemaPath` / `clientPrefix`
+ * @param factoryLogOptions Default logging options from the factory
+ * @returns A Bun plugin that rewrites `env.ts` in browser bundles
+ */
+export function createTransformPlugin(
+	pluginName: string,
+	transformOptions: BunPluginFactoryConfig,
+	factoryLogOptions?: ArkEnvLogOptions,
+): BunPlugin {
+	const {
+		schemaPath: schemaPathOption,
+		clientPrefix: clientPrefixOption,
+		...configWithoutTransformKeys
+	} = transformOptions;
+	const { pluginConfig, logOptions } = splitPluginConfig(
+		configWithoutTransformKeys,
+	);
+	const buildLog = resolveBuildLog({ ...factoryLogOptions, ...logOptions });
+
+	const state: {
+		schemaPath?: string;
+		prefixes: string[];
+		clientValues: Record<string, unknown>;
+		serverKeys: string[];
+		transformedSource?: string;
+	} = {
+		prefixes: normalizePrefixes(clientPrefixOption),
+		clientValues: {},
+		serverKeys: [],
+	};
+
+	/**
+	 * Reload validated env values and key classification from the env module.
+	 */
+	const refreshTransformState = () => {
+		if (!state.schemaPath) return;
+
+		const loaded = {
+			...process.env,
+			...(pluginConfig.env as Record<string, string | undefined> | undefined),
+		};
+
+		const validated = loadValidatedEnv(state.schemaPath, loaded);
+		const content = fs.readFileSync(state.schemaPath, "utf8");
+		const { clientKeys, sharedKeys, serverKeys } = classifyEnvKeys(
+			content,
+			state.prefixes,
+		);
+
+		const inlineKeys = new Set([...clientKeys, ...sharedKeys]);
+		const clientValues: Record<string, unknown> = {};
+		for (const key of inlineKeys) {
+			if (key in validated) {
+				clientValues[key] = validated[key];
+			}
+		}
+
+		state.clientValues = clientValues;
+		state.serverKeys = serverKeys;
+		state.transformedSource = generateClientEnvModule(clientValues, serverKeys);
+	};
+
+	return {
+		name: pluginName,
+		/**
+		 * Only apply to browser / `[serve.static]` graphs. Server runtime loads
+		 * `env.ts` through Bun's native module loader without this plugin.
+		 */
+		target: "browser",
+		setup(build) {
+			/**
+			 * Rewrite the env module in browser bundles only.
+			 *
+			 * @remarks
+			 * ADR 0021 (canonical env object surface): do not reintroduce `env.gen.ts`
+			 * codegen, client-side re-validation, or `runtimeEnv` wiring here.
+			 */
+			build.onStart(() => {
+				try {
+					state.schemaPath = resolveEnvModulePath(
+						process.cwd(),
+						schemaPathOption,
+					);
+					state.prefixes = normalizePrefixes(clientPrefixOption);
+					refreshTransformState();
+				} catch (error: unknown) {
+					buildLog.logBuildErrorWithCause(
+						"Environment validation failed",
+						error,
+					);
+					throw error;
+				}
+			});
+
+			build.onLoad({ filter: /\.(m|c)?[jt]sx?$/ }, (args) => {
+				if (!state.schemaPath) return undefined;
+				if (!isEnvModuleId(args.path, state.schemaPath)) return undefined;
+				if (!state.transformedSource) return undefined;
+
+				return {
+					contents: state.transformedSource,
+					loader: "js",
+				};
+			});
+		},
+	} satisfies BunPlugin;
+}

--- a/packages/bun-plugin/src/transform-plugin.ts
+++ b/packages/bun-plugin/src/transform-plugin.ts
@@ -98,6 +98,12 @@ export function createTransformPlugin(
 			 * @remarks
 			 * ADR 0021 (canonical env object surface): do not reintroduce `env.gen.ts`
 			 * codegen, client-side re-validation, or `runtimeEnv` wiring here.
+			 *
+			 * Dev-server refresh: `onStart` re-validates on each `Bun.build` /
+			 * `[serve.static]` rebuild. Bun does not expose a Vite-style
+			 * `handleHotUpdate` hook, so editing `.env` / `env.ts` during an
+			 * already-running `Bun.serve` requires a server restart (or a rebuild
+			 * that re-invokes `onStart`) to refresh inlined client values.
 			 */
 			build.onStart(() => {
 				try {

--- a/packages/bun-plugin/tsconfig.json
+++ b/packages/bun-plugin/tsconfig.json
@@ -13,5 +13,6 @@
 		"resolveJsonModule": true,
 		"declaration": true,
 		"declarationMap": true
-	}
+	},
+	"exclude": ["src/__fixtures__", "dist", "node_modules"]
 }

--- a/packages/bun-plugin/tsdown.config.ts
+++ b/packages/bun-plugin/tsdown.config.ts
@@ -7,5 +7,9 @@ export default defineConfig({
 	fixedExtension: false,
 	deps: {
 		alwaysBundle: ["@repo/log", "@repo/types", "@repo/utils"],
+		// jiti loads the user's env.ts at build time; keep it external so the
+		// plugin does not ship a second copy and Node/Bun can resolve project deps.
+		// @arkenv/build is a workspace runtime dependency for key extraction.
+		neverBundle: ["bun", "@arkenv/build", "jiti"],
 	},
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -886,6 +886,13 @@ importers:
         version: 6.0.3
 
   packages/bun-plugin:
+    dependencies:
+      '@arkenv/build':
+        specifier: workspace:*
+        version: link:../build
+      jiti:
+        specifier: 'catalog:'
+        version: 2.7.0
     devDependencies:
       '@arkenv/core':
         specifier: workspace:*
@@ -16662,7 +16669,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -16724,7 +16731,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.5':
     dependencies:


### PR DESCRIPTION
Fixes #1329

## Summary
- Add dual-mode `@arkenv/bun-plugin`: `arkenv()` / zero-config default rewrites `env.ts` in browser bundles (inlined coerced `BUN_PUBLIC_*` literals + server-key guards); `arkenv(schema)` keeps SPA `process.env` rewriting
- Server/`Bun.serve` continues to execute `env.ts` as-is for boot-time validation against the real environment (plugin is `target: "browser"`)
- Extend `with-bun-react` with a server-only `DATABASE_URL` and shared `import { env } from "./env"` on client and server

## Test plan
- [ ] `pnpm --filter @arkenv/bun-plugin test` passes (helpers + transform onLoad + SPA regression)
- [ ] Client `Bun.build` bundle contains inlined literals / guard stub and no validator imports
- [ ] `bun run` / `Bun.serve` fails fast when required env is missing
- [ ] SPA `arkenv(schema)` + `ProcessEnvAugmented` path still works


Made with [Cursor](https://cursor.com)