### PR TITLE
fix: Forward-port shared missing-schema errors from #1490

### DIFF
--- a/.changeset/align-v1-shared-missing-schema-errors.md
+++ b/.changeset/align-v1-shared-missing-schema-errors.md
@@ -8,10 +8,10 @@
 
 #### Make missing-schema errors short and actionable across hosts
 
-When a host cannot find an env schema, throw a consistent message that names the expected path / `schemaPath` and points to `arkenv init`, without embedding a starter `env.ts` module.
+When a host cannot find an env schema, throw a consistent message that names the expected path / `schemaPath` and points to `npx arkenv@latest init`, without embedding a starter `env.ts` module.
 
 Example:
 
 ```text
-[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in ArkEnv options (or run `arkenv init`).
+[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in ArkEnv options (or run `npx arkenv@latest init`).
 ```

--- a/.changeset/align-v1-shared-missing-schema-errors.md
+++ b/.changeset/align-v1-shared-missing-schema-errors.md
@@ -1,0 +1,11 @@
+---
+"@arkenv/build": patch
+"@arkenv/bun-plugin": patch
+"@arkenv/vite-plugin": patch
+"@arkenv/nextjs": patch
+"@arkenv/nuxt": patch
+---
+
+#### Align missing-schema errors via a shared `@arkenv/build` helper
+
+Centralize missing-schema message text in `formatMissingSchemaError` so Bun, Vite, Next, and Nuxt stay aligned: short actionable guidance (`schemaPath` + `arkenv init`), no embedded starter `env.ts` modules.

--- a/.changeset/align-v1-shared-missing-schema-errors.md
+++ b/.changeset/align-v1-shared-missing-schema-errors.md
@@ -6,6 +6,12 @@
 "@arkenv/nuxt": patch
 ---
 
-#### Align missing-schema errors via a shared `@arkenv/build` helper
+#### Make missing-schema errors short and actionable across hosts
 
-Centralize missing-schema message text in `formatMissingSchemaError` so Bun, Vite, Next, and Nuxt stay aligned: short actionable guidance (`schemaPath` + `arkenv init`), no embedded starter `env.ts` modules.
+When a host cannot find an env schema, throw a consistent message that names the expected path / `schemaPath` and points to `arkenv init`, without embedding a starter `env.ts` module.
+
+Example:
+
+```text
+[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in ArkEnv options (or run `arkenv init`).
+```

