### PR TITLE
fix: Align missing-schema severity: all hosts throw (dev → v1)

### DIFF
--- a/.changeset/0a79b58f.md
+++ b/.changeset/0a79b58f.md
@@ -1,0 +1,17 @@
+---
+"@arkenv/nuxt": minor
+---
+
+#### Throw when the Nuxt module cannot resolve an env schema
+
+**BREAKING CHANGE**: The `@arkenv/nuxt` module now throws when no schema file is found (auto-discovery or `schemaPath`), instead of silently skipping setup. Create an `env.ts` (or `src/env.ts`) schema, or set `arkenv.schemaPath` in `nuxt.config.ts`.
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ["@arkenv/nuxt/module"],
+  arkenv: {
+    schemaPath: "./env.ts", // required if auto-discovery cannot find a schema
+  },
+});
+```

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -24,6 +24,61 @@ vi.mock("@nuxt/kit", () => {
 });
 
 describe("Nuxt module integration", () => {
+	it("should throw when no schema file is found", async () => {
+		const tempDir = path.resolve(__dirname, "temp-module-missing-schema");
+		fs.mkdirSync(tempDir, { recursive: true });
+
+		const mockNuxt: any = {
+			options: {
+				dev: false,
+				rootDir: tempDir,
+				runtimeConfig: {
+					public: {},
+				},
+			},
+			hook: vi.fn(),
+		};
+
+		try {
+			expect(() =>
+				(module as any).setup({ validate: false }, mockNuxt),
+			).toThrow(
+				/\[ArkEnv\] Could not find schema file at src\/env\.ts or env\.ts/,
+			);
+			expect(mockNuxt.hook).not.toHaveBeenCalled();
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("should throw when schemaPath points to a missing file", async () => {
+		const tempDir = path.resolve(__dirname, "temp-module-missing-schema-path");
+		fs.mkdirSync(tempDir, { recursive: true });
+
+		const mockNuxt: any = {
+			options: {
+				dev: false,
+				rootDir: tempDir,
+				runtimeConfig: {
+					public: {},
+				},
+			},
+			hook: vi.fn(),
+		};
+
+		try {
+			expect(() =>
+				(module as any).setup(
+					{ schemaPath: "./missing-env.ts", validate: false },
+					mockNuxt,
+				),
+			).toThrow(/\[ArkEnv\] Could not find schema file at \.\/missing-env\.ts/);
+			expect(mockNuxt.hook).not.toHaveBeenCalled();
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("should parse and register variables to nuxt.options.runtimeConfig", async () => {
 		const tempDir = path.resolve(__dirname, "temp-module-test");
 		fs.mkdirSync(tempDir, { recursive: true });

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -89,7 +89,11 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 			: findSchemaPath(nuxt.options.rootDir);
 
 		if (!schemaPath || !fs.existsSync(schemaPath)) {
-			return;
+			throw new Error(
+				`[ArkEnv] Could not find schema file at ${
+					options.schemaPath || "src/env.ts or env.ts"
+				}. Please specify 'schemaPath' in ArkEnv options.`,
+			);
 		}
 
 		const normalizedLayout = normalizeLayout(options.layout);


### PR DESCRIPTION
Fixes #1470

## Summary
- Make `@arkenv/nuxt` **throw** when auto-discovery / `schemaPath` cannot resolve a schema (was silent `return`)
- Align severity with Bun / Next, which already throw
- Add module tests for missing auto-discovery and missing explicit `schemaPath`
- Changeset: `@arkenv/nuxt` minor (**BREAKING CHANGE** on v0)

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test -- --run` (835 passed)
- [x] `pnpm run fix`
- [x] Forward-port to `v1`: https://github.com/yamcodes/arkenv/pull/1473