### PR TITLE
docs(www): hide install Command/Prompt panel on mobile

### DIFF
--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -303,11 +303,17 @@
 	max-width: 42rem;
 }
 
-/* Install · Command / Prompt tabs */
+/* Install · Command / Prompt tabs — desktop/tablet only */
 .home-aurora__install {
-	display: grid;
+	display: none;
 	gap: var(--space-xs);
 	width: 100%;
+}
+
+@media (min-width: 40rem) {
+	.home-aurora__install {
+		display: grid;
+	}
 }
 
 .home-aurora__install-tabs {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Hide the homepage Command / Prompt install tab panel on mobile (`display: none` below `40rem`)
- Matches the existing Aurora mobile breakpoint used by the floating nav links

## Test plan
- [ ] Open `/` below 640px and confirm the Command/Prompt panel is gone
- [ ] Confirm Star GitHub still shows in the install row on mobile
- [ ] Confirm the tabbed panel returns at ≥40rem

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb723-c22c-72d9-8591-119ae789fd18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb723-c22c-72d9-8591-119ae789fd18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

