### PR TITLE
docs(www): tighten mobile hero spacing and wrap tagline

### DIFF
--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -96,7 +96,7 @@
 /* N5 · Floating pill */
 .home-aurora__nav {
 	position: fixed;
-	inset: var(--space-md) auto auto 50%;
+	inset: var(--space-sm) auto auto 50%;
 	transform: translateX(-50%);
 	z-index: 40;
 	display: inline-flex;
@@ -109,6 +109,12 @@
 	border: var(--rule-hair) solid var(--color-rule);
 	border-radius: var(--radius-pill);
 	box-shadow: var(--shadow-nav);
+}
+
+@media (min-width: 40rem) {
+	.home-aurora__nav {
+		inset-block-start: var(--space-md);
+	}
 }
 
 .home-aurora__nav-links {
@@ -222,15 +228,30 @@
 .home-aurora__shell {
 	width: min(90rem, 100%);
 	margin-inline: auto;
-	padding: calc(var(--space-3xl) + var(--space-sm)) clamp(0.75rem, 2.5vw, 1.75rem) var(--space-2xl);
+	/* Mobile: clear the floating pill without a tall empty band */
+	padding: calc(3.75rem + var(--space-xs)) clamp(0.75rem, 2.5vw, 1.75rem)
+		var(--space-2xl);
+}
+
+@media (min-width: 40rem) {
+	.home-aurora__shell {
+		padding-top: calc(var(--space-3xl) + var(--space-sm));
+	}
 }
 
 /* Workbench · hanging intro */
 .home-aurora__intro {
 	display: grid;
-	gap: var(--space-md);
+	gap: var(--space-sm);
 	max-width: none;
-	padding-block: var(--space-xl) var(--space-lg);
+	padding-block: var(--space-2xs) var(--space-md);
+}
+
+@media (min-width: 40rem) {
+	.home-aurora__intro {
+		gap: var(--space-md);
+		padding-block: var(--space-xl) var(--space-lg);
+	}
 }
 
 .home-aurora__badge {
@@ -247,9 +268,9 @@
 .home-aurora__intro h1,
 .home-aurora__tagline {
 	margin: 0;
-	max-width: none;
+	max-width: 100%;
 	font-family: var(--font-display);
-	font-size: clamp(2.75rem, 6.5vw + 1rem, 5rem);
+	font-size: clamp(2.25rem, 7vw + 0.65rem, 5rem);
 	line-height: 1.05;
 	letter-spacing: -0.035em;
 	color: var(--color-ink);
@@ -271,9 +292,17 @@
 	color: inherit;
 }
 
+/* Prefer one line; wrap between the two words when the viewport is too narrow */
 .home-aurora__digital-accent {
 	color: var(--color-accent);
-	white-space: nowrap;
+	display: inline;
+	white-space: normal;
+}
+
+@media (min-width: 36rem) {
+	.home-aurora__digital-accent {
+		white-space: nowrap;
+	}
 }
 
 .home-aurora__summary {

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -229,8 +229,7 @@
 	width: min(90rem, 100%);
 	margin-inline: auto;
 	/* Mobile: clear the floating pill without a tall empty band */
-	padding: calc(3.75rem + var(--space-xs)) clamp(0.75rem, 2.5vw, 1.75rem)
-		var(--space-2xl);
+	padding: calc(3.75rem + var(--space-xs)) clamp(0.75rem, 2.5vw, 1.75rem) var(--space-2xl);
 }
 
 @media (min-width: 40rem) {

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -29,7 +29,8 @@ export default function HomePage() {
 				<h1 id="home-hero" className="home-aurora__tagline">
 					<span className="home-aurora__lead">The simple way to validate</span>{" "}
 					<span className="home-aurora__digital home-aurora__digital-accent">
-						environment variables
+						environment{" "}
+						<span className="home-aurora__digital-word">variables</span>
 					</span>
 				</h1>
 				<p className="home-aurora__summary">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reduce mobile dead space under the floating nav (tighter shell + intro padding, slightly lower pill)
- Allow **environment / variables** to wrap below `36rem`; keep them on one line when the viewport is wide enough
- Slightly lower the hero type floor so Pixel Grid fits narrow phones

## Test plan
- [ ] Open `/` at ~320–390px: less empty space above the badge/headline
- [ ] Confirm “environment” and “variables” stack instead of overflowing
- [ ] At ≥36rem, the accent phrase stays on one line
- [ ] Desktop hero spacing still feels intentional

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb723-c22c-72d9-8591-119ae789fd18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb723-c22c-72d9-8591-119ae789fd18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

