### PR TITLE
ci: associate Actions Vercel deploys with branch domains

### DIFF
--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -42,4 +42,28 @@ jobs:
       - name: Build Project Artifacts
         run: node scripts/vercel-wrapper.cjs build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
-        run: node scripts/vercel-wrapper.cjs deploy --prebuilt --prod --archive=tgz --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          GIT_ORG: ${{ github.repository_owner }}
+          GIT_REPO: ${{ github.event.repository.name }}
+          GIT_REF: ${{ github.ref_name }}
+          GIT_SHA: ${{ github.sha }}
+          GIT_ACTOR: ${{ github.actor }}
+          GIT_COMMIT_MESSAGE: ${{ github.event.head_commit.message || github.sha }}
+          GIT_COMMIT_AUTHOR_NAME: ${{ github.event.head_commit.author.name || github.actor }}
+        run: |
+          set -o pipefail
+          SHORT_MSG="$(printf '%s\n' "$GIT_COMMIT_MESSAGE" | head -n1)"
+          # --prod already assigns production domains (arkenv.js.org / arkenv.vercel.app).
+          # Git meta keeps the deployment linked to main in the Vercel dashboard.
+          node scripts/vercel-wrapper.cjs deploy --prebuilt --prod --archive=tgz --token="$VERCEL_TOKEN" \
+            -m githubDeployment=1 \
+            -m githubOrg="$GIT_ORG" \
+            -m githubRepo="$GIT_REPO" \
+            -m githubCommitOrg="$GIT_ORG" \
+            -m githubCommitRepo="$GIT_REPO" \
+            -m githubCommitRef="$GIT_REF" \
+            -m githubCommitSha="$GIT_SHA" \
+            -m githubCommitMessage="$SHORT_MSG" \
+            -m githubCommitAuthorName="$GIT_COMMIT_AUTHOR_NAME" \
+            -m githubCommitAuthorLogin="$GIT_ACTOR"

--- a/.github/workflows/preview-www-reusable.yml
+++ b/.github/workflows/preview-www-reusable.yml
@@ -81,10 +81,59 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          # Git meta so CLI deploys associate with the correct branch (branch domains / env).
+          # See https://vercel.com/kb/guide/branch-variables-and-domains-not-linked-to-cli-deployments
+          GIT_ORG: ${{ github.repository_owner }}
+          GIT_REPO: ${{ github.event.repository.name }}
+          GIT_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          GIT_ACTOR: ${{ github.event.pull_request.head.user.login || github.actor }}
+          GIT_COMMIT_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message || github.sha }}
+          GIT_COMMIT_AUTHOR_NAME: ${{ github.event.head_commit.author.name || github.actor }}
         run: |
           set -o pipefail
-          DEPLOYMENT_URL=$(node scripts/vercel-wrapper.cjs deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" | tail -n 1)
+          SHORT_MSG="$(printf '%s\n' "$GIT_COMMIT_MESSAGE" | head -n1)"
+          DEPLOYMENT_URL=$(node scripts/vercel-wrapper.cjs deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" \
+            -m githubDeployment=1 \
+            -m githubOrg="$GIT_ORG" \
+            -m githubRepo="$GIT_REPO" \
+            -m githubCommitOrg="$GIT_ORG" \
+            -m githubCommitRepo="$GIT_REPO" \
+            -m githubCommitRef="$GIT_REF" \
+            -m githubCommitSha="$GIT_SHA" \
+            -m githubCommitMessage="$SHORT_MSG" \
+            -m githubCommitAuthorName="$GIT_COMMIT_AUTHOR_NAME" \
+            -m githubCommitAuthorLogin="$GIT_ACTOR" \
+            | tail -n 1)
           echo "DEPLOYMENT_URL=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
+      # Explicit alias so branch domains stay current without native Vercel Git builds (#1460).
+      # Only on push to dev/v1 — labeled PR previews keep ephemeral URLs and must not steal these.
+      - name: Alias branch preview domain
+        if: >-
+          github.event_name == 'push' &&
+          (github.ref_name == 'dev' || github.ref_name == 'v1') &&
+          steps.affected.outputs.is_affected == 'true'
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.DEPLOYMENT_URL }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          case "$BRANCH" in
+            dev) DOMAIN="arkenv-dev.vercel.app" ;;
+            v1) DOMAIN="arkenv-v1.vercel.app" ;;
+            *)
+              echo "No branch domain mapping for $BRANCH; skipping alias."
+              exit 0
+              ;;
+          esac
+          if [ -z "$DEPLOYMENT_URL" ]; then
+            echo "No deployment URL; skipping alias."
+            exit 0
+          fi
+          echo "Aliasing $DEPLOYMENT_URL -> $DOMAIN"
+          node scripts/vercel-wrapper.cjs alias set "$DEPLOYMENT_URL" "$DOMAIN" --token="$VERCEL_TOKEN"
       - name: Generate GitHub App Token
         id: generate-token
         uses: actions/create-github-app-token@v3

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -138,12 +138,14 @@ When working on a massive marketing push, docs facelift, or breaking API changes
    - **Develop against dev/v0**: All new features and bugfixes are first built and merged into the `dev` branch.
    - **Immediate manual porting**: Once a PR is merged into `dev`, the maintainer will manually forward-port the changes to `v1`, adapting the code to the new directory structure (e.g. under `packages/arkenv/src/` instead of `packages/cli/src/`).
    - **Update Changesets**: During the porting process, the maintainer will copy the changeset to the `v1` branch and manually update the YAML package name in the frontmatter to match the renamed package (e.g., change `"cli": patch` to `"arkenv": patch`).
