### PR TITLE
style(www): enable Geist Sans ss01/cv11 OpenType features

### DIFF
--- a/apps/playwright-www/tests/homepage.test.ts
+++ b/apps/playwright-www/tests/homepage.test.ts
@@ -19,8 +19,10 @@ test.describe("Homepage Interactivity", () => {
 		await page.goto("/");
 		await page.waitForLoadState("networkidle");
 
-		// On desktop, the header GitHub action is visible; mobile CTA is hidden (`sm:hidden`).
-		const githubLink = page.getByRole("link", { name: /^GitHub$/i });
+		// Header nav GitHub control (footer Ecosystem also has a "GitHub" link).
+		const githubLink = page
+			.getByRole("navigation", { name: "Primary" })
+			.getByRole("link", { name: /GitHub/i });
 
 		await expect(githubLink).toBeVisible();
 		await expect(githubLink).toHaveAttribute("target", "_blank");

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -8,6 +8,30 @@
 
 @import "../../tokens.css";
 
+/* Mono/outlier surfaces: don't inherit Sans stylistic sets from html */
+.home-aurora :is(
+	.home-aurora__summary code,
+	.home-aurora__faq-panel-inner code,
+	.home-aurora__install-prompt-symbol,
+	.home-aurora__install-code,
+	.home-aurora__pitch-label,
+	.home-aurora__compare-stat,
+	.home-aurora__pitch-head code,
+	.home-aurora__compare .shiki,
+	.home-aurora__window-title,
+	.home-aurora__window-url,
+	.home-aurora__ide-body,
+	.home-aurora__ide-menu li,
+	.home-aurora__validator-note code,
+	.home-aurora__secure-chip,
+	.home-aurora__terminal pre,
+	.home-aurora__transcript-reply code,
+	.home-aurora__footer-license,
+	.home-aurora__footer-grid h3
+) {
+	font-feature-settings: var(--font-feature-mono);
+}
+
 /* Load-time rise (open-slide). `backwards` avoids pinning filter after the run. */
 @keyframes home-aurora-rise {
 	from {

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -9,7 +9,8 @@
 @import "../../tokens.css";
 
 /* Mono/outlier surfaces: don't inherit Sans stylistic sets from html */
-.home-aurora :is(
+.home-aurora
+:is(
 	.home-aurora__summary code,
 	.home-aurora__faq-panel-inner code,
 	.home-aurora__install-prompt-symbol,

--- a/apps/www/app/styles/base.css
+++ b/apps/www/app/styles/base.css
@@ -3,6 +3,11 @@
 		@apply border-border outline-ring/50;
 	}
 
+	html {
+		/* Geist Sans alternate a (no spur) + open-slide-matching features */
+		font-feature-settings: "ss01", "cv11", "calt";
+	}
+
 	@media (prefers-reduced-motion: no-preference) {
 		html {
 			scroll-behavior: smooth;
@@ -12,6 +17,7 @@
 	code,
 	pre {
 		font-family: var(--font-geist-mono), var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+		font-feature-settings: normal;
 	}
 
 	button:not(:disabled) {

--- a/apps/www/app/styles/base.css
+++ b/apps/www/app/styles/base.css
@@ -5,7 +5,7 @@
 
 	html {
 		/* Geist Sans alternate a (no spur) + open-slide-matching features */
-		font-feature-settings: "ss01", "cv11", "calt";
+		font-feature-settings: var(--font-feature-sans, "ss01", "cv11", "calt");
 	}
 
 	@media (prefers-reduced-motion: no-preference) {
@@ -14,10 +14,14 @@
 		}
 	}
 
+	/* Geist Mono surfaces: don't inherit Sans stylistic sets from html */
+	:where(code, kbd, samp, pre, .font-mono) {
+		font-feature-settings: var(--font-feature-mono, normal);
+	}
+
 	code,
 	pre {
 		font-family: var(--font-geist-mono), var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-		font-feature-settings: normal;
 	}
 
 	button:not(:disabled) {

--- a/apps/www/tokens.css
+++ b/apps/www/tokens.css
@@ -29,6 +29,9 @@
 	--font-body: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
 	--font-outlier: var(--font-geist-mono), ui-monospace, monospace;
 	--font-mono: var(--font-geist-mono), ui-monospace, monospace;
+	/* OpenType: Sans uses open-slide alternates; Mono stays at defaults */
+	--font-feature-sans: "ss01", "cv11", "calt";
+	--font-feature-mono: normal;
 	/* --font-geist-pixel-grid is provided by geist/font/pixel (GeistPixelGrid) */
 
 	--space-3xs: 0.25rem;

--- a/tokens.css
+++ b/tokens.css
@@ -25,6 +25,9 @@
 	--font-body: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
 	--font-outlier: var(--font-geist-mono), ui-monospace, monospace;
 	--font-mono: var(--font-geist-mono), ui-monospace, monospace;
+	/* OpenType: Sans uses open-slide alternates; Mono stays at defaults */
+	--font-feature-sans: "ss01", "cv11", "calt";
+	--font-feature-mono: normal;
 	/* --font-geist-pixel-grid is provided by geist/font/pixel (GeistPixelGrid) */
 
 	--space-3xs: 0.25rem;


### PR DESCRIPTION
## Summary
- Enable Geist Sans `font-feature-settings: \"ss01\", \"cv11\", \"calt\"` site-wide (same as open-slide.dev)
- This swaps the default spurred lowercase `a` for the `a.ss01` alternate
- Reset features on `code`/`pre` so Geist Mono keeps default ligature behavior

## Test plan
- [ ] Open `/` and confirm lowercase `a` in headlines (e.g. “way”, “validate”) has no bottom-right spur
- [ ] Confirm docs body text matches the same `a` shape
- [ ] Confirm code blocks still look correct (mono features unchanged)