### PR TITLE
feat: (v1) Make env/internal/shared.ts optional in strict layout

### DIFF
--- a/.changeset/optional-strict-shared-v1.md
+++ b/.changeset/optional-strict-shared-v1.md
@@ -8,17 +8,17 @@
 
 #### Make `env/internal/shared.ts` optional in strict layout
 
-Strict layout auto-detection and schema discovery now treat `client.ts` + `server.ts` as enough. Explicit `layout: "strict"` no longer requires `internal/shared.ts`; when the file is absent, shared keys are treated as empty.
+Strict layout now works with just `client.ts` and `server.ts`. Omit `internal/shared.ts` when you have nothing to share — shared keys are treated as empty.
 
 ```ts
-// env/client.ts + env/server.ts alone is valid strict layout
+// env/client.ts + env/server.ts alone is enough
 export default withArkEnv(nextConfig, {
   layout: "strict",
 });
 ```
 
-On Nuxt, `#arkenv/shared-schema` / client auto-extend uses the empty-schema stub when `internal/shared.ts` is omitted (same fallback already used outside strict). A present shared file without a usable `SharedSchema` export still fails with a clear diagnostic.
+On Nuxt, omitting the shared file still auto-merges an empty schema into the client entry. If the file is present, it must export `SharedSchema`.
 
-Vite and Bun plugins remain flat-layout only: if discovery finds a strict `env/` directory, they reject it with a clear diagnostic instead of treating the directory as an env module file.
+Vite and Bun plugins only support a flat `env.ts`; a strict `env/` directory now fails with a clear error instead of a confusing filesystem failure.
 
 The CLI still scaffolds `shared.ts` by default for convenience.

--- a/.changeset/optional-strict-shared-v1.md
+++ b/.changeset/optional-strict-shared-v1.md
@@ -1,0 +1,24 @@
+---
+"@arkenv/build": patch
+"@arkenv/nextjs": patch
+"@arkenv/nuxt": patch
+"@arkenv/vite-plugin": patch
+"@arkenv/bun-plugin": patch
+---
+
+#### Make `env/internal/shared.ts` optional in strict layout
+
+Strict layout auto-detection and schema discovery now treat `client.ts` + `server.ts` as enough. Explicit `layout: "strict"` no longer requires `internal/shared.ts`; when the file is absent, shared keys are treated as empty.
+
+```ts
+// env/client.ts + env/server.ts alone is valid strict layout
+export default withArkEnv(nextConfig, {
+  layout: "strict",
+});
+```
+
+On Nuxt, `#arkenv/shared-schema` / client auto-extend uses the empty-schema stub when `internal/shared.ts` is omitted (same fallback already used outside strict). A present shared file without a usable `SharedSchema` export still fails with a clear diagnostic.
+
+Vite and Bun plugins remain flat-layout only: if discovery finds a strict `env/` directory, they reject it with a clear diagnostic instead of treating the directory as an env module file.
+
+The CLI still scaffolds `shared.ts` by default for convenience.

--- a/.changeset/optional-strict-shared-v1.md
+++ b/.changeset/optional-strict-shared-v1.md
@@ -2,8 +2,6 @@
 "@arkenv/build": patch
 "@arkenv/nextjs": patch
 "@arkenv/nuxt": patch
-"@arkenv/vite-plugin": patch
-"@arkenv/bun-plugin": patch
 ---
 
 #### Make `env/internal/shared.ts` optional in strict layout
@@ -16,9 +14,5 @@ export default withArkEnv(nextConfig, {
   layout: "strict",
 });
 ```
-
-On Nuxt, omitting the shared file still auto-merges an empty schema into the client entry. If the file is present, it must export `SharedSchema`.
-
-Vite and Bun plugins only support a flat `env.ts`; a strict `env/` directory now fails with a clear error instead of a confusing filesystem failure.
 
 The CLI still scaffolds `shared.ts` by default for convenience.

--- a/apps/www/content/docs/nextjs/layouts/strict.mdx
+++ b/apps/www/content/docs/nextjs/layouts/strict.mdx
@@ -4,13 +4,13 @@ icon: ShieldCheck
 description: Get the best security in Next.js using strictly separated client and server schemas.
 ---
 
-In this setup, you define your client, server, and shared schemas in separate files.
+In this setup, you define your client and server schemas in separate files. An optional `internal/shared.ts` holds variables shared by both.
 
 ```files
 src
 └── env
     ├── internal
-    │   └── shared.ts
+    │   └── shared.ts   # optional
     ├── client.ts
     └── server.ts
 ```
@@ -38,7 +38,7 @@ npx arkenv@latest init --strict
 
 ## Your schema
 
-When bootstrapping with the CLI, it generates three separate schema files under `src/env/`:
+When bootstrapping with the CLI, it generates separate schema files under `src/env/` (including an optional `internal/shared.ts` with `NODE_ENV` for convenience):
 
 :::note
 By default, ArkEnv for Next.js uses an automatic code generation wrapper (`withArkEnv`) in your Next.js config to compile your `runtimeEnv` block. This is why the client-side schema imports from `./generated/env.gen` rather than `@arkenv/nextjs/client`. To opt out, simply import from `@arkenv/nextjs/client` directly and provide your own `runtimeEnv` mapping.
@@ -127,9 +127,9 @@ export const env = arkenv(
     If you're using Standard Schema without ArkType, install `@arkenv/standard` instead of `@arkenv/core` — see [Zod, Valibot, and other Standard Schema validators](/docs/nextjs/using-other-validators).
     :::
 
-    ### Define shared variables [step] [!toc]
+    ### Define shared variables (optional) [step] [!toc]
 
-    Create `env/internal/shared.ts` to define schema variables that are shared across both the client and the server. We treat this as a runtime type, so it is defined using PascalCase:
+    Optionally create `env/internal/shared.ts` to define schema variables that are shared across both the client and the server. Shared is not required for strict layout—omit the file when you have nothing to share. When present, we treat it as a runtime type, so it is defined using PascalCase:
 
     ```ts title="src/env/internal/shared.ts" twoslash
     import { type } from "@arkenv/core";
