### PR TITLE
docs(www): add landing pitch sections from conversion blueprint

### DIFF
--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -576,6 +576,352 @@
 	max-width: 42ch;
 }
 
+/* Pitch sections — code-first proof */
+.home-aurora__pitch {
+	margin-top: var(--space-3xl);
+	display: grid;
+	gap: var(--space-md);
+	scroll-margin-top: 6rem;
+}
+
+.home-aurora__pitch-head {
+	display: grid;
+	gap: var(--space-2xs);
+	max-width: 40rem;
+}
+
+.home-aurora__pitch-label {
+	margin: 0;
+	font-family: var(--font-outlier);
+	font-size: var(--text-xs);
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--color-muted);
+}
+
+.home-aurora__pitch-head h2 {
+	margin: 0;
+	font-size: var(--text-display-s);
+	line-height: 1.1;
+	color: var(--color-ink);
+}
+
+.home-aurora__pitch-head p {
+	margin: 0;
+	color: var(--color-ink-2);
+	font-size: var(--text-md);
+	line-height: 1.5;
+	max-width: 46ch;
+}
+
+.home-aurora__pitch-head code {
+	font-family: var(--font-outlier);
+	font-size: 0.92em;
+	color: var(--color-ink);
+}
+
+/* Before / after compare */
+.home-aurora__compare {
+	--compare: 50%;
+	position: relative;
+	isolation: isolate;
+	width: 100%;
+	max-width: 56rem;
+	min-height: 22rem;
+	border: var(--rule-hair) solid var(--color-rule);
+	border-radius: var(--radius-frame);
+	background: var(--color-paper-2);
+	overflow: hidden;
+	user-select: none;
+}
+
+.home-aurora__compare-pane {
+	position: absolute;
+	inset: 0;
+	padding: var(--space-md);
+	display: grid;
+	align-content: start;
+	gap: var(--space-xs);
+}
+
+.home-aurora__compare-pane--before {
+	z-index: 2;
+	clip-path: inset(0 calc(100% - var(--compare)) 0 0);
+	background: color-mix(in oklch, var(--color-paper) 92%, transparent);
+}
+
+.home-aurora__compare-pane--after {
+	z-index: 1;
+}
+
+.home-aurora__compare-eyebrow {
+	margin: 0;
+	font-family: var(--font-outlier);
+	font-size: var(--text-xs);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-muted);
+}
+
+.home-aurora__compare-pane--after .home-aurora__compare-eyebrow {
+	color: var(--color-accent);
+}
+
+.home-aurora__code {
+	margin: 0;
+	overflow: auto;
+	font-family: var(--font-outlier);
+	font-size: clamp(0.78rem, 0.2vw + 0.72rem, 0.9rem);
+	line-height: 1.55;
+	color: var(--color-ink-2);
+	white-space: pre;
+}
+
+.home-aurora__compare-handle {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: var(--compare);
+	z-index: 3;
+	width: 1px;
+	background: color-mix(in oklch, var(--color-accent) 70%, var(--color-rule));
+	pointer-events: none;
+	transform: translateX(-50%);
+}
+
+.home-aurora__compare-handle::before {
+	content: "";
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	width: 1.75rem;
+	height: 1.75rem;
+	border-radius: 999px;
+	border: var(--rule-hair) solid var(--color-rule);
+	background: var(--color-paper-3);
+	transform: translate(-50%, -50%);
+	box-shadow: var(--shadow-nav);
+}
+
+.home-aurora__compare-range {
+	position: absolute;
+	inset: 0;
+	z-index: 4;
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	opacity: 0;
+	cursor: ew-resize;
+	appearance: none;
+	background: transparent;
+}
+
+.home-aurora__compare-range:focus-visible {
+	opacity: 1;
+	outline: 2px solid var(--color-focus);
+	outline-offset: -2px;
+}
+
+/* IDE autocomplete mock */
+.home-aurora__ide {
+	position: relative;
+	width: 100%;
+	max-width: 40rem;
+	border: var(--rule-hair) solid var(--color-rule);
+	border-radius: var(--radius-frame);
+	background: var(--color-paper-2);
+	overflow: hidden;
+}
+
+.home-aurora__ide-chrome {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.65rem 0.85rem;
+	border-bottom: var(--rule-hair) solid var(--color-rule);
+}
+
+.home-aurora__ide-dot {
+	width: 0.55rem;
+	height: 0.55rem;
+	border-radius: 999px;
+	background: var(--color-rule);
+}
+
+.home-aurora__ide-tab {
+	margin-left: 0.5rem;
+	font-family: var(--font-outlier);
+	font-size: var(--text-xs);
+	color: var(--color-muted);
+}
+
+.home-aurora__ide-body {
+	margin: 0;
+	padding: var(--space-md);
+	font-family: var(--font-outlier);
+	font-size: clamp(0.85rem, 0.2vw + 0.8rem, 0.98rem);
+	line-height: 1.6;
+	color: var(--color-ink-2);
+	min-height: 8.5rem;
+}
+
+.home-aurora__tok-kw {
+	color: color-mix(in oklch, var(--color-accent) 75%, var(--color-ink));
+}
+
+.home-aurora__tok-id {
+	color: var(--color-ink);
+}
+
+.home-aurora__tok-punct {
+	color: var(--color-muted);
+}
+
+.home-aurora__tok-muted {
+	color: var(--color-muted);
+}
+
+.home-aurora__tok-ok {
+	color: var(--color-success);
+}
+
+.home-aurora__tok-caret {
+	display: inline-block;
+	width: 0.55rem;
+	height: 1.1em;
+	margin-left: 1px;
+	vertical-align: text-bottom;
+	background: color-mix(in oklch, var(--color-accent) 80%, transparent);
+	animation: home-aurora-caret 1s steps(1) infinite;
+}
+
+@keyframes home-aurora-caret {
+	50% {
+		opacity: 0;
+	}
+}
+
+.home-aurora__ide-menu {
+	position: absolute;
+	left: var(--space-md);
+	bottom: var(--space-md);
+	margin: 0;
+	padding: 0.35rem;
+	list-style: none;
+	min-width: min(100% - 2 * var(--space-md), 22rem);
+	border: var(--rule-hair) solid var(--color-rule);
+	border-radius: 0.5rem;
+	background: color-mix(in oklch, var(--color-paper) 94%, transparent);
+	backdrop-filter: blur(10px);
+	box-shadow: var(--shadow-nav);
+	animation: home-aurora-menu-in var(--dur-short) var(--ease-out) both;
+}
+
+.home-aurora__ide-menu li {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: var(--space-sm);
+	padding: 0.4rem 0.55rem;
+	border-radius: 0.3rem;
+	font-family: var(--font-outlier);
+	font-size: var(--text-sm);
+	color: var(--color-ink);
+}
+
+.home-aurora__ide-menu li[data-active="true"] {
+	background: color-mix(in oklch, var(--color-accent) 18%, transparent);
+}
+
+.home-aurora__ide-type {
+	color: var(--color-muted);
+	font-size: var(--text-xs);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+@keyframes home-aurora-menu-in {
+	from {
+		opacity: 0;
+		transform: translateY(0.35rem);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+/* Agent split */
+.home-aurora__agent-split {
+	display: grid;
+	gap: var(--space-sm);
+	width: 100%;
+	max-width: 56rem;
+}
+
+@media (min-width: 48rem) {
+	.home-aurora__agent-split {
+		grid-template-columns: 1fr 1fr;
+	}
+}
+
+.home-aurora__terminal,
+.home-aurora__chat {
+	margin: 0;
+	padding: var(--space-md);
+	border: var(--rule-hair) solid var(--color-rule);
+	border-radius: var(--radius-frame);
+	background: var(--color-paper-2);
+	display: grid;
+	gap: var(--space-sm);
+	min-height: 12rem;
+}
+
+.home-aurora__terminal figcaption,
+.home-aurora__chat figcaption {
+	font-family: var(--font-outlier);
+	font-size: var(--text-xs);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-muted);
+}
+
+.home-aurora__terminal pre {
+	margin: 0;
+	font-family: var(--font-outlier);
+	font-size: clamp(0.8rem, 0.2vw + 0.75rem, 0.92rem);
+	line-height: 1.55;
+	color: var(--color-ink-2);
+	white-space: pre-wrap;
+}
+
+.home-aurora__chat-bubble {
+	padding: 0.7rem 0.85rem;
+	border-radius: 0.65rem;
+	font-size: var(--text-sm);
+	line-height: 1.45;
+	max-width: 95%;
+}
+
+.home-aurora__chat-bubble code {
+	font-family: var(--font-outlier);
+	font-size: 0.92em;
+}
+
+.home-aurora__chat-bubble--user {
+	justify-self: end;
+	background: color-mix(in oklch, var(--color-accent) 22%, var(--color-paper-3));
+	color: var(--color-ink);
+}
+
+.home-aurora__chat-bubble--agent {
+	justify-self: start;
+	background: color-mix(in oklch, var(--color-paper) 80%, transparent);
+	border: var(--rule-hair) solid var(--color-rule);
+	color: var(--color-ink-2);
+}
+
 .home-aurora__frame {
 	position: relative;
 	width: 100%;
@@ -652,7 +998,7 @@
 	line-height: 1.45;
 }
 
-/* Ft5 · Statement */
+/* Ft3 · Index-style footer */
 .home-aurora__footer {
 	margin-top: var(--space-3xl);
 	padding: var(--space-2xl) 0 var(--space-xl);
@@ -660,33 +1006,79 @@
 	gap: var(--space-lg);
 }
 
-.home-aurora__footer-line {
+.home-aurora__footer-grid {
+	display: grid;
+	gap: var(--space-lg);
+}
+
+@media (min-width: 40rem) {
+	.home-aurora__footer-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media (min-width: 64rem) {
+	.home-aurora__footer-grid {
+		grid-template-columns: 1.4fr repeat(3, minmax(0, 1fr));
+		gap: var(--space-xl);
+	}
+}
+
+.home-aurora__footer-brand {
+	display: grid;
+	gap: var(--space-xs);
+	align-content: start;
+}
+
+.home-aurora__footer-brand p {
 	margin: 0;
 	max-width: 28ch;
+	color: var(--color-ink-2);
+	font-size: var(--text-sm);
+	line-height: 1.45;
+}
+
+.home-aurora__footer-license {
+	color: var(--color-muted) !important;
+	font-family: var(--font-outlier);
+	font-size: var(--text-xs) !important;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+}
+
+.home-aurora__footer-grid h3 {
+	margin: 0 0 var(--space-xs);
+	font-family: var(--font-outlier);
+	font-size: var(--text-xs);
+	font-weight: 500;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--color-muted);
+}
+
+.home-aurora__footer-grid ul {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: grid;
+	gap: 0.45rem;
+}
+
+.home-aurora__footer-grid a {
+	color: var(--color-ink-2);
 	font-family: var(--font-display);
-	font-size: clamp(1.75rem, 5vw, 3rem);
-	font-weight: 600;
-	font-style: normal;
-	line-height: 1.05;
-	letter-spacing: -0.02em;
+	font-size: var(--text-sm);
+	text-decoration: none;
+	transition: color var(--dur-micro) var(--ease-out);
+}
+
+.home-aurora__footer-grid a:hover {
 	color: var(--color-ink);
 }
 
-.home-aurora__footer-line a {
-	color: inherit;
-	text-decoration: underline;
-	text-decoration-color: color-mix(in oklch, var(--color-accent) 70%, transparent);
-	text-underline-offset: 0.18em;
-	transition: text-decoration-color var(--dur-short) var(--ease-out);
-}
-
-.home-aurora__footer-line a:hover {
-	text-decoration-color: var(--color-accent);
-}
-
-.home-aurora__footer-line a:focus-visible {
+.home-aurora__footer-grid a:focus-visible {
 	outline: 2px solid var(--color-focus);
-	outline-offset: 3px;
+	outline-offset: 2px;
 }
 
 .home-aurora__footer-meta {
@@ -709,8 +1101,14 @@
 	.home-aurora__nav-cta,
 	.home-aurora__nav-links a,
 	.home-aurora__install-tab,
-	.home-aurora__install-copy {
+	.home-aurora__install-copy,
+	.home-aurora__ide-menu {
 		transition: opacity 120ms linear;
+	}
+
+	.home-aurora__tok-caret,
+	.home-aurora__ide-menu {
+		animation: none;
 	}
 
 	.home-aurora__frame-button:hover .home-aurora__frame-hint {

--- a/apps/www/app/(home)/home-nav.tsx
+++ b/apps/www/app/(home)/home-nav.tsx
@@ -13,16 +13,13 @@ export function HomeNav() {
 			</a>
 			<ul className="home-aurora__nav-links">
 				<li>
-					<a href="/docs/arkenv">Documentation</a>
+					<a href="/docs/arkenv">Docs</a>
 				</li>
 				<li>
-					<a
-						href="https://github.com/yamcodes/arkenv/issues/683"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Roadmap
-					</a>
+					<a href="/docs/cli/hosting-presets">Presets</a>
+				</li>
+				<li>
+					<a href="/#why">Why ArkEnv?</a>
 				</li>
 			</ul>
 			<div className="home-aurora__nav-actions">

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -60,7 +60,11 @@ export default function HomePage() {
 			<footer className="home-aurora__footer">
 				<div className="home-aurora__footer-grid">
 					<div className="home-aurora__footer-brand">
-						<a href="/" className="home-aurora__wordmark" aria-label="ArkEnv home">
+						<a
+							href="/"
+							className="home-aurora__wordmark"
+							aria-label="ArkEnv home"
+						>
 							<Logo />
 						</a>
 						<p>The simple way to validate environment variables.</p>

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -1,13 +1,16 @@
-import { ExternalLink } from "@arkenv/fumadocs-ui/components";
 import type { Metadata } from "next";
 import { AnnouncementBadge } from "~/components/announcement-badge";
 import {
+	AgentNativePitch,
+	BeforeAfterCompare,
 	CompatibilityRails,
 	InstallPanel,
 	QuickstartButton,
 	StarUsButton,
+	TypeSafetyShowcase,
 	VideoDemo,
 } from "~/components/page";
+import { Logo } from "~/components/page/logo";
 
 export const metadata: Metadata = {
 	title: "ArkEnv",
@@ -42,6 +45,10 @@ export default function HomePage() {
 				</div>
 			</section>
 
+			<BeforeAfterCompare />
+			<TypeSafetyShowcase />
+			<AgentNativePitch />
+
 			<section className="home-aurora__bench" aria-labelledby="home-bench">
 				<header className="home-aurora__bench-head">
 					<h2 id="home-bench">Try it live</h2>
@@ -51,17 +58,111 @@ export default function HomePage() {
 			</section>
 
 			<footer className="home-aurora__footer">
-				<p className="home-aurora__footer-line">
-					Proud part of the{" "}
-					<ExternalLink
-						href="https://arktype.io/docs/ecosystem#arkenv"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						ArkType ecosystem
-					</ExternalLink>
-					.
-				</p>
+				<div className="home-aurora__footer-grid">
+					<div className="home-aurora__footer-brand">
+						<a href="/" className="home-aurora__wordmark" aria-label="ArkEnv home">
+							<Logo />
+						</a>
+						<p>The simple way to validate environment variables.</p>
+						<p className="home-aurora__footer-license">
+							MIT License · Open Source
+						</p>
+					</div>
+
+					<nav aria-labelledby="footer-resources">
+						<h3 id="footer-resources">Resources</h3>
+						<ul>
+							<li>
+								<a href="/docs/arkenv">Documentation</a>
+							</li>
+							<li>
+								<a href="/docs/arkenv/quickstart">Quick Start</a>
+							</li>
+							<li>
+								<a href="/docs/nextjs">Next.js</a>
+							</li>
+							<li>
+								<a href="/docs/cli/hosting-presets">Hosting presets</a>
+							</li>
+						</ul>
+					</nav>
+
+					<nav aria-labelledby="footer-ecosystem">
+						<h3 id="footer-ecosystem">Ecosystem</h3>
+						<ul>
+							<li>
+								<a
+									href="https://github.com/yamcodes/arkenv"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									GitHub
+								</a>
+							</li>
+							<li>
+								<a
+									href="https://www.npmjs.com/package/arkenv"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									npm
+								</a>
+							</li>
+							<li>
+								<a
+									href="https://github.com/yamcodes/arkenv/releases"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Releases
+								</a>
+							</li>
+							<li>
+								<a
+									href="https://arktype.io/docs/ecosystem#arkenv"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									ArkType ecosystem
+								</a>
+							</li>
+						</ul>
+					</nav>
+
+					<nav aria-labelledby="footer-community">
+						<h3 id="footer-community">Community</h3>
+						<ul>
+							<li>
+								<a
+									href="https://github.com/sponsors/yamcodes"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Sponsor
+								</a>
+							</li>
+							<li>
+								<a
+									href="https://yam.codes"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Created by Yam
+								</a>
+							</li>
+							<li>
+								<a
+									href="https://discord.gg/zAmUyuxXH9"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Discord
+								</a>
+							</li>
+						</ul>
+					</nav>
+				</div>
+
 				<div className="home-aurora__footer-meta">
 					<span className="home-aurora__wordmark">ArkEnv</span>
 					<span>

--- a/apps/www/components/page/agent-native-pitch.tsx
+++ b/apps/www/components/page/agent-native-pitch.tsx
@@ -1,0 +1,54 @@
+/**
+ * Agent-native split: CLI for humans, prompt/chat for LLMs.
+ */
+export function AgentNativePitch() {
+	return (
+		<section
+			className="home-aurora__pitch"
+			aria-labelledby="home-agent"
+			id="agents"
+		>
+			<header className="home-aurora__pitch-head">
+				<p className="home-aurora__pitch-label">03 — Agents</p>
+				<h2 id="home-agent">Built for fingers and tokens</h2>
+				<p>
+					Manage schemas from an interactive CLI, or let your AI agent read and
+					write them flawlessly.
+				</p>
+			</header>
+
+			<div className="home-aurora__agent-split">
+				<figure className="home-aurora__terminal">
+					<figcaption>CLI</figcaption>
+					<pre>
+						<code>
+							<span className="home-aurora__tok-muted">$</span> npx arkenv@latest
+							init{"\n"}
+							<span className="home-aurora__tok-ok">✔</span> Detected Next.js
+							{"\n"}
+							<span className="home-aurora__tok-ok">✔</span> Wrote{" "}
+							<span className="home-aurora__tok-id">env.ts</span>
+							{"\n"}
+							<span className="home-aurora__tok-ok">✔</span> Wired{" "}
+							<span className="home-aurora__tok-id">@arkenv/nextjs</span>
+							{"\n"}
+							<span className="home-aurora__tok-muted">Ready.</span>
+						</code>
+					</pre>
+				</figure>
+
+				<figure className="home-aurora__chat">
+					<figcaption>Agent</figcaption>
+					<div className="home-aurora__chat-bubble home-aurora__chat-bubble--user">
+						Set up ArkEnv from my .env — use --agent
+					</div>
+					<div className="home-aurora__chat-bubble home-aurora__chat-bubble--agent">
+						Running{" "}
+						<code>npx arkenv@latest init --agent</code>. Schema matches your
+						.env keys; validation works from editor to runtime.
+					</div>
+				</figure>
+			</div>
+		</section>
+	);
+}

--- a/apps/www/components/page/agent-native-pitch.tsx
+++ b/apps/www/components/page/agent-native-pitch.tsx
@@ -22,8 +22,8 @@ export function AgentNativePitch() {
 					<figcaption>CLI</figcaption>
 					<pre>
 						<code>
-							<span className="home-aurora__tok-muted">$</span> npx arkenv@latest
-							init{"\n"}
+							<span className="home-aurora__tok-muted">$</span> npx
+							arkenv@latest init{"\n"}
 							<span className="home-aurora__tok-ok">✔</span> Detected Next.js
 							{"\n"}
 							<span className="home-aurora__tok-ok">✔</span> Wrote{" "}
@@ -43,9 +43,8 @@ export function AgentNativePitch() {
 						Set up ArkEnv from my .env — use --agent
 					</div>
 					<div className="home-aurora__chat-bubble home-aurora__chat-bubble--agent">
-						Running{" "}
-						<code>npx arkenv@latest init --agent</code>. Schema matches your
-						.env keys; validation works from editor to runtime.
+						Running <code>npx arkenv@latest init --agent</code>. Schema matches
+						your .env keys; validation works from editor to runtime.
 					</div>
 				</figure>
 			</div>

--- a/apps/www/components/page/before-after-compare.tsx
+++ b/apps/www/components/page/before-after-compare.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+/**
+ * Before / after code compare with a draggable vertical reveal.
+ * Pure CSS clip + range input — no card chrome.
+ */
+export function BeforeAfterCompare() {
+	return (
+		<section
+			className="home-aurora__pitch"
+			aria-labelledby="home-before-after"
+			id="why"
+		>
+			<header className="home-aurora__pitch-head">
+				<p className="home-aurora__pitch-label">01 — Friction</p>
+				<h2 id="home-before-after">Delete the boilerplate</h2>
+				<p>
+					Manual <code>process.env</code> checks, throws, and{" "}
+					<code>parseInt</code> coercion — or one schema.
+				</p>
+			</header>
+
+			<div className="home-aurora__compare">
+				<input
+					type="range"
+					min={8}
+					max={92}
+					defaultValue={50}
+					aria-label="Reveal ArkEnv vs the old way"
+					className="home-aurora__compare-range"
+					onInput={(event) => {
+						const value = `${(event.target as HTMLInputElement).value}%`;
+						event.currentTarget.parentElement?.style.setProperty(
+							"--compare",
+							value,
+						);
+					}}
+				/>
+				<div className="home-aurora__compare-pane home-aurora__compare-pane--after">
+					<p className="home-aurora__compare-eyebrow">The ArkEnv way</p>
+					<pre className="home-aurora__code">
+						<code>{`import arkenv from "arkenv";
+
+export const env = arkenv({
+  DATABASE_URL: "string.url",
+  PORT: "0 <= number.integer <= 65535 = 3000",
+  NODE_ENV: "'development' | 'production'",
+});
+
+// env.PORT is number — validated at boot`}</code>
+					</pre>
+				</div>
+				<div
+					className="home-aurora__compare-pane home-aurora__compare-pane--before"
+					aria-hidden="true"
+				>
+					<p className="home-aurora__compare-eyebrow">The old way</p>
+					<pre className="home-aurora__code">
+						<code>{`const url = process.env.DATABASE_URL;
+if (!url) throw new Error("DATABASE_URL missing");
+
+const portRaw = process.env.PORT ?? "3000";
+const PORT = Number.parseInt(portRaw, 10);
+if (Number.isNaN(PORT)) throw new Error("PORT invalid");
+
+const NODE_ENV = process.env.NODE_ENV ?? "development";
+if (!["development", "production"].includes(NODE_ENV)) {
+  throw new Error("NODE_ENV invalid");
+}
+
+export const env = { DATABASE_URL: url, PORT, NODE_ENV };`}</code>
+					</pre>
+				</div>
+				<div className="home-aurora__compare-handle" aria-hidden="true" />
+			</div>
+		</section>
+	);
+}

--- a/apps/www/components/page/index.ts
+++ b/apps/www/components/page/index.ts
@@ -1,3 +1,5 @@
+export * from "./agent-native-pitch";
+export * from "./before-after-compare";
 export * from "./cli-command";
 export * from "./compatibility-rails";
 export * from "./copy-button";
@@ -6,4 +8,5 @@ export * from "./install-panel";
 export * from "./logo";
 export * from "./quickstart-button";
 export * from "./star-us-button";
+export * from "./type-safety-showcase";
 export * from "./video-demo";

--- a/apps/www/components/page/type-safety-showcase.tsx
+++ b/apps/www/components/page/type-safety-showcase.tsx
@@ -3,11 +3,7 @@
  */
 export function TypeSafetyShowcase() {
 	return (
-		<section
-			className="home-aurora__pitch"
-			aria-labelledby="home-dx"
-			id="dx"
-		>
+		<section className="home-aurora__pitch" aria-labelledby="home-dx" id="dx">
 			<header className="home-aurora__pitch-head">
 				<p className="home-aurora__pitch-label">02 — Typesafety</p>
 				<h2 id="home-dx">Stop guessing your env vars</h2>
@@ -17,7 +13,11 @@ export function TypeSafetyShowcase() {
 				</p>
 			</header>
 
-			<div className="home-aurora__ide" role="img" aria-label="IDE showing env autocomplete for DATABASE_URL and PORT">
+			<div
+				className="home-aurora__ide"
+				role="img"
+				aria-label="IDE showing env autocomplete for DATABASE_URL and PORT"
+			>
 				<div className="home-aurora__ide-chrome">
 					<span className="home-aurora__ide-dot" />
 					<span className="home-aurora__ide-dot" />
@@ -27,11 +27,11 @@ export function TypeSafetyShowcase() {
 				<pre className="home-aurora__ide-body">
 					<code>
 						<span className="home-aurora__tok-kw">import</span>
-						{` { env } `}
+						{" { env } "}
 						<span className="home-aurora__tok-kw">from</span>
 						{` "./env";\n\n`}
 						<span className="home-aurora__tok-kw">const</span>
-						{` db = `}
+						{" db = "}
 						<span className="home-aurora__tok-id">env</span>
 						<span className="home-aurora__tok-punct">.</span>
 						<span className="home-aurora__tok-caret" aria-hidden="true" />

--- a/apps/www/components/page/type-safety-showcase.tsx
+++ b/apps/www/components/page/type-safety-showcase.tsx
@@ -1,0 +1,59 @@
+/**
+ * Simulated IDE autocomplete — proves typesafe env access without a video.
+ */
+export function TypeSafetyShowcase() {
+	return (
+		<section
+			className="home-aurora__pitch"
+			aria-labelledby="home-dx"
+			id="dx"
+		>
+			<header className="home-aurora__pitch-head">
+				<p className="home-aurora__pitch-label">02 — Typesafety</p>
+				<h2 id="home-dx">Stop guessing your env vars</h2>
+				<p>
+					Full IDE autocomplete and type inference across your stack — from
+					editor to runtime.
+				</p>
+			</header>
+
+			<div className="home-aurora__ide" role="img" aria-label="IDE showing env autocomplete for DATABASE_URL and PORT">
+				<div className="home-aurora__ide-chrome">
+					<span className="home-aurora__ide-dot" />
+					<span className="home-aurora__ide-dot" />
+					<span className="home-aurora__ide-dot" />
+					<span className="home-aurora__ide-tab">app.ts</span>
+				</div>
+				<pre className="home-aurora__ide-body">
+					<code>
+						<span className="home-aurora__tok-kw">import</span>
+						{` { env } `}
+						<span className="home-aurora__tok-kw">from</span>
+						{` "./env";\n\n`}
+						<span className="home-aurora__tok-kw">const</span>
+						{` db = `}
+						<span className="home-aurora__tok-id">env</span>
+						<span className="home-aurora__tok-punct">.</span>
+						<span className="home-aurora__tok-caret" aria-hidden="true" />
+					</code>
+				</pre>
+				<ul className="home-aurora__ide-menu" aria-hidden="true">
+					<li data-active="true">
+						<span>DATABASE_URL</span>
+						<span className="home-aurora__ide-type">string</span>
+					</li>
+					<li>
+						<span>PORT</span>
+						<span className="home-aurora__ide-type">number</span>
+					</li>
+					<li>
+						<span>NODE_ENV</span>
+						<span className="home-aurora__ide-type">
+							&quot;development&quot; | &quot;production&quot;
+						</span>
+					</li>
+				</ul>
+			</div>
+		</section>
+	);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds conversion-oriented pitch sections to the v1 landing redesign:

- **Nav:** Docs · Presets · Why ArkEnv? (smooth-scrolls to `#why`)
- **Before / after:** Draggable code compare (manual `process.env` boilerplate vs one `arkenv()` schema)
- **DX proof:** IDE mock with `env.` autocomplete (`DATABASE_URL`, `PORT`, `NODE_ENV`)
- **Agent-native:** CLI terminal + agent chat split
- **Footer:** Four-column Resources / Ecosystem / Community grid

Deferred for a follow-up (heavier / data-dependent): star-history chart, animated stack node-graph.

## Test plan
- [ ] Nav “Why ArkEnv?” scrolls to the before/after section
- [ ] Drag the compare slider; old way / ArkEnv way remain readable on mobile
- [ ] IDE autocomplete mock and agent split render without layout blowouts
- [ ] Footer links resolve (docs, npm, Discord, sponsors)
- [ ] Existing hero + Try it live still work

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb723-c22c-72d9-8591-119ae789fd18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb723-c22c-72d9-8591-119ae789fd18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

