### PR TITLE
docs(www): add mobile Read the docs CTA

### DIFF
--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -303,6 +303,50 @@
 	max-width: 42rem;
 }
 
+/* Mobile secondary CTA — below Star us; hidden with install panel on ≥40rem */
+.home-aurora__docs-cta {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.4rem;
+	width: 100%;
+	min-height: 3rem;
+	padding: 0.75rem 1.1rem;
+	border: var(--rule-hair) solid var(--color-rule);
+	border-radius: var(--radius-pill);
+	background: color-mix(in oklch, var(--color-paper-2) 90%, transparent);
+	color: var(--color-ink-2);
+	font-family: var(--font-display);
+	font-size: var(--text-sm);
+	font-weight: 500;
+	text-decoration: none;
+	transition:
+		color var(--dur-micro) var(--ease-out),
+		border-color var(--dur-micro) var(--ease-out),
+		background-color var(--dur-micro) var(--ease-out);
+}
+
+.home-aurora__docs-cta:hover {
+	color: var(--color-ink);
+	border-color: color-mix(in oklch, var(--color-accent) 40%, var(--color-rule));
+	background: var(--color-paper-3);
+}
+
+.home-aurora__docs-cta:focus-visible {
+	outline: 2px solid var(--color-focus);
+	outline-offset: 2px;
+}
+
+.home-aurora__docs-cta:active {
+	opacity: 0.9;
+}
+
+@media (min-width: 40rem) {
+	.home-aurora__docs-cta {
+		display: none;
+	}
+}
+
 /* Install · Command / Prompt tabs — desktop/tablet only */
 .home-aurora__install {
 	display: none;
@@ -659,6 +703,7 @@
 @media (prefers-reduced-motion: reduce) {
 	.home-aurora__frame-hint,
 	.home-aurora__cta,
+	.home-aurora__docs-cta,
 	.home-aurora__nav-cta,
 	.home-aurora__nav-links a,
 	.home-aurora__install-tab,

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -4,6 +4,7 @@ import { AnnouncementBadge } from "~/components/announcement-badge";
 import {
 	CompatibilityRails,
 	InstallPanel,
+	QuickstartButton,
 	StarUsButton,
 	VideoDemo,
 } from "~/components/page";
@@ -37,6 +38,7 @@ export default function HomePage() {
 				<div className="home-aurora__install-row">
 					<InstallPanel />
 					<StarUsButton />
+					<QuickstartButton />
 				</div>
 			</section>
 

--- a/apps/www/components/page/quickstart-button.test.tsx
+++ b/apps/www/components/page/quickstart-button.test.tsx
@@ -3,14 +3,14 @@ import { describe, expect, it } from "vitest";
 import { QuickstartButton } from "./quickstart-button";
 
 describe("QuickstartButton", () => {
-	it("renders quickstart button with correct text", () => {
+	it("renders read the docs button with correct text", () => {
 		render(<QuickstartButton />);
-		expect(screen.getByText("Get Started")).toBeInTheDocument();
+		expect(screen.getByText("Read the docs")).toBeInTheDocument();
 	});
 
-	it("renders as a link to docs/quickstart", () => {
+	it("renders as a link to docs", () => {
 		render(<QuickstartButton />);
 		const link = screen.getByRole("link");
-		expect(link).toHaveAttribute("href", "/docs/arkenv/quickstart");
+		expect(link).toHaveAttribute("href", "/docs/arkenv");
 	});
 });

--- a/apps/www/components/page/quickstart-button.tsx
+++ b/apps/www/components/page/quickstart-button.tsx
@@ -2,8 +2,8 @@
 
 export function QuickstartButton() {
 	return (
-		<a href="/docs/arkenv/quickstart" className="home-aurora__cta">
-			Get Started
+		<a href="/docs/arkenv" className="home-aurora__docs-cta">
+			Read the docs
 			<span aria-hidden="true">→</span>
 		</a>
 	);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a mobile-only **Read the docs** button under Star us on GitHub (links to `/docs/arkenv`)
- Hidden at ≥40rem where nav Documentation / Get Started already cover this path

## Test plan
- [ ] Open `/` below 640px: Star us, then Read the docs below it
- [ ] Tap Read the docs → `/docs/arkenv`
- [ ] At ≥40rem, Read the docs is hidden; install Command/Prompt panel remains

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb723-c22c-72d9-8591-119ae789fd18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb723-c22c-72d9-8591-119ae789fd18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

