### PR TITLE
fix: Forward-port align missing-schema errors from #1482

### DIFF
--- a/.changeset/align-missing-schema-host-hints.md
+++ b/.changeset/align-missing-schema-host-hints.md
@@ -1,0 +1,9 @@
+---
+"@arkenv/vite-plugin": patch
+"@arkenv/nextjs": patch
+"@arkenv/nuxt": patch
+---
+
+#### Align missing-schema errors with short, actionable host guidance
+
+Point missing-schema errors at checked paths / `schemaPath` and `arkenv init`, matching the Bun plugin style, without embedding starter `env.ts` modules.

--- a/packages/bun-plugin/src/env-module.test.ts
+++ b/packages/bun-plugin/src/env-module.test.ts
@@ -297,3 +297,33 @@ describe("SPA mode regression", () => {
 		delete process.env.BUN_PUBLIC_TEST;
 	});
 });
+
+describe("missing-schema errors", () => {
+	const temps: string[] = [];
+
+	afterEach(() => {
+		for (const dir of temps.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("throws a short discovery error without an env.ts starter", async () => {
+		const { resolveEnvModulePath } = await import("./env-module-path.js");
+		const root = mkdtempSync(join(tmpdir(), "arkenv-bun-missing-schema-"));
+		temps.push(root);
+
+		let message = "";
+		try {
+			resolveEnvModulePath(root);
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+
+		expect(message).toMatch(/could not find an env module/);
+		expect(message).toMatch(/arkenv init/);
+		expect(message).not.toMatch(/Example `src\/env\.ts`/);
+		expect(message).not.toMatch(/```/);
+		expect(message).not.toMatch(/import \{ type \} from "arktype"/);
+		expect(message).not.toMatch(/from "zod"/);
+	});
+});

--- a/packages/nextjs/src/config/setup.ts
+++ b/packages/nextjs/src/config/setup.ts
@@ -59,7 +59,7 @@ export function setupArkEnv(
 			formatBuildError(
 				`Could not find schema file at ${
 					options?.schemaPath || "src/env.ts or env.ts"
-				}. Please specify 'schemaPath' in setupArkEnv options.`,
+				}. Please specify 'schemaPath' in setupArkEnv options (or run \`arkenv init\`).`,
 			),
 		);
 	}

--- a/packages/nuxt/src/config.ts
+++ b/packages/nuxt/src/config.ts
@@ -133,7 +133,7 @@ export function setupArkEnv(
 			formatBuildError(
 				`Could not find schema file at ${
 					options?.schemaPath || "src/env.ts or env.ts"
-				}. Please specify 'schemaPath' in ArkEnv options.`,
+				}. Please specify 'schemaPath' in ArkEnv options (or run \`arkenv init\`).`,
 			),
 		);
 	}

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -82,7 +82,7 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 			throw new Error(
 				`[ArkEnv] Could not find schema file at ${
 					options.schemaPath || "src/env.ts or env.ts"
-				}. Please specify 'schemaPath' in ArkEnv options.`,
+				}. Please specify 'schemaPath' in ArkEnv options (or run \`arkenv init\`).`,
 			);
 		}
 

--- a/packages/vite-plugin/src/env-module-path.ts
+++ b/packages/vite-plugin/src/env-module-path.ts
@@ -64,7 +64,7 @@ export function resolveEnvModulePath(
 	const discovered = findSchemaPath(root);
 	if (!discovered) {
 		throw new Error(
-			`ArkEnv Vite plugin: could not find an env module. Expected "src/env.ts" or "env.ts" under "${root}", or pass schemaPath.`,
+			`ArkEnv Vite plugin: could not find an env module. Expected "src/env.ts" or "env.ts" under "${root}", or pass schemaPath (or run \`arkenv init\`).`,
 		);
 	}
 	return discovered;

--- a/packages/vite-plugin/src/env-module.test.ts
+++ b/packages/vite-plugin/src/env-module.test.ts
@@ -244,3 +244,33 @@ describe("transform mode plugin", () => {
 		expect(result?.code).not.toContain("@arkenv/core");
 	});
 });
+
+describe("missing-schema errors", () => {
+	const temps: string[] = [];
+
+	afterEach(() => {
+		for (const dir of temps.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("throws a short discovery error without an env.ts starter", async () => {
+		const { resolveEnvModulePath } = await import("./env-module-path.js");
+		const root = mkdtempSync(join(tmpdir(), "arkenv-vite-missing-schema-"));
+		temps.push(root);
+
+		let message = "";
+		try {
+			resolveEnvModulePath(root);
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+
+		expect(message).toMatch(/could not find an env module/);
+		expect(message).toMatch(/arkenv init/);
+		expect(message).not.toMatch(/Example `src\/env\.ts`/);
+		expect(message).not.toMatch(/```/);
+		expect(message).not.toMatch(/import \{ type \} from "arktype"/);
+		expect(message).not.toMatch(/from "zod"/);
+	});
+});


### PR DESCRIPTION
## Summary
- Forward-port of [#1482](https://github.com/yamcodes/arkenv/pull/1482) (`dev` / #1471) onto `v1`
- Align Vite / Next / Nuxt missing-schema errors with Bun’s short actionable style (`schemaPath` + `arkenv init`), without embedded `env.ts` starters
- Add Bun + Vite regression tests locking the no-starter policy

## Test plan
- [x] `pnpm exec vitest run packages/bun-plugin packages/vite-plugin/src/env-module.test.ts packages/nuxt/src/module.test.ts --run`
- [x] `pnpm run typecheck`
- [x] `pnpm run fix`
- [x] `pnpm run test -- --run` (1064 passed)


Made with [Cursor](https://cursor.com)