### PR TITLE
feat(www): docs TOC feedback, star CTA, and shared footer

### DIFF
--- a/apps/www/.env.example
+++ b/apps/www/.env.example
@@ -2,6 +2,14 @@
 # Example: https://github.com/yamcodes/arkenv
 NEXT_PUBLIC_GITHUB_URL=
 
+# Optional branch override for "Edit this page" links.
+# On Vercel, falls back to VERCEL_GIT_COMMIT_REF (the deploy branch); else "dev".
+# NEXT_PUBLIC_GITHUB_BRANCH=dev
+
+# Optional GitHub token for auto-creating docs feedback issues.
+# Without it, "View on GitHub" opens a prefilled new-issue URL instead.
+# GITHUB_FEEDBACK_TOKEN=
+
 # Show star counts next to GitHub links (header + mobile CTA). Off unless "true".
 # NEXT_PUBLIC_GITHUB_STAR_COUNT=true
 

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -7,6 +7,7 @@
  */
 
 @import "../../tokens.css";
+@import "../../components/site-footer.css";
 
 /* Load-time rise (open-slide). Gated by HeroMotion (`data-hero-motion`) so
  * client remounts of HomeLayout do not restart mid-flight animations. */
@@ -2178,113 +2179,7 @@
 	opacity: 0.9;
 }
 
