### PR TITLE
fix: Point missing-schema errors at npx @arkenv/cli@latest init

### DIFF
--- a/.changeset/align-dev-missing-schema-init.md
+++ b/.changeset/align-dev-missing-schema-init.md
@@ -7,10 +7,10 @@
 
 #### Make missing-schema errors short and actionable across hosts
 
-When Bun, Next, or Nuxt cannot find an env schema, throw a consistent message that names the expected path / `schemaPath` and points to `arkenv init`, without embedding a starter `env.ts` module.
+When Bun, Next, or Nuxt cannot find an env schema, throw a consistent message that names the expected path / `schemaPath` and points to `npx @arkenv/cli@latest init`, without embedding a starter `env.ts` module.
 
 Example:
 
 ```text
-[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in ArkEnv options (or run `arkenv init`).
+[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in ArkEnv options (or run `npx @arkenv/cli@latest init`).
 ```

--- a/.changeset/align-dev-missing-schema-init.md
+++ b/.changeset/align-dev-missing-schema-init.md
@@ -5,6 +5,12 @@
 "@arkenv/nuxt": patch
 ---
 
-#### Align missing-schema errors via a shared `@arkenv/build` helper
+#### Make missing-schema errors short and actionable across hosts
 
-Centralize missing-schema message text in `formatMissingSchemaError` so Bun, Next, and Nuxt stay aligned: short actionable guidance (`schemaPath` + `arkenv init`), no embedded starter `env.ts` modules.
+When Bun, Next, or Nuxt cannot find an env schema, throw a consistent message that names the expected path / `schemaPath` and points to `arkenv init`, without embedding a starter `env.ts` module.
+
+Example:
+
+```text
+[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in ArkEnv options (or run `arkenv init`).
+```

--- a/packages/build/src/index.test.ts
+++ b/packages/build/src/index.test.ts
@@ -135,13 +135,13 @@ describe("@arkenv/build extractors", () => {
 });
 
 describe("formatMissingSchemaError", () => {
-	it("formats a short host error with arkenv init and no starter", () => {
+	it("formats a short host error with CLI init and no starter", () => {
 		const message = formatMissingSchemaError({
 			optionsHint: "setupArkEnv options",
 		});
 
 		expect(message).toBe(
-			"[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in setupArkEnv options (or run `arkenv init`).",
+			"[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in setupArkEnv options (or run `npx @arkenv/cli@latest init`).",
 		);
 		expect(message).not.toMatch(/```/);
 		expect(message).not.toMatch(/Example/);
@@ -156,7 +156,7 @@ describe("formatMissingSchemaError", () => {
 		});
 
 		expect(message).toContain(
-			"@arkenv/bun-plugin: Could not find schema file at ./missing-env.ts. Please specify 'schemaPath' in plugin options (or run `arkenv init`).",
+			"@arkenv/bun-plugin: Could not find schema file at ./missing-env.ts. Please specify 'schemaPath' in plugin options (or run `npx @arkenv/cli@latest init`).",
 		);
 		expect(message).toContain("Checked paths:");
 		expect(message).toContain(" - /proj/src/env.ts");

--- a/packages/build/src/missing-schema-error.ts
+++ b/packages/build/src/missing-schema-error.ts
@@ -40,7 +40,7 @@ export function formatMissingSchemaError(
 ): string {
 	const prefix = options.prefix ?? "[ArkEnv]";
 	const location = options.schemaPath || DEFAULT_SCHEMA_LOCATIONS;
-	let message = `${prefix} Could not find schema file at ${location}. Please specify 'schemaPath' in ${options.optionsHint} (or run \`arkenv init\`).`;
+	let message = `${prefix} Could not find schema file at ${location}. Please specify 'schemaPath' in ${options.optionsHint} (or run \`npx @arkenv/cli@latest init\`).`;
 
 	if (options.checkedPaths?.length) {
 		const pathsList = options.checkedPaths.map((p) => ` - ${p}`).join("\n");

--- a/packages/bun-plugin/src/plugin.test.ts
+++ b/packages/bun-plugin/src/plugin.test.ts
@@ -101,7 +101,7 @@ describe("Bun Plugin", () => {
 
 		expect(message).toMatch(/@arkenv\/bun-plugin: Could not find schema file/);
 		expect(message).toMatch(/Checked paths:/);
-		expect(message).toMatch(/arkenv init/);
+		expect(message).toMatch(/npx @arkenv\/cli@latest init/);
 		expect(message).not.toMatch(/Example `src\/env\.ts`/);
 		expect(message).not.toMatch(/```/);
 		expect(message).not.toMatch(/import \{ type \} from "arktype"/);

--- a/packages/nextjs/src/config.test.ts
+++ b/packages/nextjs/src/config.test.ts
@@ -314,7 +314,7 @@ describe("withArkEnv wrapper", () => {
 		}
 
 		expect(message).toMatch(/\[ArkEnv\] Could not find schema file/);
-		expect(message).toMatch(/arkenv init/);
+		expect(message).toMatch(/npx @arkenv\/cli@latest init/);
 		expect(message).not.toMatch(/Example `src\/env\.ts`/);
 		expect(message).not.toMatch(/```/);
 	});

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -50,7 +50,7 @@ describe("Nuxt module integration", () => {
 			expect(message).toMatch(
 				/\[ArkEnv\] Could not find schema file at src\/env\.ts or env\.ts/,
 			);
-			expect(message).toMatch(/arkenv init/);
+			expect(message).toMatch(/npx @arkenv\/cli@latest init/);
 			expect(message).not.toMatch(/Example `src\/env\.ts`/);
 			expect(message).not.toMatch(/```/);
 			expect(mockNuxt.hook).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- On `dev`, the CLI package is still `@arkenv/cli` (not `arkenv`)
- Point missing-schema errors at `npx @arkenv/cli@latest init` to match docs / first-time setup
- Reframe the changeset around that consumer-facing guidance

## Test plan
- [x] Update helper + host tests
- [ ] `pnpm exec vitest run packages/build packages/bun-plugin packages/nextjs/src/config.test.ts packages/nuxt/src/module.test.ts --run`