### PR TITLE
Add hosting presets to the comparison table

### DIFF
--- a/apps/www/content/docs/arkenv/comparison.mdx
+++ b/apps/www/content/docs/arkenv/comparison.mdx
@@ -19,6 +19,7 @@ icon: Scale
 | **Bun fullstack dev server**    |      ✅     |    ❌   |             ❌            |  ❌  |    ❌    |      ❌      |
 | **Zero external dependencies**  |      ✅     |    ✅   |             ❌            |  ✅  |    ❌    |      ✅      |
 | **Command Line Interface**      |      ✅     |    ❌   |             ❌            |  ❌  |    ❌    |      ❌      |
+| **Hosting presets**             |      ✅     |    ✅   |             ❌            |  ❌  |    ❌    |      ❌      |
 
 \* ArkType is supported directly without the need to use ArkType's `type` for each key separately.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a **Hosting presets** row to the ArkEnv comparison cheatsheet so the CLI feature is visible next to the other differentiators.

- ArkEnv: ✅ (`arkenv init --host-preset` / `arkenv add host`)
- T3 Env: ✅ (`extends` presets)
- Other libraries in the table: ❌

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the code style of this project (double quotes, tabs, no parameter reassignment).
- [x] I have written sentence-case imperative commits / PR title (e.g. `Add support for custom error messages` - no `feat:`, no trailing period, capitalized).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have created a changeset using `pnpm changeset` (if this affects a published package).

### For v0 (dev) PRs:
- [ ] **Forward-Porting**: (For maintainers) Has this change been manually forward-ported to the `v1` branch?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fc3c616-451f-4cba-9682-da38f47eee37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fc3c616-451f-4cba-9682-da38f47eee37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

