### PR TITLE
fix: Forward-port split CLI `--help` Global/init options from dev

### DIFF
--- a/.changeset/split-help-global-init-options.md
+++ b/.changeset/split-help-global-init-options.md
@@ -1,0 +1,30 @@
+---
+"arkenv": patch
+---
+
+#### Split `--help` options into Global and `init` sections
+
+List shared flags under **Global options** and scaffolding flags under **init options**, matching the multi-command `/docs/cli` taxonomy.
+
+```bash
+npx arkenv@next --help
+```
+
+```text
+Usage:
+  arkenv init [project-name]    ...
+  arkenv add host [provider]    ...
+
+Global options:
+  --yes, -y      Skip prompts and use defaults ...
+  --quiet, -q    Quiet mode ...
+  --json, -j     Output structured JSON ...
+  --agent        Enable non-interactive, machine-readable mode ...
+  --help, -h     Show this help message
+
+init options:
+  --example                     Specify an example name ...
+  --force, -f                   Bypass checks and force scaffolding
+  --no-codegen                  Disable automatic env.gen.ts code generation ...
+  --host-preset, -H <preset>    Specify a hosting provider preset ...
+```

--- a/packages/arkenv/src/cli/commands/help.test.ts
+++ b/packages/arkenv/src/cli/commands/help.test.ts
@@ -5,7 +5,7 @@ import { version } from "../../../package.json";
 import { HelpUseCase } from "./help";
 
 describe("HelpUseCase", () => {
-	it("should display the help message with dynamic column alignment", async () => {
+	it("should display the help message with Global and init option sections", async () => {
 		const logs: string[] = [];
 		const logger = {
 			log: vi.fn().mockImplementation((msg: string) => {
@@ -37,27 +37,52 @@ describe("HelpUseCase", () => {
 			"  arkenv add host [provider]    Add hosting provider preset (vercel, netlify, cloudflare, railway, render, fly) to schema",
 		);
 
-		// Options should be aligned based on the longest option (--host-preset, -H <preset>) which is 26 chars
-		// leftPad (2) + longest flag (26) + colGap (4) = 32 characters start index for descriptions.
+		const globalHeaderIndex = logs.findIndex((l) =>
+			l.includes(pc.bold("Global options:")),
+		);
+		const initHeaderIndex = logs.findIndex((l) =>
+			l.includes(pc.bold("init options:")),
+		);
+		expect(globalHeaderIndex).toBeGreaterThan(-1);
+		expect(initHeaderIndex).toBeGreaterThan(globalHeaderIndex);
+
+		// Global options align on the longest flag in that section (--quiet, -q = 11 chars)
 		const yesOptionLog = logs.find((l) => l.includes("--yes, -y"));
 		expect(yesOptionLog).toBeDefined();
-		// "--yes, -y" is 9 chars. max (26) - 9 + colGap (4) = 21 spaces padding.
+		// "--yes, -y" is 9 chars. max (11) - 9 + colGap (4) = 6 spaces padding.
 		expect(yesOptionLog).toBe(
-			"  --yes, -y                     Skip prompts and use defaults (also passed to subprocesses)",
+			"  --yes, -y      Skip prompts and use defaults (also passed to subprocesses)",
+		);
+		expect(logs.indexOf(yesOptionLog as string)).toBeGreaterThan(
+			globalHeaderIndex,
+		);
+		expect(logs.indexOf(yesOptionLog as string)).toBeLessThan(initHeaderIndex);
+
+		const agentOptionLog = logs.find((l) => l.includes("--agent"));
+		expect(agentOptionLog).toBeDefined();
+		// "--agent" is 7 chars. max (11) - 7 + colGap (4) = 8 spaces padding.
+		expect(agentOptionLog).toBe(
+			"  --agent        Enable non-interactive, machine-readable mode for AI agents. Bypasses all prompts and outputs structured JSON. Macro for --yes --quiet --json",
+		);
+		expect(logs.indexOf(agentOptionLog as string)).toBeLessThan(
+			initHeaderIndex,
 		);
 
+		const helpOptionLog = logs.find((l) => l.includes("--help, -h"));
+		expect(helpOptionLog).toBeDefined();
+		// "--help, -h" is 10 chars. max (11) - 10 + colGap (4) = 5 spaces padding.
+		expect(helpOptionLog).toBe("  --help, -h     Show this help message");
+		expect(logs.indexOf(helpOptionLog as string)).toBeLessThan(initHeaderIndex);
+
+		// Init options align on --host-preset, -H <preset> (26 chars) and must not appear under Global
 		const exampleOptionLog = logs.find((l) => l.includes("--example"));
 		expect(exampleOptionLog).toBeDefined();
 		// "--example" is 9 chars. max (26) - 9 + colGap (4) = 21 spaces padding.
 		expect(exampleOptionLog).toBe(
 			"  --example                     Specify an example name when creating a new project",
 		);
-
-		const agentOptionLog = logs.find((l) => l.includes("--agent"));
-		expect(agentOptionLog).toBeDefined();
-		// "--agent" is 7 chars. max (26) - 7 + colGap (4) = 23 spaces padding.
-		expect(agentOptionLog).toBe(
-			"  --agent                       Enable non-interactive, machine-readable mode for AI agents. Bypasses all prompts and outputs structured JSON. Macro for --yes --quiet --json",
+		expect(logs.indexOf(exampleOptionLog as string)).toBeGreaterThan(
+			initHeaderIndex,
 		);
 
 		const noCodegenOptionLog = logs.find((l) => l.includes("--no-codegen"));
@@ -65,6 +90,9 @@ describe("HelpUseCase", () => {
 		// "--no-codegen" is 12 chars. max (26) - 12 + colGap (4) = 18 spaces padding.
 		expect(noCodegenOptionLog).toBe(
 			"  --no-codegen                  Disable automatic env.gen.ts code generation for Next.js",
+		);
+		expect(logs.indexOf(noCodegenOptionLog as string)).toBeGreaterThan(
+			initHeaderIndex,
 		);
 
 		const hostPresetOptionLog = logs.find((l) =>
@@ -75,12 +103,14 @@ describe("HelpUseCase", () => {
 		expect(hostPresetOptionLog).toBe(
 			"  --host-preset, -H <preset>    Specify a hosting provider preset (none, vercel, netlify, cloudflare, railway, render, fly)",
 		);
+		expect(logs.indexOf(hostPresetOptionLog as string)).toBeGreaterThan(
+			initHeaderIndex,
+		);
 
-		const helpOptionLog = logs.find((l) => l.includes("--help, -h"));
-		expect(helpOptionLog).toBeDefined();
-		// "--help, -h" is 10 chars. max (26) - 10 + colGap (4) = 20 spaces padding.
-		expect(helpOptionLog).toBe(
-			"  --help, -h                    Show this help message",
+		const forceOptionLog = logs.find((l) => l.includes("--force, -f"));
+		expect(forceOptionLog).toBeDefined();
+		expect(logs.indexOf(forceOptionLog as string)).toBeGreaterThan(
+			initHeaderIndex,
 		);
 	});
 });

--- a/packages/arkenv/src/cli/commands/help.ts
+++ b/packages/arkenv/src/cli/commands/help.ts
@@ -45,24 +45,10 @@ export class HelpUseCase {
 			},
 		];
 
-		const options: HelpItem[] = [
+		const globalOptions: HelpItem[] = [
 			{
 				left: "--yes, -y",
 				right: "Skip prompts and use defaults (also passed to subprocesses)",
-			},
-			{
-				left: "--force, -f",
-				right:
-					"Bypass technical requirement checks and dirty git working tree check, then force scaffolding",
-			},
-			{
-				left: "--agent",
-				right:
-					"Enable non-interactive, machine-readable mode for AI agents. Bypasses all prompts and outputs structured JSON. Macro for --yes --quiet --json",
-			},
-			{
-				left: "--example",
-				right: "Specify an example name when creating a new project",
 			},
 			{
 				left: "--quiet, -q",
@@ -73,6 +59,27 @@ export class HelpUseCase {
 				right: "Output structured JSON to stdout",
 			},
 			{
+				left: "--agent",
+				right:
+					"Enable non-interactive, machine-readable mode for AI agents. Bypasses all prompts and outputs structured JSON. Macro for --yes --quiet --json",
+			},
+			{
+				left: "--help, -h",
+				right: "Show this help message",
+			},
+		];
+
+		const initOptions: HelpItem[] = [
+			{
+				left: "--example",
+				right: "Specify an example name when creating a new project",
+			},
+			{
+				left: "--force, -f",
+				right:
+					"Bypass technical requirement checks and dirty git working tree check, then force scaffolding",
+			},
+			{
 				left: "--no-codegen",
 				right: "Disable automatic env.gen.ts code generation for Next.js",
 			},
@@ -81,10 +88,6 @@ export class HelpUseCase {
 				right:
 					"Specify a hosting provider preset (none, vercel, netlify, cloudflare, railway, render, fly)",
 			},
-			{
-				left: "--help, -h",
-				right: "Show this help message",
-			},
 		];
 
 		this.logger.log(`ArkEnv CLI v${version}`);
@@ -92,8 +95,12 @@ export class HelpUseCase {
 		for (const line of formatColumns(commands)) {
 			this.logger.log(line);
 		}
-		this.logger.log(`\n${pc.bold("Options:")}`);
-		for (const line of formatColumns(options)) {
+		this.logger.log(`\n${pc.bold("Global options:")}`);
+		for (const line of formatColumns(globalOptions)) {
+			this.logger.log(line);
+		}
+		this.logger.log(`\n${pc.bold("init options:")}`);
+		for (const line of formatColumns(initOptions)) {
 			this.logger.log(line);
 		}
 	}


### PR DESCRIPTION
## Summary
- Forward-port [#1483](https://github.com/yamcodes/arkenv/pull/1483) (Fixes #1428) from `dev` to `v1`
- Split `arkenv --help` into **Global options** and **init options** under `packages/arkenv` (v1 CLI)
- Changeset uses `"arkenv"` (v1 package name)

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test -- --run`
- [x] `pnpm run fix`
- [ ] Spot-check `arkenv --help` on the v1 CLI build


Made with [Cursor](https://cursor.com)