### PR TITLE
fix: Align missing-schema errors: no env.ts starter snippets

### DIFF
--- a/.changeset/align-bun-missing-schema-errors.md
+++ b/.changeset/align-bun-missing-schema-errors.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/bun-plugin": patch
+---
+
+#### Align Bun missing-schema errors with other hosts
+
+Use the same short, actionable missing-schema style as Next, Nuxt, and Vite: list the checked paths and point to `arkenv init`, without embedding a starter `env.ts` module in the thrown error.

--- a/.changeset/drop-bun-env-starter.md
+++ b/.changeset/drop-bun-env-starter.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/bun-plugin": patch
+---
+
+#### Drop env.ts starter from Bun missing-schema errors
+
+Keep the hybrid discovery error short and actionable (checked paths + `arkenv init` hint) instead of embedding an example `src/env.ts` module.

--- a/.changeset/drop-bun-env-starter.md
+++ b/.changeset/drop-bun-env-starter.md
@@ -1,7 +1,0 @@
----
-"@arkenv/bun-plugin": patch
----
-
-#### Drop env.ts starter from Bun missing-schema errors
-
-Keep the hybrid discovery error short and actionable (checked paths + `arkenv init` hint) instead of embedding an example `src/env.ts` module.

--- a/packages/bun-plugin/src/plugin.test.ts
+++ b/packages/bun-plugin/src/plugin.test.ts
@@ -72,4 +72,38 @@ describe("Bun Plugin", () => {
 			}),
 		);
 	});
+
+	it("should throw a short missing-schema error without an env.ts starter", async () => {
+		const { hybrid } = await import("./plugin");
+
+		vi.stubGlobal("Bun", {
+			file: () => ({
+				exists: async () => false,
+			}),
+		});
+
+		let onStart: (() => Promise<void>) | undefined;
+		hybrid.setup({
+			onStart: (callback: () => Promise<void>) => {
+				onStart = callback;
+			},
+			onLoad: () => {},
+		} as never);
+
+		expect(onStart).toBeTypeOf("function");
+
+		let message = "";
+		try {
+			await onStart?.();
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+
+		expect(message).toMatch(/@arkenv\/bun-plugin: No environment schema found/);
+		expect(message).toMatch(/Checked paths:/);
+		expect(message).toMatch(/arkenv init/);
+		expect(message).not.toMatch(/Example `src\/env\.ts`/);
+		expect(message).not.toMatch(/```/);
+		expect(message).not.toMatch(/import \{ type \} from "arktype"/);
+	});
 });

--- a/packages/bun-plugin/src/plugin.ts
+++ b/packages/bun-plugin/src/plugin.ts
@@ -100,19 +100,8 @@ hybrid.setup = (build) => {
 
 		if (!schema) {
 			const pathsList = possiblePaths.map((p) => ` - ${p}`).join("\n");
-			const example = `
-Example \`src/env.ts\`:
-\`\`\`ts
-import { type } from "arktype";
-
-export default type({
-  BUN_PUBLIC_API_URL: "string",
-  BUN_PUBLIC_DEBUG: "boolean"
-});
-\`\`\`
-`;
 			throw new Error(
-				`@arkenv/bun-plugin: No environment schema found.\n\nChecked paths:\n${pathsList}\n\nPlease create a schema file at one of these locations exporting your environment definition.\n${example}`,
+				`@arkenv/bun-plugin: No environment schema found.\n\nChecked paths:\n${pathsList}\n\nPlease create a schema file at one of these locations exporting your environment definition (or run \`arkenv init\`).`,
 			);
 		}
 


### PR DESCRIPTION
Fixes #1471

## Summary
- Drop the embedded ArkType `src/env.ts` starter from the Bun hybrid missing-schema error on `dev`
- Keep a short actionable throw (checked paths + `arkenv init` hint)
- Add a regression test asserting the error has no code-fence / starter module text
- **`v1` regression check:** confirmed no host embeds starter snippets in missing-schema errors (already fixed in #1468); no `v1` code change or changeset required

## Test plan
- [x] `pnpm exec vitest run packages/bun-plugin --run`
- [x] `pnpm run typecheck`
- [x] `pnpm run fix`
- [x] `pnpm run test -- --run` (836 passed)


Made with [Cursor](https://cursor.com)