### PR TITLE
feat: (v1) Forward-port: hosting presets Phase 4 (#1450)

### DIFF
--- a/.changeset/add-host-presets-phase-4.md
+++ b/.changeset/add-host-presets-phase-4.md
@@ -1,0 +1,19 @@
+---
+"arkenv": minor
+---
+
+#### Add hosting presets for Cloudflare, Railway, Render, and Fly.io
+
+Add hosting presets for Cloudflare, Railway, Render, and Fly.io to the interactive prompt selections in both `arkenv init` and `arkenv add host`.
+
+Usage:
+
+```bash
+npx arkenv@latest add host cloudflare
+```
+
+or
+
+```bash
+npx arkenv@latest init --host-preset cloudflare
+```

--- a/apps/www/content/docs/cli/hosting-presets.mdx
+++ b/apps/www/content/docs/cli/hosting-presets.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hosting presets
 icon: Cloud
-description: Pre-populate your schema with Vercel or Netlify system environment variables during arkenv init, or add them later with arkenv add host.
+description: Pre-populate your schema with Vercel, Netlify, Cloudflare, Railway, Render, or Fly.io system environment variables during arkenv init, or add them later with arkenv add host.
 ---
 
 Most hosting providers inject their own **system environment variables** at build and runtime (for example, Vercel sets `VERCEL_ENV` and `VERCEL_URL`, Netlify sets `CONTEXT` and `URL`). Hosting presets let `arkenv init` pre-populate your generated schema with the correct variables for your provider, already typed and marked optional, so you don't have to look them up by hand. If you already have a schema, use [`arkenv add host`](#add-host-to-an-existing-schema) to inject the same fields later.
@@ -18,9 +18,13 @@ When you run `init` interactively, the CLI shows a dedicated step:
 
 ```txt
 Select a hosting provider preset (optional):
-❯ None      Do not add any hosting-specific environment variables
-  Vercel    Add VERCEL, VERCEL_ENV, VERCEL_URL, etc.
-  Netlify   Add NETLIFY, CONTEXT, URL, DEPLOY_URL, etc.
+❯ None                          Do not add any hosting-specific environment variables
+  Vercel                        Add VERCEL, VERCEL_ENV, VERCEL_URL, etc.
+  Netlify                       Add NETLIFY, CONTEXT, URL, DEPLOY_URL, etc.
+  Cloudflare Pages/Workers      Add CF_PAGES, CF_PAGES_COMMIT_SHA, CF_PAGES_BRANCH, CF_PAGES_URL, etc.
+  Railway                       Add RAILWAY_ENVIRONMENT_NAME, RAILWAY_PUBLIC_DOMAIN, RAILWAY_GIT_COMMIT_SHA, etc.
+  Render                        Add RENDER, RENDER_SERVICE_ID, RENDER_SERVICE_TYPE, RENDER_EXTERNAL_URL, etc.
+  Fly.io                        Add FLY_APP_NAME, FLY_REGION, FLY_ALLOC_ID, etc.
 ```
 
 Choosing **None** (the default) leaves your schema untouched.
@@ -33,7 +37,7 @@ To skip the prompt - for example in scripts or with `--agent` - pass the `--host
 npx arkenv@latest init --host-preset vercel
 ```
 
-The flag accepts `none`, `vercel`, or `netlify`. The following is equivalent:
+The flag accepts `none`, `vercel`, `netlify`, `cloudflare`, `railway`, `render`, or `fly`. The following is equivalent:
 
 ```npm
 npx arkenv@latest init -H vercel
@@ -80,6 +84,41 @@ Selecting a preset adds the provider's system variables to your schema. Every va
 | `DEPLOY_URL` | `string` (optional)                                              | Server-only    |
 | `CONTEXT`    | `"production" \| "deploy-preview" \| "branch-deploy"` (optional) | Client-exposed |
 | `URL`        | `string` (optional)                                              | Client-exposed |
+
+### Cloudflare Pages/Workers
+
+| Variable              | Type                | Exposure       |
+| --------------------- | ------------------- | -------------- |
+| `CF_PAGES`            | `string` (optional) | Server-only    |
+| `CF_PAGES_COMMIT_SHA` | `string` (optional) | Server-only    |
+| `CF_PAGES_BRANCH`     | `string` (optional) | Client-exposed |
+| `CF_PAGES_URL`        | `string` (optional) | Client-exposed |
+
+### Railway
+
+| Variable                   | Type                | Exposure    |
+| -------------------------- | ------------------- | ----------- |
+| `RAILWAY_ENVIRONMENT_NAME` | `string` (optional) | Server-only |
+| `RAILWAY_PUBLIC_DOMAIN`    | `string` (optional) | Server-only |
+| `RAILWAY_SERVICE_NAME`     | `string` (optional) | Server-only |
+| `RAILWAY_GIT_COMMIT_SHA`   | `string` (optional) | Server-only |
+
+### Render
+
+| Variable              | Type                | Exposure    |
+| --------------------- | ------------------- | ----------- |
+| `RENDER`              | `string` (optional) | Server-only |
+| `RENDER_SERVICE_ID`   | `string` (optional) | Server-only |
+| `RENDER_SERVICE_TYPE` | `string` (optional) | Server-only |
+| `RENDER_EXTERNAL_URL` | `string` (optional) | Server-only |
+
+### Fly.io
+
+| Variable       | Type                | Exposure    |
+| -------------- | ------------------- | ----------- |
+| `FLY_APP_NAME` | `string` (optional) | Server-only |
+| `FLY_REGION`   | `string` (optional) | Server-only |
+| `FLY_ALLOC_ID` | `string` (optional) | Server-only |
 
 ## Framework prefixes
 
@@ -214,6 +253,215 @@ The examples below show the schema generated for a plain Node.js project (no fra
     	DEPLOY_URL: v.optional(v.string()),
     	CONTEXT: v.optional(v.picklist(["production", "deploy-preview", "branch-deploy"])),
     	URL: v.optional(v.string()),
+    });
+    ```
+  </Tab>
+</Tabs>
+
+### Cloudflare Pages/Workers
+
+<Tabs items={['ArkType', 'Zod', 'Valibot']}>
+  <Tab value="ArkType">
+    ```ts title="env.ts"
+    import arkenv, { type } from "@arkenv/core";
+
+    export const Env = type({
+    	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+    	PORT: "number.port = 3000",
+    	CF_PAGES: "string?",
+    	CF_PAGES_COMMIT_SHA: "string?",
+    	CF_PAGES_BRANCH: "string?",
+    	CF_PAGES_URL: "string?",
+    });
+
+    export const env = arkenv(Env);
+    ```
+  </Tab>
+
+  <Tab value="Zod">
+    ```ts title="env.ts"
+    import arkenv from "@arkenv/standard";
+    import { z } from "zod";
+
+    export const env = arkenv({
+    	NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+    	PORT: z.coerce.number().int().min(1).max(65535).default(3000),
+    	CF_PAGES: z.string().optional(),
+    	CF_PAGES_COMMIT_SHA: z.string().optional(),
+    	CF_PAGES_BRANCH: z.string().optional(),
+    	CF_PAGES_URL: z.string().optional(),
+    });
+    ```
+  </Tab>
+
+  <Tab value="Valibot">
+    ```ts title="env.ts"
+    import arkenv from "@arkenv/standard";
+    import * as v from "valibot";
+
+    export const env = arkenv({
+    	NODE_ENV: v.optional(v.picklist(["development", "production", "test"]), "development"),
+    	PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),
+    	CF_PAGES: v.optional(v.string()),
+    	CF_PAGES_COMMIT_SHA: v.optional(v.string()),
+    	CF_PAGES_BRANCH: v.optional(v.string()),
+    	CF_PAGES_URL: v.optional(v.string()),
+    });
+    ```
+  </Tab>
+</Tabs>
+
+### Railway
+
+<Tabs items={['ArkType', 'Zod', 'Valibot']}>
+  <Tab value="ArkType">
+    ```ts title="env.ts"
+    import arkenv, { type } from "@arkenv/core";
+
+    export const Env = type({
+    	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+    	PORT: "number.port = 3000",
+    	RAILWAY_ENVIRONMENT_NAME: "string?",
+    	RAILWAY_PUBLIC_DOMAIN: "string?",
+    	RAILWAY_SERVICE_NAME: "string?",
+    	RAILWAY_GIT_COMMIT_SHA: "string?",
+    });
+
+    export const env = arkenv(Env);
+    ```
+  </Tab>
+
+  <Tab value="Zod">
+    ```ts title="env.ts"
+    import arkenv from "@arkenv/standard";
+    import { z } from "zod";
+
+    export const env = arkenv({
+    	NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+    	PORT: z.coerce.number().int().min(1).max(65535).default(3000),
+    	RAILWAY_ENVIRONMENT_NAME: z.string().optional(),
+    	RAILWAY_PUBLIC_DOMAIN: z.string().optional(),
+    	RAILWAY_SERVICE_NAME: z.string().optional(),
+    	RAILWAY_GIT_COMMIT_SHA: z.string().optional(),
+    });
+    ```
+  </Tab>
+
+  <Tab value="Valibot">
+    ```ts title="env.ts"
+    import arkenv from "@arkenv/standard";
+    import * as v from "valibot";
+
+    export const env = arkenv({
+    	NODE_ENV: v.optional(v.picklist(["development", "production", "test"]), "development"),
+    	PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),
+    	RAILWAY_ENVIRONMENT_NAME: v.optional(v.string()),
+    	RAILWAY_PUBLIC_DOMAIN: v.optional(v.string()),
+    	RAILWAY_SERVICE_NAME: v.optional(v.string()),
+    	RAILWAY_GIT_COMMIT_SHA: v.optional(v.string()),
+    });
+    ```
+  </Tab>
+</Tabs>
+
+### Render
+
+<Tabs items={['ArkType', 'Zod', 'Valibot']}>
+  <Tab value="ArkType">
+    ```ts title="env.ts"
+    import arkenv, { type } from "@arkenv/core";
+
+    export const Env = type({
+    	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+    	PORT: "number.port = 3000",
+    	RENDER: "string?",
+    	RENDER_SERVICE_ID: "string?",
+    	RENDER_SERVICE_TYPE: "string?",
+    	RENDER_EXTERNAL_URL: "string?",
+    });
+
+    export const env = arkenv(Env);
+    ```
+  </Tab>
+
+  <Tab value="Zod">
+    ```ts title="env.ts"
+    import arkenv from "@arkenv/standard";
+    import { z } from "zod";
+
+    export const env = arkenv({
+    	NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+    	PORT: z.coerce.number().int().min(1).max(65535).default(3000),
+    	RENDER: z.string().optional(),
+    	RENDER_SERVICE_ID: z.string().optional(),
+    	RENDER_SERVICE_TYPE: z.string().optional(),
+    	RENDER_EXTERNAL_URL: z.string().optional(),
+    });
+    ```
+  </Tab>
+
+  <Tab value="Valibot">
+    ```ts title="env.ts"
+    import arkenv from "@arkenv/standard";
+    import * as v from "valibot";
+
+    export const env = arkenv({
+    	NODE_ENV: v.optional(v.picklist(["development", "production", "test"]), "development"),
+    	PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),
+    	RENDER: v.optional(v.string()),
+    	RENDER_SERVICE_ID: v.optional(v.string()),
+    	RENDER_SERVICE_TYPE: v.optional(v.string()),
+    	RENDER_EXTERNAL_URL: v.optional(v.string()),
+    });
+    ```
+  </Tab>
+</Tabs>
+
+### Fly.io
+
+<Tabs items={['ArkType', 'Zod', 'Valibot']}>
+  <Tab value="ArkType">
+    ```ts title="env.ts"
+    import arkenv, { type } from "@arkenv/core";
+
+    export const Env = type({
+    	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+    	PORT: "number.port = 3000",
+    	FLY_APP_NAME: "string?",
+    	FLY_REGION: "string?",
+    	FLY_ALLOC_ID: "string?",
+    });
+
+    export const env = arkenv(Env);
+    ```
+  </Tab>
+
+  <Tab value="Zod">
+    ```ts title="env.ts"
+    import arkenv from "@arkenv/standard";
+    import { z } from "zod";
+
+    export const env = arkenv({
+    	NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+    	PORT: z.coerce.number().int().min(1).max(65535).default(3000),
+    	FLY_APP_NAME: z.string().optional(),
+    	FLY_REGION: z.string().optional(),
+    	FLY_ALLOC_ID: z.string().optional(),
+    });
+    ```
+  </Tab>
+
+  <Tab value="Valibot">
+    ```ts title="env.ts"
+    import arkenv from "@arkenv/standard";
+    import * as v from "valibot";
+
+    export const env = arkenv({
+    	NODE_ENV: v.optional(v.picklist(["development", "production", "test"]), "development"),
+    	PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),
+    	FLY_APP_NAME: v.optional(v.string()),
+    	FLY_REGION: v.optional(v.string()),
+    	FLY_ALLOC_ID: v.optional(v.string()),
     });
     ```
   </Tab>

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -23,16 +23,16 @@ The command adjusts its workflow depending on where it is executed:
 
 #### Options [!toc]
 
-| Flag            | Alias | Description                                                                                                                                        |
-| --------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--example`     |       | Specify an example name when creating a new project.                                                                                               |
-| `--force`       | `-f`  | Bypass checks and force initialization.                                                                                                            |
-| `--no-codegen`  |       | Disable automatic env.gen.ts code generation for Next.js (falls back to manual runtimeEnv destructuring).                                          |
-| `--host-preset` | `-H`  | Pre-populate the schema with a hosting provider's system env vars (`none`, `vercel`, `netlify`). See [Hosting presets](/docs/cli/hosting-presets). |
+| Flag            | Alias | Description                                                                                                                                                                                  |
+| --------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--example`     |       | Specify an example name when creating a new project.                                                                                                                                         |
+| `--force`       | `-f`  | Bypass checks and force initialization.                                                                                                                                                      |
+| `--no-codegen`  |       | Disable automatic env.gen.ts code generation for Next.js (falls back to manual runtimeEnv destructuring).                                                                                    |
+| `--host-preset` | `-H`  | Pre-populate the schema with a hosting provider's system env vars (`none`, `vercel`, `netlify`, `cloudflare`, `railway`, `render`, `fly`). See [Hosting presets](/docs/cli/hosting-presets). |
 
 ### `add host`
 
-Add a hosting provider preset (Vercel or Netlify) to an existing schema.
+Add a hosting provider preset (Vercel, Netlify, Cloudflare, Railway, Render, or Fly.io) to an existing schema.
 
 ```npm
 npx arkenv@latest add host [provider]

--- a/packages/arkenv/src/cli/cli.test.ts
+++ b/packages/arkenv/src/cli/cli.test.ts
@@ -281,6 +281,28 @@ describe("CLI parser", () => {
 				"vercle",
 			]);
 			expect(cli4.validationError).toBe("Invalid host preset: vercle");
+
+			const cli5 = new CLI([
+				"node",
+				"arkenv",
+				"init",
+				"--host-preset",
+				"cloudflare",
+			]);
+			expect(cli5.hostPreset).toBe("cloudflare");
+			expect(cli5.initInput.hostPreset).toBe("cloudflare");
+			expect(cli5.validationError).toBeUndefined();
+
+			const cli6 = new CLI([
+				"node",
+				"arkenv",
+				"init",
+				"--host-preset",
+				"railway",
+			]);
+			expect(cli6.hostPreset).toBe("railway");
+			expect(cli6.initInput.hostPreset).toBe("railway");
+			expect(cli6.validationError).toBeUndefined();
 		});
 
 		it("should parse the -H alias for --host-preset", () => {
@@ -305,6 +327,20 @@ describe("CLI parser", () => {
 				const cli = new CLI(["node", "arkenv", "add", "host", "netlify"]);
 				expect(cli.command).toBe("add");
 				expect(cli.addInput.provider).toBe("netlify");
+				expect(cli.validationError).toBeUndefined();
+			});
+
+			it("should parse valid add host cloudflare command", () => {
+				const cli = new CLI(["node", "arkenv", "add", "host", "cloudflare"]);
+				expect(cli.command).toBe("add");
+				expect(cli.addInput.provider).toBe("cloudflare");
+				expect(cli.validationError).toBeUndefined();
+			});
+
+			it("should parse valid add host railway command", () => {
+				const cli = new CLI(["node", "arkenv", "add", "host", "railway"]);
+				expect(cli.command).toBe("add");
+				expect(cli.addInput.provider).toBe("railway");
 				expect(cli.validationError).toBeUndefined();
 			});
 

--- a/packages/arkenv/src/cli/cli.ts
+++ b/packages/arkenv/src/cli/cli.ts
@@ -1,5 +1,10 @@
 import { Logger } from "@/adapters";
-import { type HostPreset, isHostPreset } from "@/features/scaffold/presets";
+import {
+	type HostPreset,
+	type HostProvider,
+	isHostPreset,
+	isHostProvider,
+} from "@/features/scaffold/presets";
 import type { InitInput } from "./commands/init";
 
 const FLAG_CONFIG = {
@@ -125,11 +130,7 @@ export class CLI {
 					this.validationError = `Unknown argument: ${positionalArgs[2]}`;
 				} else {
 					const provider = positionalArgs[1];
-					if (
-						provider !== undefined &&
-						provider !== "vercel" &&
-						provider !== "netlify"
-					) {
+					if (provider !== undefined && !isHostProvider(provider)) {
 						this.validationError = `Invalid host preset: ${provider}`;
 					}
 				}
@@ -244,10 +245,10 @@ export class CLI {
 	/**
 	 * Returns the parsed input consumed by the add command.
 	 */
-	get addInput(): { provider?: "vercel" | "netlify"; isYes?: boolean } {
+	get addInput(): { provider?: HostProvider; isYes?: boolean } {
 		const provider = this.positionalArgs[1];
 		const isYes = this.isYes;
-		if (provider === "vercel" || provider === "netlify") {
+		if (provider !== undefined && isHostProvider(provider)) {
 			return { provider, isYes };
 		}
 		return { isYes };

--- a/packages/arkenv/src/cli/commands/add.test.ts
+++ b/packages/arkenv/src/cli/commands/add.test.ts
@@ -139,6 +139,98 @@ describe("AddUseCase", () => {
 		);
 	});
 
+	it("mutates env.ts with cloudflare preset keys", async () => {
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) =>
+			p.endsWith("env.ts"),
+		);
+		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
+			import { type } from "@arkenv/core";
+			export const Env = type({
+				DATABASE_URL: "string",
+			});
+		`);
+
+		const result = await useCase.execute({ provider: "cloudflare" });
+		expect(result).toBe(true);
+		expect(workspace.writeFile).toHaveBeenCalledWith(
+			expect.stringContaining("env.ts"),
+			expect.stringContaining('CF_PAGES: "string?"'),
+		);
+		expect(workspace.writeFile).toHaveBeenCalledWith(
+			expect.stringContaining("env.ts"),
+			expect.stringContaining('CF_PAGES_URL: "string?"'),
+		);
+		expect(logger.success).toHaveBeenCalledWith(
+			expect.stringContaining("Added Cloudflare"),
+		);
+	});
+
+	it("mutates env.ts with railway preset keys", async () => {
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) =>
+			p.endsWith("env.ts"),
+		);
+		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
+			import { type } from "@arkenv/core";
+			export const Env = type({
+				DATABASE_URL: "string",
+			});
+		`);
+
+		const result = await useCase.execute({ provider: "railway" });
+		expect(result).toBe(true);
+		expect(workspace.writeFile).toHaveBeenCalledWith(
+			expect.stringContaining("env.ts"),
+			expect.stringContaining('RAILWAY_ENVIRONMENT_NAME: "string?"'),
+		);
+		expect(logger.success).toHaveBeenCalledWith(
+			expect.stringContaining("Added Railway"),
+		);
+	});
+
+	it("mutates env.ts with render preset keys", async () => {
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) =>
+			p.endsWith("env.ts"),
+		);
+		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
+			import { type } from "@arkenv/core";
+			export const Env = type({
+				DATABASE_URL: "string",
+			});
+		`);
+
+		const result = await useCase.execute({ provider: "render" });
+		expect(result).toBe(true);
+		expect(workspace.writeFile).toHaveBeenCalledWith(
+			expect.stringContaining("env.ts"),
+			expect.stringContaining('RENDER: "string?"'),
+		);
+		expect(logger.success).toHaveBeenCalledWith(
+			expect.stringContaining("Added Render"),
+		);
+	});
+
+	it("mutates env.ts with fly preset keys", async () => {
+		vi.mocked(workspace.exists).mockImplementation(async (p: string) =>
+			p.endsWith("env.ts"),
+		);
+		vi.mocked(workspace.readFile).mockResolvedValue(dedent`
+			import { type } from "@arkenv/core";
+			export const Env = type({
+				DATABASE_URL: "string",
+			});
+		`);
+
+		const result = await useCase.execute({ provider: "fly" });
+		expect(result).toBe(true);
+		expect(workspace.writeFile).toHaveBeenCalledWith(
+			expect.stringContaining("env.ts"),
+			expect.stringContaining('FLY_APP_NAME: "string?"'),
+		);
+		expect(logger.success).toHaveBeenCalledWith(
+			expect.stringContaining("Added Fly.io"),
+		);
+	});
+
 	it("locates and mutates src/env.ts in nested layouts", async () => {
 		vi.mocked(workspace.exists).mockImplementation(async (p: string) => {
 			return p.endsWith("src/env.ts");

--- a/packages/arkenv/src/cli/commands/add.ts
+++ b/packages/arkenv/src/cli/commands/add.ts
@@ -7,6 +7,9 @@ import { FRAMEWORK_CLIENT_PREFIXES } from "@/features/scaffold/frameworks";
 import type { Validator } from "@/features/scaffold/plan";
 import {
 	getPresetKeys,
+	type HostPreset,
+	type HostProvider,
+	PRESETS,
 	partitionPresetKeys,
 } from "@/features/scaffold/presets";
 import type {
@@ -17,12 +20,12 @@ import type {
 } from "@/shared/ports";
 
 export type AddInput = {
-	provider?: "vercel" | "netlify";
+	provider?: HostProvider;
 	isYes?: boolean;
 };
 
 /**
- * Use case for adding a hosting preset (Vercel/Netlify) to an existing schema.
+ * Use case for adding a hosting preset (Vercel/Netlify/Cloudflare/etc.) to an existing schema.
  */
 export class AddUseCase {
 	constructor(
@@ -33,7 +36,10 @@ export class AddUseCase {
 	) {}
 
 	/**
-	 * Executes the add command by finding/mutating the env schema.
+	 * Execute the add command by finding and mutating the env schema.
+	 *
+	 * @param input Provider selection and non-interactive flags
+	 * @returns Whether the command completed (including no-op success paths)
 	 */
 	async execute(input: AddInput): Promise<boolean> {
 		this.logger.interactiveStdout(true);
@@ -45,23 +51,16 @@ export class AddUseCase {
 				if (input.isYes) {
 					provider = "vercel";
 				} else {
-					const selected = await this.prompt.select(
+					const selected = (await this.prompt.select(
 						"Select a hosting provider preset:",
-						[
-							{
-								value: "vercel",
-								label: "Vercel",
-								hint: "Add VERCEL, VERCEL_ENV, VERCEL_URL, etc.",
-							},
-							{
-								value: "netlify",
-								label: "Netlify",
-								hint: "Add NETLIFY, CONTEXT, URL, DEPLOY_URL, etc.",
-							},
-						],
+						Object.entries(PRESETS).map(([value, def]) => ({
+							value,
+							label: def.label,
+							hint: def.hint,
+						})),
 						"vercel",
-					);
-					if (selected === "vercel" || selected === "netlify") {
+					)) as HostPreset;
+					if (selected && selected !== "none") {
 						provider = selected;
 					} else {
 						return false;
@@ -177,7 +176,7 @@ export class AddUseCase {
 					anyUpdated = true;
 				}
 
-				const providerName = provider === "vercel" ? "Vercel" : "Netlify";
+				const providerName = PRESETS[provider].label;
 				if (anyUpdated) {
 					this.logger.success(
 						`Added ${providerName} environment variables to ${relClientPath} and ${relServerPath}`,
@@ -245,11 +244,11 @@ export class AddUseCase {
 			if (result.updated) {
 				await this.workspace.writeFile(envPath, result.code);
 				this.logger.success(
-					`Added ${provider === "vercel" ? "Vercel" : "Netlify"} environment variables to ${relativeEnvPath}`,
+					`Added ${PRESETS[provider].label} environment variables to ${relativeEnvPath}`,
 				);
 			} else {
 				this.logger.info(
-					`All ${provider === "vercel" ? "Vercel" : "Netlify"} environment variables are already present in ${relativeEnvPath}`,
+					`All ${PRESETS[provider].label} environment variables are already present in ${relativeEnvPath}`,
 				);
 			}
 

--- a/packages/arkenv/src/cli/commands/help.test.ts
+++ b/packages/arkenv/src/cli/commands/help.test.ts
@@ -34,7 +34,7 @@ describe("HelpUseCase", () => {
 		);
 		expect(addCommandLog).toBeDefined();
 		expect(addCommandLog).toBe(
-			"  arkenv add host [provider]    Add hosting provider preset (vercel, netlify) to schema",
+			"  arkenv add host [provider]    Add hosting provider preset (vercel, netlify, cloudflare, railway, render, fly) to schema",
 		);
 
 		// Options should be aligned based on the longest option (--host-preset, -H <preset>) which is 26 chars
@@ -73,7 +73,7 @@ describe("HelpUseCase", () => {
 		expect(hostPresetOptionLog).toBeDefined();
 		// "--host-preset, -H <preset>" is 26 chars. max (26) - 26 + colGap (4) = 4 spaces padding.
 		expect(hostPresetOptionLog).toBe(
-			"  --host-preset, -H <preset>    Specify a hosting provider preset (none, vercel, netlify)",
+			"  --host-preset, -H <preset>    Specify a hosting provider preset (none, vercel, netlify, cloudflare, railway, render, fly)",
 		);
 
 		const helpOptionLog = logs.find((l) => l.includes("--help, -h"));

--- a/packages/arkenv/src/cli/commands/help.ts
+++ b/packages/arkenv/src/cli/commands/help.ts
@@ -40,7 +40,8 @@ export class HelpUseCase {
 			},
 			{
 				left: "arkenv add host [provider]",
-				right: "Add hosting provider preset (vercel, netlify) to schema",
+				right:
+					"Add hosting provider preset (vercel, netlify, cloudflare, railway, render, fly) to schema",
 			},
 		];
 
@@ -77,7 +78,8 @@ export class HelpUseCase {
 			},
 			{
 				left: "--host-preset, -H <preset>",
-				right: "Specify a hosting provider preset (none, vercel, netlify)",
+				right:
+					"Specify a hosting provider preset (none, vercel, netlify, cloudflare, railway, render, fly)",
 			},
 			{
 				left: "--help, -h",

--- a/packages/arkenv/src/features/scaffold/plan.ts
+++ b/packages/arkenv/src/features/scaffold/plan.ts
@@ -38,7 +38,7 @@ export type ProjectOptions = {
 	envExampleContent?: string;
 	envContent?: string;
 	gitignoreContent?: string;
-	/** Hosting provider preset selected during init (`none` / Vercel / Netlify). */
+	/** Hosting provider preset selected during init (`none` / Vercel / Netlify / Cloudflare / etc.). */
 	hostPreset?: HostPreset;
 };
 

--- a/packages/arkenv/src/features/scaffold/planner.test.ts
+++ b/packages/arkenv/src/features/scaffold/planner.test.ts
@@ -790,5 +790,35 @@ PORT=3000`;
 			expect(dotenvExample?.content).toContain("VERCEL_ENV=");
 			expect(dotenvExample?.content).toContain("VERCEL_URL=");
 		});
+
+		it("includes cloudflare preset keys in generated config and .env templates", () => {
+			const state: CollectedState = {
+				...defaultState,
+				existingFiles: [],
+				options: {
+					...defaultState.options,
+					hostPreset: "cloudflare",
+				},
+			};
+			const plan = createPlan(state);
+
+			const envTs = plan.files.find((f) => f.path.endsWith("env.ts"));
+			const dotenv = plan.files.find((f) => f.path.endsWith(".env"));
+			const dotenvExample = plan.files.find((f) =>
+				f.path.endsWith(".env.example"),
+			);
+
+			expect(envTs).toBeDefined();
+			expect(envTs?.content).toContain("CF_PAGES");
+			expect(envTs?.content).toContain("CF_PAGES_URL");
+
+			expect(dotenv).toBeDefined();
+			expect(dotenv?.content).toContain("CF_PAGES=");
+			expect(dotenv?.content).toContain("CF_PAGES_URL=");
+
+			expect(dotenvExample).toBeDefined();
+			expect(dotenvExample?.content).toContain("CF_PAGES=");
+			expect(dotenvExample?.content).toContain("CF_PAGES_URL=");
+		});
 	});
 });

--- a/packages/arkenv/src/features/scaffold/presets.ts
+++ b/packages/arkenv/src/features/scaffold/presets.ts
@@ -53,14 +53,78 @@ export const PRESETS = {
 			URL: { type: "string" },
 		},
 	},
+	cloudflare: {
+		label: "Cloudflare Pages/Workers",
+		hint: "Add CF_PAGES, CF_PAGES_COMMIT_SHA, CF_PAGES_BRANCH, CF_PAGES_URL, etc.",
+		serverOnlyKeys: ["CF_PAGES", "CF_PAGES_COMMIT_SHA"],
+		clientExposedKeys: ["CF_PAGES_BRANCH", "CF_PAGES_URL"],
+		fields: {
+			CF_PAGES: { type: "string" },
+			CF_PAGES_COMMIT_SHA: { type: "string" },
+			CF_PAGES_BRANCH: { type: "string" },
+			CF_PAGES_URL: { type: "string" },
+		},
+	},
+	railway: {
+		label: "Railway",
+		hint: "Add RAILWAY_ENVIRONMENT_NAME, RAILWAY_PUBLIC_DOMAIN, RAILWAY_GIT_COMMIT_SHA, etc.",
+		serverOnlyKeys: [
+			"RAILWAY_ENVIRONMENT_NAME",
+			"RAILWAY_PUBLIC_DOMAIN",
+			"RAILWAY_SERVICE_NAME",
+			"RAILWAY_GIT_COMMIT_SHA",
+		],
+		clientExposedKeys: [],
+		fields: {
+			RAILWAY_ENVIRONMENT_NAME: { type: "string" },
+			RAILWAY_PUBLIC_DOMAIN: { type: "string" },
+			RAILWAY_SERVICE_NAME: { type: "string" },
+			RAILWAY_GIT_COMMIT_SHA: { type: "string" },
+		},
+	},
+	render: {
+		label: "Render",
+		hint: "Add RENDER, RENDER_SERVICE_ID, RENDER_SERVICE_TYPE, RENDER_EXTERNAL_URL, etc.",
+		serverOnlyKeys: [
+			"RENDER",
+			"RENDER_SERVICE_ID",
+			"RENDER_SERVICE_TYPE",
+			"RENDER_EXTERNAL_URL",
+		],
+		clientExposedKeys: [],
+		fields: {
+			RENDER: { type: "string" },
+			RENDER_SERVICE_ID: { type: "string" },
+			RENDER_SERVICE_TYPE: { type: "string" },
+			RENDER_EXTERNAL_URL: { type: "string" },
+		},
+	},
+	fly: {
+		label: "Fly.io",
+		hint: "Add FLY_APP_NAME, FLY_REGION, FLY_ALLOC_ID, etc.",
+		serverOnlyKeys: ["FLY_APP_NAME", "FLY_REGION", "FLY_ALLOC_ID"],
+		clientExposedKeys: [],
+		fields: {
+			FLY_APP_NAME: { type: "string" },
+			FLY_REGION: { type: "string" },
+			FLY_ALLOC_ID: { type: "string" },
+		},
+	},
 } as const satisfies Record<string, PresetDefinition>;
+
+/**
+ * Hosting provider id (excludes the explicit opt-out `"none"`).
+ *
+ * Derived from {@link PRESETS} so adding a host stays a single registry edit.
+ */
+export type HostProvider = keyof typeof PRESETS;
 
 /**
  * Hosting preset id including the explicit opt-out (`"none"`).
  *
  * Derived from {@link PRESETS} so adding a host stays a single registry edit.
  */
-export type HostPreset = "none" | keyof typeof PRESETS;
+export type HostPreset = "none" | HostProvider;
 
 /**
  * Type-guard for CLI / flag values against {@link HostPreset}.
@@ -71,6 +135,17 @@ export type HostPreset = "none" | keyof typeof PRESETS;
 export function isHostPreset(value: string): value is HostPreset {
 	// Own-key check compatible with es2020 (no Object.hasOwn) and noPrototypeBuiltins.
 	return value === "none" || Object.keys(PRESETS).includes(value);
+}
+
+/**
+ * Type-guard for `add host` provider values against {@link HostProvider}.
+ *
+ * @param value Raw CLI string
+ * @returns Whether `value` is a known hosting provider id
+ */
+export function isHostProvider(value: string): value is HostProvider {
+	// Own-key check compatible with es2020 (no Object.hasOwn) and noPrototypeBuiltins.
+	return Object.keys(PRESETS).includes(value);
 }
 
 /**


### PR DESCRIPTION
Fixes #1452

Forward-port hosting presets Phase 4 from #1450 onto `v1`: Cloudflare, Railway, Render, and Fly.io presets for `arkenv init` / `arkenv add host`, with matching docs, tests, and an `arkenv` changeset.


Made with [Cursor](https://cursor.com)