### PR TITLE
fix: (v1) Align missing-schema severity — Nuxt throws

### DIFF
--- a/.changeset/align-missing-schema-throw.md
+++ b/.changeset/align-missing-schema-throw.md
@@ -1,0 +1,17 @@
+---
+"@arkenv/nuxt": major
+---
+
+#### Throw when the Nuxt module cannot resolve an env schema
+
+**BREAKING CHANGE**: The `@arkenv/nuxt` module now throws when no schema file is found (auto-discovery or `schemaPath`), instead of warning and skipping setup. Create an `env.ts` (or `src/env.ts`) schema, or set `arkenv.schemaPath` in `nuxt.config.ts`.
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ["@arkenv/nuxt/module"],
+  arkenv: {
+    schemaPath: "./env.ts", // required if auto-discovery cannot find a schema
+  },
+});
+```

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -529,11 +529,10 @@ describe("Nuxt module integration", () => {
 		}
 	});
 
-	it("warns and skips setup when no schema file is found", async () => {
+	it("throws when no schema file is found", async () => {
 		const tempDir = path.resolve(__dirname, "temp-module-missing-schema");
 		fs.mkdirSync(tempDir, { recursive: true });
 
-		const warn = vi.fn();
 		const mockNuxt: any = {
 			options: {
 				dev: false,
@@ -546,24 +545,41 @@ describe("Nuxt module integration", () => {
 		};
 
 		try {
-			await (module as any).setup(
-				{
-					validate: false,
-					logger: {
-						debug: vi.fn(),
-						info: vi.fn(),
-						warn,
-						error: vi.fn(),
-					},
-				},
-				mockNuxt,
-			);
-
-			expect(warn).toHaveBeenCalledWith(
-				expect.stringContaining("No environment schema found"),
+			expect(() =>
+				(module as any).setup({ validate: false }, mockNuxt),
+			).toThrow(
+				/\[ArkEnv\] Could not find schema file at src\/env\.ts or env\.ts/,
 			);
 			expect(mockNuxt.hook).not.toHaveBeenCalled();
 			expect(mockNuxt.options.runtimeConfig.DATABASE_URL).toBeUndefined();
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("throws when schemaPath points to a missing file", async () => {
+		const tempDir = path.resolve(__dirname, "temp-module-missing-schema-path");
+		fs.mkdirSync(tempDir, { recursive: true });
+
+		const mockNuxt: any = {
+			options: {
+				dev: false,
+				rootDir: tempDir,
+				runtimeConfig: {
+					public: {},
+				},
+			},
+			hook: vi.fn(),
+		};
+
+		try {
+			expect(() =>
+				(module as any).setup(
+					{ schemaPath: "./missing-env.ts", validate: false },
+					mockNuxt,
+				),
+			).toThrow(/\[ArkEnv\] Could not find schema file at \.\/missing-env\.ts/);
+			expect(mockNuxt.hook).not.toHaveBeenCalled();
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -79,12 +79,11 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 			: findSchemaPath(nuxt.options.rootDir);
 
 		if (!schemaPath || !fs.existsSync(schemaPath)) {
-			buildLog.logBuildWarning(
-				`No environment schema found at ${
+			throw new Error(
+				`[ArkEnv] Could not find schema file at ${
 					options.schemaPath || "src/env.ts or env.ts"
-				}. Skipping ArkEnv Nuxt module setup. Create a schema file or set \`arkenv.schemaPath\` in your Nuxt config.`,
+				}. Please specify 'schemaPath' in ArkEnv options.`,
 			);
-			return;
 		}
 
 		const resolver = createResolver(import.meta.url);


### PR DESCRIPTION
Fixes #1470

Forward-port of https://github.com/yamcodes/arkenv/pull/1472 onto `v1`.

## Summary
- Replace Nuxt **warn-and-skip** (from #1468) with **throw** when no schema is found
- Keep Bun / Vite / Next throw behavior unchanged
- Update module tests (including the warn-specific case from #1468)
- Changeset: `@arkenv/nuxt` major (**BREAKING CHANGE**)

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test -- --run` (1062 passed)
- [x] `pnpm run fix`


Made with [Cursor](https://cursor.com)