### PR TITLE
feat(www): hide theme toggle behind PostHog feature flag

### DIFF
--- a/apps/www/components/ui/theme-toggle.tsx
+++ b/apps/www/components/ui/theme-toggle.tsx
@@ -9,6 +9,8 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "~/components/ui/tooltip";
+import { useFeatureFlag } from "~/hooks/use-feature-flag";
+import { FeatureFlag } from "~/lib/posthog/feature-flags";
 import { cn } from "~/lib/utils";
 
 type Option = {
@@ -22,6 +24,7 @@ let hydrated = false;
 let cachedTheme: string | undefined;
 
 export function ThemeToggle({ className }: { className?: string }) {
+	const themeToggleEnabled = useFeatureFlag(FeatureFlag.THEME_TOGGLE);
 	const { theme, setTheme } = useTheme();
 	const [mounted, setMounted] = useState(hydrated);
 
@@ -34,6 +37,10 @@ export function ThemeToggle({ className }: { className?: string }) {
 		hydrated = true;
 		setMounted(true);
 	}, []);
+
+	if (themeToggleEnabled !== true) {
+		return null;
+	}
 
 	const options = [
 		{ value: "light", icon: Sun, label: "Light" },

--- a/apps/www/hooks/use-feature-flag.test.ts
+++ b/apps/www/hooks/use-feature-flag.test.ts
@@ -1,8 +1,8 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import posthog from "posthog-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useFeatureFlag } from "./use-feature-flag";
 import { FeatureFlag } from "~/lib/posthog/feature-flags";
+import { useFeatureFlag } from "./use-feature-flag";
 
 vi.mock("posthog-js", () => ({
 	default: {

--- a/apps/www/hooks/use-feature-flag.test.ts
+++ b/apps/www/hooks/use-feature-flag.test.ts
@@ -1,0 +1,48 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import posthog from "posthog-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useFeatureFlag } from "./use-feature-flag";
+import { FeatureFlag } from "~/lib/posthog/feature-flags";
+
+vi.mock("posthog-js", () => ({
+	default: {
+		isFeatureEnabled: vi.fn(),
+		onFeatureFlags: vi.fn(),
+	},
+}));
+
+describe("useFeatureFlag", () => {
+	beforeEach(() => {
+		vi.mocked(posthog.isFeatureEnabled).mockReset();
+		vi.mocked(posthog.onFeatureFlags).mockReset();
+		vi.mocked(posthog.onFeatureFlags).mockReturnValue(() => undefined);
+	});
+
+	it("returns false until the flag is explicitly true", async () => {
+		vi.mocked(posthog.isFeatureEnabled).mockReturnValue(undefined);
+		const { result } = renderHook(() =>
+			useFeatureFlag(FeatureFlag.THEME_TOGGLE),
+		);
+		expect(result.current).toBe(false);
+	});
+
+	it("returns true when PostHog reports the flag enabled", async () => {
+		vi.mocked(posthog.isFeatureEnabled).mockReturnValue(true);
+		const { result } = renderHook(() =>
+			useFeatureFlag(FeatureFlag.THEME_TOGGLE),
+		);
+		await waitFor(() => {
+			expect(result.current).toBe(true);
+		});
+	});
+
+	it("returns false for non-true flag values", async () => {
+		vi.mocked(posthog.isFeatureEnabled).mockReturnValue(false);
+		const { result } = renderHook(() =>
+			useFeatureFlag(FeatureFlag.THEME_TOGGLE),
+		);
+		await waitFor(() => {
+			expect(result.current).toBe(false);
+		});
+	});
+});

--- a/apps/www/hooks/use-feature-flag.ts
+++ b/apps/www/hooks/use-feature-flag.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import posthog from "posthog-js";
+import { useEffect, useState } from "react";
+import type { FeatureFlag } from "~/lib/posthog/feature-flags";
+
+/**
+ * Subscribe to a PostHog boolean feature flag.
+ * Returns true only when the flag is explicitly enabled.
+ */
+export function useFeatureFlag(flag: FeatureFlag): boolean {
+	const [enabled, setEnabled] = useState(false);
+
+	useEffect(() => {
+		const sync = () => {
+			setEnabled(posthog.isFeatureEnabled(flag) === true);
+		};
+
+		sync();
+		return posthog.onFeatureFlags(sync);
+	}, [flag]);
+
+	return enabled;
+}

--- a/apps/www/lib/posthog/feature-flags.ts
+++ b/apps/www/lib/posthog/feature-flags.ts
@@ -1,0 +1,8 @@
+/**
+ * PostHog feature flag keys.
+ * Keep each flag consumed in as few places as possible.
+ */
+export enum FeatureFlag {
+	/** When true, show the light/dark/system theme switcher. Default: off. */
+	THEME_TOGGLE = "theme-toggle",
+}

--- a/apps/www/lib/posthog/index.ts
+++ b/apps/www/lib/posthog/index.ts
@@ -1,1 +1,2 @@
 export * from "./config";
+export * from "./feature-flags";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Hide the theme switcher behind PostHog feature flag `theme-toggle`
- Gate lives inside `ThemeToggle` (single callsite) — home, docs, and 404 all respect it
- Shows only when the flag is **explicitly** `true`; default / missing / false keeps it hidden

## PostHog setup
Create a boolean flag named `theme-toggle` (default off). Turn it on when you want the switcher back.

## Test plan
- [ ] With flag off / unset: no theme toggle on `/`, docs, or 404
- [ ] Enable `theme-toggle` in PostHog: toggle reappears after flags load
- [ ] System / default theme still applies via next-themes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb723-c22c-72d9-8591-119ae789fd18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb723-c22c-72d9-8591-119ae789fd18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