--- a/packages/arkenv/src/cli/commands/init.test.ts
+++ b/packages/arkenv/src/cli/commands/init.test.ts
@@ -65,7 +65,20 @@ describe("InitUseCase", () => {
 			checkGitStatus: vi.fn().mockResolvedValue({ status: "clean" }),
 		} as unknown as ProjectScannerPort;
 
-		useCase = new InitUseCase(logger, workspace, prompt, scanner);
+		const registry = {
+			fetchRegistry: vi.fn().mockResolvedValue({
+				examples: [
+					{
+						id: "basic",
+						name: "Basic",
+						description: "A minimal ArkEnv setup in Node.js",
+						framework: "vanilla",
+					},
+				],
+			}),
+		};
+
+		useCase = new InitUseCase(logger, workspace, prompt, scanner, registry);
 	});
 
 	it("should enter new project flow if no package.json and empty directory", async () => {

--- a/packages/build/src/core.test.ts
+++ b/packages/build/src/core.test.ts
@@ -51,13 +51,13 @@ describe("@arkenv/build layout resolution", () => {
 });
 
 describe("formatMissingSchemaError", () => {
-	it("formats a short host error with arkenv init and no starter", () => {
+	it("formats a short host error with npx arkenv@latest init and no starter", () => {
 		const message = formatMissingSchemaError({
 			optionsHint: "setupArkEnv options",
 		});
 
 		expect(message).toBe(
-			"[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in setupArkEnv options (or run `arkenv init`).",
+			"[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in setupArkEnv options (or run `npx arkenv@latest init`).",
 		);
 		expect(message).not.toMatch(/```/);
 		expect(message).not.toMatch(/Example/);
@@ -73,6 +73,6 @@ describe("formatMissingSchemaError", () => {
 		expect(message).toContain("ArkEnv Vite plugin: Could not find schema file");
 		expect(message).toContain("Checked paths:");
 		expect(message).toContain(" - /proj/src/env.ts");
-		expect(message).toContain("arkenv init");
+		expect(message).toContain("npx arkenv@latest init");
 	});
 });

--- a/packages/build/src/core.test.ts
+++ b/packages/build/src/core.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { extractKeys, resolveLayout } from "./core";
+import { extractKeys, formatMissingSchemaError, resolveLayout } from "./core";
 
 describe("@arkenv/build layout resolution", () => {
 	it("treats flat as simple layout", () => {
@@ -47,5 +47,32 @@ describe("@arkenv/build layout resolution", () => {
 		const res = extractKeys(content, "NUXT_PUBLIC_");
 		expect(res.serverKeys).toEqual(["DATABASE_URL", "DESCRIPTION"]);
 		expect(res.clientKeys).toEqual(["NUXT_PUBLIC_API_URL"]);
+	});
+});
+
+describe("formatMissingSchemaError", () => {
+	it("formats a short host error with arkenv init and no starter", () => {
+		const message = formatMissingSchemaError({
+			optionsHint: "setupArkEnv options",
+		});
+
+		expect(message).toBe(
+			"[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in setupArkEnv options (or run `arkenv init`).",
+		);
+		expect(message).not.toMatch(/```/);
+		expect(message).not.toMatch(/Example/);
+	});
+
+	it("includes checked paths when provided", () => {
+		const message = formatMissingSchemaError({
+			prefix: "ArkEnv Vite plugin:",
+			optionsHint: "plugin options",
+			checkedPaths: ["/proj/src/env.ts", "/proj/env.ts"],
+		});
+
+		expect(message).toContain("ArkEnv Vite plugin: Could not find schema file");
+		expect(message).toContain("Checked paths:");
+		expect(message).toContain(" - /proj/src/env.ts");
+		expect(message).toContain("arkenv init");
 	});
 });

--- a/packages/build/src/core.ts
+++ b/packages/build/src/core.ts
@@ -8,6 +8,12 @@ import {
 } from "@repo/log";
 import { watch as chokidarWatch, type FSWatcher } from "chokidar";
 
+export {
+	DEFAULT_SCHEMA_LOCATIONS,
+	type FormatMissingSchemaErrorOptions,
+	formatMissingSchemaError,
+} from "./missing-schema-error";
+
 // Global watcher reference isolated to this bundle's scope
 let activeWatcher: FSWatcher | undefined;
 
@@ -114,17 +120,23 @@ export function resolveLayout(
 }
 
 /**
+ * Return the default absolute schema file candidates for a project root.
+ *
+ * @param cwd The working directory to search from (defaults to process.cwd())
+ * @returns Absolute paths for `src/env.ts` and `env.ts`
+ */
+export function getDefaultSchemaFileCandidates(cwd = process.cwd()): string[] {
+	return [path.join(cwd, "src", "env.ts"), path.join(cwd, "env.ts")];
+}
+
+/**
  * Find the path to the schema file or directory in the project.
  *
  * @param cwd The working directory to search from (defaults to process.cwd())
  * @returns The absolute path to the schema file/directory, or null if not found
  */
 export function findSchemaPath(cwd = process.cwd()): string | null {
-	const possiblePaths = [
-		path.join(cwd, "src", "env.ts"),
-		path.join(cwd, "env.ts"),
-	];
-	for (const p of possiblePaths) {
+	for (const p of getDefaultSchemaFileCandidates(cwd)) {
 		if (fs.existsSync(p)) return p;
 	}
 

--- a/packages/build/src/missing-schema-error.ts
+++ b/packages/build/src/missing-schema-error.ts
@@ -1,0 +1,51 @@
+/**
+ * Default relative schema locations hosts search when `schemaPath` is omitted.
+ */
+export const DEFAULT_SCHEMA_LOCATIONS = "src/env.ts or env.ts";
+
+export type FormatMissingSchemaErrorOptions = {
+	/**
+	 * Explicit `schemaPath` that was missing.
+	 * Omit to refer to {@link DEFAULT_SCHEMA_LOCATIONS}.
+	 */
+	schemaPath?: string;
+	/**
+	 * Where to set `schemaPath` (e.g. `"setupArkEnv options"`, `"ArkEnv options"`,
+	 * `"plugin options"`).
+	 */
+	optionsHint: string;
+	/**
+	 * Brand prefix for the error.
+	 * @default "[ArkEnv]"
+	 */
+	prefix?: string;
+	/**
+	 * Absolute paths that were checked during discovery.
+	 * Appended as a `Checked paths` section when present.
+	 */
+	checkedPaths?: string[];
+};
+
+/**
+ * Format a missing-schema error shared by host integrations.
+ *
+ * Owns the no-starter policy: hosts must use this helper instead of inlining
+ * example `env.ts` modules in thrown errors.
+ *
+ * @param options Host-specific labels and optional discovery paths
+ * @returns A short, actionable missing-schema error message
+ */
+export function formatMissingSchemaError(
+	options: FormatMissingSchemaErrorOptions,
+): string {
+	const prefix = options.prefix ?? "[ArkEnv]";
+	const location = options.schemaPath || DEFAULT_SCHEMA_LOCATIONS;
+	let message = `${prefix} Could not find schema file at ${location}. Please specify 'schemaPath' in ${options.optionsHint} (or run \`arkenv init\`).`;
+
+	if (options.checkedPaths?.length) {
+		const pathsList = options.checkedPaths.map((p) => ` - ${p}`).join("\n");
+		message += `\n\nChecked paths:\n${pathsList}`;
+	}
+
+	return message;
+}

--- a/packages/build/src/missing-schema-error.ts
+++ b/packages/build/src/missing-schema-error.ts
@@ -40,7 +40,7 @@ export function formatMissingSchemaError(
 ): string {
 	const prefix = options.prefix ?? "[ArkEnv]";
 	const location = options.schemaPath || DEFAULT_SCHEMA_LOCATIONS;
-	let message = `${prefix} Could not find schema file at ${location}. Please specify 'schemaPath' in ${options.optionsHint} (or run \`arkenv init\`).`;
+	let message = `${prefix} Could not find schema file at ${location}. Please specify 'schemaPath' in ${options.optionsHint} (or run \`npx arkenv@latest init\`).`;
 
 	if (options.checkedPaths?.length) {
 		const pathsList = options.checkedPaths.map((p) => ` - ${p}`).join("\n");

--- a/packages/bun-plugin/src/env-module-path.ts
+++ b/packages/bun-plugin/src/env-module-path.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import { findSchemaPath } from "@arkenv/build";
+import {
+	findSchemaPath,
+	formatMissingSchemaError,
+	getDefaultSchemaFileCandidates,
+} from "@arkenv/build";
 
 /**
  * Strip query suffixes from a module path.
@@ -61,7 +65,11 @@ export function resolveEnvModulePath(
 	const discovered = findSchemaPath(root);
 	if (!discovered) {
 		throw new Error(
-			`ArkEnv Bun plugin: could not find an env module. Expected "src/env.ts" or "env.ts" under "${root}", or pass schemaPath (or run \`arkenv init\`).`,
+			formatMissingSchemaError({
+				prefix: "ArkEnv Bun plugin:",
+				optionsHint: "plugin options",
+				checkedPaths: getDefaultSchemaFileCandidates(root),
+			}),
 		);
 	}
 	return discovered;

--- a/packages/bun-plugin/src/env-module.test.ts
+++ b/packages/bun-plugin/src/env-module.test.ts
@@ -320,7 +320,7 @@ describe("missing-schema errors", () => {
 		}
 
 		expect(message).toMatch(/Could not find schema file/);
-		expect(message).toMatch(/arkenv init/);
+		expect(message).toMatch(/npx arkenv@latest init/);
 		expect(message).toMatch(/Checked paths:/);
 		expect(message).not.toMatch(/Example `src\/env\.ts`/);
 		expect(message).not.toMatch(/```/);

--- a/packages/bun-plugin/src/env-module.test.ts
+++ b/packages/bun-plugin/src/env-module.test.ts
@@ -319,8 +319,9 @@ describe("missing-schema errors", () => {
 			message = error instanceof Error ? error.message : String(error);
 		}
 
-		expect(message).toMatch(/could not find an env module/);
+		expect(message).toMatch(/Could not find schema file/);
 		expect(message).toMatch(/arkenv init/);
+		expect(message).toMatch(/Checked paths:/);
 		expect(message).not.toMatch(/Example `src\/env\.ts`/);
 		expect(message).not.toMatch(/```/);
 		expect(message).not.toMatch(/import \{ type \} from "arktype"/);

--- a/packages/nextjs/src/config/setup.ts
+++ b/packages/nextjs/src/config/setup.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { findSchemaPath, resolveLayout, watchSchema } from "@arkenv/build";
+import {
+	findSchemaPath,
+	formatMissingSchemaError,
+	resolveLayout,
+	watchSchema,
+} from "@arkenv/build";
 import {
 	formatBuildError,
 	resolveBuildLog,
@@ -56,11 +61,10 @@ export function setupArkEnv(
 
 	if (!schemaPath || !schemaPathExists(schemaPath)) {
 		throw new Error(
-			formatBuildError(
-				`Could not find schema file at ${
-					options?.schemaPath || "src/env.ts or env.ts"
-				}. Please specify 'schemaPath' in setupArkEnv options (or run \`arkenv init\`).`,
-			),
+			formatMissingSchemaError({
+				schemaPath: options?.schemaPath,
+				optionsHint: "setupArkEnv options",
+			}),
 		);
 	}
 

--- a/packages/nuxt/src/config.ts
+++ b/packages/nuxt/src/config.ts
@@ -5,11 +5,11 @@ import {
 	extractClientKeys,
 	extractSharedKeys,
 	findSchemaPath,
+	formatMissingSchemaError,
 	resolveLayout,
 } from "@arkenv/build";
 import {
 	type BuildLogHelpers,
-	formatBuildError,
 	type Logger,
 	type LogLevel,
 	resolveBuildLog,
@@ -26,6 +26,7 @@ export {
 	extractArkenvBlock,
 	extractServerKeys,
 	findSchemaPath,
+	formatMissingSchemaError,
 	resolveLayout,
 } from "@arkenv/build";
 export { extractClientKeys, extractSharedKeys, validateSchema };
@@ -130,11 +131,10 @@ export function setupArkEnv(
 
 	if (!schemaPath || !exists) {
 		throw new Error(
-			formatBuildError(
-				`Could not find schema file at ${
-					options?.schemaPath || "src/env.ts or env.ts"
-				}. Please specify 'schemaPath' in ArkEnv options (or run \`arkenv init\`).`,
-			),
+			formatMissingSchemaError({
+				schemaPath: options?.schemaPath,
+				optionsHint: "ArkEnv options",
+			}),
 		);
 	}
 

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -545,11 +545,19 @@ describe("Nuxt module integration", () => {
 		};
 
 		try {
-			expect(() =>
-				(module as any).setup({ validate: false }, mockNuxt),
-			).toThrow(
+			let message = "";
+			try {
+				(module as any).setup({ validate: false }, mockNuxt);
+			} catch (error) {
+				message = error instanceof Error ? error.message : String(error);
+			}
+
+			expect(message).toMatch(
 				/\[ArkEnv\] Could not find schema file at src\/env\.ts or env\.ts/,
 			);
+			expect(message).toMatch(/arkenv init/);
+			expect(message).not.toMatch(/Example `src\/env\.ts`/);
+			expect(message).not.toMatch(/```/);
 			expect(mockNuxt.hook).not.toHaveBeenCalled();
 			expect(mockNuxt.options.runtimeConfig.DATABASE_URL).toBeUndefined();
 		} finally {

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -555,7 +555,7 @@ describe("Nuxt module integration", () => {
 			expect(message).toMatch(
 				/\[ArkEnv\] Could not find schema file at src\/env\.ts or env\.ts/,
 			);
-			expect(message).toMatch(/arkenv init/);
+			expect(message).toMatch(/npx arkenv@latest init/);
 			expect(message).not.toMatch(/Example `src\/env\.ts`/);
 			expect(message).not.toMatch(/```/);
 			expect(mockNuxt.hook).not.toHaveBeenCalled();

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -12,6 +12,7 @@ import {
 	extractServerKeys,
 	extractSharedKeys,
 	findSchemaPath,
+	formatMissingSchemaError,
 	normalizeLayout,
 	resolveLayout,
 	validateSchema,
@@ -80,9 +81,10 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 
 		if (!schemaPath || !fs.existsSync(schemaPath)) {
 			throw new Error(
-				`[ArkEnv] Could not find schema file at ${
-					options.schemaPath || "src/env.ts or env.ts"
-				}. Please specify 'schemaPath' in ArkEnv options (or run \`arkenv init\`).`,
+				formatMissingSchemaError({
+					schemaPath: options.schemaPath,
+					optionsHint: "ArkEnv options",
+				}),
 			);
 		}
 

--- a/packages/vite-plugin/src/env-module-path.ts
+++ b/packages/vite-plugin/src/env-module-path.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import { findSchemaPath } from "@arkenv/build";
+import {
+	findSchemaPath,
+	formatMissingSchemaError,
+	getDefaultSchemaFileCandidates,
+} from "@arkenv/build";
 
 /**
  * Strip Vite virtual-module and query suffixes from a module id.
@@ -64,7 +68,11 @@ export function resolveEnvModulePath(
 	const discovered = findSchemaPath(root);
 	if (!discovered) {
 		throw new Error(
-			`ArkEnv Vite plugin: could not find an env module. Expected "src/env.ts" or "env.ts" under "${root}", or pass schemaPath (or run \`arkenv init\`).`,
+			formatMissingSchemaError({
+				prefix: "ArkEnv Vite plugin:",
+				optionsHint: "plugin options",
+				checkedPaths: getDefaultSchemaFileCandidates(root),
+			}),
 		);
 	}
 	return discovered;

--- a/packages/vite-plugin/src/env-module.test.ts
+++ b/packages/vite-plugin/src/env-module.test.ts
@@ -267,7 +267,7 @@ describe("missing-schema errors", () => {
 		}
 
 		expect(message).toMatch(/Could not find schema file/);
-		expect(message).toMatch(/arkenv init/);
+		expect(message).toMatch(/npx arkenv@latest init/);
 		expect(message).toMatch(/Checked paths:/);
 		expect(message).not.toMatch(/Example `src\/env\.ts`/);
 		expect(message).not.toMatch(/```/);

--- a/packages/vite-plugin/src/env-module.test.ts
+++ b/packages/vite-plugin/src/env-module.test.ts
@@ -266,8 +266,9 @@ describe("missing-schema errors", () => {
 			message = error instanceof Error ? error.message : String(error);
 		}
 
-		expect(message).toMatch(/could not find an env module/);
+		expect(message).toMatch(/Could not find schema file/);
 		expect(message).toMatch(/arkenv init/);
+		expect(message).toMatch(/Checked paths:/);
 		expect(message).not.toMatch(/Example `src\/env\.ts`/);
 		expect(message).not.toMatch(/```/);
 		expect(message).not.toMatch(/import \{ type \} from "arktype"/);


### PR DESCRIPTION
## Summary
- Forward-port of [#1490](https://github.com/yamcodes/arkenv/pull/1490) (`dev`) onto `v1`
- Centralize missing-schema text in `formatMissingSchemaError` (`@arkenv/build`)
- Wire **Bun, Vite, Next, and Nuxt** through the shared helper (Vite included on `v1` because it has a discovery miss path; `dev` Vite does not)
- Mock registry fetch in CLI init tests (same flake fix as #1490)

## Test plan
- [x] `pnpm exec vitest run packages/build packages/bun-plugin/src/env-module.test.ts packages/vite-plugin/src/env-module.test.ts packages/nuxt/src/module.test.ts packages/arkenv/src/cli/commands/init.test.ts --run`
- [x] `pnpm run typecheck`
- [x] `pnpm run fix`
- [x] `pnpm run test -- --run` (1066 passed)


Made with [Cursor](https://cursor.com)