### PR TITLE
feat: Make env/internal/shared.ts optional in strict layout (dev/v0)

### DIFF
--- a/.changeset/optional-strict-shared.md
+++ b/.changeset/optional-strict-shared.md
@@ -1,0 +1,18 @@
+---
+"@arkenv/build": patch
+"@arkenv/nextjs": patch
+"@arkenv/nuxt": patch
+---
+
+#### Make `env/internal/shared.ts` optional in strict layout
+
+Strict layout auto-detection and schema discovery now treat `client.ts` + `server.ts` as enough. Explicit `layout: "strict"` no longer requires `internal/shared.ts`; when the file is absent, shared keys are treated as empty.
+
+```ts
+// env/client.ts + env/server.ts alone is valid strict layout
+export default withArkEnv(nextConfig, {
+  layout: "strict",
+});
+```
+
+The CLI still scaffolds `shared.ts` by default for convenience.

--- a/apps/www/content/docs/nextjs/layouts/strict.mdx
+++ b/apps/www/content/docs/nextjs/layouts/strict.mdx
@@ -4,13 +4,13 @@ icon: ShieldCheck
 description: Get the best security in Next.js using strictly separated client and server schemas.
 ---
 
-In this setup, you define your client, server, and shared schemas in separate files.
+In this setup, you define your client and server schemas in separate files. An optional `internal/shared.ts` holds variables shared by both.
 
 ```files
 src
 └── env
     ├── internal
-    │   └── shared.ts
+    │   └── shared.ts   # optional
     ├── client.ts
     └── server.ts
 ```
@@ -27,7 +27,7 @@ npx @arkenv/cli@latest init --strict
 
 ## Your schema
 
-When bootstrapping with the CLI, it generates three separate schema files under `src/env/`:
+When bootstrapping with the CLI, it generates separate schema files under `src/env/` (including an optional `internal/shared.ts` with `NODE_ENV` for convenience):
 
 :::note
 By default, ArkEnv for Next.js uses an automatic code generation wrapper (`withArkEnv`) in your Next.js config to compile your `runtimeEnv` block. This is why the client-side schema imports from `./generated/env.gen` rather than `@arkenv/nextjs/client`. To opt out, simply import from `@arkenv/nextjs/client` directly and provide your own `runtimeEnv` mapping.