-/* Ft3 · Index-style footer */
-.home-aurora__footer {
-	margin-top: var(--space-xl);
-	padding: var(--space-xl) 0 0;
-	display: grid;
-	gap: var(--space-lg);
-}
-
-.home-aurora__footer-grid {
-	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: var(--space-lg);
-}
-
-.home-aurora__footer-brand {
-	grid-column: 1 / -1;
-	display: grid;
-	gap: var(--space-xs);
-	align-content: start;
-}
-
-@media (min-width: 64rem) {
-	.home-aurora__footer-grid {
-		grid-template-columns: 1.4fr repeat(3, minmax(0, 1fr));
-		gap: var(--space-xl);
-	}
-
-	.home-aurora__footer-brand {
-		grid-column: auto;
-	}
-
-	.home-aurora__footer-brand p {
-		max-width: 28ch;
-	}
-}
-
-.home-aurora__footer-brand p {
-	margin: 0;
-	color: var(--color-ink-2);
-	font-size: var(--text-sm);
-	line-height: 1.45;
-}
-
-.home-aurora__footer-grid h3 {
-	margin: 0 0 var(--space-xs);
-	font-family: var(--font-outlier);
-	font-size: var(--text-xs);
-	font-weight: 500;
-	letter-spacing: 0.08em;
-	text-transform: uppercase;
-	color: var(--color-muted);
-}
-
-.home-aurora__footer-grid ul {
-	margin: 0;
-	padding: 0;
-	list-style: none;
-	display: grid;
-	gap: 0.45rem;
-}
-
-.home-aurora__footer-grid a {
-	color: var(--color-ink-2);
-	font-family: var(--font-display);
-	font-size: var(--text-sm);
-	text-decoration: none;
-	transition: color var(--dur-micro) var(--ease-out);
-}
-
-.home-aurora__footer-grid a:hover {
-	color: var(--color-ink);
-}
-
-.home-aurora__footer-grid a:focus-visible {
-	outline: 2px solid var(--color-focus);
-	outline-offset: 2px;
-}
-
-.home-aurora__footer-meta {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: space-between;
-	align-items: baseline;
-	gap: var(--space-sm);
-	padding-block-start: var(--space-sm);
-	border-top: var(--rule-hair) solid var(--color-rule);
-	color: var(--color-muted);
-	font-family: var(--font-display);
-	font-size: var(--text-sm);
-}
-
-.home-aurora__footer-meta a {
-	color: var(--color-ink);
-	text-decoration: none;
-	transition: color var(--dur-micro) var(--ease-out);
-}
-
-.home-aurora__footer-meta a:hover {
-	color: var(--color-ink);
-	text-decoration: underline;
-	text-underline-offset: 0.15em;
-}
-
-.home-aurora__footer-meta a:focus-visible {
-	outline: 2px solid var(--color-focus);
-	outline-offset: 2px;
-}
+/* Footer styles: components/site-footer.css */
 
 @media (prefers-reduced-motion: reduce) {
 	.home-aurora__frame-hint,

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { AnnouncementBadge } from "~/components/announcement-badge";
-import { DiscordListItem } from "~/components/discord-list-item";
 import {
 	AgentNativePitch,
 	BeforeAfterCompare,
@@ -15,8 +14,7 @@ import {
 	TypeSafetyShowcase,
 	VideoDemo,
 } from "~/components/page";
-import { Logo } from "~/components/page/logo";
-import { getGithubRepoUrl } from "~/lib/github-links";
+import { SiteFooter } from "~/components/site-footer";
 
 export const metadata: Metadata = {
 	title: "ArkEnv",
@@ -24,8 +22,6 @@ export const metadata: Metadata = {
 };
 
 export default function HomePage() {
-	const githubRepoUrl = getGithubRepoUrl();
-
 	return (
 		<div className="home-aurora__shell">
 			<section className="home-aurora__intro" aria-labelledby="home-hero">
@@ -108,142 +104,7 @@ export default function HomePage() {
 				</div>
 			</section>
 
-			<footer className="home-aurora__footer" data-reveal="fade">
-				<div className="home-aurora__footer-grid">
-					<div className="home-aurora__footer-brand">
-						<a
-							href="/"
-							className="home-aurora__wordmark"
-							aria-label="ArkEnv home"
-						>
-							<Logo />
-						</a>
-						<p>The simple way to validate environment variables.</p>
-					</div>
-
-					<nav aria-labelledby="footer-resources">
-						<h3 id="footer-resources">Resources</h3>
-						<ul>
-							<li>
-								<a
-									href="https://stackblitz.com/github/yamcodes/arkenv/tree/main/examples/stackblitz?file=index.ts"
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									Live demo
-								</a>
-							</li>
-							<li>
-								<a
-									href={`${githubRepoUrl}/releases`}
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									Releases
-								</a>
-							</li>
-							<li>
-								<a href="/docs">Docs</a>
-							</li>
-							<li>
-								<a href="/#faq">FAQ</a>
-							</li>
-						</ul>
-					</nav>
-
-					<nav aria-labelledby="footer-integrations">
-						<h3 id="footer-integrations">Integrations</h3>
-						<ul>
-							<li>
-								<a href="/docs/getting-started/editor-integration">IDE</a>
-							</li>
-							<li>
-								<a href="/docs/reference/init">Terminal</a>
-							</li>
-							<li>
-								<a
-									href="https://arktype.io/docs/ecosystem#arkenv"
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									ArkType
-								</a>
-							</li>
-							<li>
-								<a href="/docs/core-concepts/standard-schema">
-									Standard Schema
-								</a>
-							</li>
-						</ul>
-					</nav>
-
-					<nav aria-labelledby="footer-elsewhere">
-						<h3 id="footer-elsewhere">Elsewhere</h3>
-						<ul>
-							<li>
-								<a
-									href={githubRepoUrl}
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									GitHub
-								</a>
-							</li>
-							<li>
-								<a
-									href="https://www.npmjs.com/package/@arkenv/core"
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									npm
-								</a>
-							</li>
-							<li>
-								<a
-									href="https://www.skills.sh/yamcodes/arkenv/arkenv"
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									Skills
-								</a>
-							</li>
-							<li>
-								<a
-									href="https://x.com/_yamcodes"
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									X
-								</a>
-							</li>
-							<DiscordListItem />
-						</ul>
-					</nav>
-				</div>
-
-				<div className="home-aurora__footer-meta">
-					<span>
-						Free and open-source under the{" "}
-						<a
-							href={`${githubRepoUrl}/blob/dev/LICENSE`}
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							MIT License
-						</a>
-					</span>
-					<span>
-						© 2025-present{" "}
-						<a
-							href="https://yam.codes"
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							Yam Borodetsky
-						</a>
-					</span>
-				</div>
-			</footer>
+			<SiteFooter reveal />
 		</div>
 	);
 }

--- a/apps/www/app/docs/[[...slug]]/page.tsx
+++ b/apps/www/app/docs/[[...slug]]/page.tsx
@@ -16,6 +16,14 @@ import { source } from "~/lib/source";
 import { getLinkTitleAndHref } from "~/lib/utils";
 import { getMDXComponents } from "~/mdx-components";
 
+function getDocsEditHref(pagePath: string): string {
+	const basePath = (
+		process.env.NEXT_PUBLIC_DOCS_CONTENT_PATH ?? "apps/www/content/docs/"
+	).replace(/\/$/, "");
+	const normalizedPath = pagePath.replace(/^\//, "");
+	return getLinkTitleAndHref(`${basePath}/${normalizedPath}`).href;
+}
+
 export default async function Page(props: {
 	params: Promise<{ slug?: string[] }>;
 }) {
@@ -25,7 +33,10 @@ export default async function Page(props: {
 
 	const MDX = page.data.body;
 	const full = page.data.full;
-	const tocLinks = <DocsTocLinks pageTitle={page.data.title} />;
+	const editHref = getDocsEditHref(page.path);
+	const tocLinks = (
+		<DocsTocLinks pageTitle={page.data.title} editHref={editHref} />
+	);
 
 	return (
 		<DocsPage
@@ -39,21 +50,7 @@ export default async function Page(props: {
 				<DocsTitle className="mb-4">{page.data.title}</DocsTitle>
 				<DocsDescription>{page.data.description}</DocsDescription>
 				<div className="flex flex-row gap-2 items-center border-b pt-2 pb-6 mb-8 mt-4">
-					<AIActions
-						markdownUrl={`${page.url}.mdx`}
-						githubUrl={
-							getLinkTitleAndHref(
-								(() => {
-									const basePath = (
-										process.env.NEXT_PUBLIC_DOCS_CONTENT_PATH ??
-										"apps/www/content/docs/"
-									).replace(/\/$/, ""); // Remove trailing slash if present
-									const pagePath = page.path.replace(/^\//, ""); // Remove leading slash if present
-									return `${basePath}/${pagePath}`;
-								})(),
-							).href
-						}
-					/>
+					<AIActions markdownUrl={`${page.url}.mdx`} githubUrl={editHref} />
 				</div>
 				<DocsBody>
 					<MDX

--- a/apps/www/app/docs/layout.tsx
+++ b/apps/www/app/docs/layout.tsx
@@ -4,6 +4,8 @@ import type { CSSProperties, ReactNode } from "react";
 import { DocsSidebarTrigger } from "~/components/docs/sidebar-trigger";
 import { HeaderGithubLink } from "~/components/page/header-github-link";
 import { Logo } from "~/components/page/logo";
+import { SiteFooter } from "~/components/site-footer";
+import "~/components/site-footer.css";
 import { SearchToggle } from "~/components/ui/search-toggle";
 import { ThemeToggle } from "~/components/ui/theme-toggle";
 import { source } from "~/lib/source";
@@ -73,6 +75,11 @@ export default function Layout({ children }: { children: ReactNode }) {
 			>
 				{children}
 			</DocsLayout>
+			<div className="site-footer-bleed">
+				<div className="site-footer-band">
+					<SiteFooter />
+				</div>
+			</div>
 		</main>
 	);
 }

--- a/apps/www/components/docs/docs-feedback.tsx
+++ b/apps/www/components/docs/docs-feedback.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { SiMarkdown } from "@icons-pack/react-simple-icons";
+import { ThumbsUpIcon } from "lucide-react";
+import { usePathname } from "next/navigation";
+import {
+	type FormEventHandler,
+	useEffect,
+	useEffectEvent,
+	useState,
+	useTransition,
+} from "react";
+import { Button } from "~/components/ui/button";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "~/components/ui/popover";
+import { submitDocsFeedback } from "~/lib/docs-feedback/action";
+import {
+	type DocsFeedbackEmotion,
+	docsFeedbackEmotions,
+} from "~/lib/docs-feedback/emotions";
+import type { DocsPageFeedback } from "~/lib/docs-feedback/schema";
+import { cn } from "~/lib/utils/cn";
+
+/**
+ * Geist Docs / Turborepo-style feedback popover.
+ * Submit path mirrors Fumadocs: opinion + message → server action → thank-you,
+ * with GitHub as the durable sink (issue create or prefilled new-issue tab).
+ */
+export function DocsFeedbackButton({ pageTitle }: { pageTitle: string }) {
+	const pathname = usePathname();
+	const storageKey = `docs-feedback-${pathname}`;
+	const [open, setOpen] = useState(false);
+	const [submitted, setSubmitted] = useState(false);
+	const [emotion, setEmotion] = useState<DocsFeedbackEmotion | null>(null);
+	const [message, setMessage] = useState("");
+	const [error, setError] = useState<string | null>(null);
+	const [githubUrl, setGithubUrl] = useState<string | null>(null);
+	const [isPending, startTransition] = useTransition();
+
+	const restore = useEffectEvent((key: string) => {
+		try {
+			const raw = localStorage.getItem(key);
+			if (!raw) {
+				setSubmitted(false);
+				setGithubUrl(null);
+				return;
+			}
+			const parsed = JSON.parse(raw) as { githubUrl?: string };
+			setSubmitted(true);
+			setGithubUrl(parsed.githubUrl ?? null);
+		} catch {
+			setSubmitted(false);
+			setGithubUrl(null);
+		}
+	});
+
+	useEffect(() => {
+		restore(storageKey);
+	}, [storageKey]);
+
+	const submit: FormEventHandler<HTMLFormElement> = (e) => {
+		e.preventDefault();
+		if (!emotion || message.trim().length === 0) return;
+
+		setError(null);
+
+		// Open a blank tab synchronously so popup blockers allow the GitHub
+		// destination after the async server action (prefill / created issue).
+		const pendingTab = window.open("about:blank", "_blank");
+
+		startTransition(async () => {
+			const feedback: DocsPageFeedback = {
+				url: window.location.href,
+				pageTitle,
+				opinion: emotion,
+				message: message.trim(),
+			};
+
+			const response = await submitDocsFeedback(feedback);
+
+			if (!response.success || !response.githubUrl) {
+				pendingTab?.close();
+				setError(response.error ?? "Could not submit feedback. Try again.");
+				return;
+			}
+
+			localStorage.setItem(
+				storageKey,
+				JSON.stringify({ githubUrl: response.githubUrl }),
+			);
+			setGithubUrl(response.githubUrl);
+			setSubmitted(true);
+			setMessage("");
+			setEmotion(null);
+
+			if (pendingTab) {
+				pendingTab.location.href = response.githubUrl;
+			} else {
+				window.open(response.githubUrl, "_blank", "noopener,noreferrer");
+			}
+		});
+	};
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					className="flex items-center gap-1.5 text-sm text-fd-muted-foreground transition-colors hover:text-fd-foreground"
+				>
+					<ThumbsUpIcon className="size-3.5" aria-hidden="true" />
+					<span>Give feedback</span>
+				</button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="start"
+				side="top"
+				sideOffset={8}
+				className="w-72 overflow-hidden rounded-lg border-fd-border bg-fd-popover p-0 text-fd-popover-foreground shadow-md backdrop-blur-none"
+			>
+				<div className="overflow-visible">
+					{submitted ? (
+						<div className="flex flex-col items-center gap-3 bg-fd-muted/40 px-3 py-6 text-center text-sm">
+							<p>Thank you for your feedback!</p>
+							{githubUrl ? (
+								<a
+									href={githubUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="text-xs text-fd-muted-foreground underline-offset-2 hover:text-fd-foreground hover:underline"
+								>
+									View on GitHub
+								</a>
+							) : null}
+							<button
+								type="button"
+								className="text-xs text-fd-muted-foreground hover:text-fd-foreground"
+								onClick={() => {
+									localStorage.removeItem(storageKey);
+									setSubmitted(false);
+									setGithubUrl(null);
+								}}
+							>
+								Submit again
+							</button>
+						</div>
+					) : (
+						<form className="flex flex-col" onSubmit={submit}>
+							<div className="p-2">
+								<textarea
+									autoFocus
+									aria-label="Feedback"
+									autoComplete="off"
+									required
+									value={message}
+									onChange={(e) => setMessage(e.target.value)}
+									placeholder="Leave your feedback…"
+									className="field-sizing-content max-h-48 min-h-24 w-full resize-none rounded-md border border-fd-border bg-transparent px-3 py-2 text-sm text-fd-foreground shadow-none outline-none placeholder:text-fd-muted-foreground focus-visible:border-fd-border focus-visible:ring-1 focus-visible:ring-fd-border"
+									onKeyDown={(e) => {
+										if (!e.shiftKey && e.key === "Enter") {
+											e.currentTarget.form?.requestSubmit();
+										}
+									}}
+								/>
+							</div>
+							<div className="flex items-center justify-end gap-1 px-2 text-fd-muted-foreground">
+								<SiMarkdown className="inline size-3" aria-hidden="true" />
+								<p className="text-xs">supported</p>
+							</div>
+							{error ? (
+								<p className="px-2 pb-1 text-xs text-red-500" role="alert">
+									{error}
+								</p>
+							) : null}
+							<div className="mt-2 flex items-center justify-between border-t border-fd-border bg-fd-muted/40 p-2">
+								<div className="flex items-center gap-px">
+									{docsFeedbackEmotions.map((e) => (
+										<Button
+											key={e.name}
+											type="button"
+											size="sm"
+											variant="ghost"
+											aria-label={e.name}
+											aria-pressed={emotion === e.name}
+											className={cn(
+												"h-8 px-2 text-fd-muted-foreground hover:bg-fd-accent hover:text-fd-foreground",
+												emotion === e.name && "bg-fd-accent text-fd-foreground",
+											)}
+											onClick={() => setEmotion(e.name)}
+										>
+											<span aria-hidden="true" className="text-base leading-none">
+												{e.emoji}
+											</span>
+											<span className="sr-only">{e.name}</span>
+										</Button>
+									))}
+								</div>
+								<Button
+									type="submit"
+									size="sm"
+									disabled={isPending || !emotion || !message.trim()}
+									className="bg-fd-foreground text-fd-background hover:bg-fd-foreground/90"
+								>
+									{isPending ? "Sending…" : "Send"}
+								</Button>
+							</div>
+						</form>
+					)}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/www/components/docs/docs-star-card.css
+++ b/apps/www/components/docs/docs-star-card.css
@@ -1,0 +1,137 @@
+/* TOC star CTA — mirrors home outro atmosphere (blooms + dots). */
+.docs-star-card {
+	--docs-star-bloom-a: oklch(52% 0.11 195 / 0.32);
+	--docs-star-bloom-b: oklch(42% 0.09 220 / 0.22);
+
+	position: relative;
+	display: block;
+	isolation: isolate;
+	overflow: hidden;
+	margin-top: 0.25rem;
+	padding: 0.85rem 0.9rem;
+	border: 1px solid var(--color-fd-border);
+	border-radius: 0.75rem;
+	background: var(--color-fd-card);
+	color: var(--color-fd-foreground);
+	text-decoration: none;
+	transition:
+		border-color 120ms ease,
+		background-color 120ms ease;
+}
+
+.docs-star-card:hover {
+	border-color: color-mix(in oklch, oklch(74% 0.13 195) 40%, var(--color-fd-border));
+}
+
+.docs-star-card:focus-visible {
+	outline: 2px solid var(--color-fd-ring);
+	outline-offset: 2px;
+}
+
+.docs-star-card__atmosphere {
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+	overflow: hidden;
+	background-image:
+		radial-gradient(
+			ellipse 55% 60% at 92% 78%,
+			var(--docs-star-bloom-a),
+			transparent 70%
+		),
+		radial-gradient(
+			ellipse 50% 55% at 8% 18%,
+			var(--docs-star-bloom-b),
+			transparent 72%
+		);
+	mask-image: linear-gradient(
+		to bottom,
+		transparent 0%,
+		#000 18%,
+		#000 82%,
+		transparent 100%
+	);
+	-webkit-mask-image: linear-gradient(
+		to bottom,
+		transparent 0%,
+		#000 18%,
+		#000 82%,
+		transparent 100%
+	);
+}
+
+.docs-star-card__atmosphere .home-aurora__dot-grid {
+	display: block;
+	width: 100%;
+	height: 100%;
+	color: color-mix(in oklch, var(--color-fd-foreground) 14%, transparent);
+	background-image: radial-gradient(currentColor 0.75px, transparent 1.1px);
+	background-size: var(--dot-spacing, 14px) var(--dot-spacing, 14px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.docs-star-card__atmosphere .home-aurora__dot-grid {
+		opacity: 0.85;
+	}
+}
+
+.docs-star-card__body {
+	position: relative;
+	z-index: 1;
+	display: flex;
+	flex-direction: column;
+	gap: 0.45rem;
+}
+
+.docs-star-card__eyebrow {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+	font-size: 0.65rem;
+	font-weight: 500;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--color-fd-muted-foreground);
+}
+
+.docs-star-card__eyebrow-label {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+}
+
+.docs-star-card__count {
+	font-variant-numeric: tabular-nums;
+	letter-spacing: 0;
+	text-transform: none;
+}
+
+.docs-star-card__title {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-size: 0.875rem;
+	font-weight: 600;
+	line-height: 1.25;
+	color: var(--color-fd-foreground);
+}
+
+.docs-star-card__title-star {
+	flex-shrink: 0;
+	width: 0.875rem;
+	height: 0.875rem;
+	color: oklch(74% 0.13 195);
+}
+
+.docs-star-card__cta {
+	font-size: 0.75rem;
+	line-height: 1.3;
+	color: var(--color-fd-muted-foreground);
+	transition: color 120ms ease;
+}
+
+.docs-star-card:hover .docs-star-card__cta {
+	color: var(--color-fd-foreground);
+}

--- a/apps/www/components/docs/docs-star-card.tsx
+++ b/apps/www/components/docs/docs-star-card.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { SiGithub } from "@icons-pack/react-simple-icons";
+import { Star } from "lucide-react";
+import { DotGrid } from "~/components/page/dot-grid";
+import { getGithubRepoUrl } from "~/lib/github-links";
+import { useGithubStarCount } from "~/lib/use-github-star-count";
+import "./docs-star-card.css";
+
+/**
+ * TOC rail CTA to star the repo — home-outro atmosphere + direct copy.
+ */
+export function DocsStarCard() {
+	const starCount = useGithubStarCount();
+	const githubUrl = getGithubRepoUrl();
+
+	const label =
+		starCount !== null
+			? `Star ArkEnv on GitHub · ${starCount.toLocaleString()} stars`
+			: "Star ArkEnv on GitHub";
+
+	return (
+		<a
+			href={githubUrl}
+			target="_blank"
+			rel="noopener noreferrer"
+			aria-label={label}
+			className="docs-star-card group"
+		>
+			<span className="docs-star-card__atmosphere" aria-hidden="true">
+				<DotGrid spacing={14} radius={0.75} />
+			</span>
+
+			<span className="docs-star-card__body">
+				<span className="docs-star-card__eyebrow">
+					<span className="docs-star-card__eyebrow-label">
+						<SiGithub aria-hidden="true" className="size-3 shrink-0" />
+						GitHub
+					</span>
+					{starCount !== null ? (
+						<span className="docs-star-card__count">
+							{starCount.toLocaleString()}
+						</span>
+					) : null}
+				</span>
+
+				<span className="docs-star-card__title">
+					<Star
+						aria-hidden="true"
+						className="docs-star-card__title-star"
+						fill="currentColor"
+					/>
+					Enjoying the docs?
+				</span>
+
+				<span className="docs-star-card__cta">
+					Leave a star
+					<span aria-hidden="true"> →</span>
+				</span>
+			</span>
+		</a>
+	);
+}

--- a/apps/www/components/docs/toc-links.tsx
+++ b/apps/www/components/docs/toc-links.tsx
@@ -1,27 +1,49 @@
-import { getGithubDocsFeedbackUrl, getGithubRepoUrl } from "~/lib/github-links";
+"use client";
+
+import { CircleArrowUp, Pencil } from "lucide-react";
+import { DocsFeedbackButton } from "~/components/docs/docs-feedback";
+import { DocsStarCard } from "~/components/docs/docs-star-card";
 
 /**
- * Quiet TOC actions: feedback + star. Passed as `tableOfContent.footer`.
+ * TOC page actions: scroll / edit / feedback + Star on GitHub card.
+ * Passed as `tableOfContent.footer` / popover footer.
  */
-export function DocsTocLinks({ pageTitle }: { pageTitle: string }) {
+export function DocsTocLinks({
+	pageTitle,
+	editHref,
+}: {
+	pageTitle: string;
+	editHref: string;
+}) {
 	return (
-		<div className="mt-6 flex flex-col gap-2 border-t border-fd-border pt-4 text-sm text-fd-muted-foreground">
-			<a
-				href={getGithubDocsFeedbackUrl(pageTitle)}
-				target="_blank"
-				rel="noopener noreferrer"
-				className="hover:text-fd-foreground transition-colors"
+		<div className="mt-6 flex flex-col gap-3 border-t border-fd-border pt-4 first:mt-0 first:border-t-0 first:pt-0">
+			<nav
+				aria-label="Page actions"
+				className="flex flex-col gap-2 text-sm text-fd-muted-foreground"
 			>
-				Give feedback
-			</a>
-			<a
-				href={getGithubRepoUrl()}
-				target="_blank"
-				rel="noopener noreferrer"
-				className="hover:text-fd-foreground transition-colors"
-			>
-				Star on GitHub
-			</a>
+				<button
+					type="button"
+					onClick={() => {
+						window.scrollTo({ top: 0, behavior: "smooth" });
+					}}
+					className="inline-flex items-center gap-2 text-left hover:text-fd-foreground transition-colors"
+				>
+					<CircleArrowUp aria-hidden="true" className="size-3.5 shrink-0" />
+					Scroll to top
+				</button>
+				<a
+					href={editHref}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="inline-flex items-center gap-2 hover:text-fd-foreground transition-colors"
+				>
+					<Pencil aria-hidden="true" className="size-3.5 shrink-0" />
+					Edit this page
+				</a>
+				<DocsFeedbackButton pageTitle={pageTitle} />
+			</nav>
+
+			<DocsStarCard />
 		</div>
 	);
 }

--- a/apps/www/components/page/dot-grid.tsx
+++ b/apps/www/components/page/dot-grid.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type CSSProperties } from "react";
 
 /** Physics tuned for a quiet Aurora field - push ripples, then settle. */
-const SPACING = 24;
-const DOT_RADIUS = 1;
+const DEFAULT_SPACING = 24;
+const DEFAULT_RADIUS = 1;
 const INFLUENCE = 110;
 const STIFFNESS = 130;
 const DAMPING = 9;
@@ -18,7 +18,15 @@ const REST_THRESHOLD = 0.01;
  * Interactive faded-dot atmosphere for the home hero.
  * Static CSS dots paint first; the canvas takes over after hydration.
  */
-export function DotGrid() {
+export function DotGrid({
+	spacing = DEFAULT_SPACING,
+	radius = DEFAULT_RADIUS,
+}: {
+	/** Dot grid pitch in CSS pixels. Smaller = denser / more zoomed-out. */
+	spacing?: number;
+	/** Dot radius in CSS pixels. */
+	radius?: number;
+} = {}) {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 
 	useEffect(() => {
@@ -60,10 +68,10 @@ export function DotGrid() {
 			for (let row = 0; row < rows; row++) {
 				for (let col = 0; col < cols; col++) {
 					const idx = (row * cols + col) * 4;
-					const x = SPACING / 2 + col * SPACING + dots[idx];
-					const y = SPACING / 2 + row * SPACING + dots[idx + 1];
-					ctx.moveTo(x + DOT_RADIUS, y);
-					ctx.arc(x, y, DOT_RADIUS, 0, Math.PI * 2);
+					const x = spacing / 2 + col * spacing + dots[idx];
+					const y = spacing / 2 + row * spacing + dots[idx + 1];
+					ctx.moveTo(x + radius, y);
+					ctx.arc(x, y, radius, 0, Math.PI * 2);
 				}
 			}
 			ctx.fill();
@@ -73,10 +81,10 @@ export function DotGrid() {
 			const influenceSq = INFLUENCE * INFLUENCE;
 			let moving = false;
 			for (let row = 0; row < rows; row++) {
-				const baseY = SPACING / 2 + row * SPACING;
+				const baseY = spacing / 2 + row * spacing;
 				for (let col = 0; col < cols; col++) {
 					const idx = (row * cols + col) * 4;
-					const baseX = SPACING / 2 + col * SPACING;
+					const baseX = spacing / 2 + col * spacing;
 					let ox = dots[idx];
 					let oy = dots[idx + 1];
 					let vx = dots[idx + 2];
@@ -170,8 +178,8 @@ export function DotGrid() {
 			canvas.width = Math.round(width * dpr);
 			canvas.height = Math.round(height * dpr);
 			ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-			cols = Math.ceil(width / SPACING);
-			rows = Math.ceil(height / SPACING);
+			cols = Math.ceil(width / spacing);
+			rows = Math.ceil(height / spacing);
 			dots = new Float32Array(cols * rows * 4);
 			draw();
 		};
@@ -258,9 +266,18 @@ export function DotGrid() {
 			window.removeEventListener("scroll", deactivatePointer);
 			reduceMotion.removeEventListener("change", onMotionPreferenceChange);
 		};
-	}, []);
+	}, [radius, spacing]);
 
 	return (
-		<canvas ref={canvasRef} aria-hidden className="home-aurora__dot-grid" />
+		<canvas
+			ref={canvasRef}
+			aria-hidden
+			className="home-aurora__dot-grid"
+			style={
+				{
+					["--dot-spacing"]: `${spacing}px`,
+				} as CSSProperties
+			}
+		/>
 	);
 }

--- a/apps/www/components/site-footer.css
+++ b/apps/www/components/site-footer.css
@@ -1,0 +1,190 @@
+/* Shared site footer (home Ft5 + docs).
+ * Default to fumadocs tokens — Tailwind's `--color-muted` is a *surface*,
+ * so using it for text makes titles/meta invisible on dark docs chrome.
+ * Aurora ink tokens are applied only under `.home-aurora`. */
+
+.home-aurora__footer {
+	--sf-ink: var(--color-fd-foreground);
+	--sf-ink-2: var(--color-fd-muted-foreground);
+	--sf-muted: var(--color-fd-muted-foreground);
+	--sf-rule: var(--color-fd-border);
+	--sf-focus: var(--color-fd-ring);
+	--sf-font-display: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+	--sf-font-outlier: var(--font-geist-mono), ui-monospace, monospace;
+	--sf-space-xs: 0.75rem;
+	--sf-space-sm: 1rem;
+	--sf-space-lg: 2rem;
+	--sf-space-xl: 3rem;
+	--sf-text-xs: 0.75rem;
+	--sf-text-sm: 0.875rem;
+	--sf-dur: 120ms;
+	--sf-ease: cubic-bezier(0.16, 1, 0.3, 1);
+	--sf-rule-w: 1px;
+
+	margin-top: var(--sf-space-xl);
+	padding: var(--sf-space-xl) 0 0;
+	display: grid;
+	gap: var(--sf-space-lg);
+}
+
+.home-aurora .home-aurora__footer {
+	--sf-ink: var(--color-ink);
+	--sf-ink-2: var(--color-ink-2);
+	--sf-muted: var(--color-muted);
+	--sf-rule: var(--color-rule);
+	--sf-focus: var(--color-focus);
+	--sf-font-display: var(--font-display);
+	--sf-font-outlier: var(--font-outlier);
+	--sf-space-xs: var(--space-xs);
+	--sf-space-sm: var(--space-sm);
+	--sf-space-lg: var(--space-lg);
+	--sf-space-xl: var(--space-xl);
+	--sf-text-xs: var(--text-xs);
+	--sf-text-sm: var(--text-sm);
+	--sf-dur: var(--dur-micro);
+	--sf-ease: var(--ease-out);
+	--sf-rule-w: var(--rule-hair);
+}
+
+.home-aurora__footer-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: var(--sf-space-lg);
+}
+
+.home-aurora__footer-brand {
+	grid-column: 1 / -1;
+	display: grid;
+	gap: var(--sf-space-xs);
+	align-content: start;
+}
+
+@media (min-width: 64rem) {
+	.home-aurora__footer-grid {
+		grid-template-columns: 1.4fr repeat(3, minmax(0, 1fr));
+		gap: var(--sf-space-xl);
+	}
+
+	.home-aurora__footer-brand {
+		grid-column: auto;
+	}
+
+	.home-aurora__footer-brand p {
+		max-width: 28ch;
+	}
+}
+
+.home-aurora__footer-brand p {
+	margin: 0;
+	color: var(--sf-ink-2);
+	font-size: var(--sf-text-sm);
+	line-height: 1.45;
+}
+
+.home-aurora__footer-grid h3 {
+	margin: 0 0 var(--sf-space-xs);
+	font-family: var(--sf-font-display);
+	font-size: var(--sf-text-sm);
+	font-weight: 400;
+	letter-spacing: normal;
+	color: var(--sf-ink);
+}
+
+.home-aurora__footer-grid ul {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: grid;
+	gap: 0.45rem;
+}
+
+.home-aurora__footer-grid a {
+	color: var(--sf-ink-2);
+	font-family: var(--sf-font-display);
+	font-size: var(--sf-text-sm);
+	text-decoration: none;
+	transition: color var(--sf-dur) var(--sf-ease);
+}
+
+.home-aurora__footer-grid a:hover {
+	color: var(--sf-ink);
+}
+
+.home-aurora__footer-grid a:focus-visible {
+	outline: 2px solid var(--sf-focus);
+	outline-offset: 2px;
+}
+
+.home-aurora__footer-meta {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	align-items: baseline;
+	gap: var(--sf-space-sm);
+	padding-block-start: var(--sf-space-sm);
+	border-top: var(--sf-rule-w) solid var(--sf-rule);
+	color: var(--sf-muted);
+	font-family: var(--sf-font-display);
+	font-size: var(--sf-text-sm);
+}
+
+.home-aurora__footer-meta a {
+	color: var(--sf-ink);
+	text-decoration: none;
+	transition: color var(--sf-dur) var(--sf-ease);
+}
+
+.home-aurora__footer-meta a:hover {
+	color: var(--sf-ink);
+	text-decoration: underline;
+	text-underline-offset: 0.15em;
+}
+
+.home-aurora__footer-meta a:focus-visible {
+	outline: 2px solid var(--sf-focus);
+	outline-offset: 2px;
+}
+
+/* Docs chrome: full-bleed top rule, constrained content */
+.site-footer-bleed {
+	width: 100%;
+	margin-top: 2rem;
+	border-top: 1px solid var(--color-fd-border);
+}
+
+.site-footer-band {
+	width: 100%;
+	max-width: var(--fd-layout-width, 1400px);
+	margin-inline: auto;
+	padding-inline: 1rem;
+	padding-bottom: 2rem;
+}
+
+.site-footer-band .home-aurora__wordmark {
+	display: inline-flex;
+	align-items: center;
+	flex-shrink: 0;
+	color: var(--color-fd-foreground);
+	text-decoration: none;
+}
+
+.site-footer-band .home-aurora__footer {
+	margin-top: 0;
+	padding-top: 2rem;
+}
+
+/* Pin docs footer text to fumadocs tokens (avoid Tailwind surface vars). */
+.site-footer-band .home-aurora__footer-brand p,
+.site-footer-band .home-aurora__footer-meta {
+	color: var(--color-fd-muted-foreground);
+}
+
+.site-footer-band .home-aurora__footer-grid h3,
+.site-footer-band .home-aurora__footer-grid a:hover,
+.site-footer-band .home-aurora__footer-meta a {
+	color: var(--color-fd-foreground);
+}
+
+.site-footer-band .home-aurora__footer-grid a {
+	color: var(--color-fd-muted-foreground);
+}

--- a/apps/www/components/site-footer.tsx
+++ b/apps/www/components/site-footer.tsx
@@ -1,0 +1,146 @@
+import { DiscordListItem } from "~/components/discord-list-item";
+import { Logo } from "~/components/page/logo";
+import { getGithubRepoUrl } from "~/lib/github-links";
+
+/**
+ * Shared site footer used on the home page and docs.
+ * Structure matches the home aurora footer (Ft5).
+ */
+export function SiteFooter({
+	className,
+	reveal = false,
+}: {
+	className?: string;
+	/** Enable home-page scroll-reveal attribute. */
+	reveal?: boolean;
+}) {
+	const githubRepoUrl = getGithubRepoUrl();
+
+	return (
+		<footer
+			className={className ?? "home-aurora__footer"}
+			{...(reveal ? { "data-reveal": "fade" as const } : {})}
+		>
+			<div className="home-aurora__footer-grid">
+				<div className="home-aurora__footer-brand">
+					<a href="/" className="home-aurora__wordmark" aria-label="ArkEnv home">
+						<Logo />
+					</a>
+					<p>The simple way to validate environment variables.</p>
+				</div>
+
+				<nav aria-labelledby="footer-resources">
+					<h3 id="footer-resources">Resources</h3>
+					<ul>
+						<li>
+							<a
+								href="https://stackblitz.com/github/yamcodes/arkenv/tree/main/examples/stackblitz?file=index.ts"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Live demo
+							</a>
+						</li>
+						<li>
+							<a
+								href={`${githubRepoUrl}/releases`}
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Releases
+							</a>
+						</li>
+						<li>
+							<a href="/docs">Docs</a>
+						</li>
+						<li>
+							<a href="/#faq">FAQ</a>
+						</li>
+					</ul>
+				</nav>
+
+				<nav aria-labelledby="footer-integrations">
+					<h3 id="footer-integrations">Integrations</h3>
+					<ul>
+						<li>
+							<a href="/docs/getting-started/editor-integration">IDE</a>
+						</li>
+						<li>
+							<a href="/docs/reference/init">Terminal</a>
+						</li>
+						<li>
+							<a
+								href="https://arktype.io/docs/ecosystem#arkenv"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								ArkType
+							</a>
+						</li>
+						<li>
+							<a href="/docs/core-concepts/standard-schema">Standard Schema</a>
+						</li>
+					</ul>
+				</nav>
+
+				<nav aria-labelledby="footer-elsewhere">
+					<h3 id="footer-elsewhere">Elsewhere</h3>
+					<ul>
+						<li>
+							<a href={githubRepoUrl} target="_blank" rel="noopener noreferrer">
+								GitHub
+							</a>
+						</li>
+						<li>
+							<a
+								href="https://www.npmjs.com/package/@arkenv/core"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								npm
+							</a>
+						</li>
+						<li>
+							<a
+								href="https://www.skills.sh/yamcodes/arkenv/arkenv"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Skills
+							</a>
+						</li>
+						<li>
+							<a
+								href="https://x.com/_yamcodes"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								X
+							</a>
+						</li>
+						<DiscordListItem />
+					</ul>
+				</nav>
+			</div>
+
+			<div className="home-aurora__footer-meta">
+				<span>
+					Free and open-source under the{" "}
+					<a
+						href={`${githubRepoUrl}/blob/dev/LICENSE`}
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						MIT License
+					</a>
+				</span>
+				<span>
+					© 2025-present{" "}
+					<a href="https://yam.codes" target="_blank" rel="noopener noreferrer">
+						Yam Borodetsky
+					</a>
+				</span>
+			</div>
+		</footer>
+	);
+}

--- a/apps/www/lib/docs-feedback/action.ts
+++ b/apps/www/lib/docs-feedback/action.ts
@@ -1,0 +1,134 @@
+"use server";
+
+import { PostHog } from "posthog-node";
+import { getGithubRepoUrl } from "~/lib/github-links";
+import { POSTHOG_API_ENDPOINT } from "~/lib/posthog/config";
+import { breakDownGithubUrl } from "~/lib/utils/github";
+import { docsFeedbackEmotions } from "./emotions";
+import {
+	type DocsFeedbackActionResponse,
+	type DocsPageFeedback,
+	docsPageFeedback,
+} from "./schema";
+
+function buildPrefillIssueUrl(feedback: DocsPageFeedback): string {
+	const emoji =
+		docsFeedbackEmotions.find((e) => e.name === feedback.opinion)?.emoji ??
+		feedback.opinion;
+	const url = new URL(`${getGithubRepoUrl()}/issues/new`);
+	url.searchParams.set(
+		"title",
+		`Docs feedback [${feedback.opinion}]: ${feedback.pageTitle}`,
+	);
+	url.searchParams.set(
+		"body",
+		[
+			`${emoji} **${feedback.opinion}**`,
+			"",
+			feedback.message,
+			"",
+			"---",
+			`Page: ${feedback.url}`,
+			"",
+			"> Forwarded from docs feedback.",
+		].join("\n"),
+	);
+	return url.toString();
+}
+
+async function capturePostHog(feedback: DocsPageFeedback): Promise<void> {
+	const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+	if (!key) return;
+
+	const posthog = new PostHog(key, { host: POSTHOG_API_ENDPOINT });
+	try {
+		posthog.capture({
+			distinctId: "docs-feedback-anonymous",
+			event: "on_rate_docs",
+			properties: {
+				...feedback,
+				$current_url: feedback.url,
+			},
+		});
+		await posthog.shutdown();
+	} catch {
+		// Analytics must not block feedback submission.
+	}
+}
+
+async function createGithubIssue(
+	feedback: DocsPageFeedback,
+): Promise<string | undefined> {
+	const token = process.env.GITHUB_FEEDBACK_TOKEN;
+	if (!token) return undefined;
+
+	const emoji =
+		docsFeedbackEmotions.find((e) => e.name === feedback.opinion)?.emoji ??
+		feedback.opinion;
+	const { owner, repo } = breakDownGithubUrl();
+	const response = await fetch(
+		`https://api.github.com/repos/${owner}/${repo}/issues`,
+		{
+			method: "POST",
+			headers: {
+				Accept: "application/vnd.github+json",
+				Authorization: `Bearer ${token}`,
+				"X-GitHub-Api-Version": "2022-11-28",
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				title: `Docs feedback [${feedback.opinion}]: ${feedback.pageTitle}`,
+				body: [
+					`${emoji} **${feedback.opinion}**`,
+					"",
+					feedback.message,
+					"",
+					"---",
+					`Page: ${feedback.url}`,
+					"",
+					"> Forwarded from docs feedback.",
+				].join("\n"),
+				labels: ["docs", "www"],
+			}),
+		},
+	);
+
+	if (!response.ok) {
+		const text = await response.text().catch(() => "");
+		console.error("[docs-feedback] GitHub issue create failed", response.status, text);
+		return undefined;
+	}
+
+	const data = (await response.json()) as { html_url?: string };
+	return data.html_url;
+}
+
+/**
+ * Fumadocs-style submit: persist feedback (PostHog + GitHub issue when possible).
+ * Without `GITHUB_FEEDBACK_TOKEN`, returns a prefilled issue URL for the client to open.
+ */
+export async function submitDocsFeedback(
+	input: DocsPageFeedback,
+): Promise<DocsFeedbackActionResponse> {
+	try {
+		const feedback = docsPageFeedback.parse(input);
+		await capturePostHog(feedback);
+
+		const createdUrl = await createGithubIssue(feedback);
+		if (createdUrl) {
+			return { success: true, githubUrl: createdUrl, created: true };
+		}
+
+		return {
+			success: true,
+			githubUrl: buildPrefillIssueUrl(feedback),
+			created: false,
+		};
+	} catch (error) {
+		console.error("[docs-feedback] submit failed", error);
+		return {
+			success: false,
+			error: error instanceof Error ? error.message : "Failed to submit feedback",
+		};
+	}
+}

--- a/apps/www/lib/docs-feedback/emotions.ts
+++ b/apps/www/lib/docs-feedback/emotions.ts
@@ -1,0 +1,8 @@
+export const docsFeedbackEmotions = [
+	{ emoji: "😭", name: "cry" },
+	{ emoji: "😕", name: "sad" },
+	{ emoji: "🙂", name: "happy" },
+	{ emoji: "🤩", name: "amazed" },
+] as const;
+
+export type DocsFeedbackEmotion = (typeof docsFeedbackEmotions)[number]["name"];

--- a/apps/www/lib/docs-feedback/schema.ts
+++ b/apps/www/lib/docs-feedback/schema.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { docsFeedbackEmotions } from "./emotions";
+
+const emotionNames = docsFeedbackEmotions.map((e) => e.name) as [
+	(typeof docsFeedbackEmotions)[number]["name"],
+	...(typeof docsFeedbackEmotions)[number]["name"][],
+];
+
+/** Fumadocs-style page feedback payload (Geist Docs / Turbo emotions). */
+export const docsPageFeedback = z.object({
+	url: z.string().min(1),
+	pageTitle: z.string().min(1),
+	opinion: z.enum(emotionNames),
+	message: z.string().trim().min(1).max(4000),
+});
+
+export type DocsPageFeedback = z.infer<typeof docsPageFeedback>;
+
+export const docsFeedbackActionResponse = z.object({
+	success: z.boolean(),
+	/** Created issue URL, or prefilled `/issues/new` URL when no token. */
+	githubUrl: z.string().optional(),
+	/** True when an issue was created via API (not just a prefill link). */
+	created: z.boolean().optional(),
+	error: z.string().optional(),
+});
+
+export type DocsFeedbackActionResponse = z.infer<
+	typeof docsFeedbackActionResponse
+>;

--- a/apps/www/lib/utils/github.test.ts
+++ b/apps/www/lib/utils/github.test.ts
@@ -55,6 +55,31 @@ describe("github utilities", () => {
 			});
 		});
 
+		it("should use Vercel deploy branch when no manual branch override", () => {
+			vi.stubEnv("VERCEL_GIT_COMMIT_REF", "v1");
+
+			const result = breakDownGithubUrl("https://github.com/yamcodes/arkenv");
+
+			expect(result).toEqual({
+				owner: "yamcodes",
+				repo: "arkenv",
+				defaultBranch: "v1",
+			});
+		});
+
+		it("should prefer NEXT_PUBLIC_GITHUB_BRANCH over Vercel deploy branch", () => {
+			vi.stubEnv("NEXT_PUBLIC_GITHUB_BRANCH", "dev");
+			vi.stubEnv("VERCEL_GIT_COMMIT_REF", "simplify-docs");
+
+			const result = breakDownGithubUrl("https://github.com/yamcodes/arkenv");
+
+			expect(result).toEqual({
+				owner: "yamcodes",
+				repo: "arkenv",
+				defaultBranch: "dev",
+			});
+		});
+
 		it("should use fallback URL when no URL is configured", () => {
 			const result = breakDownGithubUrl();
 

--- a/apps/www/lib/utils/github.ts
+++ b/apps/www/lib/utils/github.ts
@@ -10,7 +10,11 @@ export const breakDownGithubUrl = (githubUrl?: string) => {
 		process.env.NEXT_PUBLIC_GITHUB_URL ??
 		"https://github.com/yamcodes/arkenv";
 
-	const defaultBranch = process.env.NEXT_PUBLIC_GITHUB_BRANCH ?? "dev";
+	// Manual override → Vercel deploy branch → local/default.
+	const defaultBranch =
+		process.env.NEXT_PUBLIC_GITHUB_BRANCH ??
+		process.env.VERCEL_GIT_COMMIT_REF ??
+		"dev";
 	const cleanUrl = url.replace(/\/$/, "");
 	const urlObj = new URL(cleanUrl);
 	const [owner, repo] = urlObj.pathname.split("/").filter(Boolean).slice(-2);

--- a/packages/fumadocs-ui/src/components/docs-toc.tsx
+++ b/packages/fumadocs-ui/src/components/docs-toc.tsx
@@ -8,25 +8,55 @@ import {
 } from "fumadocs-ui/layouts/docs/page/slots/toc";
 import type { ComponentProps } from "react";
 
-/** Keep the TOC grid column (layout spacing) even when a page has no headings. */
+const tocColumnClassName =
+	"sticky top-(--fd-docs-row-1) h-[calc(var(--fd-docs-height)-var(--fd-docs-row-1))] flex flex-col [grid-area:toc] w-(--fd-toc-width) pt-12 pe-4 pb-2 xl:layout:[--fd-toc-width:268px] max-xl:hidden";
+
+/**
+ * TOC rail: keep the layout column when a footer exists, but hide the
+ * "On this page" / "No Headings" chrome when the page has no headings.
+ */
 function DocsTOCMain(props: ComponentProps<typeof TOC>) {
 	const items = useTOCItems();
 
-	if (items.length === 0 && !props.footer && !props.header) {
+	if (items.length === 0) {
+		if (!props.footer && !props.header) {
+			return (
+				<div
+					id="nd-toc"
+					aria-hidden="true"
+					className="sticky top-(--fd-docs-row-1) h-[calc(var(--fd-docs-height)-var(--fd-docs-row-1))] [grid-area:toc] w-(--fd-toc-width) xl:layout:[--fd-toc-width:268px] max-xl:hidden"
+				/>
+			);
+		}
+
 		return (
-			<div
-				id="nd-toc"
-				aria-hidden="true"
-				className="sticky top-(--fd-docs-row-1) h-[calc(var(--fd-docs-height)-var(--fd-docs-row-1))] [grid-area:toc] w-(--fd-toc-width) xl:layout:[--fd-toc-width:268px] max-xl:hidden"
-			/>
+			<div id="nd-toc" className={tocColumnClassName}>
+				{props.header}
+				{props.footer}
+			</div>
 		);
 	}
 
 	return <TOC {...props} />;
 }
 
+/**
+ * Mobile TOC popover: drop the empty-state list chrome when there are no headings.
+ * Footer actions (edit / feedback / star) still render.
+ */
+function DocsTOCPopover(props: ComponentProps<typeof TOCPopover>) {
+	const items = useTOCItems();
+
+	if (items.length === 0) {
+		// Hide TOCItems' empty "No Headings" card; keep trigger + footer.
+		return <TOCPopover {...props} list={{ ...props.list, className: "hidden" }} />;
+	}
+
+	return <TOCPopover {...props} />;
+}
+
 export const docsTocSlots = {
 	provider: TOCProvider,
 	main: DocsTOCMain,
-	popover: TOCPopover,
+	popover: DocsTOCPopover,
 };


### PR DESCRIPTION
## Summary
- Enrich the docs right TOC with scroll/edit/feedback actions and an aurora-style GitHub star card
- Mount the shared home footer on docs pages (full-bleed top rule, Title Case section labels)
- Hide empty “On this page” / “No Headings” chrome when a page has no TOC items

Stacked into the Simplify Docs tracking branch (`simplify-docs` → #1527).

## Test plan
- [ ] Open a docs page with headings: TOC links + star card render; star card has dots/bloom atmosphere
- [ ] Open a docs page with no headings: no “On this page” / “No Headings”; page actions + star card remain
- [ ] Give feedback flow works (issue create or prefilled URL fallback)
- [ ] Docs footer matches home footer links/layout; top separator is full viewport width
- [ ] Home page still uses shared `SiteFooter` and DotGrid defaults unchanged


Made with [Cursor](https://cursor.com)