-4. **Previews & Betas:** Vercel will automatically deploy the `v1` branch as a Preview environment for marketing review. To safely publish pre-release npm packages from this branch (e.g., `1.0.0-next.0`) without affecting the `latest` npm tag, initialize Changesets pre-release mode on the `v1` branch by running `pnpm changeset pre enter next`. As you write `major` changesets for your breaking changes, they will be published under the `next` tag.
+4. **Previews & Betas:** Pushes to `v1` deploy the docs via GitHub Actions (Vercel CLI) and alias `https://arkenv-v1.vercel.app` for marketing review. To safely publish pre-release npm packages from this branch (e.g., `1.0.0-next.0`) without affecting the `latest` npm tag, initialize Changesets pre-release mode on the `v1` branch by running `pnpm changeset pre enter next`. As you write `major` changesets for your breaking changes, they will be published under the `next` tag.
 5. **The Big Release:** When Launch Day arrives, merge `v1` into `dev`. Then, run `pnpm changeset pre exit` to graduate from the `next` pre-release phase to stable. The standard **Use Case 2** workflow takes over, producing a final "Version Packages" PR that publishes `1.0.0` to the `latest` tag and fast-forwards `main`.
 
 ## Preview deployments
 
-PR previews for the `www` app are opt-in. A maintainer (triage+) applies the `preview` label to trigger a Vercel preview deployment when the label is added, and again on subsequent `synchronize` / `ready_for_review` events while the label remains (a preview is only produced when the `www` app is actually affected). This works for same-repo and fork PRs; fork authors cannot self-serve the label. Pushes to `dev` or `v1` continue to deploy rolling branch previews automatically.
+PR previews for the `www` app are opt-in. A maintainer (triage+) applies the `preview` label to trigger a Vercel preview deployment when the label is added, and again on subsequent `synchronize` / `ready_for_review` events while the label remains (a preview is only produced when the `www` app is actually affected). This works for same-repo and fork PRs; fork authors cannot self-serve the label.
+
+Pushes to `dev` or `v1` always deploy via GitHub Actions (Vercel CLI). Those deploys pass git metadata and alias the rolling branch domains (`https://arkenv-dev.vercel.app`, `https://arkenv-v1.vercel.app`) so the domains stay current without relying on native Vercel Git builds. Labeled PR previews keep ephemeral deployment URLs and do not take over those branch domains.
 
 ## Changesets
 


### PR DESCRIPTION
## Summary
- Pass Vercel-documented git `--meta` on preview and production CLI deploys so deployments associate with the correct git branch.
- On `push` to `dev` / `v1` only, `vercel alias` the deployment to `arkenv-dev.vercel.app` / `arkenv-v1.vercel.app` so branch domains stay current without native Vercel Git builds.
- Labeled PR previews keep ephemeral URLs (they do not steal branch domains).
- Update CONTRIBUTING to describe the Actions-owned branch-domain story.

Part of #1460 (Actions wiring + docs). **Does not close the issue** — maintainer still needs the live verification and Vercel Git disconnect steps below.

## Maintainer follow-up (#1460)
After merge:
1. Wait for (or trigger) a `dev` push that deploys www; confirm Actions “Alias branch preview domain” succeeds.
2. Spot-check https://arkenv-dev.vercel.app serves that deployment.
3. Same for `v1` → https://arkenv-v1.vercel.app if you push there.
4. Confirm production still updates via Deploy www → https://arkenv.js.org.
5. **Only then** disconnect Vercel↔GitHub / disable automatic Git deployments in the Vercel project.
6. Confirm a new PR no longer shows native Vercel approve/status noise.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: Actions deploy on `dev` push includes git meta + alias step
- [ ] https://arkenv-dev.vercel.app reflects the new deployment
- [ ] PR with `preview` still gets an ephemeral URL (not the branch domain)


Made with [Cursor](https://cursor.com)