@@ -145,7 +145,7 @@ export const env = arkenv(
 
     ### Define client variables [step] [!toc]
 
-    Create `env/client.ts` importing `@arkenv/core` from the auto-generated `./generated/env.gen.ts` helper file. All local keys **must** be prefixed with `NEXT_PUBLIC_` and you must extend `SharedSchema`:
+    Create `env/client.ts` importing `@arkenv/core` from the auto-generated `./generated/env.gen.ts` helper file. All local keys **must** be prefixed with `NEXT_PUBLIC_`. When you define `SharedSchema`, extend it here:
 
     ```ts title="src/env/client.ts" twoslash
     // @filename: /env/internal/shared.ts

--- a/apps/www/content/docs/nuxt/configuration.mdx
+++ b/apps/www/content/docs/nuxt/configuration.mdx
@@ -81,10 +81,10 @@ Thrown validation errors are separate from logged diagnostics — the logger onl
 
 In strict layout, the module automatically composes:
 
-1. `env/internal/shared.ts` → client entry (as `SharedSchema`)
+1. `env/internal/shared.ts` → client entry (as `SharedSchema`), when the file exists
 2. Client env → server entry
 
-The shared file must live at `internal/shared.ts` under your schema directory and export `SharedSchema`. That relative path is not configurable. To change composition — for example to extend additional schemas, or to skip the default merge — pass an explicit `extends` option in your client or server entry. See [Extending your schema](/docs/nuxt/layouts/strict#extending-your-schema).
+Shared is optional: omit `internal/shared.ts` when you have nothing to share (empty merge). When present, the file must live at `internal/shared.ts` under your schema directory and export `SharedSchema`. That relative path is not configurable. To change composition — for example to extend additional schemas, or to skip the default merge — pass an explicit `extends` option in your client or server entry. See [Extending your schema](/docs/nuxt/layouts/strict#extending-your-schema).
 
 `schemaPath` only relocates the schema directory as a whole (for example `src/env` instead of `env`). It does not rename `internal/shared.ts` inside that directory.
 

--- a/apps/www/content/docs/nuxt/layouts/strict.mdx
+++ b/apps/www/content/docs/nuxt/layouts/strict.mdx
@@ -4,12 +4,12 @@ icon: ShieldCheck
 description: Get the best security in Nuxt using strictly separated client and server schemas.
 ---
 
-In this setup, you define your client, server, and shared schemas in separate files.
+In this setup, you define your client and server schemas in separate files. An optional `internal/shared.ts` holds variables shared by both.
 
 ```files
 env
 ├── internal
-│   └── shared.ts
+│   └── shared.ts   # optional
 ├── client.ts
 └── server.ts
 ```
@@ -37,7 +37,7 @@ npx arkenv@latest init --strict
 
 ## Your schema
 
-When bootstrapping with the CLI, it generates three separate schema files under `env/`:
+When bootstrapping with the CLI, it generates separate schema files under `env/` (including an optional `internal/shared.ts` with `NODE_ENV` for convenience):
 
 ```ts twoslash title="env/internal/shared.ts"
 import { type } from "@arkenv/core";
@@ -85,10 +85,10 @@ export const env = arkenv({
 
 With `@arkenv/nuxt/module` registered:
 
-- The **client** entry includes `SharedSchema` from `env/internal/shared.ts`
-- The **server** entry includes the composed client env (and therefore shared variables)
+- The **client** entry includes `SharedSchema` from `env/internal/shared.ts` when that file exists (otherwise shared is empty)
+- The **server** entry includes the composed client env (and therefore any shared variables)
 
-`env/internal/shared.ts` is always part of the strict layout, even when you only define client and server variables. If nothing is shared, export an empty schema (`type({})`) — do not omit the file or the `SharedSchema` export.
+Shared is not required for strict layout—omit `env/internal/shared.ts` when you have nothing to share. When the file is present, it must export `SharedSchema`.
 
 The shared schema path is fixed relative to your schema directory: `internal/shared.ts`. There is no module option to relocate it (for example to `env/hidden/shared.ts`). To compose different schemas — or to opt out of the default merge — pass an explicit `extends` list:
 
@@ -157,9 +157,9 @@ See [Configuration & API](/docs/nuxt/configuration) for module options such as `
     If you're using Standard Schema without ArkType, install `@arkenv/standard` instead of `@arkenv/core` — see [Zod, Valibot, and other Standard Schema validators](/docs/nuxt/using-other-validators).
     :::
 
-    ### Define shared variables [step] [!toc]
+    ### Define shared variables (optional) [step] [!toc]
 
-    Create `env/internal/shared.ts` to define schema variables that are shared across both the client and the server. We treat this as a runtime type, so it is defined using PascalCase:
+    Optionally create `env/internal/shared.ts` to define schema variables that are shared across both the client and the server. Shared is not required for strict layout—omit the file when you have nothing to share. When present, we treat it as a runtime type, so it is defined using PascalCase:
 
     ```ts twoslash title="env/internal/shared.ts"
     import { type } from "@arkenv/core";

--- a/packages/build/src/core.test.ts
+++ b/packages/build/src/core.test.ts
@@ -1,7 +1,15 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { extractKeys, formatMissingSchemaError, resolveLayout } from "./core";
+import {
+	assertFlatSchemaFile,
+	extractKeys,
+	findSchemaPath,
+	formatMissingSchemaError,
+	isStrictLayoutDir,
+	resolveLayout,
+} from "./core";
 
 describe("@arkenv/build layout resolution", () => {
 	it("treats flat as simple layout", () => {
@@ -16,6 +24,119 @@ describe("@arkenv/build layout resolution", () => {
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
+	});
+
+	describe("strict layout detection", () => {
+		const makeTempDir = () =>
+			fs.mkdtempSync(path.join(os.tmpdir(), "arkenv-build-layout-"));
+
+		it("treats client.ts + server.ts as strict without internal/shared.ts", () => {
+			const tempDir = makeTempDir();
+			try {
+				fs.writeFileSync(
+					path.join(tempDir, "client.ts"),
+					"export const env = {}",
+				);
+				fs.writeFileSync(
+					path.join(tempDir, "server.ts"),
+					"export const env = {}",
+				);
+
+				expect(isStrictLayoutDir(tempDir)).toBe(true);
+				expect(resolveLayout(tempDir)).toEqual({
+					layout: "strict",
+					baseDir: tempDir,
+				});
+				expect(resolveLayout(path.join(tempDir, "client.ts"))).toEqual({
+					layout: "strict",
+					baseDir: tempDir,
+				});
+				expect(
+					resolveLayout(path.join(tempDir, "client.ts"), "strict"),
+				).toEqual({
+					layout: "strict",
+					baseDir: tempDir,
+				});
+			} finally {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+
+		it("findSchemaPath discovers env/ without requiring shared.ts", () => {
+			const tempDir = makeTempDir();
+			try {
+				const envDir = path.join(tempDir, "env");
+				fs.mkdirSync(envDir, { recursive: true });
+				fs.writeFileSync(
+					path.join(envDir, "client.ts"),
+					"export const env = {}",
+				);
+				fs.writeFileSync(
+					path.join(envDir, "server.ts"),
+					"export const env = {}",
+				);
+
+				expect(findSchemaPath(tempDir)).toBe(envDir);
+			} finally {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+
+		it("findSchemaPath discovers src/env/ without requiring shared.ts", () => {
+			const tempDir = makeTempDir();
+			try {
+				const envDir = path.join(tempDir, "src", "env");
+				fs.mkdirSync(envDir, { recursive: true });
+				fs.writeFileSync(
+					path.join(envDir, "client.ts"),
+					"export const env = {}",
+				);
+				fs.writeFileSync(
+					path.join(envDir, "server.ts"),
+					"export const env = {}",
+				);
+
+				expect(findSchemaPath(tempDir)).toBe(envDir);
+			} finally {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+
+		it("throws for explicit strict when client.ts is missing", () => {
+			const tempDir = makeTempDir();
+			try {
+				fs.writeFileSync(
+					path.join(tempDir, "server.ts"),
+					"export const env = {}",
+				);
+				expect(() =>
+					resolveLayout(path.join(tempDir, "missing.ts"), "strict"),
+				).toThrow(
+					`[ArkEnv] Strict layout requires "${path.join(tempDir, "client.ts")}" to exist`,
+				);
+			} finally {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+
+		it("assertFlatSchemaFile rejects strict layout directories", () => {
+			const tempDir = makeTempDir();
+			try {
+				fs.writeFileSync(
+					path.join(tempDir, "client.ts"),
+					"export const env = {}",
+				);
+				fs.writeFileSync(
+					path.join(tempDir, "server.ts"),
+					"export const env = {}",
+				);
+				expect(() =>
+					assertFlatSchemaFile(tempDir, "ArkEnv Vite plugin"),
+				).toThrow(/only supports a flat env module file/);
+			} finally {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
 	});
 
 	it("extracts keys from flat layout schema with NUXT_PUBLIC_ prefix", () => {

--- a/packages/build/src/core.test.ts
+++ b/packages/build/src/core.test.ts
@@ -131,7 +131,7 @@ describe("@arkenv/build layout resolution", () => {
 					"export const env = {}",
 				);
 				expect(() =>
-					assertFlatSchemaFile(tempDir, "ArkEnv Vite plugin"),
+					assertFlatSchemaFile(tempDir, "ArkEnv Vite plugin:"),
 				).toThrow(/only supports a flat env module file/);
 			} finally {
 				fs.rmSync(tempDir, { recursive: true, force: true });

--- a/packages/build/src/core.ts
+++ b/packages/build/src/core.ts
@@ -28,22 +28,34 @@ export type ResolvedLayout = {
 };
 
 /**
+ * Return whether a directory looks like a strict split layout.
+ *
+ * Strict auto-detection requires `client.ts` and `server.ts`.
+ * `internal/shared.ts` is optional and treated as empty when absent.
+ *
+ * @param dir Absolute path to a candidate env directory
+ * @returns `true` when both `client.ts` and `server.ts` exist
+ */
+export function isStrictLayoutDir(dir: string): boolean {
+	return (
+		fs.existsSync(path.join(dir, "client.ts")) &&
+		fs.existsSync(path.join(dir, "server.ts"))
+	);
+}
+
+/**
  * Resolve the layout mode and base directory for a given schema file path.
  *
  * @param schemaPath The absolute path to the schema file or directory
  * @param layoutOption An optional explicit layout configuration ("flat", "simple", or "strict")
  * @returns An object containing the resolved layout mode and the base directory path
- * @throws An error if explicit "strict" layout is requested but required split files are missing
+ * @throws An error if explicit "strict" layout is requested but `client.ts` is missing
  */
 export function resolveLayout(
 	schemaPath: string,
 	layoutOption?: LayoutInput,
 ): ResolvedLayout {
 	const layout = layoutOption === "flat" ? "simple" : layoutOption;
-	const checkStrict = (dir: string) =>
-		fs.existsSync(path.join(dir, "internal", "shared.ts")) &&
-		fs.existsSync(path.join(dir, "client.ts")) &&
-		fs.existsSync(path.join(dir, "server.ts"));
 
 	const resolveBaseDir = (p: string): string => {
 		const ext = path.extname(p);
@@ -60,7 +72,7 @@ export function resolveLayout(
 	if (!layout) {
 		const resolved = resolveBaseDir(schemaPath);
 		if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
-			if (checkStrict(resolved)) {
+			if (isStrictLayoutDir(resolved)) {
 				return { layout: "strict", baseDir: resolved };
 			}
 			return { layout: "simple", baseDir: resolved };
@@ -72,16 +84,16 @@ export function resolveLayout(
 		if (
 			fs.existsSync(baseWithoutExt) &&
 			fs.statSync(baseWithoutExt).isDirectory() &&
-			checkStrict(baseWithoutExt)
+			isStrictLayoutDir(baseWithoutExt)
 		) {
 			return { layout: "strict", baseDir: baseWithoutExt };
 		}
-		if (checkStrict(parent)) {
+		if (isStrictLayoutDir(parent)) {
 			return { layout: "strict", baseDir: parent };
 		}
 		if (
 			path.basename(parent) === "internal" &&
-			checkStrict(path.dirname(parent))
+			isStrictLayoutDir(path.dirname(parent))
 		) {
 			return { layout: "strict", baseDir: path.dirname(parent) };
 		}
@@ -103,12 +115,11 @@ export function resolveLayout(
 		}
 
 		const clientPath = path.join(baseDir, "client.ts");
-		const sharedPath = path.join(baseDir, "internal", "shared.ts");
-		if (!fs.existsSync(clientPath) || !fs.existsSync(sharedPath)) {
+		if (!fs.existsSync(clientPath)) {
 			throw new Error(
 				formatBuildError(
-					`Strict layout requires "${clientPath}" and "${sharedPath}" to exist. ` +
-						`Ensure both files are present or remove the 'layout: "strict"' option to let ArkEnv auto-detect.`,
+					`Strict layout requires "${clientPath}" to exist. ` +
+						`Ensure it is present or remove the 'layout: "strict"' option to let ArkEnv auto-detect.`,
 				),
 			);
 		}
@@ -142,16 +153,39 @@ export function findSchemaPath(cwd = process.cwd()): string | null {
 
 	const possibleDirs = [path.join(cwd, "src", "env"), path.join(cwd, "env")];
 	for (const d of possibleDirs) {
-		if (
-			fs.existsSync(d) &&
-			fs.existsSync(path.join(d, "internal", "shared.ts")) &&
-			fs.existsSync(path.join(d, "client.ts")) &&
-			fs.existsSync(path.join(d, "server.ts"))
-		) {
+		if (fs.existsSync(d) && isStrictLayoutDir(d)) {
 			return d;
 		}
 	}
 	return null;
+}
+
+/**
+ * Ensure a discovered schema path is a flat env module file.
+ *
+ * Vite/Bun plugins only support a single `env.ts` module. Strict layout
+ * directories discovered by {@link findSchemaPath} are rejected with a clear
+ * host-specific diagnostic.
+ *
+ * @param schemaPath Absolute path returned by discovery or plugin options
+ * @param hostLabel Short host name for the error prefix (e.g. `"ArkEnv Vite plugin"`)
+ * @returns The same `schemaPath` when it is an existing file
+ * @throws When `schemaPath` is a directory (typically a strict layout)
+ */
+export function assertFlatSchemaFile(
+	schemaPath: string,
+	hostLabel: string,
+): string {
+	if (fs.existsSync(schemaPath) && fs.statSync(schemaPath).isDirectory()) {
+		throw new Error(
+			formatBuildError(
+				`${hostLabel}: discovered a schema directory at "${schemaPath}". ` +
+					`This integration only supports a flat env module file (env.ts). ` +
+					`Point schemaPath at that file, or use @arkenv/nextjs / @arkenv/nuxt for strict layout.`,
+			),
+		);
+	}
+	return schemaPath;
 }
 
 /**

--- a/packages/build/src/core.ts
+++ b/packages/build/src/core.ts
@@ -168,21 +168,19 @@ export function findSchemaPath(cwd = process.cwd()): string | null {
  * host-specific diagnostic.
  *
  * @param schemaPath Absolute path returned by discovery or plugin options
- * @param hostLabel Short host name for the error prefix (e.g. `"ArkEnv Vite plugin"`)
+ * @param prefix Brand prefix for the error (e.g. `"ArkEnv Vite plugin:"`)
  * @returns The same `schemaPath` when it is an existing file
  * @throws When `schemaPath` is a directory (typically a strict layout)
  */
 export function assertFlatSchemaFile(
 	schemaPath: string,
-	hostLabel: string,
+	prefix: string,
 ): string {
 	if (fs.existsSync(schemaPath) && fs.statSync(schemaPath).isDirectory()) {
 		throw new Error(
-			formatBuildError(
-				`${hostLabel}: discovered a schema directory at "${schemaPath}". ` +
-					"This integration only supports a flat env module file (env.ts). " +
-					"Point schemaPath at that file, or use @arkenv/nextjs / @arkenv/nuxt for strict layout.",
-			),
+			`${prefix} discovered a schema directory at "${schemaPath}". ` +
+				"This integration only supports a flat env module file (env.ts). " +
+				"Point schemaPath at that file, or use @arkenv/nextjs / @arkenv/nuxt for strict layout.",
 		);
 	}
 	return schemaPath;

--- a/packages/build/src/core.ts
+++ b/packages/build/src/core.ts
@@ -180,8 +180,8 @@ export function assertFlatSchemaFile(
 		throw new Error(
 			formatBuildError(
 				`${hostLabel}: discovered a schema directory at "${schemaPath}". ` +
-					`This integration only supports a flat env module file (env.ts). ` +
-					`Point schemaPath at that file, or use @arkenv/nextjs / @arkenv/nuxt for strict layout.`,
+					"This integration only supports a flat env module file (env.ts). " +
+					"Point schemaPath at that file, or use @arkenv/nextjs / @arkenv/nuxt for strict layout.",
 			),
 		);
 	}

--- a/packages/bun-plugin/src/env-module-path.ts
+++ b/packages/bun-plugin/src/env-module-path.ts
@@ -60,7 +60,7 @@ export function resolveEnvModulePath(
 				`ArkEnv Bun plugin: schemaPath "${schemaPath}" does not exist (resolved to "${resolved}").`,
 			);
 		}
-		return assertFlatSchemaFile(resolved, "ArkEnv Bun plugin");
+		return assertFlatSchemaFile(resolved, "ArkEnv Bun plugin:");
 	}
 
 	const discovered = findSchemaPath(root);
@@ -73,7 +73,7 @@ export function resolveEnvModulePath(
 			}),
 		);
 	}
-	return assertFlatSchemaFile(discovered, "ArkEnv Bun plugin");
+	return assertFlatSchemaFile(discovered, "ArkEnv Bun plugin:");
 }
 
 /**

--- a/packages/bun-plugin/src/env-module-path.ts
+++ b/packages/bun-plugin/src/env-module-path.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
+	assertFlatSchemaFile,
 	findSchemaPath,
 	formatMissingSchemaError,
 	getDefaultSchemaFileCandidates,
@@ -59,7 +60,7 @@ export function resolveEnvModulePath(
 				`ArkEnv Bun plugin: schemaPath "${schemaPath}" does not exist (resolved to "${resolved}").`,
 			);
 		}
-		return resolved;
+		return assertFlatSchemaFile(resolved, "ArkEnv Bun plugin");
 	}
 
 	const discovered = findSchemaPath(root);
@@ -72,7 +73,7 @@ export function resolveEnvModulePath(
 			}),
 		);
 	}
-	return discovered;
+	return assertFlatSchemaFile(discovered, "ArkEnv Bun plugin");
 }
 
 /**

--- a/packages/bun-plugin/src/env-module.test.ts
+++ b/packages/bun-plugin/src/env-module.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -326,5 +326,19 @@ describe("missing-schema errors", () => {
 		expect(message).not.toMatch(/```/);
 		expect(message).not.toMatch(/import \{ type \} from "arktype"/);
 		expect(message).not.toMatch(/from "zod"/);
+	});
+
+	it("rejects a discovered strict layout directory", async () => {
+		const { resolveEnvModulePath } = await import("./env-module-path.js");
+		const root = mkdtempSync(join(tmpdir(), "arkenv-bun-strict-dir-"));
+		temps.push(root);
+		const envDir = join(root, "env");
+		mkdirSync(envDir, { recursive: true });
+		writeFileSync(join(envDir, "client.ts"), "export const env = {}");
+		writeFileSync(join(envDir, "server.ts"), "export const env = {}");
+
+		expect(() => resolveEnvModulePath(root)).toThrow(
+			/only supports a flat env module file/,
+		);
 	});
 });

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -46,7 +46,7 @@ export type ArkEnvConfigOptions = {
 	 * Specify the configuration layout.
 	 *
 	 * - `"flat"` (default): A single `env.ts` schema file.
-	 * - `"strict"`: A 3-file split schema layout (`env/internal/shared.ts`, `env/client.ts`, `env/server.ts`).
+	 * - `"strict"`: A split schema layout (`env/client.ts`, `env/server.ts`, and optionally `env/internal/shared.ts`).
 	 *
 	 * @default "flat"
 	 */

--- a/packages/nuxt/src/boot-gate.ts
+++ b/packages/nuxt/src/boot-gate.ts
@@ -278,24 +278,22 @@ export function loadSchemaViaCapture(
 						"internal",
 						"shared.ts",
 					);
-					if (!fs.existsSync(strictUserSharedPath)) {
-						throw new Error(
-							`[arkenv] Strict layout requires "internal/shared.ts" with a usable SharedSchema export under "${config.baseDir}".`,
-						);
+					// Absent shared.ts → empty merge (aliases already point at
+					// empty-shared-schema). A present file must export SharedSchema.
+					if (fs.existsSync(strictUserSharedPath)) {
+						const sharedMod = jiti(strictUserSharedPath) as {
+							SharedSchema?: SchemaShape;
+							default?: { SharedSchema?: SchemaShape };
+						};
+						const sharedSchema =
+							sharedMod.SharedSchema ?? sharedMod.default?.SharedSchema;
+						if (sharedSchema === undefined || sharedSchema === null) {
+							throw new Error(
+								`[arkenv] Strict layout requires a usable SharedSchema export from "${strictUserSharedPath}".`,
+							);
+						}
+						g.__ARKENV_SHARED_SCHEMA__ = sharedSchema;
 					}
-
-					const sharedMod = jiti(strictUserSharedPath) as {
-						SharedSchema?: SchemaShape;
-						default?: { SharedSchema?: SchemaShape };
-					};
-					const sharedSchema =
-						sharedMod.SharedSchema ?? sharedMod.default?.SharedSchema;
-					if (sharedSchema === undefined || sharedSchema === null) {
-						throw new Error(
-							`[arkenv] Strict layout requires a usable SharedSchema export from "${strictUserSharedPath}".`,
-						);
-					}
-					g.__ARKENV_SHARED_SCHEMA__ = sharedSchema;
 
 					const strictUserClientPath = path.join(config.baseDir, "client.ts");
 					if (fs.existsSync(strictUserClientPath)) {

--- a/packages/nuxt/src/config.ts
+++ b/packages/nuxt/src/config.ts
@@ -73,12 +73,12 @@ export type ArkEnvConfigOptions = {
 	 * Specify the configuration layout.
 	 *
 	 * When omitted, the layout is auto-detected from the schema structure: it is
-	 * `"strict"` when the split files (`env/internal/shared.ts`, `env/client.ts`,
-	 * `env/server.ts`) are present, and falls back to `"flat"` (a single
+	 * `"strict"` when `env/client.ts` and `env/server.ts` are present (with
+	 * optional `env/internal/shared.ts`), and falls back to `"flat"` (a single
 	 * `env.ts`) otherwise.
 	 *
 	 * - `"flat"`: A single `env.ts` schema file.
-	 * - `"strict"`: A multi-file split schema layout.
+	 * - `"strict"`: A split schema layout (`env/client.ts`, `env/server.ts`, and optionally `env/internal/shared.ts`).
 	 */
 	layout?:
 		| "flat"

--- a/packages/nuxt/src/empty-shared-schema.ts
+++ b/packages/nuxt/src/empty-shared-schema.ts
@@ -1,6 +1,7 @@
 /**
  * Empty shared schema used when `#arkenv/shared-schema` is imported outside
- * strict layout (so the client entry can keep a static import without Vite
- * failing to resolve the virtual specifier).
+ * strict layout, or in strict layout when `env/internal/shared.ts` is omitted
+ * (so the client entry can keep a static import without Vite failing to
+ * resolve the virtual specifier).
  */
 export const SharedSchema = {};

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -340,13 +340,14 @@ describe("Nuxt module integration", () => {
 		}
 	});
 
-	it("throws when strict layout is missing internal/shared.ts", async () => {
+	it("aliases #arkenv/shared-schema to empty stub when internal/shared.ts is omitted", async () => {
 		const tempDir = path.resolve(__dirname, "temp-strict-missing-shared");
 		const envDir = path.join(tempDir, "env");
 		fs.mkdirSync(envDir, { recursive: true });
 
 		try {
-			fs.writeFileSync(path.join(envDir, "client.ts"), "export const env = {}");
+			const clientPath = path.join(envDir, "client.ts");
+			fs.writeFileSync(clientPath, "export const env = {}");
 			fs.writeFileSync(path.join(envDir, "server.ts"), "export const env = {}");
 
 			const mockNuxt: any = {
@@ -355,20 +356,27 @@ describe("Nuxt module integration", () => {
 					rootDir: tempDir,
 					srcDir: tempDir,
 					runtimeConfig: { public: {} },
+					alias: {},
 				},
 				hook: vi.fn(),
 			};
 
-			expect(() =>
-				(module as any).setup(
-					{
-						schemaPath: "./env",
-						layout: "strict",
-						validate: false,
-					},
-					mockNuxt,
-				),
-			).toThrow(/internal\/shared\.ts/);
+			await (module as any).setup(
+				{
+					schemaPath: "./env",
+					layout: "strict",
+					validate: false,
+				},
+				mockNuxt,
+			);
+
+			expect(mockNuxt.options.alias["#arkenv/client-env"]).toBe(clientPath);
+			const sharedAlias = mockNuxt.options.alias["#arkenv/shared-schema"] as string;
+			expect(sharedAlias).toBeDefined();
+			expect(sharedAlias).toMatch(/empty-shared-schema/);
+			expect(
+				fs.existsSync(path.join(envDir, "internal", "shared.ts")),
+			).toBe(false);
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -371,12 +371,14 @@ describe("Nuxt module integration", () => {
 			);
 
 			expect(mockNuxt.options.alias["#arkenv/client-env"]).toBe(clientPath);
-			const sharedAlias = mockNuxt.options.alias["#arkenv/shared-schema"] as string;
+			const sharedAlias = mockNuxt.options.alias[
+				"#arkenv/shared-schema"
+			] as string;
 			expect(sharedAlias).toBeDefined();
 			expect(sharedAlias).toMatch(/empty-shared-schema/);
-			expect(
-				fs.existsSync(path.join(envDir, "internal", "shared.ts")),
-			).toBe(false);
+			expect(fs.existsSync(path.join(envDir, "internal", "shared.ts"))).toBe(
+				false,
+			);
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -182,7 +182,12 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 		let clientKeys: string[] = [];
 		let sharedKeys: string[] = [];
 
-		if (resolvedLayout === "strict" && baseDir && strictClientPath) {
+		if (
+			resolvedLayout === "strict" &&
+			baseDir &&
+			strictClientPath &&
+			strictSharedPath
+		) {
 			const serverPath = path.join(baseDir, "server.ts");
 
 			const clientContent = fs.readFileSync(strictClientPath, "utf-8");
@@ -197,11 +202,7 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 			sharedKeys = extractSharedKeys(sharedContent);
 			serverKeys = extractServerKeys(serverContent);
 
-			registerStrictLayoutHooks(
-				nuxt,
-				strictClientPath,
-				strictSharedPath ?? emptySharedSchema,
-			);
+			registerStrictLayoutHooks(nuxt, strictClientPath, strictSharedPath);
 		} else {
 			const fileContent = fs.readFileSync(schemaPath, "utf-8");
 			const extracted = extractKeys(fileContent);

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -23,7 +23,6 @@ import {
 	registerStrictLayoutHooks,
 	registerViteExtendHook,
 } from "./strict-layout-hooks";
-import { missingSharedTsError } from "./strict-shared-schema";
 
 /**
  * Configuration options for the ArkEnv Nuxt module.
@@ -131,19 +130,21 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 			nuxt.options.srcDir ?? nuxt.options.rootDir,
 		);
 
+		const emptySharedSchema = resolver.resolve("./empty-shared-schema");
+
 		let strictClientPath: string | undefined;
 		let strictSharedPath: string | undefined;
+		let userSharedPath: string | undefined;
 		if (resolvedLayout === "strict" && baseDir) {
 			const clientPath = path.join(baseDir, "client.ts");
 			if (!fs.existsSync(clientPath)) {
 				throw new Error(missingClientTsError(clientPath, baseDir));
 			}
 			const sharedPath = path.join(baseDir, "internal", "shared.ts");
-			if (!fs.existsSync(sharedPath)) {
-				throw new Error(missingSharedTsError(sharedPath, baseDir));
-			}
+			userSharedPath = fs.existsSync(sharedPath) ? sharedPath : undefined;
 			strictClientPath = clientPath;
-			strictSharedPath = sharedPath;
+			// Missing shared.ts is intentional empty; alias to the package stub.
+			strictSharedPath = userSharedPath ?? emptySharedSchema;
 		}
 
 		if (nuxt.options.dev) {
@@ -181,16 +182,13 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 		let clientKeys: string[] = [];
 		let sharedKeys: string[] = [];
 
-		if (
-			resolvedLayout === "strict" &&
-			baseDir &&
-			strictClientPath &&
-			strictSharedPath
-		) {
+		if (resolvedLayout === "strict" && baseDir && strictClientPath) {
 			const serverPath = path.join(baseDir, "server.ts");
 
 			const clientContent = fs.readFileSync(strictClientPath, "utf-8");
-			const sharedContent = fs.readFileSync(strictSharedPath, "utf-8");
+			const sharedContent = userSharedPath
+				? fs.readFileSync(userSharedPath, "utf-8")
+				: "";
 			const serverContent = fs.existsSync(serverPath)
 				? fs.readFileSync(serverPath, "utf-8")
 				: "";
@@ -199,7 +197,11 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 			sharedKeys = extractSharedKeys(sharedContent);
 			serverKeys = extractServerKeys(serverContent);
 
-			registerStrictLayoutHooks(nuxt, strictClientPath, strictSharedPath);
+			registerStrictLayoutHooks(
+				nuxt,
+				strictClientPath,
+				strictSharedPath ?? emptySharedSchema,
+			);
 		} else {
 			const fileContent = fs.readFileSync(schemaPath, "utf-8");
 			const extracted = extractKeys(fileContent);

--- a/packages/nuxt/src/strict-layout-hooks.ts
+++ b/packages/nuxt/src/strict-layout-hooks.ts
@@ -28,7 +28,8 @@ declare module "@nuxt/schema" {
  *
  * @param nuxt The Nuxt instance
  * @param strictClientPath Absolute path to the project's `env/client.ts`
- * @param strictSharedPath Absolute path to the project's `env/internal/shared.ts`
+ * @param strictSharedPath Absolute path to the project's `env/internal/shared.ts`,
+ *   or the package `empty-shared-schema` stub when that file is omitted
  */
 export function registerStrictLayoutHooks(
 	nuxt: Nuxt,
@@ -150,7 +151,7 @@ export function registerViteExtendHook(
 						id === CLIENT_ENV_SPECIFIER ||
 						id === `\0${CLIENT_ENV_SPECIFIER}`
 					) {
-						if (strictClientPath && fs.existsSync(strictClientPath)) {
+						if (fs.existsSync(strictClientPath)) {
 							return strictClientPath;
 						}
 						throw new Error(UNRESOLVED_CLIENT_ENV_ERROR);
@@ -165,7 +166,8 @@ export function registerViteExtendHook(
 						id === SHARED_SCHEMA_SPECIFIER ||
 						id === `\0${SHARED_SCHEMA_SPECIFIER}`
 					) {
-						if (strictSharedPath && fs.existsSync(strictSharedPath)) {
+						// `strictSharedPath` is either the user file or empty-shared-schema.
+						if (fs.existsSync(strictSharedPath)) {
 							return strictSharedPath;
 						}
 						throw new Error(UNRESOLVED_SHARED_SCHEMA_ERROR);

--- a/packages/nuxt/src/strict-shared-schema.ts
+++ b/packages/nuxt/src/strict-shared-schema.ts
@@ -1,11 +1,9 @@
-import { formatBuildError } from "@repo/log";
-
 export const SHARED_SCHEMA_SPECIFIER = "#arkenv/shared-schema";
 
 export const UNRESOLVED_SHARED_SCHEMA_ERROR =
 	"[arkenv] Could not resolve #arkenv/shared-schema.\n" +
-	"Ensure @arkenv/nuxt/module is registered in nuxt.config and env/internal/shared.ts\n" +
-	"exports SharedSchema, or pass extends: [SharedSchema] explicitly.";
+	"Ensure @arkenv/nuxt/module is registered in nuxt.config. When present,\n" +
+	"env/internal/shared.ts must export SharedSchema, or pass extends: [SharedSchema] explicitly.";
 
 type GlobalStrictState = {
 	__ARKENV_SHARED_SCHEMA__?: unknown;
@@ -16,7 +14,8 @@ type GlobalStrictState = {
  *
  * Prefers the Jiti validation injection on `globalThis`, then falls back to
  * the statically imported `#arkenv/shared-schema` module (aliased by the Nuxt
- * module). Never uses `node:module` / `createRequire`.
+ * module to the project file or `empty-shared-schema` when absent). Never uses
+ * `node:module` / `createRequire`.
  *
  * @param importedSharedSchema The `SharedSchema` export from `#arkenv/shared-schema`
  * @returns The shared schema to pass through `extends`
@@ -35,24 +34,4 @@ export function resolveStrictSharedSchema(
 	}
 
 	throw new Error(UNRESOLVED_SHARED_SCHEMA_ERROR);
-}
-
-/**
- * Build the fail-fast error for a missing strict-layout `internal/shared.ts`.
- *
- * @param sharedPath The absolute path where `internal/shared.ts` was expected
- * @param baseDir The strict layout base directory
- * @returns A formatted ArkEnv build error message
- */
-export function missingSharedTsError(
-	sharedPath: string,
-	baseDir: string,
-): string {
-	return formatBuildError(
-		`Strict layout requires "internal/shared.ts" but it was not found at "${sharedPath}".\n` +
-			`Expected strict layout structure under "${baseDir}":\n` +
-			"  ├── internal/shared.ts\n" +
-			"  ├── client.ts\n" +
-			"  └── server.ts",
-	);
 }

--- a/packages/nuxt/src/validation.test.ts
+++ b/packages/nuxt/src/validation.test.ts
@@ -287,6 +287,41 @@ describe("build-time environment validation", () => {
 			}).toThrow(/SharedSchema/);
 		});
 
+		it("should pass when internal/shared.ts is omitted", () => {
+			fs.writeFileSync(
+				clientPath,
+				`
+				import arkenv from "@arkenv/nuxt/client";
+				export const env = arkenv({
+					NUXT_PUBLIC_API_URL: "string",
+				});
+				`,
+				"utf-8",
+			);
+
+			fs.writeFileSync(
+				serverPath,
+				`
+				import arkenv from "${path.resolve(__dirname, "./server.ts")}";
+				export const env = arkenv({
+					DATABASE_URL: "string",
+				});
+				`,
+				"utf-8",
+			);
+
+			process.env.DATABASE_URL = "postgres://localhost/db";
+			process.env.NUXT_PUBLIC_API_URL = "https://api.example.com";
+
+			expect(() => {
+				setupArkEnv({
+					schemaPath: strictBaseDir,
+					layout: "strict",
+					validate: true,
+				});
+			}).not.toThrow();
+		}, 15_000);
+
 		it("should still honor explicit extends in strict layout validation", () => {
 			fs.writeFileSync(
 				sharedPath,

--- a/packages/vite-plugin/src/env-module-path.ts
+++ b/packages/vite-plugin/src/env-module-path.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
+	assertFlatSchemaFile,
 	findSchemaPath,
 	formatMissingSchemaError,
 	getDefaultSchemaFileCandidates,
@@ -62,7 +63,7 @@ export function resolveEnvModulePath(
 				`ArkEnv Vite plugin: schemaPath "${schemaPath}" does not exist (resolved to "${resolved}").`,
 			);
 		}
-		return resolved;
+		return assertFlatSchemaFile(resolved, "ArkEnv Vite plugin");
 	}
 
 	const discovered = findSchemaPath(root);
@@ -75,7 +76,7 @@ export function resolveEnvModulePath(
 			}),
 		);
 	}
-	return discovered;
+	return assertFlatSchemaFile(discovered, "ArkEnv Vite plugin");
 }
 
 /**

--- a/packages/vite-plugin/src/env-module-path.ts
+++ b/packages/vite-plugin/src/env-module-path.ts
@@ -63,7 +63,7 @@ export function resolveEnvModulePath(
 				`ArkEnv Vite plugin: schemaPath "${schemaPath}" does not exist (resolved to "${resolved}").`,
 			);
 		}
-		return assertFlatSchemaFile(resolved, "ArkEnv Vite plugin");
+		return assertFlatSchemaFile(resolved, "ArkEnv Vite plugin:");
 	}
 
 	const discovered = findSchemaPath(root);
@@ -76,7 +76,7 @@ export function resolveEnvModulePath(
 			}),
 		);
 	}
-	return assertFlatSchemaFile(discovered, "ArkEnv Vite plugin");
+	return assertFlatSchemaFile(discovered, "ArkEnv Vite plugin:");
 }
 
 /**

--- a/packages/vite-plugin/src/env-module.test.ts
+++ b/packages/vite-plugin/src/env-module.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as vite from "vite";

--- a/packages/vite-plugin/src/env-module.test.ts
+++ b/packages/vite-plugin/src/env-module.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as vite from "vite";
@@ -273,5 +273,19 @@ describe("missing-schema errors", () => {
 		expect(message).not.toMatch(/```/);
 		expect(message).not.toMatch(/import \{ type \} from "arktype"/);
 		expect(message).not.toMatch(/from "zod"/);
+	});
+
+	it("rejects a discovered strict layout directory", async () => {
+		const { resolveEnvModulePath } = await import("./env-module-path.js");
+		const root = mkdtempSync(join(tmpdir(), "arkenv-vite-strict-dir-"));
+		temps.push(root);
+		const envDir = join(root, "env");
+		mkdirSync(envDir, { recursive: true });
+		writeFileSync(join(envDir, "client.ts"), "export const env = {}");
+		writeFileSync(join(envDir, "server.ts"), "export const env = {}");
+
+		expect(() => resolveEnvModulePath(root)).toThrow(
+			/only supports a flat env module file/,
+		);
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1449  
Forward-port of #1503 / #1448

## Summary
- `@arkenv/build`: strict auto-detect / `findSchemaPath` treat `client.ts` + `server.ts` as enough; `internal/shared.ts` optional (empty when absent). Explicit `layout: "strict"` only requires `client.ts`. Shared `isStrictLayoutDir` + `assertFlatSchemaFile` keep host integrations DRY.
- `@arkenv/nuxt`: missing shared aliases `#arkenv/shared-schema` to `empty-shared-schema` (same stub as non-strict); present file without usable `SharedSchema` still fails.
- `@arkenv/nextjs`: codegen already treated missing shared as empty; JSDoc + docs updated.
- `@arkenv/vite-plugin` / `@arkenv/bun-plugin`: flat-only; reject a discovered strict `env/` directory via `assertFlatSchemaFile` instead of reading a directory as a module.
- Docs describe shared as optional; CLI still scaffolds `shared.ts` by default.

## Test plan
- [x] Affected package tests + typecheck (`@arkenv/build`, `nextjs`, `nuxt`, `vite-plugin`, `bun-plugin`)
- [ ] Strict `env/` with only `client.ts` + `server.ts` auto-detects as strict
- [ ] Nuxt strict succeeds without `internal/shared.ts` (empty auto-extend)
- [ ] Present shared without `SharedSchema` export still fails
- [ ] Vite/Bun discovery of a strict directory throws a clear flat-only error
- [ ] CLI `init --strict` still scaffolds `shared.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f99b4-bcdc-7919-bf75-9f63f0191dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f99b4-bcdc-7919-bf75-9f63f0191dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