@@ -104,9 +104,9 @@ export const env = arkenv(
 
 <Accordions>
   <Accordion title="Manual Setup">
-    ### Define shared variables [step] [!toc]
+    ### Define shared variables (optional) [step] [!toc]
 
-    Create `env/internal/shared.ts` to define schema variables that are shared across both the client and the server. We treat this as a runtime type, so it is defined using PascalCase:
+    Optionally create `env/internal/shared.ts` to define schema variables that are shared across both the client and the server. Shared is not required for strict layout—omit the file when you have nothing to share. When present, we treat it as a runtime type, so it is defined using PascalCase:
 
     ```ts title="src/env/internal/shared.ts" twoslash
     import { type } from "@arkenv/nextjs/shared";
@@ -122,7 +122,7 @@ export const env = arkenv(
 
     ### Define client variables [step] [!toc]
 
-    Create `env/client.ts` importing `arkenv` from the auto-generated `./generated/env.gen.ts` helper file. All local keys **must** be prefixed with `NEXT_PUBLIC_` and you must extend `SharedSchema`:
+    Create `env/client.ts` importing `arkenv` from the auto-generated `./generated/env.gen.ts` helper file. All local keys **must** be prefixed with `NEXT_PUBLIC_`. When you define `SharedSchema`, extend it here:
 
     ```ts title="src/env/client.ts" twoslash
     // @filename: /env/internal/shared.ts

--- a/apps/www/content/docs/nuxt/layouts/strict.mdx
+++ b/apps/www/content/docs/nuxt/layouts/strict.mdx
@@ -4,12 +4,12 @@ icon: ShieldCheck
 description: Get the best security in Nuxt using strictly separated client and server schemas.
 ---
 
-In this setup, you define your client, server, and shared schemas in separate files.
+In this setup, you define your client and server schemas in separate files. An optional `internal/shared.ts` holds variables shared by both.
 
 ```files
 env
 ├── internal
-│   └── shared.ts
+│   └── shared.ts   # optional
 ├── client.ts
 └── server.ts
 ```
@@ -26,7 +26,7 @@ npx @arkenv/cli@latest init --strict
 
 ## Your schema
 
-When bootstrapping with the CLI, it generates three separate schema files under `env/`:
+When bootstrapping with the CLI, it generates separate schema files under `env/` (including an optional `internal/shared.ts` with `NODE_ENV` for convenience):
 
 ```ts twoslash title="env/internal/shared.ts"
 import { type } from "@arkenv/nuxt/shared";
@@ -91,9 +91,9 @@ export const env = arkenv(
 
 <Accordions>
   <Accordion title="Manual setup">
-    ### Define shared variables [step] [!toc]
+    ### Define shared variables (optional) [step] [!toc]
 
-    Create `env/internal/shared.ts` to define schema variables that are shared across both the client and the server. We treat this as a runtime type, so it is defined using PascalCase:
+    Optionally create `env/internal/shared.ts` to define schema variables that are shared across both the client and the server. Shared is not required for strict layout—omit the file when you have nothing to share. When present, we treat it as a runtime type, so it is defined using PascalCase:
 
     ```ts twoslash title="env/internal/shared.ts"
     import { type } from "@arkenv/nuxt/shared";
@@ -109,7 +109,7 @@ export const env = arkenv(
 
     ### Define client variables [step] [!toc]
 
-    Create `env/client.ts` importing from `@arkenv/nuxt/client`. All local keys **must** be prefixed with `NUXT_PUBLIC_` and you must extend `SharedSchema`:
+    Create `env/client.ts` importing from `@arkenv/nuxt/client`. All local keys **must** be prefixed with `NUXT_PUBLIC_`. When you define `SharedSchema`, extend it here:
 
     ```ts twoslash title="env/client.ts"
     // @filename: env/internal/shared.ts

--- a/packages/build/src/index.test.ts
+++ b/packages/build/src/index.test.ts
@@ -1,10 +1,16 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	extractArkenvBlock,
 	extractBlock,
 	extractKeys,
+	findSchemaPath,
 	formatMissingSchemaError,
+	isStrictLayoutDir,
 	parseBlockKeys,
+	resolveLayout,
 } from "./index";
 
 describe("@arkenv/build extractors", () => {
@@ -131,6 +137,86 @@ describe("@arkenv/build extractors", () => {
 				'DATABASE_URL: "string",\n\t\t\t\t\tPORT: "number"',
 			);
 		});
+	});
+});
+
+describe("strict layout detection", () => {
+	const makeTempDir = () =>
+		fs.mkdtempSync(path.join(os.tmpdir(), "arkenv-build-layout-"));
+
+	it("treats client.ts + server.ts as strict without internal/shared.ts", () => {
+		const tempDir = makeTempDir();
+		try {
+			fs.writeFileSync(
+				path.join(tempDir, "client.ts"),
+				"export const env = {}",
+			);
+			fs.writeFileSync(
+				path.join(tempDir, "server.ts"),
+				"export const env = {}",
+			);
+
+			expect(isStrictLayoutDir(tempDir)).toBe(true);
+			expect(resolveLayout(tempDir)).toEqual({
+				layout: "strict",
+				baseDir: tempDir,
+			});
+			expect(resolveLayout(path.join(tempDir, "client.ts"))).toEqual({
+				layout: "strict",
+				baseDir: tempDir,
+			});
+			expect(resolveLayout(path.join(tempDir, "client.ts"), "strict")).toEqual({
+				layout: "strict",
+				baseDir: tempDir,
+			});
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("findSchemaPath discovers env/ without requiring shared.ts", () => {
+		const tempDir = makeTempDir();
+		try {
+			const envDir = path.join(tempDir, "env");
+			fs.mkdirSync(envDir, { recursive: true });
+			fs.writeFileSync(path.join(envDir, "client.ts"), "export const env = {}");
+			fs.writeFileSync(path.join(envDir, "server.ts"), "export const env = {}");
+
+			expect(findSchemaPath(tempDir)).toBe(envDir);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("findSchemaPath discovers src/env/ without requiring shared.ts", () => {
+		const tempDir = makeTempDir();
+		try {
+			const envDir = path.join(tempDir, "src", "env");
+			fs.mkdirSync(envDir, { recursive: true });
+			fs.writeFileSync(path.join(envDir, "client.ts"), "export const env = {}");
+			fs.writeFileSync(path.join(envDir, "server.ts"), "export const env = {}");
+
+			expect(findSchemaPath(tempDir)).toBe(envDir);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("throws for explicit strict when client.ts is missing", () => {
+		const tempDir = makeTempDir();
+		try {
+			fs.writeFileSync(
+				path.join(tempDir, "server.ts"),
+				"export const env = {}",
+			);
+			expect(() =>
+				resolveLayout(path.join(tempDir, "missing.ts"), "strict"),
+			).toThrow(
+				`[ArkEnv] Strict layout requires "${path.join(tempDir, "client.ts")}" to exist`,
+			);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -24,22 +24,33 @@ export type Logger = {
 };
 
 /**
+ * Return whether a directory looks like a strict split layout.
+ *
+ * Strict auto-detection requires `client.ts` and `server.ts`.
+ * `internal/shared.ts` is optional and treated as empty when absent.
+ *
+ * @param dir Absolute path to a candidate env directory
+ * @returns `true` when both `client.ts` and `server.ts` exist
+ */
+export function isStrictLayoutDir(dir: string): boolean {
+	return (
+		fs.existsSync(path.join(dir, "client.ts")) &&
+		fs.existsSync(path.join(dir, "server.ts"))
+	);
+}
+
+/**
  * Resolve the layout mode and base directory for a given schema file path.
  *
  * @param schemaPath The absolute path to the schema file or directory
  * @param layoutOption An optional explicit layout configuration ("simple" or "strict")
  * @returns An object containing the resolved layout mode and the base directory path
- * @throws An error if explicit "strict" layout is requested but required split files are missing
+ * @throws An error if explicit "strict" layout is requested but `client.ts` is missing
  */
 export function resolveLayout(
 	schemaPath: string,
 	layoutOption?: LayoutMode,
 ): ResolvedLayout {
-	const checkStrict = (dir: string) =>
-		fs.existsSync(path.join(dir, "internal", "shared.ts")) &&
-		fs.existsSync(path.join(dir, "client.ts")) &&
-		fs.existsSync(path.join(dir, "server.ts"));
-
 	const resolveBaseDir = (p: string): string => {
 		const ext = path.extname(p);
 		const baseWithoutExt = ext ? p.slice(0, -ext.length) : p;
@@ -55,7 +66,7 @@ export function resolveLayout(
 	if (!layoutOption) {
 		const resolved = resolveBaseDir(schemaPath);
 		if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
-			if (checkStrict(resolved)) {
+			if (isStrictLayoutDir(resolved)) {
 				return { layout: "strict", baseDir: resolved };
 			}
 			return { layout: "simple", baseDir: resolved };
@@ -67,16 +78,16 @@ export function resolveLayout(
 		if (
 			fs.existsSync(baseWithoutExt) &&
 			fs.statSync(baseWithoutExt).isDirectory() &&
-			checkStrict(baseWithoutExt)
+			isStrictLayoutDir(baseWithoutExt)
 		) {
 			return { layout: "strict", baseDir: baseWithoutExt };
 		}
-		if (checkStrict(parent)) {
+		if (isStrictLayoutDir(parent)) {
 			return { layout: "strict", baseDir: parent };
 		}
 		if (
 			path.basename(parent) === "internal" &&
-			checkStrict(path.dirname(parent))
+			isStrictLayoutDir(path.dirname(parent))
 		) {
 			return { layout: "strict", baseDir: path.dirname(parent) };
 		}
@@ -98,11 +109,10 @@ export function resolveLayout(
 		}
 
 		const clientPath = path.join(baseDir, "client.ts");
-		const sharedPath = path.join(baseDir, "internal", "shared.ts");
-		if (!fs.existsSync(clientPath) || !fs.existsSync(sharedPath)) {
+		if (!fs.existsSync(clientPath)) {
 			throw new Error(
-				`[ArkEnv] Strict layout requires "${clientPath}" and "${sharedPath}" to exist. ` +
-					`Ensure both files are present or remove the 'layout: "strict"' option to let ArkEnv auto-detect.`,
+				`[ArkEnv] Strict layout requires "${clientPath}" to exist. ` +
+					`Ensure it is present or remove the 'layout: "strict"' option to let ArkEnv auto-detect.`,
 			);
 		}
 
@@ -135,12 +145,7 @@ export function findSchemaPath(cwd = process.cwd()): string | null {
 
 	const possibleDirs = [path.join(cwd, "src", "env"), path.join(cwd, "env")];
 	for (const d of possibleDirs) {
-		if (
-			fs.existsSync(d) &&
-			fs.existsSync(path.join(d, "internal", "shared.ts")) &&
-			fs.existsSync(path.join(d, "client.ts")) &&
-			fs.existsSync(path.join(d, "server.ts"))
-		) {
+		if (fs.existsSync(d) && isStrictLayoutDir(d)) {
 			return d;
 		}
 	}

--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -80,7 +80,7 @@ export type ArkEnvConfigOptions = {
 	 * Specify the configuration layout.
 	 *
 	 * - `"flat"` (default): A single `env.ts` schema file.
-	 * - `"strict"`: A 3-file split schema layout (`env/internal/shared.ts`, `env/client.ts`, `env/server.ts`).
+	 * - `"strict"`: A split schema layout (`env/client.ts`, `env/server.ts`, and optionally `env/internal/shared.ts`).
 	 *
 	 * @default "flat"
 	 */

--- a/packages/nuxt/src/config.ts
+++ b/packages/nuxt/src/config.ts
@@ -73,12 +73,12 @@ export type ArkEnvConfigOptions = {
 	 * Specify the configuration layout.
 	 *
 	 * When omitted, the layout is auto-detected from the schema structure: it is
-	 * `"strict"` when the split files (`env/internal/shared.ts`, `env/client.ts`,
-	 * `env/server.ts`) are present, and falls back to `"flat"` (a single
+	 * `"strict"` when `env/client.ts` and `env/server.ts` are present (with
+	 * optional `env/internal/shared.ts`), and falls back to `"flat"` (a single
 	 * `env.ts`) otherwise.
 	 *
 	 * - `"flat"`: A single `env.ts` schema file.
-	 * - `"strict"`: A 3-file split schema layout (`env/internal/shared.ts`, `env/client.ts`, `env/server.ts`).
+	 * - `"strict"`: A split schema layout (`env/client.ts`, `env/server.ts`, and optionally `env/internal/shared.ts`).
 	 */
 	layout?:
 		| "flat"


### PR DESCRIPTION
Fixes #1448

## Summary
- Strict layout auto-detect and `findSchemaPath` now treat `client.ts` + `server.ts` as enough; `internal/shared.ts` is optional (empty when absent)
- Explicit `layout: "strict"` only requires `client.ts`
- Docs updated to describe shared as optional; CLI still scaffolds it by default

## Test plan
- [ ] Confirm `pnpm run typecheck` / `pnpm run test -- --run` / `pnpm run fix` pass
- [ ] Strict `env/` with only `client.ts` + `server.ts` auto-detects as strict
- [ ] `layout: "strict"` succeeds without `internal/shared.ts`
- [ ] CLI `init --strict` still scaffolds `shared.ts`


Made with [Cursor](https://cursor.com)