### PR TITLE
docs: Forward-port triage out-of-scope skill fix from #1464

### DIFF
--- a/skills/triage/OUT-OF-SCOPE.md
+++ b/skills/triage/OUT-OF-SCOPE.md
@@ -1,6 +1,16 @@
 # Out-of-scope knowledge base
 
-The `.out-of-scope/` directory in a repo stores persistent records of rejected feature requests. It serves two purposes:
+> **ArkEnv override:** This repo does **not** use a root `.out-of-scope/` directory. That convention came from the generic triage skill and has no precedent here (see closed PR #1462). For ArkEnv:
+>
+> - **Architectural / product rejects** → record in `docs/adr/` (amend the relevant ADR, or add one if the reject is itself a hard-to-reverse decision). Example: #1440’s ambient SPA augment types belong in the ADR 0015 amendment on #1333.
+> - **Simple wontfix with no ADR-worthy trade-off** → a closing issue comment is enough; do not invent a new top-level folder.
+> - During triage, check `docs/adr/` (and closed related issues) instead of `.out-of-scope/*.md`.
+>
+> The remainder of this file documents the generic `.out-of-scope/` pattern for reference only — **do not create that directory in ArkEnv**.
+
+---
+
+The (generic) `.out-of-scope/` directory stores persistent records of rejected feature requests. It serves two purposes:
 
 1. **Institutional memory** - why a feature was rejected, so the reasoning isn't lost when the issue is closed
 2. **Deduplication** - when a new issue comes in that matches a prior rejection, the skill can surface the previous decision instead of re-litigating it

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -18,7 +18,7 @@ Every comment or issue posted to the issue tracker during triage **must** start 
 ## Reference docs
 
 - [AGENT-BRIEF.md](AGENT-BRIEF.md) - how to write durable agent briefs
-- [OUT-OF-SCOPE.md](OUT-OF-SCOPE.md) - how the `.out-of-scope/` knowledge base works
+- [OUT-OF-SCOPE.md](OUT-OF-SCOPE.md) - how rejected enhancements are recorded (**ArkEnv: use `docs/adr/`, not a root `.out-of-scope/` folder**)
 
 ## Roles
 
@@ -66,7 +66,7 @@ Show counts and a one-line summary per issue. Let the maintainer pick.
 
 ## Triage a specific issue
 
-1. **Gather context.** Read the full issue (body, comments, labels, reporter, dates). Parse any prior triage notes so you don't re-ask resolved questions. Explore the codebase using the project's domain glossary, respecting ADRs in the area. Read `.out-of-scope/*.md` and surface any prior rejection that resembles this issue.
+1. **Gather context.** Read the full issue (body, comments, labels, reporter, dates). Parse any prior triage notes so you don't re-ask resolved questions. Explore the codebase using the project's domain glossary, respecting ADRs in the area. Check `docs/adr/` (and related closed issues) for prior rejections that resemble this issue — **do not** look for or create a root `.out-of-scope/` directory in this repo (see [OUT-OF-SCOPE.md](OUT-OF-SCOPE.md)).
 
 2. **Recommend.** Tell the maintainer your category and state recommendation with reasoning, plus a brief codebase summary relevant to the issue. Wait for direction.
 
@@ -79,7 +79,7 @@ Show counts and a one-line summary per issue. Let the maintainer pick.
    - `ready-for-human` - same structure as an agent brief, but note why it can't be delegated (judgment calls, external access, design decisions, manual testing).
    - `needs-info` - post triage notes (template below).
    - `wontfix` (bug) - polite explanation, then close.
-   - `wontfix` (enhancement) - write to `.out-of-scope/`, link to it from a comment, then close ([OUT-OF-SCOPE.md](OUT-OF-SCOPE.md)).
+   - `wontfix` (enhancement) - record in `docs/adr/` when architectural; otherwise a closing comment is enough. Link the record from the issue, then close ([OUT-OF-SCOPE.md](OUT-OF-SCOPE.md)). **Never** create `.out-of-scope/` in ArkEnv.
    - `needs-triage` - apply the role. Optional comment if there's partial progress.
 
 ## Quick state override


### PR DESCRIPTION
## Summary
- Forward-ports [#1464](https://github.com/yamcodes/arkenv/pull/1464) onto `v1`: triage skill records ArkEnv rejects in `docs/adr/` (or a closing comment), never a root `.out-of-scope/` folder.
- Same paths on both branches (`skills/triage/*`); no package remapping or changeset.

## Source
- Dev PR: https://github.com/yamcodes/arkenv/pull/1464
- Merge commit: `874b95a8`

## Test plan
- [x] Cherry-pick applied cleanly on `origin/v1`
- [ ] Spot-check `skills/triage/SKILL.md` and `OUT-OF-SCOPE.md` for the ArkEnv override
- [ ] No need for package typecheck/tests (skills markdown only)


Made with [Cursor](https://cursor.com)