### PR TITLE
fix: Align Next/Nuxt missing-schema errors with Bun

### DIFF
--- a/.changeset/align-dev-missing-schema-init.md
+++ b/.changeset/align-dev-missing-schema-init.md
@@ -1,8 +1,10 @@
 ---
+"@arkenv/build": patch
+"@arkenv/bun-plugin": patch
 "@arkenv/nextjs": patch
 "@arkenv/nuxt": patch
 ---
 
-#### Align Next and Nuxt missing-schema errors with Bun
+#### Align missing-schema errors via a shared `@arkenv/build` helper
 
-Point missing-schema errors at `schemaPath` and `arkenv init`, matching the Bun plugin style, without embedding starter `env.ts` modules.
+Centralize missing-schema message text in `formatMissingSchemaError` so Bun, Next, and Nuxt stay aligned: short actionable guidance (`schemaPath` + `arkenv init`), no embedded starter `env.ts` modules.

--- a/.changeset/align-dev-missing-schema-init.md
+++ b/.changeset/align-dev-missing-schema-init.md
@@ -1,0 +1,8 @@
+---
+"@arkenv/nextjs": patch
+"@arkenv/nuxt": patch
+---
+
+#### Align Next and Nuxt missing-schema errors with Bun
+
+Point missing-schema errors at `schemaPath` and `arkenv init`, matching the Bun plugin style, without embedding starter `env.ts` modules.

--- a/packages/build/src/index.test.ts
+++ b/packages/build/src/index.test.ts
@@ -3,6 +3,7 @@ import {
 	extractArkenvBlock,
 	extractBlock,
 	extractKeys,
+	formatMissingSchemaError,
 	parseBlockKeys,
 } from "./index";
 
@@ -130,5 +131,35 @@ describe("@arkenv/build extractors", () => {
 				'DATABASE_URL: "string",\n\t\t\t\t\tPORT: "number"',
 			);
 		});
