### PR TITLE
docs: Align optional-shared changeset prose with v1

### DIFF
--- a/.changeset/optional-strict-shared.md
+++ b/.changeset/optional-strict-shared.md
@@ -6,10 +6,10 @@
 
 #### Make `env/internal/shared.ts` optional in strict layout
 
-Strict layout auto-detection and schema discovery now treat `client.ts` + `server.ts` as enough. Explicit `layout: "strict"` no longer requires `internal/shared.ts`; when the file is absent, shared keys are treated as empty.
+Strict layout now works with just `client.ts` and `server.ts`. Omit `internal/shared.ts` when you have nothing to share — shared keys are treated as empty.
 
 ```ts
-// env/client.ts + env/server.ts alone is valid strict layout
+// env/client.ts + env/server.ts alone is enough
 export default withArkEnv(nextConfig, {
   layout: "strict",
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Align the still-unconsumed `#1503` changeset on `dev` with the consumer-facing prose from the v1 forward-port (#1505). Same packages, bump, title, example, and CLI note — clearer body wording only.

## Test plan
- [ ] Diff is limited to `.changeset/optional-strict-shared.md` prose
- [ ] Wording matches `.changeset/optional-strict-shared-v1.md` on the v1 PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f99b4-bcdc-7919-bf75-9f63f0191dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f99b4-bcdc-7919-bf75-9f63f0191dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

