### PR TITLE
ci: trigger www branch domain alias verification

### DIFF
--- a/.github/workflows/preview-www-reusable.yml
+++ b/.github/workflows/preview-www-reusable.yml
@@ -49,6 +49,13 @@ jobs:
           fi
           echo "Comparing base ref: $BASE_SHA with head: $HEAD_SHA"
 
+          # Deploy-path edits must still rebuild/alias branch domains (turbo won't mark www).
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE '^(\.github/workflows/preview-www|scripts/vercel-wrapper\.cjs)'; then
+            echo "Preview deploy path changed; forcing www deploy."
+            echo "is_affected=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if pnpm exec turbo query affected --packages=www --base="$BASE_SHA" --head="$HEAD_SHA" --exit-code; then
             echo "www is NOT affected."
             echo "is_affected=false" >> "$GITHUB_OUTPUT"

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -20,7 +20,7 @@ const config = {
 	],
 	// cacheComponents: true, // TODO: Uncomment this once https://github.com/getsentry/sentry-javascript/issues/17895 is fixed
 	typescript: {
-		// We check typesafety on ci
+		// Typecheck runs in CI (`pnpm typecheck`); skip during next build.
 		ignoreBuildErrors: true,
 	},
 	experimental: {


### PR DESCRIPTION
## Summary
- Force Preview www deploy when `.github/workflows/preview-www*` or `scripts/vercel-wrapper.cjs` changes (turbo does not mark `www` for those).
- Tiny `apps/www` comment tweak so this merge itself deploys and aliases `arkenv-dev.vercel.app` for #1460 verification.

Part of #1460 maintainer verification.


Made with [Cursor](https://cursor.com)