+	});
+});
+
+describe("formatMissingSchemaError", () => {
+	it("formats a short host error with arkenv init and no starter", () => {
+		const message = formatMissingSchemaError({
+			optionsHint: "setupArkEnv options",
+		});
+
+		expect(message).toBe(
+			"[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in setupArkEnv options (or run `arkenv init`).",
+		);
+		expect(message).not.toMatch(/```/);
+		expect(message).not.toMatch(/Example/);
+	});
+
+	it("includes an explicit schemaPath and checked paths when provided", () => {
+		const message = formatMissingSchemaError({
+			prefix: "@arkenv/bun-plugin:",
+			schemaPath: "./missing-env.ts",
+			optionsHint: "plugin options",
+			checkedPaths: ["/proj/src/env.ts", "/proj/env.ts"],
+		});
+
+		expect(message).toContain(
+			"@arkenv/bun-plugin: Could not find schema file at ./missing-env.ts. Please specify 'schemaPath' in plugin options (or run `arkenv init`).",
+		);
+		expect(message).toContain("Checked paths:");
+		expect(message).toContain(" - /proj/src/env.ts");
+		expect(message).toContain(" - /proj/env.ts");
 	});
 });

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -2,6 +2,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { watch as chokidarWatch, type FSWatcher } from "chokidar";
 
+export {
+	DEFAULT_SCHEMA_LOCATIONS,
+	type FormatMissingSchemaErrorOptions,
+	formatMissingSchemaError,
+} from "./missing-schema-error";
+
 // Global watcher reference isolated to this bundle's scope
 let activeWatcher: FSWatcher | undefined;
 
@@ -107,17 +113,23 @@ export function resolveLayout(
 }
 
 /**
+ * Return the default absolute schema file candidates for a project root.
+ *
+ * @param cwd The working directory to search from (defaults to process.cwd())
+ * @returns Absolute paths for `src/env.ts` and `env.ts`
+ */
+export function getDefaultSchemaFileCandidates(cwd = process.cwd()): string[] {
+	return [path.join(cwd, "src", "env.ts"), path.join(cwd, "env.ts")];
+}
+
+/**
  * Find the path to the schema file or directory in the project.
  *
  * @param cwd The working directory to search from (defaults to process.cwd())
  * @returns The absolute path to the schema file/directory, or null if not found
  */
 export function findSchemaPath(cwd = process.cwd()): string | null {
-	const possiblePaths = [
-		path.join(cwd, "src", "env.ts"),
-		path.join(cwd, "env.ts"),
-	];
-	for (const p of possiblePaths) {
+	for (const p of getDefaultSchemaFileCandidates(cwd)) {
 		if (fs.existsSync(p)) return p;
 	}
 

--- a/packages/build/src/missing-schema-error.ts
+++ b/packages/build/src/missing-schema-error.ts
@@ -1,0 +1,51 @@
+/**
+ * Default relative schema locations hosts search when `schemaPath` is omitted.
+ */
+export const DEFAULT_SCHEMA_LOCATIONS = "src/env.ts or env.ts";
+
+export type FormatMissingSchemaErrorOptions = {
+	/**
+	 * Explicit `schemaPath` that was missing.
+	 * Omit to refer to {@link DEFAULT_SCHEMA_LOCATIONS}.
+	 */
+	schemaPath?: string;
+	/**
+	 * Where to set `schemaPath` (e.g. `"setupArkEnv options"`, `"ArkEnv options"`,
+	 * `"plugin options"`).
+	 */
+	optionsHint: string;
+	/**
+	 * Brand prefix for the error.
+	 * @default "[ArkEnv]"
+	 */
+	prefix?: string;
+	/**
+	 * Absolute paths that were checked during discovery.
+	 * Appended as a `Checked paths` section when present.
+	 */
+	checkedPaths?: string[];
+};
+
+/**
+ * Format a missing-schema error shared by host integrations.
+ *
+ * Owns the no-starter policy: hosts must use this helper instead of inlining
+ * example `env.ts` modules in thrown errors.
+ *
+ * @param options Host-specific labels and optional discovery paths
+ * @returns A short, actionable missing-schema error message
+ */
+export function formatMissingSchemaError(
+	options: FormatMissingSchemaErrorOptions,
+): string {
+	const prefix = options.prefix ?? "[ArkEnv]";
+	const location = options.schemaPath || DEFAULT_SCHEMA_LOCATIONS;
+	let message = `${prefix} Could not find schema file at ${location}. Please specify 'schemaPath' in ${options.optionsHint} (or run \`arkenv init\`).`;
+
+	if (options.checkedPaths?.length) {
+		const pathsList = options.checkedPaths.map((p) => ` - ${p}`).join("\n");
+		message += `\n\nChecked paths:\n${pathsList}`;
+	}
+
+	return message;
+}

--- a/packages/bun-plugin/package.json
+++ b/packages/bun-plugin/package.json
@@ -9,6 +9,7 @@
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",
 	"dependencies": {
+		"@arkenv/build": "workspace:*",
 		"arkenv": "workspace:*"
 	},
 	"devDependencies": {
@@ -71,6 +72,7 @@
 			"limit": "2.6 kB",
 			"import": "*",
 			"ignore": [
+				"@arkenv/build",
 				"bun",
 				"arktype",
 				"node:path",

--- a/packages/bun-plugin/src/plugin.test.ts
+++ b/packages/bun-plugin/src/plugin.test.ts
@@ -99,7 +99,7 @@ describe("Bun Plugin", () => {
 			message = error instanceof Error ? error.message : String(error);
 		}
 
-		expect(message).toMatch(/@arkenv\/bun-plugin: No environment schema found/);
+		expect(message).toMatch(/@arkenv\/bun-plugin: Could not find schema file/);
 		expect(message).toMatch(/Checked paths:/);
 		expect(message).toMatch(/arkenv init/);
 		expect(message).not.toMatch(/Example `src\/env\.ts`/);

--- a/packages/bun-plugin/src/plugin.ts
+++ b/packages/bun-plugin/src/plugin.ts
@@ -1,4 +1,7 @@
-import { join } from "node:path";
+import {
+	formatMissingSchemaError,
+	getDefaultSchemaFileCandidates,
+} from "@arkenv/build";
 import type { CompiledEnvSchema, SchemaShape } from "@repo/types";
 import type { ArkEnvConfig, EnvSchema } from "arkenv";
 import type { BunPlugin } from "bun";
@@ -78,7 +81,7 @@ hybrid.setup = (build) => {
 		const cwd = process.cwd();
 		let schema: any;
 
-		const possiblePaths = [join(cwd, "src", "env.ts"), join(cwd, "env.ts")];
+		const possiblePaths = getDefaultSchemaFileCandidates(cwd);
 
 		for (const p of possiblePaths) {
 			if (await Bun.file(p).exists()) {
@@ -99,9 +102,12 @@ hybrid.setup = (build) => {
 		}
 
 		if (!schema) {
-			const pathsList = possiblePaths.map((p) => ` - ${p}`).join("\n");
 			throw new Error(
-				`@arkenv/bun-plugin: No environment schema found.\n\nChecked paths:\n${pathsList}\n\nPlease create a schema file at one of these locations exporting your environment definition (or run \`arkenv init\`).`,
+				formatMissingSchemaError({
+					prefix: "@arkenv/bun-plugin:",
+					optionsHint: "plugin options",
+					checkedPaths: possiblePaths,
+				}),
 			);
 		}
 

--- a/packages/cli/src/cli/commands/init.test.ts
+++ b/packages/cli/src/cli/commands/init.test.ts
@@ -65,7 +65,20 @@ describe("InitUseCase", () => {
 			checkGitStatus: vi.fn().mockResolvedValue({ status: "clean" }),
 		} as unknown as ProjectScannerPort;
 
-		useCase = new InitUseCase(logger, workspace, prompt, scanner);
+		const registry = {
+			fetchRegistry: vi.fn().mockResolvedValue({
+				examples: [
+					{
+						id: "basic",
+						name: "Basic",
+						description: "A minimal ArkEnv setup in Node.js",
+						framework: "vanilla",
+					},
+				],
+			}),
+		};
+
+		useCase = new InitUseCase(logger, workspace, prompt, scanner, registry);
 	});
 
 	it("should enter new project flow if no package.json and empty directory", async () => {

--- a/packages/nextjs/src/config.test.ts
+++ b/packages/nextjs/src/config.test.ts
@@ -29,6 +29,7 @@ import {
 	extractKeys,
 	extractSharedKeys,
 	runCodegen,
+	setupArkEnv,
 	withArkEnv,
 } from "./config";
 
@@ -295,6 +296,27 @@ describe("withArkEnv wrapper", () => {
 		if (fs.existsSync(tempDir)) {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
+	});
+
+	it("should throw a short missing-schema error without an env.ts starter", () => {
+		if (!fs.existsSync(tempDir)) {
+			fs.mkdirSync(tempDir, { recursive: true });
+		}
+
+		let message = "";
+		try {
+			setupArkEnv({
+				schemaPath: path.join(tempDir, "missing-env.ts"),
+				validate: false,
+			});
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+
+		expect(message).toMatch(/\[ArkEnv\] Could not find schema file/);
+		expect(message).toMatch(/arkenv init/);
+		expect(message).not.toMatch(/Example `src\/env\.ts`/);
+		expect(message).not.toMatch(/```/);
 	});
 
 	it("should pass nextConfig through unchanged", () => {

--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -140,7 +140,7 @@ export function setupArkEnv(
 		throw new Error(
 			`[ArkEnv] Could not find schema file at ${
 				options?.schemaPath || "src/env.ts or env.ts"
-			}. Please specify 'schemaPath' in setupArkEnv options.`,
+			}. Please specify 'schemaPath' in setupArkEnv options (or run \`arkenv init\`).`,
 		);
 	}
 

--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -6,6 +6,7 @@ import {
 	extractClientKeys,
 	extractSharedKeys,
 	findSchemaPath,
+	formatMissingSchemaError,
 	resolveLayout,
 	watchSchema,
 } from "@arkenv/build";
@@ -138,9 +139,10 @@ export function setupArkEnv(
 
 	if (!schemaPath || !exists) {
 		throw new Error(
-			`[ArkEnv] Could not find schema file at ${
-				options?.schemaPath || "src/env.ts or env.ts"
-			}. Please specify 'schemaPath' in setupArkEnv options (or run \`arkenv init\`).`,
+			formatMissingSchemaError({
+				schemaPath: options?.schemaPath,
+				optionsHint: "setupArkEnv options",
+			}),
 		);
 	}
 

--- a/packages/nuxt/src/config.ts
+++ b/packages/nuxt/src/config.ts
@@ -6,6 +6,7 @@ import {
 	extractClientKeys,
 	extractSharedKeys,
 	findSchemaPath,
+	formatMissingSchemaError,
 	resolveLayout,
 } from "@arkenv/build";
 import { createJiti } from "jiti";
@@ -15,6 +16,7 @@ export {
 	extractArkenvBlock,
 	extractServerKeys,
 	findSchemaPath,
+	formatMissingSchemaError,
 	resolveLayout,
 } from "@arkenv/build";
 export { extractClientKeys, extractSharedKeys };
@@ -126,9 +128,10 @@ export function setupArkEnv(
 
 	if (!schemaPath || !exists) {
 		throw new Error(
-			`[ArkEnv] Could not find schema file at ${
-				options?.schemaPath || "src/env.ts or env.ts"
-			}. Please specify 'schemaPath' in ArkEnv options (or run \`arkenv init\`).`,
+			formatMissingSchemaError({
+				schemaPath: options?.schemaPath,
+				optionsHint: "ArkEnv options",
+			}),
 		);
 	}
 

--- a/packages/nuxt/src/config.ts
+++ b/packages/nuxt/src/config.ts
@@ -128,7 +128,7 @@ export function setupArkEnv(
 		throw new Error(
 			`[ArkEnv] Could not find schema file at ${
 				options?.schemaPath || "src/env.ts or env.ts"
-			}. Please specify 'schemaPath' in ArkEnv options.`,
+			}. Please specify 'schemaPath' in ArkEnv options (or run \`arkenv init\`).`,
 		);
 	}
 

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -40,11 +40,19 @@ describe("Nuxt module integration", () => {
 		};
 
 		try {
-			expect(() =>
-				(module as any).setup({ validate: false }, mockNuxt),
-			).toThrow(
+			let message = "";
+			try {
+				(module as any).setup({ validate: false }, mockNuxt);
+			} catch (error) {
+				message = error instanceof Error ? error.message : String(error);
+			}
+
+			expect(message).toMatch(
 				/\[ArkEnv\] Could not find schema file at src\/env\.ts or env\.ts/,
 			);
+			expect(message).toMatch(/arkenv init/);
+			expect(message).not.toMatch(/Example `src\/env\.ts`/);
+			expect(message).not.toMatch(/```/);
 			expect(mockNuxt.hook).not.toHaveBeenCalled();
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -92,7 +92,7 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 			throw new Error(
 				`[ArkEnv] Could not find schema file at ${
 					options.schemaPath || "src/env.ts or env.ts"
-				}. Please specify 'schemaPath' in ArkEnv options.`,
+				}. Please specify 'schemaPath' in ArkEnv options (or run \`arkenv init\`).`,
 			);
 		}
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -10,6 +10,7 @@ import {
 	extractServerKeys,
 	extractSharedKeys,
 	findSchemaPath,
+	formatMissingSchemaError,
 	normalizeLayout,
 	resolveLayout,
 	validateSchema,
@@ -90,9 +91,10 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 
 		if (!schemaPath || !fs.existsSync(schemaPath)) {
 			throw new Error(
-				`[ArkEnv] Could not find schema file at ${
-					options.schemaPath || "src/env.ts or env.ts"
-				}. Please specify 'schemaPath' in ArkEnv options (or run \`arkenv init\`).`,
+				formatMissingSchemaError({
+					schemaPath: options.schemaPath,
+					optionsHint: "ArkEnv options",
+				}),
 			);
 		}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -867,6 +867,9 @@ importers:
 
   packages/bun-plugin:
     dependencies:
+      '@arkenv/build':
+        specifier: workspace:*
+        version: link:../build
       arkenv:
         specifier: workspace:*
         version: link:../arkenv
@@ -16524,7 +16527,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -16586,7 +16589,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.5':
     dependencies:


### PR DESCRIPTION
## Summary
- Close the remaining `dev` messaging gap: Next, Nuxt, and Bun missing-schema errors share one helper (`formatMissingSchemaError` in `@arkenv/build`)
- Short actionable guidance (`schemaPath` + `arkenv init`), no embedded starter `env.ts` modules
- Bun discovery candidates come from `getDefaultSchemaFileCandidates` (same paths as `findSchemaPath`)
- Regression tests on `@arkenv/build`, Bun, Next, and Nuxt
- Vite on `dev` still has no file-discovery miss path (structural; unchanged)

## Test plan
- [x] `pnpm exec vitest run packages/build packages/bun-plugin packages/nextjs/src/config.test.ts packages/nuxt/src/module.test.ts --run`
- [x] `pnpm run typecheck`
- [x] `pnpm run fix`
- [x] `pnpm run test -- --run` (839 passed)
- [x] `pnpm --filter @arkenv/bun-plugin size`