### PR TITLE
docs(www): populate Validating environment variables guides

### DIFF
--- a/apps/www/content/docs/validating-environment-variables/client-vs-server.mdx
+++ b/apps/www/content/docs/validating-environment-variables/client-vs-server.mdx
@@ -3,29 +3,32 @@ title: Client vs. server
 description: Keep public env keys out of private secrets and off the browser bundle.
 ---
 
-Public keys belong in the client schema. Secrets belong only on the server. Mixing them is how `DATABASE_URL` ends up in a browser bundle.
+Browser bundles and server processes do not share the same trust boundary. A secret that reaches the client is gone: anyone can read it from the network tab or a published chunk. That is why frameworks invented public prefixes (`NEXT_PUBLIC_*`, `VITE_*`, and friends), and why env libraries treat "which keys may ship to the browser" as a first-class problem.
 
-ArkEnv core has no client/server split. Framework packages and plugins enforce the boundary using each host's public prefix.
+ArkEnv validates that split. The core `arkenv()` API stays a flat schema call; the Next.js, Nuxt, Vite, and Bun packages enforce prefixes, strip server values from client graphs, and throw when application code reaches across the boundary. You still write one schema style. The integration owns the fence.
+
+Public keys belong in the client-visible set. Secrets stay server-only. Mixing them is how `DATABASE_URL` ends up in a browser bundle.
 
 <Callout type="error">
-  Importing a server schema into client code exposes secrets. Treat that as a
-  broken build, not a soft warning.
+	ArkEnv treats a server secret read from client code as a hard failure. The
+	runtime proxy throws; strict layouts also keep the server schema out of the
+	client module graph. Do not soften that into a warning.
 </Callout>
 
 ## Public prefixes
 
-| Framework     | Client-visible prefix |
-| ------------- | --------------------- |
-| Next.js       | `NEXT_PUBLIC_*`       |
-| Nuxt          | `NUXT_PUBLIC_*`       |
-| Vite          | `VITE_*`              |
-| Bun (bundler) | `BUN_PUBLIC_*`        |
+| Framework | Client-visible prefix |
+| --- | --- |
+| Next.js | `NEXT_PUBLIC_*` |
+| Nuxt | `NUXT_PUBLIC_*` |
+| Vite | `VITE_*` |
+| Bun (bundler) | `BUN_PUBLIC_*` |
 
 Keys without the prefix stay server-only. `NODE_ENV` is treated as shared on Next.js.
 
-## Flat layout
+## Flat layout (Recommended)
 
-Flat mode uses one `env.ts`. Prefixes decide which keys reach the client. This is the default when you run `arkenv init`.
+Flat layout uses one `env.ts`. Prefixes decide which keys reach the client. This is the default when you run `arkenv init`, and the right choice for most apps.
 
 ```ts title="./env.ts"
 import arkenv from "@/generated/env.gen";
@@ -48,37 +51,43 @@ const nextConfig: NextConfig = {};
 export default withArkEnv(nextConfig);
 ```
 
-On Nuxt flat mode, import from `@arkenv/nuxt` and register `@arkenv/nuxt/module`. Vite and Bun plugins read the same schema and only inline public keys into the client.
+On Nuxt flat layout, import from `@arkenv/nuxt` and register `@arkenv/nuxt/module`. Vite and Bun plugins read the same schema and only inline public keys into the client.
 
-### What flat mode protects
+### What flat layout protects
 
-|        | Secret **value** in client bundle | Variable **name + type** in client       |
-| ------ | --------------------------------- | ---------------------------------------- |
-| Flat   | Blocked                           | Visible (schema ships with client types) |
-| Strict | Blocked                           | Blocked (separate modules)               |
+| | Secret **value** in client bundle | Variable **name + type** in client |
+| --- | --- | --- |
+| Flat layout | Blocked | Visible (schema ships with client types) |
+| Strict layout | Blocked | Blocked (separate modules) |
 
-Flat mode relies on a runtime proxy: reading `env.DATABASE_URL` in a Client Component throws. Autocomplete may still show the key because TypeScript sees one schema file. [`@t3-oss/env-nextjs`](https://env.t3.gg) uses the same single-file pattern.
+Values stay off the wire. Flat layout still types the full schema in one file, so TypeScript may autocomplete server keys in Client Components and the **names and types** of those keys can appear in the client type graph. A runtime proxy throws if you read a server key on the client.
 
-Use strict mode when variable **names** reveal infrastructure you want out of the client graph.
+[`@t3-oss/env-nextjs`](https://env.t3.gg) uses the same single-file pattern for DX, and both projects recommend a split-file layout when you need names and types out of the client graph as well as values.
+
+Pick strict layout when secret **names or types** reveal infrastructure you refuse to ship in client types (internal hostnames, vendor-shaped keys, and similar).
 
 ## Strict layout
 
-Strict mode splits files so the server schema never enters the client module graph:
+Strict layout splits files so the server schema never enters the client module graph:
+
+<Callout type="info">
+	Most apps do not need this. Flat layout already blocks secret values and
+	throws on misuse. Strict layout costs more files and import discipline for a
+	tighter TypeScript boundary. Use it when that boundary is a requirement, not
+	by default.
+</Callout>
 
 <Files>
-  <Folder name="env" defaultOpen>
-    <File name="client.ts" />
-
-    <File name="server.ts" />
-
-    <Folder name="generated" defaultOpen>
-      <File name="env.gen.ts" />
-    </Folder>
-
-    <Folder name="internal" defaultOpen>
-      <File name="shared.ts" />
-    </Folder>
-  </Folder>
+	<Folder name="env" defaultOpen>
+		<File name="client.ts" />
+		<File name="server.ts" />
+		<Folder name="generated" defaultOpen>
+			<File name="env.gen.ts" />
+		</Folder>
+		<Folder name="internal" defaultOpen>
+			<File name="shared.ts" />
+		</Folder>
+	</Folder>
 </Files>
 
 ```ts title="./env/internal/shared.ts"
@@ -119,12 +128,7 @@ Scaffold with:
 pnpm dlx arkenv@latest init --strict
 ```
 
-Nuxt strict uses `@arkenv/nuxt/client` and `@arkenv/nuxt/server`. Omitting `extends` can auto-merge shared and client schemas via Nuxt virtual aliases. Details live in the [Next.js](/docs/guides/frameworks/nextjs) and [Nuxt](/docs/guides/frameworks/nuxt) guides.
-
-## Choosing a layout
-
-- **Flat** for most apps: one file, full autocomplete, runtime guard on misuse.
-- **Strict** when you need compile-time isolation or secret names out of client types.
+Nuxt strict layout uses `@arkenv/nuxt/client` and `@arkenv/nuxt/server`. Omitting `extends` can auto-merge shared and client schemas via Nuxt virtual aliases. Details live in the [Next.js](/docs/guides/frameworks/nextjs) and [Nuxt](/docs/guides/frameworks/nuxt) guides.
 
 ## Next steps
 

--- a/apps/www/content/docs/validating-environment-variables/client-vs-server.mdx
+++ b/apps/www/content/docs/validating-environment-variables/client-vs-server.mdx
@@ -8,18 +8,18 @@ Public keys belong in the client schema. Secrets belong only on the server. Mixi
 ArkEnv core has no client/server split. Framework packages and plugins enforce the boundary using each host's public prefix.
 
 <Callout type="error">
-	Importing a server schema into client code exposes secrets. Treat that as a
-	broken build, not a soft warning.
+  Importing a server schema into client code exposes secrets. Treat that as a
+  broken build, not a soft warning.
 </Callout>
 
 ## Public prefixes
 
-| Framework | Client-visible prefix |
-| --- | --- |
-| Next.js | `NEXT_PUBLIC_*` |
-| Nuxt | `NUXT_PUBLIC_*` |
-| Vite | `VITE_*` |
-| Bun (bundler) | `BUN_PUBLIC_*` |
+| Framework     | Client-visible prefix |
+| ------------- | --------------------- |
+| Next.js       | `NEXT_PUBLIC_*`       |
+| Nuxt          | `NUXT_PUBLIC_*`       |
+| Vite          | `VITE_*`              |
+| Bun (bundler) | `BUN_PUBLIC_*`        |
 
 Keys without the prefix stay server-only. `NODE_ENV` is treated as shared on Next.js.
 
@@ -52,10 +52,10 @@ On Nuxt flat mode, import from `@arkenv/nuxt` and register `@arkenv/nuxt/module`
 
 ### What flat mode protects
 
-| | Secret **value** in client bundle | Variable **name + type** in client |
-| --- | --- | --- |
-| Flat | Blocked | Visible (schema ships with client types) |
-| Strict | Blocked | Blocked (separate modules) |
+|        | Secret **value** in client bundle | Variable **name + type** in client       |
+| ------ | --------------------------------- | ---------------------------------------- |
+| Flat   | Blocked                           | Visible (schema ships with client types) |
+| Strict | Blocked                           | Blocked (separate modules)               |
 
 Flat mode relies on a runtime proxy: reading `env.DATABASE_URL` in a Client Component throws. Autocomplete may still show the key because TypeScript sees one schema file. [`@t3-oss/env-nextjs`](https://env.t3.gg) uses the same single-file pattern.
 
@@ -66,13 +66,15 @@ Use strict mode when variable **names** reveal infrastructure you want out of th
 Strict mode splits files so the server schema never enters the client module graph:
 
 <Files>
-	<Folder name="env" defaultOpen>
-		<File name="client.ts" />
-		<File name="server.ts" />
-		<Folder name="internal" defaultOpen>
-			<File name="shared.ts" />
-		</Folder>
-	</Folder>
+  <Folder name="env" defaultOpen>
+    <File name="client.ts" />
+
+    <File name="server.ts" />
+
+    <Folder name="internal" defaultOpen>
+      <File name="shared.ts" />
+    </Folder>
+  </Folder>
 </Files>
 
 ```ts title="./env/internal/shared.ts"

--- a/apps/www/content/docs/validating-environment-variables/client-vs-server.mdx
+++ b/apps/www/content/docs/validating-environment-variables/client-vs-server.mdx
@@ -10,19 +10,19 @@ ArkEnv validates that split. The core `arkenv()` API stays a flat schema call; t
 Public keys belong in the client-visible set. Secrets stay server-only. Mixing them is how `DATABASE_URL` ends up in a browser bundle.
 
 <Callout type="error">
-	ArkEnv treats a server secret read from client code as a hard failure. The
-	runtime proxy throws; strict layouts also keep the server schema out of the
-	client module graph. Do not soften that into a warning.
+  ArkEnv treats a server secret read from client code as a hard failure. The
+  runtime proxy throws; strict layouts also keep the server schema out of the
+  client module graph. Do not soften that into a warning.
 </Callout>
 
 ## Public prefixes
 
-| Framework | Client-visible prefix |
-| --- | --- |
-| Next.js | `NEXT_PUBLIC_*` |
-| Nuxt | `NUXT_PUBLIC_*` |
-| Vite | `VITE_*` |
-| Bun (bundler) | `BUN_PUBLIC_*` |
+| Framework     | Client-visible prefix |
+| ------------- | --------------------- |
+| Next.js       | `NEXT_PUBLIC_*`       |
+| Nuxt          | `NUXT_PUBLIC_*`       |
+| Vite          | `VITE_*`              |
+| Bun (bundler) | `BUN_PUBLIC_*`        |
 
 Keys without the prefix stay server-only. `NODE_ENV` is treated as shared on Next.js.
 
@@ -55,10 +55,10 @@ On Nuxt flat layout, import from `@arkenv/nuxt` and register `@arkenv/nuxt/modul
 
 ### What flat layout protects
 
-| | Secret **value** in client bundle | Variable **name + type** in client |
-| --- | --- | --- |
-| Flat layout | Blocked | Visible (schema ships with client types) |
-| Strict layout | Blocked | Blocked (separate modules) |
+|               | Secret **value** in client bundle | Variable **name + type** in client       |
+| ------------- | --------------------------------- | ---------------------------------------- |
+| Flat layout   | Blocked                           | Visible (schema ships with client types) |
+| Strict layout | Blocked                           | Blocked (separate modules)               |
 
 Values stay off the wire. Flat layout still types the full schema in one file, so TypeScript may autocomplete server keys in Client Components and the **names and types** of those keys can appear in the client type graph. A runtime proxy throws if you read a server key on the client.
 
@@ -71,23 +71,26 @@ Pick strict layout when secret **names or types** reveal infrastructure you refu
 Strict layout splits files so the server schema never enters the client module graph:
 
 <Callout type="info">
-	Most apps do not need this. Flat layout already blocks secret values and
-	throws on misuse. Strict layout costs more files and import discipline for a
-	tighter TypeScript boundary. Use it when that boundary is a requirement, not
-	by default.
+  Most apps do not need this. Flat layout already blocks secret values and
+  throws on misuse. Strict layout costs more files and import discipline for a
+  tighter TypeScript boundary. Use it when that boundary is a requirement, not
+  by default.
 </Callout>
 
 <Files>
-	<Folder name="env" defaultOpen>
-		<File name="client.ts" />
-		<File name="server.ts" />
-		<Folder name="generated" defaultOpen>
-			<File name="env.gen.ts" />
-		</Folder>
-		<Folder name="internal" defaultOpen>
-			<File name="shared.ts" />
-		</Folder>
-	</Folder>
+  <Folder name="env" defaultOpen>
+    <File name="client.ts" />
+
+    <File name="server.ts" />
+
+    <Folder name="generated" defaultOpen>
+      <File name="env.gen.ts" />
+    </Folder>
+
+    <Folder name="internal" defaultOpen>
+      <File name="shared.ts" />
+    </Folder>
+  </Folder>
 </Files>
 
 ```ts title="./env/internal/shared.ts"

--- a/apps/www/content/docs/validating-environment-variables/client-vs-server.mdx
+++ b/apps/www/content/docs/validating-environment-variables/client-vs-server.mdx
@@ -1,0 +1,125 @@
+---
+title: Client vs. server
+description: Keep public env keys out of private secrets and off the browser bundle.
+---
+
+Public keys belong in the client schema. Secrets belong only on the server. Mixing them is how `DATABASE_URL` ends up in a browser bundle.
+
+ArkEnv core has no client/server split. Framework packages and plugins enforce the boundary using each host's public prefix.
+
+<Callout type="error">
+	Importing a server schema into client code exposes secrets. Treat that as a
+	broken build, not a soft warning.
+</Callout>
+
+## Public prefixes
+
+| Framework | Client-visible prefix |
+| --- | --- |
+| Next.js | `NEXT_PUBLIC_*` |
+| Nuxt | `NUXT_PUBLIC_*` |
+| Vite | `VITE_*` |
+| Bun (bundler) | `BUN_PUBLIC_*` |
+
+Keys without the prefix stay server-only. `NODE_ENV` is treated as shared on Next.js.
+
+## Flat layout
+
+Flat mode uses one `env.ts`. Prefixes decide which keys reach the client. This is the default when you run `arkenv init`.
+
+```ts title="./env.ts"
+import arkenv from "@/generated/env.gen";
+
+export const env = arkenv({
+	DATABASE_URL: "string",
+	NEXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
+	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+});
+```
+
+Wire the Next.js config plugin so codegen and build-time exclusion run:
+
+```ts title="./next.config.ts"
+import type { NextConfig } from "next";
+import { withArkEnv } from "@arkenv/nextjs/config";
+
+const nextConfig: NextConfig = {};
+
+export default withArkEnv(nextConfig);
+```
+
+On Nuxt flat mode, import from `@arkenv/nuxt` and register `@arkenv/nuxt/module`. Vite and Bun plugins read the same schema and only inline public keys into the client.
+
+### What flat mode protects
+
+| | Secret **value** in client bundle | Variable **name + type** in client |
+| --- | --- | --- |
+| Flat | Blocked | Visible (schema ships with client types) |
+| Strict | Blocked | Blocked (separate modules) |
+
+Flat mode relies on a runtime proxy: reading `env.DATABASE_URL` in a Client Component throws. Autocomplete may still show the key because TypeScript sees one schema file. [`@t3-oss/env-nextjs`](https://env.t3.gg) uses the same single-file pattern.
+
+Use strict mode when variable **names** reveal infrastructure you want out of the client graph.
+
+## Strict layout
+
+Strict mode splits files so the server schema never enters the client module graph:
+
+<Files>
+	<Folder name="env" defaultOpen>
+		<File name="client.ts" />
+		<File name="server.ts" />
+		<Folder name="internal" defaultOpen>
+			<File name="shared.ts" />
+		</Folder>
+	</Folder>
+</Files>
+
+```ts title="./env/internal/shared.ts"
+import { type } from "@arkenv/core";
+
+export const SharedSchema = type({
+	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+});
+```
+
+```ts title="./env/client.ts"
+import arkenv from "./generated/env.gen";
+import { SharedSchema } from "./internal/shared";
+
+export const env = arkenv(
+	{
+		NEXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
+	},
+	{ extends: [SharedSchema] },
+);
+```
+
+```ts title="./env/server.ts"
+import arkenv from "@arkenv/nextjs/server";
+import { env as clientEnv } from "./client";
+
+export const env = arkenv(
+	{
+		DATABASE_URL: "string",
+	},
+	{ extends: [clientEnv] },
+);
+```
+
+Scaffold with:
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init --strict
+```
+
+Nuxt strict uses `@arkenv/nuxt/client` and `@arkenv/nuxt/server`. Omitting `extends` can auto-merge shared and client schemas via Nuxt virtual aliases. Details live in the [Next.js](/docs/guides/frameworks/nextjs) and [Nuxt](/docs/guides/frameworks/nuxt) guides.
+
+## Choosing a layout
+
+- **Flat** for most apps: one file, full autocomplete, runtime guard on misuse.
+- **Strict** when you need compile-time isolation or secret names out of client types.
+
+## Next steps
+
+With boundaries set, configure [coercion and parsing](/docs/validating-environment-variables/coercion-and-parsing) for non-string values.

--- a/apps/www/content/docs/validating-environment-variables/client-vs-server.mdx
+++ b/apps/www/content/docs/validating-environment-variables/client-vs-server.mdx
@@ -66,15 +66,16 @@ Use strict mode when variable **names** reveal infrastructure you want out of th
 Strict mode splits files so the server schema never enters the client module graph:
 
 <Files>
-  <Folder name="env" defaultOpen>
-    <File name="client.ts" />
-
-    <File name="server.ts" />
-
-    <Folder name="internal" defaultOpen>
-      <File name="shared.ts" />
-    </Folder>
-  </Folder>
+	<Folder name="env" defaultOpen>
+		<File name="client.ts" />
+		<File name="server.ts" />
+		<Folder name="generated" defaultOpen>
+			<File name="env.gen.ts" />
+		</Folder>
+		<Folder name="internal" defaultOpen>
+			<File name="shared.ts" />
+		</Folder>
+	</Folder>
 </Files>
 
 ```ts title="./env/internal/shared.ts"

--- a/apps/www/content/docs/validating-environment-variables/client-vs-server.mdx
+++ b/apps/www/content/docs/validating-environment-variables/client-vs-server.mdx
@@ -66,16 +66,19 @@ Use strict mode when variable **names** reveal infrastructure you want out of th
 Strict mode splits files so the server schema never enters the client module graph:
 
 <Files>
-	<Folder name="env" defaultOpen>
-		<File name="client.ts" />
-		<File name="server.ts" />
-		<Folder name="generated" defaultOpen>
-			<File name="env.gen.ts" />
-		</Folder>
-		<Folder name="internal" defaultOpen>
-			<File name="shared.ts" />
-		</Folder>
-	</Folder>
+  <Folder name="env" defaultOpen>
+    <File name="client.ts" />
+
+    <File name="server.ts" />
+
+    <Folder name="generated" defaultOpen>
+      <File name="env.gen.ts" />
+    </Folder>
+
+    <Folder name="internal" defaultOpen>
+      <File name="shared.ts" />
+    </Folder>
+  </Folder>
 </Files>
 
 ```ts title="./env/internal/shared.ts"

--- a/apps/www/content/docs/validating-environment-variables/coercion-and-parsing.mdx
+++ b/apps/www/content/docs/validating-environment-variables/coercion-and-parsing.mdx
@@ -1,0 +1,156 @@
+---
+title: Coercion and parsing
+description: Turn raw string env values into numbers, booleans, arrays, and objects.
+---
+
+Environment variables arrive as strings. ArkEnv coerces those strings into the types your schema declares so application code can treat `PORT` as a number and `DEBUG` as a boolean.
+
+Coercion runs on a copy of the input before validation. Disable it with `{ coerce: false }` when you need the raw strings.
+
+## Numbers
+
+Any field typed as `number` or a numeric subtype (including [`number.port`](/docs/reference/keywords)) is parsed from the string form:
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv(
+	{
+		PORT: "number.port",
+		RETRY_COUNT: "number.integer = 3",
+		AGE: "0 <= number.integer <= 120",
+	},
+	{
+		env: {
+			PORT: "8080",
+			RETRY_COUNT: "5",
+			AGE: "30",
+		},
+	},
+);
+
+env.PORT; // number
+```
+
+## Booleans
+
+`boolean` accepts `"true"` and `"false"`:
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv(
+	{ DEBUG: "boolean = false" },
+	{ env: { DEBUG: "true" } },
+);
+
+env.DEBUG; // true
+```
+
+## Arrays
+
+By default ArkEnv splits on commas and trims each entry:
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv(
+	{
+		TAGS: "string[]",
+		PORTS: "number[]",
+	},
+	{
+		env: {
+			TAGS: "web, app, api",
+			PORTS: "3000, 8080",
+		},
+	},
+);
+```
+
+Switch to JSON arrays with `arrayFormat: "json"`:
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv(
+	{ TAGS: "string[]" },
+	{
+		arrayFormat: "json",
+		env: { TAGS: '["web", "app"]' },
+	},
+);
+```
+
+## Objects
+
+JSON strings map onto nested object schemas. Nested fields are coerced too:
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv(
+	{
+		DATABASE: {
+			HOST: "string",
+			PORT: "number",
+		},
+	},
+	{
+		env: {
+			DATABASE: '{"HOST": "localhost", "PORT": "5432"}',
+		},
+	},
+);
+
+env.DATABASE.PORT; // number
+```
+
+## Morphs
+
+For custom transforms, use ArkType `.pipe` via `type()`:
+
+```ts title="./env.ts" twoslash
+import arkenv, { type } from "@arkenv/core";
+
+export const env = arkenv({
+	BUILD_ID: type("string").pipe((value) => value.trim().toUpperCase()),
+});
+```
+
+Morphs run as part of ArkType validation. Coercion still handles the common string-to-number and string-to-boolean cases first.
+
+## Standard Schema coercion
+
+[`@arkenv/standard`](/docs/reference/standard) coerces when the validator exposes JSON Schema that ArkEnv can introspect. Support includes Zod (v4.2+), Valibot (v1.2+ with `@valibot/to-json-schema`), Zod Mini, VineJS (v4.3+), and other Standard JSON Schema v1 libraries.
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/standard";
+import { z } from "zod";
+
+export const env = arkenv({
+	PORT: z.number().int(),
+	DEBUG: z.boolean(),
+});
+```
+
+You can also lean on the validator's own coercion (`z.coerce.number()`) and keep ArkEnv's `coerce` option as a backup.
+
+## Disabling coercion
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv(
+	{ PORT: "string" },
+	{ coerce: false, env: { PORT: "3000" } },
+);
+
+env.PORT; // "3000"
+```
+
+With `coerce: false`, a schema of `"number"` rejects `"3000"` unless you morph it yourself.
+
+## Next steps
+
+See what happens when a value fails validation under [error reporting](/docs/validating-environment-variables/error-reporting).

--- a/apps/www/content/docs/validating-environment-variables/coercion-and-parsing.mdx
+++ b/apps/www/content/docs/validating-environment-variables/coercion-and-parsing.mdx
@@ -11,7 +11,7 @@ Coercion runs on a copy of the input before validation. Disable it with `{ coerc
 
 Any field typed as `number` or a numeric subtype (including [`number.port`](/docs/reference/keywords)) is parsed from the string form:
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -36,7 +36,7 @@ env.PORT; // number
 
 `boolean` accepts `"true"` and `"false"`:
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -51,7 +51,7 @@ env.DEBUG; // true
 
 By default ArkEnv splits on commas and trims each entry:
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -70,7 +70,7 @@ export const env = arkenv(
 
 Switch to JSON arrays with `arrayFormat: "json"`:
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -86,7 +86,7 @@ export const env = arkenv(
 
 JSON strings map onto nested object schemas. Nested fields are coerced too:
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -110,7 +110,7 @@ env.DATABASE.PORT; // number
 
 For custom transforms, use ArkType `.pipe` via `type()`:
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv, { type } from "@arkenv/core";
 
 export const env = arkenv({
@@ -124,7 +124,7 @@ Morphs run as part of ArkType validation. Coercion still handles the common stri
 
 [`@arkenv/standard`](/docs/reference/standard) coerces when the validator exposes JSON Schema that ArkEnv can introspect. Support includes Zod (v4.2+), Valibot (v1.2+ with `@valibot/to-json-schema`), Zod Mini, VineJS (v4.3+), and other Standard JSON Schema v1 libraries.
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/standard";
 import { z } from "zod";
 
@@ -138,7 +138,7 @@ You can also lean on the validator's own coercion (`z.coerce.number()`) and keep
 
 ## Disabling coercion
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(

--- a/apps/www/content/docs/validating-environment-variables/coercion-and-parsing.mdx
+++ b/apps/www/content/docs/validating-environment-variables/coercion-and-parsing.mdx
@@ -5,13 +5,13 @@ description: Turn raw string env values into numbers, booleans, arrays, and obje
 
 Environment variables arrive as strings. ArkEnv coerces those strings into the types your schema declares so application code can treat `PORT` as a number and `DEBUG` as a boolean.
 
-Coercion runs on a copy of the input before validation. Disable it with `{ coerce: false }` when you need the raw strings.
+Disable coercion with `{ coerce: false }` when you need the raw strings.
 
 ## Numbers
 
 Any field typed as `number` or a numeric subtype (including [`number.port`](/docs/reference/keywords)) is parsed from the string form:
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -29,14 +29,15 @@ export const env = arkenv(
 	},
 );
 
-env.PORT; // number
+env.PORT;
+// ^?
 ```
 
 ## Booleans
 
-`boolean` accepts `"true"` and `"false"`:
+`boolean` accepts the lowercase strings `"true"` and `"false"` only. Values like `"0"`, `"1"`, `"True"`, `"YES"`, or `"on"` are **not** coerced and fail validation.
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -44,14 +45,17 @@ export const env = arkenv(
 	{ env: { DEBUG: "true" } },
 );
 
-env.DEBUG; // true
+env.DEBUG;
+// ^?
 ```
+
+Need a wider truthy set? Normalize with a morph (ArkType) or the validator's own transform (Zod/Valibot), or keep the field as `string` and map it in application code.
 
 ## Arrays
 
 By default ArkEnv splits on commas and trims each entry:
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -66,11 +70,16 @@ export const env = arkenv(
 		},
 	},
 );
+
+env.TAGS;
+// ^?
+env.PORTS;
+// ^?
 ```
 
 Switch to JSON arrays with `arrayFormat: "json"`:
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -80,13 +89,16 @@ export const env = arkenv(
 		env: { TAGS: '["web", "app"]' },
 	},
 );
+
+env.TAGS;
+// ^?
 ```
 
 ## Objects
 
 JSON strings map onto nested object schemas. Nested fields are coerced too:
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -103,42 +115,55 @@ export const env = arkenv(
 	},
 );
 
-env.DATABASE.PORT; // number
+env.DATABASE;
+// ^?
 ```
 
-## Morphs
+## Morphs (ArkType)
 
-For custom transforms, use ArkType `.pipe` via `type()`:
+Custom transforms with `@arkenv/core` use ArkType `.pipe` via `type()`. Zod and Valibot use their own `.transform` / pipe APIs on the field schema instead.
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv, { type } from "@arkenv/core";
 
-export const env = arkenv({
-	BUILD_ID: type("string").pipe((value) => value.trim().toUpperCase()),
-});
+export const env = arkenv(
+	{
+		BUILD_ID: type("string").pipe((value) => value.trim().toUpperCase()),
+	},
+	{ env: { BUILD_ID: "  abc  " } },
+);
+
+env.BUILD_ID;
+// ^?
 ```
 
-Morphs run as part of ArkType validation. Coercion still handles the common string-to-number and string-to-boolean cases first.
+ArkEnv's built-in coercion still handles the common string-to-number and string-to-boolean cases before ArkType morphs run.
 
-## Standard Schema coercion
+## Standard Schema coercion (Zod, Valibot, etc.)
 
-[`@arkenv/standard`](/docs/reference/standard) coerces when the validator exposes JSON Schema that ArkEnv can introspect. Support includes Zod (v4.2+), Valibot (v1.2+ with `@valibot/to-json-schema`), Zod Mini, VineJS (v4.3+), and other Standard JSON Schema v1 libraries.
+[`@arkenv/standard`](/docs/reference/standard) coerces when the validator exposes JSON Schema that ArkEnv can introspect. Support includes Zod (v4.2+), Valibot (v1.2+ with `@valibot/to-json-schema`), Zod Mini, VineJS (v4.3+), and other libraries on the [Standard JSON Schema](https://standardschema.dev/json-schema#what-schema-libraries-support-this-spec) list.
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/standard";
 import { z } from "zod";
 
-export const env = arkenv({
-	PORT: z.number().int(),
-	DEBUG: z.boolean(),
-});
+export const env = arkenv(
+	{
+		PORT: z.number().int(),
+		DEBUG: z.boolean(),
+	},
+	{ env: { PORT: "3000", DEBUG: "true" } },
+);
+
+env.PORT;
+// ^?
 ```
 
 You can also lean on the validator's own coercion (`z.coerce.number()`) and keep ArkEnv's `coerce` option as a backup.
 
 ## Disabling coercion
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -146,7 +171,8 @@ export const env = arkenv(
 	{ coerce: false, env: { PORT: "3000" } },
 );
 
-env.PORT; // "3000"
+env.PORT;
+// ^?
 ```
 
 With `coerce: false`, a schema of `"number"` rejects `"3000"` unless you morph it yourself.

--- a/apps/www/content/docs/validating-environment-variables/defining-types.mdx
+++ b/apps/www/content/docs/validating-environment-variables/defining-types.mdx
@@ -9,7 +9,7 @@ Environment values arrive as strings. Your schema tells ArkEnv which TypeScript 
 
 A bare `string` requires the key. Append `= 'value'` for a default when the key is missing:
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 export const env = arkenv({
@@ -25,7 +25,7 @@ export const env = arkenv({
 
 Declare numeric and boolean targets. ArkEnv [coerces](/docs/validating-environment-variables/coercion-and-parsing) `"3000"` and `"true"` for you when coercion is on (the default):
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 export const env = arkenv({
@@ -41,7 +41,7 @@ export const env = arkenv({
 
 Use ArkType string literals for fixed sets of values:
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 export const env = arkenv({
@@ -59,7 +59,7 @@ export const env = arkenv({
 | `string.host` | An IP address or `"localhost"` |
 | `number.port` | An integer from `0` to `65535` |
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 export const env = arkenv({
@@ -74,7 +74,7 @@ Keywords work only with `@arkenv/core` and ArkType. Full details live under [key
 
 For morphs, function defaults, or reuse across files, build the field with `type()`:
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv, { type } from "@arkenv/core";
 
 export const env = arkenv({
@@ -90,7 +90,7 @@ See [reusing schemas](/docs/validating-environment-variables/reusing-schemas) wh
 
 With `@arkenv/standard`, pass Zod (or Valibot, ArkType via Standard Schema, and others) schemas as values:
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/standard";
 import { z } from "zod";
 

--- a/apps/www/content/docs/validating-environment-variables/defining-types.mdx
+++ b/apps/www/content/docs/validating-environment-variables/defining-types.mdx
@@ -54,8 +54,8 @@ export const env = arkenv({
 
 `@arkenv/core` adds env-oriented keywords on top of [ArkType's primitives](https://arktype.io/docs/primitives):
 
-| Keyword | Meaning |
-| --- | --- |
+| Keyword       | Meaning                        |
+| ------------- | ------------------------------ |
 | `string.host` | An IP address or `"localhost"` |
 | `number.port` | An integer from `0` to `65535` |
 

--- a/apps/www/content/docs/validating-environment-variables/defining-types.mdx
+++ b/apps/www/content/docs/validating-environment-variables/defining-types.mdx
@@ -10,53 +10,54 @@ Your schema is a map from env key names to validators. `@arkenv/core` uses the A
 ## Strings, numbers, booleans, enums
 
 <Tabs items={["ArkType (@arkenv/core)", "Zod (@arkenv/standard)"]}>
-	<Tab value="ArkType (@arkenv/core)">
-		```ts title="./env.ts" twoslash
-		import arkenv from "@arkenv/core";
+  <Tab value="ArkType (@arkenv/core)">
+    ```ts title="./env.ts" twoslash
+    import arkenv from "@arkenv/core";
 
-		export const env = arkenv({
-			API_URL: "string",
-			APP_NAME: "string = 'My App'",
-			OPTIONAL_NOTE: "string | undefined",
-			PORT: "number.port = 3000",
-			RETRY_COUNT: "number.integer = 3",
-			DEBUG: "boolean = false",
-			NODE_ENV: "'development' | 'production' | 'test' = 'development'",
-			LOG_LEVEL: "'debug' | 'info' | 'warn' | 'error' = 'info'",
-		});
-		```
+    export const env = arkenv({
+    	API_URL: "string",
+    	APP_NAME: "string = 'My App'",
+    	OPTIONAL_NOTE: "string | undefined",
+    	PORT: "number.port = 3000",
+    	RETRY_COUNT: "number.integer = 3",
+    	DEBUG: "boolean = false",
+    	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+    	LOG_LEVEL: "'debug' | 'info' | 'warn' | 'error' = 'info'",
+    });
+    ```
 
-		A bare `string` requires the key. Append `= 'value'` for a default. `string | undefined` accepts a missing key. An empty string (`NOTE=`) still counts as present unless you set [`emptyAsUndefined`](/docs/reference/options).
-	</Tab>
-	<Tab value="Zod (@arkenv/standard)">
-		```ts title="./env.ts" twoslash
-		import arkenv from "@arkenv/standard";
-		import { z } from "zod";
+    A bare `string` requires the key. Append `= 'value'` for a default. `string | undefined` accepts a missing key. An empty string (`NOTE=`) still counts as present unless you set [`emptyAsUndefined`](/docs/reference/options).
+  </Tab>
 
-		export const env = arkenv({
-			API_URL: z.string(),
-			APP_NAME: z.string().default("My App"),
-			OPTIONAL_NOTE: z.string().optional(),
-			PORT: z.coerce.number().int().min(0).max(65535).default(3000),
-			RETRY_COUNT: z.coerce.number().int().default(3),
-			DEBUG: z.coerce.boolean().default(false),
-			NODE_ENV: z
-				.enum(["development", "production", "test"])
-				.default("development"),
-			LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]).default("info"),
-		});
-		```
+  <Tab value="Zod (@arkenv/standard)">
+    ```ts title="./env.ts" twoslash
+    import arkenv from "@arkenv/standard";
+    import { z } from "zod";
 
-		Valibot (and other Standard Schema libraries) follow the same pattern: pass each field's schema as the map value. See [`@arkenv/standard`](/docs/reference/standard).
-	</Tab>
+    export const env = arkenv({
+    	API_URL: z.string(),
+    	APP_NAME: z.string().default("My App"),
+    	OPTIONAL_NOTE: z.string().optional(),
+    	PORT: z.coerce.number().int().min(0).max(65535).default(3000),
+    	RETRY_COUNT: z.coerce.number().int().default(3),
+    	DEBUG: z.coerce.boolean().default(false),
+    	NODE_ENV: z
+    		.enum(["development", "production", "test"])
+    		.default("development"),
+    	LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]).default("info"),
+    });
+    ```
+
+    Valibot (and other Standard Schema libraries) follow the same pattern: pass each field's schema as the map value. See [`@arkenv/standard`](/docs/reference/standard).
+  </Tab>
 </Tabs>
 
 ## ArkEnv keywords (ArkType)
 
 `@arkenv/core` adds env-oriented keywords on top of [ArkType's primitives](https://arktype.io/docs/primitives). They are not available on `@arkenv/standard`.
 
-| Keyword | Meaning |
-| --- | --- |
+| Keyword       | Meaning                        |
+| ------------- | ------------------------------ |
 | `string.host` | An IP address or `"localhost"` |
 | `number.port` | An integer from `0` to `65535` |
 
@@ -76,28 +77,29 @@ Full details: [keywords](/docs/reference/keywords).
 For morphs, function defaults, or reuse across files:
 
 <Tabs items={["ArkType type()", "Zod"]}>
-	<Tab value="ArkType type()">
-		```ts title="./env.ts" twoslash
-		import arkenv, { type } from "@arkenv/core";
+  <Tab value="ArkType type()">
+    ```ts title="./env.ts" twoslash
+    import arkenv, { type } from "@arkenv/core";
 
-		export const env = arkenv({
-			PORT: "number.port = 3000",
-			FEATURE_FLAGS: type("string[]").default(() => []),
-			BUILD_ID: type("string").pipe((value) => value.trim()),
-		});
-		```
-	</Tab>
-	<Tab value="Zod">
-		```ts title="./env.ts" twoslash
-		import arkenv from "@arkenv/standard";
-		import { z } from "zod";
+    export const env = arkenv({
+    	PORT: "number.port = 3000",
+    	FEATURE_FLAGS: type("string[]").default(() => []),
+    	BUILD_ID: type("string").pipe((value) => value.trim()),
+    });
+    ```
+  </Tab>
 
-		export const env = arkenv({
-			PORT: z.coerce.number().int().min(0).max(65535).default(3000),
-			BUILD_ID: z.string().transform((value) => value.trim()),
-		});
-		```
-	</Tab>
+  <Tab value="Zod">
+    ```ts title="./env.ts" twoslash
+    import arkenv from "@arkenv/standard";
+    import { z } from "zod";
+
+    export const env = arkenv({
+    	PORT: z.coerce.number().int().min(0).max(65535).default(3000),
+    	BUILD_ID: z.string().transform((value) => value.trim()),
+    });
+    ```
+  </Tab>
 </Tabs>
 
 See [reusing schemas](/docs/validating-environment-variables/reusing-schemas) when the whole schema should be shared.

--- a/apps/www/content/docs/validating-environment-variables/defining-types.mdx
+++ b/apps/www/content/docs/validating-environment-variables/defining-types.mdx
@@ -3,63 +3,64 @@ title: Defining types
 description: Declare string, number, boolean, enum, and keyword schemas for env keys.
 ---
 
-Environment values arrive as strings. Your schema tells ArkEnv which TypeScript types you want after validation. This guide covers the ArkType DSL used by `@arkenv/core`.
+Your schema is a map from env key names to validators. `@arkenv/core` uses the ArkType DSL (and ArkEnv keywords). `@arkenv/standard` accepts Zod, Valibot, and other [Standard Schema](https://standardschema.dev/) validators. Pick one stack per project; both paths produce a typed `env` object.
 
-## Strings and defaults
+[Coercion and parsing](/docs/validating-environment-variables/coercion-and-parsing) covers how strings become numbers and booleans. This page is about declaring the shape.
 
-A bare `string` requires the key. Append `= 'value'` for a default when the key is missing:
+## Strings, numbers, booleans, enums
 
-```ts title="./env.ts"
-import arkenv from "@arkenv/core";
+<Tabs items={["ArkType (@arkenv/core)", "Zod (@arkenv/standard)"]}>
+	<Tab value="ArkType (@arkenv/core)">
+		```ts title="./env.ts" twoslash
+		import arkenv from "@arkenv/core";
 
-export const env = arkenv({
-	API_URL: "string",
-	APP_NAME: "string = 'My App'",
-	OPTIONAL_NOTE: "string | undefined",
-});
-```
+		export const env = arkenv({
+			API_URL: "string",
+			APP_NAME: "string = 'My App'",
+			OPTIONAL_NOTE: "string | undefined",
+			PORT: "number.port = 3000",
+			RETRY_COUNT: "number.integer = 3",
+			DEBUG: "boolean = false",
+			NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+			LOG_LEVEL: "'debug' | 'info' | 'warn' | 'error' = 'info'",
+		});
+		```
 
-`string | undefined` accepts a missing key. An empty string (`NOTE=`) still counts as present unless you set [`emptyAsUndefined`](/docs/reference/options).
+		A bare `string` requires the key. Append `= 'value'` for a default. `string | undefined` accepts a missing key. An empty string (`NOTE=`) still counts as present unless you set [`emptyAsUndefined`](/docs/reference/options).
+	</Tab>
+	<Tab value="Zod (@arkenv/standard)">
+		```ts title="./env.ts" twoslash
+		import arkenv from "@arkenv/standard";
+		import { z } from "zod";
 
-## Numbers and booleans
+		export const env = arkenv({
+			API_URL: z.string(),
+			APP_NAME: z.string().default("My App"),
+			OPTIONAL_NOTE: z.string().optional(),
+			PORT: z.coerce.number().int().min(0).max(65535).default(3000),
+			RETRY_COUNT: z.coerce.number().int().default(3),
+			DEBUG: z.coerce.boolean().default(false),
+			NODE_ENV: z
+				.enum(["development", "production", "test"])
+				.default("development"),
+			LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]).default("info"),
+		});
+		```
 
-Declare numeric and boolean targets. ArkEnv [coerces](/docs/validating-environment-variables/coercion-and-parsing) `"3000"` and `"true"` for you when coercion is on (the default):
+		Valibot (and other Standard Schema libraries) follow the same pattern: pass each field's schema as the map value. See [`@arkenv/standard`](/docs/reference/standard).
+	</Tab>
+</Tabs>
 
-```ts title="./env.ts"
-import arkenv from "@arkenv/core";
+## ArkEnv keywords (ArkType)
 
-export const env = arkenv({
-	PORT: "number.port = 3000",
-	RETRY_COUNT: "number.integer = 3",
-	DEBUG: "boolean = false",
-});
-```
+`@arkenv/core` adds env-oriented keywords on top of [ArkType's primitives](https://arktype.io/docs/primitives). They are not available on `@arkenv/standard`.
 
-`env.PORT` is a `number`. `env.DEBUG` is a `boolean`.
-
-## Enums and unions
-
-Use ArkType string literals for fixed sets of values:
-
-```ts title="./env.ts"
-import arkenv from "@arkenv/core";
-
-export const env = arkenv({
-	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
-	LOG_LEVEL: "'debug' | 'info' | 'warn' | 'error' = 'info'",
-});
-```
-
-## ArkEnv keywords
-
-`@arkenv/core` adds env-oriented keywords on top of [ArkType's primitives](https://arktype.io/docs/primitives):
-
-| Keyword       | Meaning                        |
-| ------------- | ------------------------------ |
+| Keyword | Meaning |
+| --- | --- |
 | `string.host` | An IP address or `"localhost"` |
 | `number.port` | An integer from `0` to `65535` |
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/core";
 
 export const env = arkenv({
@@ -68,38 +69,38 @@ export const env = arkenv({
 });
 ```
 
-Keywords work only with `@arkenv/core` and ArkType. Full details live under [keywords](/docs/reference/keywords).
+Full details: [keywords](/docs/reference/keywords).
 
-## Richer definitions with `type()`
+## Richer field definitions
 
-For morphs, function defaults, or reuse across files, build the field with `type()`:
+For morphs, function defaults, or reuse across files:
 
-```ts title="./env.ts"
-import arkenv, { type } from "@arkenv/core";
+<Tabs items={["ArkType type()", "Zod"]}>
+	<Tab value="ArkType type()">
+		```ts title="./env.ts" twoslash
+		import arkenv, { type } from "@arkenv/core";
 
-export const env = arkenv({
-	PORT: "number.port = 3000",
-	FEATURE_FLAGS: type("string[]").default(() => []),
-	BUILD_ID: type("string").pipe((value) => value.trim()),
-});
-```
+		export const env = arkenv({
+			PORT: "number.port = 3000",
+			FEATURE_FLAGS: type("string[]").default(() => []),
+			BUILD_ID: type("string").pipe((value) => value.trim()),
+		});
+		```
+	</Tab>
+	<Tab value="Zod">
+		```ts title="./env.ts" twoslash
+		import arkenv from "@arkenv/standard";
+		import { z } from "zod";
 
-See [reusing schemas](/docs/validating-environment-variables/reusing-schemas) when the whole schema should be a shared `type()` object.
+		export const env = arkenv({
+			PORT: z.coerce.number().int().min(0).max(65535).default(3000),
+			BUILD_ID: z.string().transform((value) => value.trim()),
+		});
+		```
+	</Tab>
+</Tabs>
 
-## Standard Schema validators
-
-With `@arkenv/standard`, pass Zod (or Valibot, ArkType via Standard Schema, and others) schemas as values:
-
-```ts title="./env.ts"
-import arkenv from "@arkenv/standard";
-import { z } from "zod";
-
-export const env = arkenv({
-	NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
-	PORT: z.coerce.number().int().min(0).max(65535).default(3000),
-	DEBUG: z.coerce.boolean().default(false),
-});
-```
+See [reusing schemas](/docs/validating-environment-variables/reusing-schemas) when the whole schema should be shared.
 
 ## Next steps
 

--- a/apps/www/content/docs/validating-environment-variables/defining-types.mdx
+++ b/apps/www/content/docs/validating-environment-variables/defining-types.mdx
@@ -1,0 +1,106 @@
+---
+title: Defining types
+description: Declare string, number, boolean, enum, and keyword schemas for env keys.
+---
+
+Environment values arrive as strings. Your schema tells ArkEnv which TypeScript types you want after validation. This guide covers the ArkType DSL used by `@arkenv/core`.
+
+## Strings and defaults
+
+A bare `string` requires the key. Append `= 'value'` for a default when the key is missing:
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+	API_URL: "string",
+	APP_NAME: "string = 'My App'",
+	OPTIONAL_NOTE: "string | undefined",
+});
+```
+
+`string | undefined` accepts a missing key. An empty string (`NOTE=`) still counts as present unless you set [`emptyAsUndefined`](/docs/reference/options).
+
+## Numbers and booleans
+
+Declare numeric and boolean targets. ArkEnv [coerces](/docs/validating-environment-variables/coercion-and-parsing) `"3000"` and `"true"` for you when coercion is on (the default):
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+	PORT: "number.port = 3000",
+	RETRY_COUNT: "number.integer = 3",
+	DEBUG: "boolean = false",
+});
+```
+
+`env.PORT` is a `number`. `env.DEBUG` is a `boolean`.
+
+## Enums and unions
+
+Use ArkType string literals for fixed sets of values:
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+	LOG_LEVEL: "'debug' | 'info' | 'warn' | 'error' = 'info'",
+});
+```
+
+## ArkEnv keywords
+
+`@arkenv/core` adds env-oriented keywords on top of [ArkType's primitives](https://arktype.io/docs/primitives):
+
+| Keyword | Meaning |
+| --- | --- |
+| `string.host` | An IP address or `"localhost"` |
+| `number.port` | An integer from `0` to `65535` |
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+	HOST: "string.host = 'localhost'",
+	PORT: "number.port = 3000",
+});
+```
+
+Keywords work only with `@arkenv/core` and ArkType. Full details live under [keywords](/docs/reference/keywords).
+
+## Richer definitions with `type()`
+
+For morphs, function defaults, or reuse across files, build the field with `type()`:
+
+```ts title="./env.ts" twoslash
+import arkenv, { type } from "@arkenv/core";
+
+export const env = arkenv({
+	PORT: "number.port = 3000",
+	FEATURE_FLAGS: type("string[]").default(() => []),
+	BUILD_ID: type("string").pipe((value) => value.trim()),
+});
+```
+
+See [reusing schemas](/docs/validating-environment-variables/reusing-schemas) when the whole schema should be a shared `type()` object.
+
+## Standard Schema validators
+
+With `@arkenv/standard`, pass Zod (or Valibot, ArkType via Standard Schema, and others) schemas as values:
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/standard";
+import { z } from "zod";
+
+export const env = arkenv({
+	NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+	PORT: z.coerce.number().int().min(0).max(65535).default(3000),
+	DEBUG: z.coerce.boolean().default(false),
+});
+```
+
+## Next steps
+
+If the app has a browser bundle, set [client vs. server boundaries](/docs/validating-environment-variables/client-vs-server) next.

--- a/apps/www/content/docs/validating-environment-variables/error-reporting.mdx
+++ b/apps/www/content/docs/validating-environment-variables/error-reporting.mdx
@@ -3,7 +3,7 @@ title: Error reporting
 description: Fail fast on invalid env with clear console output and structured issues.
 ---
 
-ArkEnv throws at the call site when a required variable is missing or a value fails the schema. Bad config stays out of running processes.
+ArkEnv throws at the call site when a required variable is missing or a value fails the schema. Bad config stays out of running processes, builds, and plugin runs.
 
 ## What you see in the console
 
@@ -16,6 +16,8 @@ Errors found while validating environment variables
 ```
 
 Paths are highlighted; the header is red when ANSI color is available.
+
+Most apps let that throw stop the process. You do not need a `try/catch` around every `arkenv()` call. Catch only when you want to inspect `ArkEnvError` yourself (custom boot UI, tests, or a wrapper):
 
 ```ts title="./boot.ts"
 import arkenv, { ArkEnvError } from "@arkenv/core";
@@ -41,33 +43,35 @@ try {
 
 Each entry in `error.issues` includes a machine-readable `code`:
 
-| Code                                  | Typical cause                                 |
-| ------------------------------------- | --------------------------------------------- |
-| `MISSING_VARIABLE`                    | Required key absent                           |
-| `INVALID_TYPE`                        | Value could not match the declared type       |
-| `VALUE_TOO_SMALL` / `VALUE_TOO_LARGE` | Numeric or length bounds                      |
-| `PATTERN_MISMATCH`                    | String failed a pattern                       |
-| `INVALID_FORMAT`                      | Format keyword failed (for example host/port) |
-| `UNDECLARED_KEY`                      | Extra key with `onUndeclaredKey: "reject"`    |
-| `INVALID_SCHEMA`                      | Schema itself is invalid                      |
-| `CUSTOM`                              | Validator-specific failure                    |
+| Code | Typical cause |
+| --- | --- |
+| `MISSING_VARIABLE` | Required key absent |
+| `INVALID_TYPE` | Value could not match the declared type |
+| `VALUE_TOO_SMALL` / `VALUE_TOO_LARGE` | Numeric or length bounds |
+| `PATTERN_MISMATCH` | String failed a pattern |
+| `INVALID_FORMAT` | Format keyword failed (for example host/port) |
+| `UNDECLARED_KEY` | Extra key with `onUndeclaredKey: "reject"` |
+| `INVALID_SCHEMA` | Schema itself is invalid |
+| `CUSTOM` | Validator-specific failure |
 
 Use these codes in CI scripts and health checks instead of scraping message text.
 
 ## Secret redaction
 
-Values for sensitive keys are redacted in error output by default. Set `debugSecrets: true` on the config object, or export `ARKENV_DEBUG_SECRETS=1`, when you need the raw value while debugging locally.
+Values for sensitive keys are redacted in error output by default. Leave that alone in CI and production.
+
+`debugSecrets: true` (or `ARKENV_DEBUG_SECRETS=1`) prints the raw value. Treat it as a local escape hatch only.
 
 <Callout type="warn">
-  Leave secret debugging off in shared CI logs and production. Redaction exists
-  so a failed boot does not print credentials.
+	Do not enable secret debugging in shared logs. Redaction exists so a failed
+	boot does not print credentials.
 </Callout>
 
 ## Safe mode
 
 Pass `{ safe: true }` when you want a result object instead of a throw (tests, custom boot UI):
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/core";
 
 const result = arkenv(
@@ -80,17 +84,19 @@ if (!result.success) {
 }
 ```
 
-Framework adapters omit `safe` so a bad env still fails the build or server start.
+Framework integrations do not expose `safe`. Invalid env still fails the build or server start there on purpose.
 
 ## Framework boundary errors
 
-Client/server misuse raises a different message than schema validation:
+Reading a server-only key from client code raises a boundary error, not a schema `ArkEnvError`:
 
 ```txt
 ArkEnv Error: Attempted to access server environment variable 'DATABASE_URL' on the client.
 ```
 
-On Nuxt strict layouts, importing the server schema into client code fails at build time. See [client vs. server](/docs/validating-environment-variables/client-vs-server).
+That `"ArkEnv Error:"` prefix differs from the validation header (`Errors found while validating environment variables`). Tracking: [#1558](https://github.com/yamcodes/arkenv/issues/1558).
+
+Next.js, Nuxt, Vite, and Bun each enforce the boundary (runtime proxy, build-time import bans, or both). See [client vs. server](/docs/validating-environment-variables/client-vs-server).
 
 ## Next steps
 

--- a/apps/www/content/docs/validating-environment-variables/error-reporting.mdx
+++ b/apps/www/content/docs/validating-environment-variables/error-reporting.mdx
@@ -17,7 +17,7 @@ Errors found while validating environment variables
 
 Paths are highlighted; the header is red when ANSI color is available.
 
-```ts title="./boot.ts" twoslash
+```ts title="./boot.ts"
 import arkenv, { ArkEnvError } from "@arkenv/core";
 
 try {

--- a/apps/www/content/docs/validating-environment-variables/error-reporting.mdx
+++ b/apps/www/content/docs/validating-environment-variables/error-reporting.mdx
@@ -1,0 +1,97 @@
+---
+title: Error reporting
+description: Fail fast on invalid env with clear console output and structured issues.
+---
+
+ArkEnv throws at the call site when a required variable is missing or a value fails the schema. Bad config stays out of running processes.
+
+## What you see in the console
+
+Invalid input raises `ArkEnvError`. The message lists every failing path:
+
+```txt
+Errors found while validating environment variables
+  PORT must be an integer between 0 and 65535 (was "abc")
+  DATABASE_URL is required
+```
+
+Paths are highlighted; the header is red when ANSI color is available.
+
+```ts title="./boot.ts" twoslash
+import arkenv, { ArkEnvError } from "@arkenv/core";
+
+try {
+	arkenv(
+		{
+			PORT: "number.port",
+			DATABASE_URL: "string",
+		},
+		{ env: { PORT: "abc" } },
+	);
+} catch (error) {
+	if (error instanceof ArkEnvError) {
+		console.error(error.message);
+		console.error(error.issues);
+	}
+	throw error;
+}
+```
+
+## Issue codes
+
+Each entry in `error.issues` includes a machine-readable `code`:
+
+| Code | Typical cause |
+| --- | --- |
+| `MISSING_VARIABLE` | Required key absent |
+| `INVALID_TYPE` | Value could not match the declared type |
+| `VALUE_TOO_SMALL` / `VALUE_TOO_LARGE` | Numeric or length bounds |
+| `PATTERN_MISMATCH` | String failed a pattern |
+| `INVALID_FORMAT` | Format keyword failed (for example host/port) |
+| `UNDECLARED_KEY` | Extra key with `onUndeclaredKey: "reject"` |
+| `INVALID_SCHEMA` | Schema itself is invalid |
+| `CUSTOM` | Validator-specific failure |
+
+Use these codes in CI scripts and health checks instead of scraping message text.
+
+## Secret redaction
+
+Values for sensitive keys are redacted in error output by default. Set `debugSecrets: true` on the config object, or export `ARKENV_DEBUG_SECRETS=1`, when you need the raw value while debugging locally.
+
+<Callout type="warn">
+	Leave secret debugging off in shared CI logs and production. Redaction exists
+	so a failed boot does not print credentials.
+</Callout>
+
+## Safe mode
+
+Pass `{ safe: true }` when you want a result object instead of a throw (tests, custom boot UI):
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+const result = arkenv(
+	{ PORT: "number.port" },
+	{ safe: true, env: { PORT: "nope" } },
+);
+
+if (!result.success) {
+	console.error(result.issues);
+}
+```
+
+Framework adapters omit `safe` so a bad env still fails the build or server start.
+
+## Framework boundary errors
+
+Client/server misuse raises a different message than schema validation:
+
+```txt
+ArkEnv Error: Attempted to access server environment variable 'DATABASE_URL' on the client.
+```
+
+On Nuxt strict layouts, importing the server schema into client code fails at build time. See [client vs. server](/docs/validating-environment-variables/client-vs-server).
+
+## Next steps
+
+Reuse the schema across runtimes with [reusing schemas](/docs/validating-environment-variables/reusing-schemas).

--- a/apps/www/content/docs/validating-environment-variables/error-reporting.mdx
+++ b/apps/www/content/docs/validating-environment-variables/error-reporting.mdx
@@ -43,16 +43,16 @@ try {
 
 Each entry in `error.issues` includes a machine-readable `code`:
 
-| Code | Typical cause |
-| --- | --- |
-| `MISSING_VARIABLE` | Required key absent |
-| `INVALID_TYPE` | Value could not match the declared type |
-| `VALUE_TOO_SMALL` / `VALUE_TOO_LARGE` | Numeric or length bounds |
-| `PATTERN_MISMATCH` | String failed a pattern |
-| `INVALID_FORMAT` | Format keyword failed (for example host/port) |
-| `UNDECLARED_KEY` | Extra key with `onUndeclaredKey: "reject"` |
-| `INVALID_SCHEMA` | Schema itself is invalid |
-| `CUSTOM` | Validator-specific failure |
+| Code                                  | Typical cause                                 |
+| ------------------------------------- | --------------------------------------------- |
+| `MISSING_VARIABLE`                    | Required key absent                           |
+| `INVALID_TYPE`                        | Value could not match the declared type       |
+| `VALUE_TOO_SMALL` / `VALUE_TOO_LARGE` | Numeric or length bounds                      |
+| `PATTERN_MISMATCH`                    | String failed a pattern                       |
+| `INVALID_FORMAT`                      | Format keyword failed (for example host/port) |
+| `UNDECLARED_KEY`                      | Extra key with `onUndeclaredKey: "reject"`    |
+| `INVALID_SCHEMA`                      | Schema itself is invalid                      |
+| `CUSTOM`                              | Validator-specific failure                    |
 
 Use these codes in CI scripts and health checks instead of scraping message text.
 
@@ -63,8 +63,8 @@ Values for sensitive keys are redacted in error output by default. Leave that al
 `debugSecrets: true` (or `ARKENV_DEBUG_SECRETS=1`) prints the raw value. Treat it as a local escape hatch only.
 
 <Callout type="warn">
-	Do not enable secret debugging in shared logs. Redaction exists so a failed
-	boot does not print credentials.
+  Do not enable secret debugging in shared logs. Redaction exists so a failed
+  boot does not print credentials.
 </Callout>
 
 ## Safe mode

--- a/apps/www/content/docs/validating-environment-variables/error-reporting.mdx
+++ b/apps/www/content/docs/validating-environment-variables/error-reporting.mdx
@@ -67,7 +67,7 @@ Values for sensitive keys are redacted in error output by default. Set `debugSec
 
 Pass `{ safe: true }` when you want a result object instead of a throw (tests, custom boot UI):
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 const result = arkenv(

--- a/apps/www/content/docs/validating-environment-variables/error-reporting.mdx
+++ b/apps/www/content/docs/validating-environment-variables/error-reporting.mdx
@@ -41,16 +41,16 @@ try {
 
 Each entry in `error.issues` includes a machine-readable `code`:
 
-| Code | Typical cause |
-| --- | --- |
-| `MISSING_VARIABLE` | Required key absent |
-| `INVALID_TYPE` | Value could not match the declared type |
-| `VALUE_TOO_SMALL` / `VALUE_TOO_LARGE` | Numeric or length bounds |
-| `PATTERN_MISMATCH` | String failed a pattern |
-| `INVALID_FORMAT` | Format keyword failed (for example host/port) |
-| `UNDECLARED_KEY` | Extra key with `onUndeclaredKey: "reject"` |
-| `INVALID_SCHEMA` | Schema itself is invalid |
-| `CUSTOM` | Validator-specific failure |
+| Code                                  | Typical cause                                 |
+| ------------------------------------- | --------------------------------------------- |
+| `MISSING_VARIABLE`                    | Required key absent                           |
+| `INVALID_TYPE`                        | Value could not match the declared type       |
+| `VALUE_TOO_SMALL` / `VALUE_TOO_LARGE` | Numeric or length bounds                      |
+| `PATTERN_MISMATCH`                    | String failed a pattern                       |
+| `INVALID_FORMAT`                      | Format keyword failed (for example host/port) |
+| `UNDECLARED_KEY`                      | Extra key with `onUndeclaredKey: "reject"`    |
+| `INVALID_SCHEMA`                      | Schema itself is invalid                      |
+| `CUSTOM`                              | Validator-specific failure                    |
 
 Use these codes in CI scripts and health checks instead of scraping message text.
 
@@ -59,8 +59,8 @@ Use these codes in CI scripts and health checks instead of scraping message text
 Values for sensitive keys are redacted in error output by default. Set `debugSecrets: true` on the config object, or export `ARKENV_DEBUG_SECRETS=1`, when you need the raw value while debugging locally.
 
 <Callout type="warn">
-	Leave secret debugging off in shared CI logs and production. Redaction exists
-	so a failed boot does not print credentials.
+  Leave secret debugging off in shared CI logs and production. Redaction exists
+  so a failed boot does not print credentials.
 </Callout>
 
 ## Safe mode

--- a/apps/www/content/docs/validating-environment-variables/framework-integration.mdx
+++ b/apps/www/content/docs/validating-environment-variables/framework-integration.mdx
@@ -10,26 +10,13 @@ Pick the package that matches your host, then follow the linked guide for layout
 ## Choose your stack
 
 <Cards>
-	<Card
-		href="/docs/guides/frameworks/nextjs"
-		title="Next.js"
-		description="@arkenv/nextjs with withArkEnv, flat or strict layouts, and env.gen codegen."
-	/>
-	<Card
-		href="/docs/guides/frameworks/nuxt"
-		title="Nuxt"
-		description="@arkenv/nuxt module, runtimeConfig mapping, and NUXT_PUBLIC_ boundaries."
-	/>
-	<Card
-		href="/docs/guides/frameworks/vite"
-		title="Vite"
-		description="@arkenv/vite-plugin for build and dev validation of VITE_ keys."
-	/>
-	<Card
-		href="/docs/guides/frameworks/bun"
-		title="Bun"
-		description="@arkenv/bun-plugin for Bun bundler apps that inline BUN_PUBLIC_ keys."
-	/>
+  <Card href="/docs/guides/frameworks/nextjs" title="Next.js" description="@arkenv/nextjs with withArkEnv, flat or strict layouts, and env.gen codegen." />
+
+  <Card href="/docs/guides/frameworks/nuxt" title="Nuxt" description="@arkenv/nuxt module, runtimeConfig mapping, and NUXT_PUBLIC_ boundaries." />
+
+  <Card href="/docs/guides/frameworks/vite" title="Vite" description="@arkenv/vite-plugin for build and dev validation of VITE_ keys." />
+
+  <Card href="/docs/guides/frameworks/bun" title="Bun" description="@arkenv/bun-plugin for Bun bundler apps that inline BUN_PUBLIC_ keys." />
 </Cards>
 
 ## Install pattern
@@ -55,12 +42,12 @@ pnpm dlx arkenv@latest init --strict
 
 ## What each integration adds
 
-| Host | Package | Boundary mechanism |
-| --- | --- | --- |
-| Next.js | `@arkenv/nextjs` | `withArkEnv` codegen, `NEXT_PUBLIC_*`, runtime proxy, optional strict file split |
-| Nuxt | `@arkenv/nuxt` | Nuxt module, `NUXT_PUBLIC_*`, client/server entrypoints |
-| Vite | `@arkenv/vite-plugin` | Dev/build validation; only `VITE_*` (and optional `NODE_ENV`) reach the client |
-| Bun | `@arkenv/bun-plugin` | Bun bundler / fullstack inlining for `BUN_PUBLIC_*` |
+| Host    | Package               | Boundary mechanism                                                               |
+| ------- | --------------------- | -------------------------------------------------------------------------------- |
+| Next.js | `@arkenv/nextjs`      | `withArkEnv` codegen, `NEXT_PUBLIC_*`, runtime proxy, optional strict file split |
+| Nuxt    | `@arkenv/nuxt`        | Nuxt module, `NUXT_PUBLIC_*`, client/server entrypoints                          |
+| Vite    | `@arkenv/vite-plugin` | Dev/build validation; only `VITE_*` (and optional `NODE_ENV`) reach the client   |
+| Bun     | `@arkenv/bun-plugin`  | Bun bundler / fullstack inlining for `BUN_PUBLIC_*`                              |
 
 Plain Node or Bun **backend** scripts can stay on `@arkenv/core` alone. The Bun plugin targets apps that ship a browser bundle through Bun's bundler.
 

--- a/apps/www/content/docs/validating-environment-variables/framework-integration.mdx
+++ b/apps/www/content/docs/validating-environment-variables/framework-integration.mdx
@@ -1,0 +1,79 @@
+---
+title: Framework integration
+description: Connect ArkEnv to Next.js, Nuxt, Vite, or Bun.
+---
+
+Core `arkenv()` validates whatever record you pass it. Framework packages add loaders, public-prefix rules, codegen, and build plugins so client bundles never receive server secrets.
+
+Pick the package that matches your host, then follow the linked guide for layout details.
+
+## Choose your stack
+
+<Cards>
+	<Card
+		href="/docs/guides/frameworks/nextjs"
+		title="Next.js"
+		description="@arkenv/nextjs with withArkEnv, flat or strict layouts, and env.gen codegen."
+	/>
+	<Card
+		href="/docs/guides/frameworks/nuxt"
+		title="Nuxt"
+		description="@arkenv/nuxt module, runtimeConfig mapping, and NUXT_PUBLIC_ boundaries."
+	/>
+	<Card
+		href="/docs/guides/frameworks/vite"
+		title="Vite"
+		description="@arkenv/vite-plugin for build and dev validation of VITE_ keys."
+	/>
+	<Card
+		href="/docs/guides/frameworks/bun"
+		title="Bun"
+		description="@arkenv/bun-plugin for Bun bundler apps that inline BUN_PUBLIC_ keys."
+	/>
+</Cards>
+
+## Install pattern
+
+Always install a validation package (`@arkenv/core` + `arktype`, or `@arkenv/standard`) alongside the framework package:
+
+```package-install
+# Next.js example
+pnpm add @arkenv/core @arkenv/nextjs arktype
+```
+
+```package-install
+# Or Standard Schema + Next.js
+pnpm add @arkenv/standard @arkenv/nextjs zod
+```
+
+Scaffold with the CLI when you want files generated for you:
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init
+pnpm dlx arkenv@latest init --strict
+```
+
+## What each integration adds
+
+| Host | Package | Boundary mechanism |
+| --- | --- | --- |
+| Next.js | `@arkenv/nextjs` | `withArkEnv` codegen, `NEXT_PUBLIC_*`, runtime proxy, optional strict file split |
+| Nuxt | `@arkenv/nuxt` | Nuxt module, `NUXT_PUBLIC_*`, client/server entrypoints |
+| Vite | `@arkenv/vite-plugin` | Dev/build validation; only `VITE_*` (and optional `NODE_ENV`) reach the client |
+| Bun | `@arkenv/bun-plugin` | Bun bundler / fullstack inlining for `BUN_PUBLIC_*` |
+
+Plain Node or Bun **backend** scripts can stay on `@arkenv/core` alone. The Bun plugin targets apps that ship a browser bundle through Bun's bundler.
+
+## Loading `.env` files
+
+ArkEnv does not read `.env` files. Frameworks load them before your schema runs:
+
+- **Next.js / Nuxt**: built-in env loading
+- **Vite**: `loadEnv` / Vite's `.env*` convention
+- **Node**: `dotenv` or your process manager
+
+After values are in `process.env` (or a custom record), `arkenv()` validates them.
+
+## Next steps
+
+Add provider system variables with [hosting presets](/docs/validating-environment-variables/hosting-presets), or jump to the framework guide for your stack.

--- a/apps/www/content/docs/validating-environment-variables/framework-integration.mdx
+++ b/apps/www/content/docs/validating-environment-variables/framework-integration.mdx
@@ -3,25 +3,38 @@ title: Framework integration
 description: Connect ArkEnv to Next.js, Nuxt, Vite, or Bun.
 ---
 
-Core `arkenv()` validates whatever record you pass it. Framework packages add loaders, public-prefix rules, codegen, and build plugins so client bundles never receive server secrets.
+ArkEnv is built around a flat `arkenv()` call: one schema, one typed `env` object. Framework packages exist so that same call stays honest on each host. They add public-prefix rules, codegen, build plugins, and runtime guards so you do not invent a second API for Next.js or Vite. Radical simplicity at the call site; the integration absorbs the host's complexity.
 
 Pick the package that matches your host, then follow the linked guide for layout details.
 
 ## Choose your stack
 
 <Cards>
-  <Card href="/docs/guides/frameworks/nextjs" title="Next.js" description="@arkenv/nextjs with withArkEnv, flat or strict layouts, and env.gen codegen." />
-
-  <Card href="/docs/guides/frameworks/nuxt" title="Nuxt" description="@arkenv/nuxt module, runtimeConfig mapping, and NUXT_PUBLIC_ boundaries." />
-
-  <Card href="/docs/guides/frameworks/vite" title="Vite" description="@arkenv/vite-plugin for build and dev validation of VITE_ keys." />
-
-  <Card href="/docs/guides/frameworks/bun" title="Bun" description="@arkenv/bun-plugin for Bun bundler apps that inline BUN_PUBLIC_ keys." />
+	<Card
+		href="/docs/guides/frameworks/nextjs"
+		title="Next.js"
+		description="@arkenv/nextjs with withArkEnv, flat or strict layouts, and env.gen codegen."
+	/>
+	<Card
+		href="/docs/guides/frameworks/nuxt"
+		title="Nuxt"
+		description="@arkenv/nuxt module, runtimeConfig mapping, and NUXT_PUBLIC_ boundaries."
+	/>
+	<Card
+		href="/docs/guides/frameworks/vite"
+		title="Vite"
+		description="@arkenv/vite-plugin for build and dev validation of VITE_ keys."
+	/>
+	<Card
+		href="/docs/guides/frameworks/bun"
+		title="Bun bundler / fullstack"
+		description="@arkenv/bun-plugin for Bun bundler and fullstack apps that inline BUN_PUBLIC_ keys."
+	/>
 </Cards>
 
 ## Install pattern
 
-Always install a validation package (`@arkenv/core` + `arktype`, or `@arkenv/standard`) alongside the framework package:
+Install a validation package (`@arkenv/core` + `arktype`, or `@arkenv/standard`) alongside the framework package:
 
 ```package-install
 # Next.js example
@@ -42,22 +55,23 @@ pnpm dlx arkenv@latest init --strict
 
 ## What each integration adds
 
-| Host    | Package               | Boundary mechanism                                                               |
-| ------- | --------------------- | -------------------------------------------------------------------------------- |
-| Next.js | `@arkenv/nextjs`      | `withArkEnv` codegen, `NEXT_PUBLIC_*`, runtime proxy, optional strict file split |
-| Nuxt    | `@arkenv/nuxt`        | Nuxt module, `NUXT_PUBLIC_*`, client/server entrypoints                          |
-| Vite    | `@arkenv/vite-plugin` | Dev/build validation; only `VITE_*` (and optional `NODE_ENV`) reach the client   |
-| Bun     | `@arkenv/bun-plugin`  | Bun bundler / fullstack inlining for `BUN_PUBLIC_*`                              |
+| Host | Package | Boundary mechanism |
+| --- | --- | --- |
+| Next.js | `@arkenv/nextjs` | `withArkEnv` codegen, `NEXT_PUBLIC_*`, runtime proxy, optional strict file split |
+| Nuxt | `@arkenv/nuxt` | Nuxt module, `NUXT_PUBLIC_*`, client/server entrypoints |
+| Vite | `@arkenv/vite-plugin` | Dev/build validation; only `VITE_*` (and optional `NODE_ENV`) reach the client |
+| Bun | `@arkenv/bun-plugin` | Bun bundler / fullstack inlining for `BUN_PUBLIC_*` |
 
-Plain Node or Bun **backend** scripts can stay on `@arkenv/core` alone. The Bun plugin targets apps that ship a browser bundle through Bun's bundler.
+Plain Node or Bun **as a runtime** (no browser bundle) can stay on `@arkenv/core` alone. The Bun plugin targets apps that ship client code through Bun's bundler or fullstack server, not Bun-as-Node replacements or Bun-as-package-manager.
 
 ## Loading `.env` files
 
-ArkEnv does not read `.env` files. Frameworks load them before your schema runs:
+ArkEnv does not read `.env` files. Something else must load them before `arkenv()` runs:
 
 - **Next.js / Nuxt**: built-in env loading
 - **Vite**: `loadEnv` / Vite's `.env*` convention
-- **Node**: `dotenv` or your process manager
+- **Bun**: Bun's built-in `.env` loading when you run under Bun
+- **Node**: `dotenv`, your process manager, or an executor such as `tsx` that loads env files
 
 After values are in `process.env` (or a custom record), `arkenv()` validates them.
 

--- a/apps/www/content/docs/validating-environment-variables/framework-integration.mdx
+++ b/apps/www/content/docs/validating-environment-variables/framework-integration.mdx
@@ -10,26 +10,13 @@ Pick the package that matches your host, then follow the linked guide for layout
 ## Choose your stack
 
 <Cards>
-	<Card
-		href="/docs/guides/frameworks/nextjs"
-		title="Next.js"
-		description="@arkenv/nextjs with withArkEnv, flat or strict layouts, and env.gen codegen."
-	/>
-	<Card
-		href="/docs/guides/frameworks/nuxt"
-		title="Nuxt"
-		description="@arkenv/nuxt module, runtimeConfig mapping, and NUXT_PUBLIC_ boundaries."
-	/>
-	<Card
-		href="/docs/guides/frameworks/vite"
-		title="Vite"
-		description="@arkenv/vite-plugin for build and dev validation of VITE_ keys."
-	/>
-	<Card
-		href="/docs/guides/frameworks/bun"
-		title="Bun bundler / fullstack"
-		description="@arkenv/bun-plugin for Bun bundler and fullstack apps that inline BUN_PUBLIC_ keys."
-	/>
+  <Card href="/docs/guides/frameworks/nextjs" title="Next.js" description="@arkenv/nextjs with withArkEnv, flat or strict layouts, and env.gen codegen." />
+
+  <Card href="/docs/guides/frameworks/nuxt" title="Nuxt" description="@arkenv/nuxt module, runtimeConfig mapping, and NUXT_PUBLIC_ boundaries." />
+
+  <Card href="/docs/guides/frameworks/vite" title="Vite" description="@arkenv/vite-plugin for build and dev validation of VITE_ keys." />
+
+  <Card href="/docs/guides/frameworks/bun" title="Bun bundler / fullstack" description="@arkenv/bun-plugin for Bun bundler and fullstack apps that inline BUN_PUBLIC_ keys." />
 </Cards>
 
 ## Install pattern
@@ -55,12 +42,12 @@ pnpm dlx arkenv@latest init --strict
 
 ## What each integration adds
 
-| Host | Package | Boundary mechanism |
-| --- | --- | --- |
-| Next.js | `@arkenv/nextjs` | `withArkEnv` codegen, `NEXT_PUBLIC_*`, runtime proxy, optional strict file split |
-| Nuxt | `@arkenv/nuxt` | Nuxt module, `NUXT_PUBLIC_*`, client/server entrypoints |
-| Vite | `@arkenv/vite-plugin` | Dev/build validation; only `VITE_*` (and optional `NODE_ENV`) reach the client |
-| Bun | `@arkenv/bun-plugin` | Bun bundler / fullstack inlining for `BUN_PUBLIC_*` |
+| Host    | Package               | Boundary mechanism                                                               |
+| ------- | --------------------- | -------------------------------------------------------------------------------- |
+| Next.js | `@arkenv/nextjs`      | `withArkEnv` codegen, `NEXT_PUBLIC_*`, runtime proxy, optional strict file split |
+| Nuxt    | `@arkenv/nuxt`        | Nuxt module, `NUXT_PUBLIC_*`, client/server entrypoints                          |
+| Vite    | `@arkenv/vite-plugin` | Dev/build validation; only `VITE_*` (and optional `NODE_ENV`) reach the client   |
+| Bun     | `@arkenv/bun-plugin`  | Bun bundler / fullstack inlining for `BUN_PUBLIC_*`                              |
 
 Plain Node or Bun **as a runtime** (no browser bundle) can stay on `@arkenv/core` alone. The Bun plugin targets apps that ship client code through Bun's bundler or fullstack server, not Bun-as-Node replacements or Bun-as-package-manager.
 

--- a/apps/www/content/docs/validating-environment-variables/hosting-presets.mdx
+++ b/apps/www/content/docs/validating-environment-variables/hosting-presets.mdx
@@ -1,0 +1,133 @@
+---
+title: Hosting presets
+description: Pre-populate schemas with Vercel, Netlify, Cloudflare, Railway, Render, or Fly.io variables.
+---
+
+Hosting providers inject their own system environment variables at build and runtime. Presets teach `arkenv init` (and `arkenv add host`) which keys to add, already typed and optional, so you do not look them up by hand.
+
+Presets work with ArkType, Zod, and Valibot, and with both [flat and strict](/docs/validating-environment-variables/client-vs-server) layouts.
+
+## Select a preset during init
+
+### Interactive prompt
+
+`arkenv init` asks for a hosting provider when you run it without flags:
+
+```txt
+Select a hosting provider preset (optional):
+❯ None                          Do not add any hosting-specific environment variables
+  Vercel                        Add VERCEL, VERCEL_ENV, VERCEL_URL, etc.
+  Netlify                       Add NETLIFY, CONTEXT, URL, DEPLOY_URL, etc.
+  Cloudflare Pages/Workers      Add CF_PAGES, CF_PAGES_COMMIT_SHA, CF_PAGES_BRANCH, CF_PAGES_URL, etc.
+  Railway                       Add RAILWAY_ENVIRONMENT_NAME, RAILWAY_PUBLIC_DOMAIN, RAILWAY_GIT_COMMIT_SHA, etc.
+  Render                        Add RENDER, RENDER_SERVICE_ID, RENDER_SERVICE_TYPE, RENDER_EXTERNAL_URL, etc.
+  Fly.io                        Add FLY_APP_NAME, FLY_REGION, FLY_ALLOC_ID, etc.
+```
+
+**None** leaves the schema without provider fields.
+
+### `--host-preset` flag
+
+Skip the prompt in scripts or agent mode:
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init --host-preset vercel
+pnpm dlx arkenv@latest init -H netlify --agent
+```
+
+Accepted values: `none`, `vercel`, `netlify`, `cloudflare`, `railway`, `render`, `fly`.
+
+## Add a host to an existing schema
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest add host vercel
+pnpm dlx arkenv@latest add host
+```
+
+Omit the provider to pick interactively. The command detects layout, framework prefix, and validator, then merges missing keys. Existing keys stay unchanged. If the schema cannot be parsed, the CLI prints the proposed fields for manual paste.
+
+With `--yes` or `--agent`, an omitted provider defaults to `vercel`.
+
+## What each preset adds
+
+Every preset field is **optional** (present only on that provider). Fields split into:
+
+- **Server-only**: no client prefix; kept off the client
+- **Client-exposed**: safe on the client; the CLI also writes a framework-prefixed copy when a prefix applies (`NEXT_PUBLIC_`, `NUXT_PUBLIC_`, `VITE_`)
+
+### Vercel
+
+| Variable | Type | Exposure |
+| --- | --- | --- |
+| `VERCEL` | `string` (optional) | Server-only |
+| `VERCEL_ENV` | `"production" \| "preview" \| "development"` (optional) | Client-exposed |
+| `VERCEL_URL` | `string` (optional) | Client-exposed |
+
+### Netlify
+
+| Variable | Type | Exposure |
+| --- | --- | --- |
+| `NETLIFY` | `string` (optional) | Server-only |
+| `DEPLOY_URL` | `string` (optional) | Server-only |
+| `CONTEXT` | `"production" \| "deploy-preview" \| "branch-deploy"` (optional) | Client-exposed |
+| `URL` | `string` (optional) | Client-exposed |
+
+### Cloudflare Pages/Workers
+
+| Variable | Type | Exposure |
+| --- | --- | --- |
+| `CF_PAGES` | `string` (optional) | Server-only |
+| `CF_PAGES_COMMIT_SHA` | `string` (optional) | Server-only |
+| `CF_PAGES_BRANCH` | `string` (optional) | Client-exposed |
+| `CF_PAGES_URL` | `string` (optional) | Client-exposed |
+
+### Railway
+
+| Variable | Type | Exposure |
+| --- | --- | --- |
+| `RAILWAY_ENVIRONMENT_NAME` | `string` (optional) | Server-only |
+| `RAILWAY_PUBLIC_DOMAIN` | `string` (optional) | Server-only |
+| `RAILWAY_SERVICE_NAME` | `string` (optional) | Server-only |
+| `RAILWAY_GIT_COMMIT_SHA` | `string` (optional) | Server-only |
+
+### Render
+
+| Variable | Type | Exposure |
+| --- | --- | --- |
+| `RENDER` | `string` (optional) | Server-only |
+| `RENDER_SERVICE_ID` | `string` (optional) | Server-only |
+| `RENDER_SERVICE_TYPE` | `string` (optional) | Server-only |
+| `RENDER_EXTERNAL_URL` | `string` (optional) | Server-only |
+
+### Fly.io
+
+| Variable | Type | Exposure |
+| --- | --- | --- |
+| `FLY_APP_NAME` | `string` (optional) | Server-only |
+| `FLY_REGION` | `string` (optional) | Server-only |
+| `FLY_ALLOC_ID` | `string` (optional) | Server-only |
+
+## Example: Vercel + ArkType flat schema
+
+After `arkenv init -H vercel` on a Next.js app, the generated schema includes the preset fields alongside your own:
+
+```ts title="./env.ts"
+import arkenv from "@/generated/env.gen";
+
+export const env = arkenv({
+	DATABASE_URL: "string",
+	NEXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
+	// Hosting preset (Vercel)
+	VERCEL: "string?",
+	VERCEL_ENV: "'production' | 'preview' | 'development'?",
+	VERCEL_URL: "string?",
+	NEXT_PUBLIC_VERCEL_ENV: "'production' | 'preview' | 'development'?",
+	NEXT_PUBLIC_VERCEL_URL: "string?",
+});
+```
+
+Exact output varies by validator and framework. Re-run `add host` when you move providers instead of copying keys by hand.
+
+## Next steps
+
+You finished the validating-environment-variables path. Dig into [API reference](/docs/reference) for options and packages, or [core concepts](/docs/core-concepts) for coercion, morphs, and Standard Schema.

--- a/apps/www/content/docs/validating-environment-variables/hosting-presets.mdx
+++ b/apps/www/content/docs/validating-environment-variables/hosting-presets.mdx
@@ -57,54 +57,54 @@ Every preset field is **optional** (present only on that provider). Fields split
 
 ### Vercel
 
-| Variable | Type | Exposure |
-| --- | --- | --- |
-| `VERCEL` | `string` (optional) | Server-only |
+| Variable     | Type                                                    | Exposure       |
+| ------------ | ------------------------------------------------------- | -------------- |
+| `VERCEL`     | `string` (optional)                                     | Server-only    |
 | `VERCEL_ENV` | `"production" \| "preview" \| "development"` (optional) | Client-exposed |
-| `VERCEL_URL` | `string` (optional) | Client-exposed |
+| `VERCEL_URL` | `string` (optional)                                     | Client-exposed |
 
 ### Netlify
 
-| Variable | Type | Exposure |
-| --- | --- | --- |
-| `NETLIFY` | `string` (optional) | Server-only |
-| `DEPLOY_URL` | `string` (optional) | Server-only |
-| `CONTEXT` | `"production" \| "deploy-preview" \| "branch-deploy"` (optional) | Client-exposed |
-| `URL` | `string` (optional) | Client-exposed |
+| Variable     | Type                                                             | Exposure       |
+| ------------ | ---------------------------------------------------------------- | -------------- |
+| `NETLIFY`    | `string` (optional)                                              | Server-only    |
+| `DEPLOY_URL` | `string` (optional)                                              | Server-only    |
+| `CONTEXT`    | `"production" \| "deploy-preview" \| "branch-deploy"` (optional) | Client-exposed |
+| `URL`        | `string` (optional)                                              | Client-exposed |
 
 ### Cloudflare Pages/Workers
 
-| Variable | Type | Exposure |
-| --- | --- | --- |
-| `CF_PAGES` | `string` (optional) | Server-only |
-| `CF_PAGES_COMMIT_SHA` | `string` (optional) | Server-only |
-| `CF_PAGES_BRANCH` | `string` (optional) | Client-exposed |
-| `CF_PAGES_URL` | `string` (optional) | Client-exposed |
+| Variable              | Type                | Exposure       |
+| --------------------- | ------------------- | -------------- |
+| `CF_PAGES`            | `string` (optional) | Server-only    |
+| `CF_PAGES_COMMIT_SHA` | `string` (optional) | Server-only    |
+| `CF_PAGES_BRANCH`     | `string` (optional) | Client-exposed |
+| `CF_PAGES_URL`        | `string` (optional) | Client-exposed |
 
 ### Railway
 
-| Variable | Type | Exposure |
-| --- | --- | --- |
+| Variable                   | Type                | Exposure    |
+| -------------------------- | ------------------- | ----------- |
 | `RAILWAY_ENVIRONMENT_NAME` | `string` (optional) | Server-only |
-| `RAILWAY_PUBLIC_DOMAIN` | `string` (optional) | Server-only |
-| `RAILWAY_SERVICE_NAME` | `string` (optional) | Server-only |
-| `RAILWAY_GIT_COMMIT_SHA` | `string` (optional) | Server-only |
+| `RAILWAY_PUBLIC_DOMAIN`    | `string` (optional) | Server-only |
+| `RAILWAY_SERVICE_NAME`     | `string` (optional) | Server-only |
+| `RAILWAY_GIT_COMMIT_SHA`   | `string` (optional) | Server-only |
 
 ### Render
 
-| Variable | Type | Exposure |
-| --- | --- | --- |
-| `RENDER` | `string` (optional) | Server-only |
-| `RENDER_SERVICE_ID` | `string` (optional) | Server-only |
+| Variable              | Type                | Exposure    |
+| --------------------- | ------------------- | ----------- |
+| `RENDER`              | `string` (optional) | Server-only |
+| `RENDER_SERVICE_ID`   | `string` (optional) | Server-only |
 | `RENDER_SERVICE_TYPE` | `string` (optional) | Server-only |
 | `RENDER_EXTERNAL_URL` | `string` (optional) | Server-only |
 
 ### Fly.io
 
-| Variable | Type | Exposure |
-| --- | --- | --- |
+| Variable       | Type                | Exposure    |
+| -------------- | ------------------- | ----------- |
 | `FLY_APP_NAME` | `string` (optional) | Server-only |
-| `FLY_REGION` | `string` (optional) | Server-only |
+| `FLY_REGION`   | `string` (optional) | Server-only |
 | `FLY_ALLOC_ID` | `string` (optional) | Server-only |
 
 ## Example: Vercel + ArkType flat schema

--- a/apps/www/content/docs/validating-environment-variables/hosting-presets.mdx
+++ b/apps/www/content/docs/validating-environment-variables/hosting-presets.mdx
@@ -7,6 +7,8 @@ Hosting providers inject their own system environment variables at build and run
 
 Presets work with ArkType, Zod, and Valibot, and with both [flat and strict](/docs/validating-environment-variables/client-vs-server) layouts.
 
+Not on this list? Choose **None** during init (or skip `add host`) and declare the provider's variables yourself in the schema the same way you declare `DATABASE_URL`. Presets are a convenience for common hosts, not a requirement.
+
 ## Select a preset during init
 
 ### Interactive prompt

--- a/apps/www/content/docs/validating-environment-variables/index.mdx
+++ b/apps/www/content/docs/validating-environment-variables/index.mdx
@@ -1,19 +1,62 @@
 ---
 title: Validating environment variables
-description: Step-by-step guides for designing, parsing, and securing environment variables with ArkEnv.
+description: Design, parse, and secure environment variables with ArkEnv.
 ---
 
-Architecting environment validation ensures your application crashes immediately at startup if critical configuration or secrets are missing.
+Missing or malformed environment variables should stop your app at startup. These guides walk you through designing a schema, parsing values, and keeping secrets off the client.
 
-These guides walk you through designing, structuring, and running env-var validation with ArkEnv.
+Read them in order when you are new to ArkEnv. Jump ahead when you already know the shape you need.
 
-## Step-by-Step Guides
+<Callout type="info">
+	ArkEnv validates and types your environment. Loading `.env` files is still
+	your runtime or framework's job. See [loaders and frameworks](/docs/validating-environment-variables/framework-integration).
+</Callout>
 
-1. **[1. Structuring your schema](/docs/validating-environment-variables/structuring-your-schema)**: Design where and how to define your `env.ts` schema.
-2. **[2. Defining types & primitives](/docs/validating-environment-variables/defining-types)**: Learn how to define string, boolean, numeric, and complex enum types.
-3. **[3. Client vs. Server boundaries](/docs/validating-environment-variables/client-vs-server)**: Enforce strict separation between public keys and private server secrets.
-4. **[4. Type coercion & parsing](/docs/validating-environment-variables/coercion-and-parsing)**: Automatically coerce raw string environment values to real numbers, booleans, and JSON objects.
-5. **[5. Fail-fast error reporting](/docs/validating-environment-variables/error-reporting)**: Understand error formatting and fail-fast startup behavior.
-6. **[6. Reusing & sharing schemas](/docs/validating-environment-variables/reusing-schemas)**: Share environment schemas across packages in monorepos.
-7. **[7. Integrating your framework](/docs/validating-environment-variables/framework-integration)**: Connect ArkEnv to Next.js, Nuxt, Vite, or Bun.
-8. **[8. Hosting presets & deployment](/docs/validating-environment-variables/hosting-presets)**: Manage hosting provider environment variables across deployment environments.
+## From schema to deploy
+
+<Cards>
+	<Card
+		href="/docs/validating-environment-variables/structuring-your-schema"
+		title="1. Structuring your schema"
+		description="Put env.ts in the right place and export a typed env object."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/defining-types"
+		title="2. Defining types"
+		description="Declare strings, numbers, booleans, enums, and ArkEnv keywords."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/client-vs-server"
+		title="3. Client vs. server"
+		description="Keep public keys and private secrets in separate buckets."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/coercion-and-parsing"
+		title="4. Coercion and parsing"
+		description="Turn raw strings into numbers, booleans, arrays, and objects."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/error-reporting"
+		title="5. Error reporting"
+		description="Fail fast with clear console output and issue codes."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/reusing-schemas"
+		title="6. Reusing schemas"
+		description="Share one schema across runtimes and packages."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/framework-integration"
+		title="7. Framework integration"
+		description="Wire ArkEnv into Next.js, Nuxt, Vite, or Bun."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/hosting-presets"
+		title="8. Hosting presets"
+		description="Add Vercel, Netlify, Cloudflare, and other provider vars."
+	/>
+</Cards>
+
+## Next steps
+
+Start with [structuring your schema](/docs/validating-environment-variables/structuring-your-schema), or skim [Getting started](/docs/getting-started) if you still need to install packages.

--- a/apps/www/content/docs/validating-environment-variables/index.mdx
+++ b/apps/www/content/docs/validating-environment-variables/index.mdx
@@ -8,53 +8,28 @@ Missing or malformed environment variables should fail as early as ArkEnv can se
 Read them in order the first time. Skip ahead once you know which slice you need.
 
 <Callout type="info">
-	ArkEnv validates and types your environment. Loading `.env` files is still
-	your runtime or framework's job. See [loaders and frameworks](/docs/validating-environment-variables/framework-integration).
+  ArkEnv validates and types your environment. Loading `.env` files is still
+  your runtime or framework's job. See [loaders and frameworks](/docs/validating-environment-variables/framework-integration).
 </Callout>
 
 ## From schema to deploy
 
 <Cards>
-	<Card
-		href="/docs/validating-environment-variables/structuring-your-schema"
-		title="1. Structuring your schema"
-		description="Put env.ts in the right place and export a typed env object."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/defining-types"
-		title="2. Defining types"
-		description="Declare strings, numbers, booleans, enums, and ArkEnv keywords."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/client-vs-server"
-		title="3. Client vs. server"
-		description="Keep public keys and private secrets in separate buckets."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/coercion-and-parsing"
-		title="4. Coercion and parsing"
-		description="Turn raw strings into numbers, booleans, arrays, and objects."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/error-reporting"
-		title="5. Error reporting"
-		description="Fail fast with clear console output and issue codes."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/reusing-schemas"
-		title="6. Reusing schemas"
-		description="Share one schema across runtimes and packages."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/framework-integration"
-		title="7. Framework integration"
-		description="Wire ArkEnv into Next.js, Nuxt, Vite, or Bun."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/hosting-presets"
-		title="8. Hosting presets"
-		description="Add Vercel, Netlify, Cloudflare, and other provider vars."
-	/>
+  <Card href="/docs/validating-environment-variables/structuring-your-schema" title="1. Structuring your schema" description="Put env.ts in the right place and export a typed env object." />
+
+  <Card href="/docs/validating-environment-variables/defining-types" title="2. Defining types" description="Declare strings, numbers, booleans, enums, and ArkEnv keywords." />
+
+  <Card href="/docs/validating-environment-variables/client-vs-server" title="3. Client vs. server" description="Keep public keys and private secrets in separate buckets." />
+
+  <Card href="/docs/validating-environment-variables/coercion-and-parsing" title="4. Coercion and parsing" description="Turn raw strings into numbers, booleans, arrays, and objects." />
+
+  <Card href="/docs/validating-environment-variables/error-reporting" title="5. Error reporting" description="Fail fast with clear console output and issue codes." />
+
+  <Card href="/docs/validating-environment-variables/reusing-schemas" title="6. Reusing schemas" description="Share one schema across runtimes and packages." />
+
+  <Card href="/docs/validating-environment-variables/framework-integration" title="7. Framework integration" description="Wire ArkEnv into Next.js, Nuxt, Vite, or Bun." />
+
+  <Card href="/docs/validating-environment-variables/hosting-presets" title="8. Hosting presets" description="Add Vercel, Netlify, Cloudflare, and other provider vars." />
 </Cards>
 
 ## Next steps

--- a/apps/www/content/docs/validating-environment-variables/index.mdx
+++ b/apps/www/content/docs/validating-environment-variables/index.mdx
@@ -8,53 +8,28 @@ Missing or malformed environment variables should stop your app at startup. Thes
 Read them in order when you are new to ArkEnv. Jump ahead when you already know the shape you need.
 
 <Callout type="info">
-	ArkEnv validates and types your environment. Loading `.env` files is still
-	your runtime or framework's job. See [loaders and frameworks](/docs/validating-environment-variables/framework-integration).
+  ArkEnv validates and types your environment. Loading `.env` files is still
+  your runtime or framework's job. See [loaders and frameworks](/docs/validating-environment-variables/framework-integration).
 </Callout>
 
 ## From schema to deploy
 
 <Cards>
-	<Card
-		href="/docs/validating-environment-variables/structuring-your-schema"
-		title="1. Structuring your schema"
-		description="Put env.ts in the right place and export a typed env object."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/defining-types"
-		title="2. Defining types"
-		description="Declare strings, numbers, booleans, enums, and ArkEnv keywords."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/client-vs-server"
-		title="3. Client vs. server"
-		description="Keep public keys and private secrets in separate buckets."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/coercion-and-parsing"
-		title="4. Coercion and parsing"
-		description="Turn raw strings into numbers, booleans, arrays, and objects."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/error-reporting"
-		title="5. Error reporting"
-		description="Fail fast with clear console output and issue codes."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/reusing-schemas"
-		title="6. Reusing schemas"
-		description="Share one schema across runtimes and packages."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/framework-integration"
-		title="7. Framework integration"
-		description="Wire ArkEnv into Next.js, Nuxt, Vite, or Bun."
-	/>
-	<Card
-		href="/docs/validating-environment-variables/hosting-presets"
-		title="8. Hosting presets"
-		description="Add Vercel, Netlify, Cloudflare, and other provider vars."
-	/>
+  <Card href="/docs/validating-environment-variables/structuring-your-schema" title="1. Structuring your schema" description="Put env.ts in the right place and export a typed env object." />
+
+  <Card href="/docs/validating-environment-variables/defining-types" title="2. Defining types" description="Declare strings, numbers, booleans, enums, and ArkEnv keywords." />
+
+  <Card href="/docs/validating-environment-variables/client-vs-server" title="3. Client vs. server" description="Keep public keys and private secrets in separate buckets." />
+
+  <Card href="/docs/validating-environment-variables/coercion-and-parsing" title="4. Coercion and parsing" description="Turn raw strings into numbers, booleans, arrays, and objects." />
+
+  <Card href="/docs/validating-environment-variables/error-reporting" title="5. Error reporting" description="Fail fast with clear console output and issue codes." />
+
+  <Card href="/docs/validating-environment-variables/reusing-schemas" title="6. Reusing schemas" description="Share one schema across runtimes and packages." />
+
+  <Card href="/docs/validating-environment-variables/framework-integration" title="7. Framework integration" description="Wire ArkEnv into Next.js, Nuxt, Vite, or Bun." />
+
+  <Card href="/docs/validating-environment-variables/hosting-presets" title="8. Hosting presets" description="Add Vercel, Netlify, Cloudflare, and other provider vars." />
 </Cards>
 
 ## Next steps

--- a/apps/www/content/docs/validating-environment-variables/index.mdx
+++ b/apps/www/content/docs/validating-environment-variables/index.mdx
@@ -3,35 +3,60 @@ title: Validating environment variables
 description: Design, parse, and secure environment variables with ArkEnv.
 ---
 
-Missing or malformed environment variables should stop your app at startup. These guides walk you through designing a schema, parsing values, and keeping secrets off the client.
+Missing or malformed environment variables should fail as early as ArkEnv can see them: in `next build`, during Vite/Bun plugin runs, on server boot, and anywhere else you call `arkenv()`. These guides walk you through designing a schema, parsing values, and keeping secrets off the client.
 
-Read them in order when you are new to ArkEnv. Jump ahead when you already know the shape you need.
+Read them in order the first time. Skip ahead once you know which slice you need.
 
 <Callout type="info">
-  ArkEnv validates and types your environment. Loading `.env` files is still
-  your runtime or framework's job. See [loaders and frameworks](/docs/validating-environment-variables/framework-integration).
+	ArkEnv validates and types your environment. Loading `.env` files is still
+	your runtime or framework's job. See [loaders and frameworks](/docs/validating-environment-variables/framework-integration).
 </Callout>
 
 ## From schema to deploy
 
 <Cards>
-  <Card href="/docs/validating-environment-variables/structuring-your-schema" title="1. Structuring your schema" description="Put env.ts in the right place and export a typed env object." />
-
-  <Card href="/docs/validating-environment-variables/defining-types" title="2. Defining types" description="Declare strings, numbers, booleans, enums, and ArkEnv keywords." />
-
-  <Card href="/docs/validating-environment-variables/client-vs-server" title="3. Client vs. server" description="Keep public keys and private secrets in separate buckets." />
-
-  <Card href="/docs/validating-environment-variables/coercion-and-parsing" title="4. Coercion and parsing" description="Turn raw strings into numbers, booleans, arrays, and objects." />
-
-  <Card href="/docs/validating-environment-variables/error-reporting" title="5. Error reporting" description="Fail fast with clear console output and issue codes." />
-
-  <Card href="/docs/validating-environment-variables/reusing-schemas" title="6. Reusing schemas" description="Share one schema across runtimes and packages." />
-
-  <Card href="/docs/validating-environment-variables/framework-integration" title="7. Framework integration" description="Wire ArkEnv into Next.js, Nuxt, Vite, or Bun." />
-
-  <Card href="/docs/validating-environment-variables/hosting-presets" title="8. Hosting presets" description="Add Vercel, Netlify, Cloudflare, and other provider vars." />
+	<Card
+		href="/docs/validating-environment-variables/structuring-your-schema"
+		title="1. Structuring your schema"
+		description="Put env.ts in the right place and export a typed env object."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/defining-types"
+		title="2. Defining types"
+		description="Declare strings, numbers, booleans, enums, and ArkEnv keywords."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/client-vs-server"
+		title="3. Client vs. server"
+		description="Keep public keys and private secrets in separate buckets."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/coercion-and-parsing"
+		title="4. Coercion and parsing"
+		description="Turn raw strings into numbers, booleans, arrays, and objects."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/error-reporting"
+		title="5. Error reporting"
+		description="Fail fast with clear console output and issue codes."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/reusing-schemas"
+		title="6. Reusing schemas"
+		description="Share one schema across runtimes and packages."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/framework-integration"
+		title="7. Framework integration"
+		description="Wire ArkEnv into Next.js, Nuxt, Vite, or Bun."
+	/>
+	<Card
+		href="/docs/validating-environment-variables/hosting-presets"
+		title="8. Hosting presets"
+		description="Add Vercel, Netlify, Cloudflare, and other provider vars."
+	/>
 </Cards>
 
 ## Next steps
 
-Start with [structuring your schema](/docs/validating-environment-variables/structuring-your-schema), or skim [Getting started](/docs/getting-started) if you still need to install packages.
+New project: run [`arkenv init`](/docs/reference/init) (or follow [Getting started](/docs/getting-started)), then open [structuring your schema](/docs/validating-environment-variables/structuring-your-schema).

--- a/apps/www/content/docs/validating-environment-variables/reusing-schemas.mdx
+++ b/apps/www/content/docs/validating-environment-variables/reusing-schemas.mdx
@@ -3,11 +3,18 @@ title: Reusing schemas
 description: Define a schema once and validate it across runtimes and packages.
 ---
 
-Calling `arkenv({ ... })` defines the schema and parses the current environment in one step. Two runtimes that need the same keys (Vite config on Node and the browser client, or several packages in a monorepo) should extract the schema with `type()` and pass it into each `arkenv()` call.
+Calling `arkenv({ ... })` both defines the schema and parses the current environment. That is the happy path for a single process. The moment the same keys must be validated in more than one place, extract the schema once and pass it into each `arkenv()` call.
+
+Common cases:
+
+- **Two runtimes in one app.** Vite's `vite.config.ts` runs in Node while the browser client reads `VITE_*` keys. Both need the same shape; only the env source differs.
+- **Monorepos.** Several packages share `DATABASE_URL` / public API URLs but each app still exports its own `env`.
+- **Tests.** Feed `{ env: { ... } }` fixtures without redefining the schema.
+- **Custom integrations.** Workers bindings, CLI tools, and advanced boot paths that re-parse the same schema against a different record.
 
 ## Shared `type()` definition
 
-```ts title="./env-schema.ts"
+```ts title="./env-schema.ts" twoslash
 import arkenv, { type } from "@arkenv/core";
 
 export const Env = type({
@@ -75,7 +82,7 @@ export const env = arkenv(AppEnv);
 
 Each app still owns its `env` export. Shared packages export schemas, not a process-wide singleton, so tests can pass a custom `{ env: ... }` per case.
 
-## Standard Schema maps
+## Standard Schema maps (Zod, Valibot, etc.)
 
 With `@arkenv/standard`, reuse means exporting the same field map:
 

--- a/apps/www/content/docs/validating-environment-variables/reusing-schemas.mdx
+++ b/apps/www/content/docs/validating-environment-variables/reusing-schemas.mdx
@@ -1,0 +1,104 @@
+---
+title: Reusing schemas
+description: Define a schema once and validate it across runtimes and packages.
+---
+
+Calling `arkenv({ ... })` defines the schema and parses the current environment in one step. Two runtimes that need the same keys (Vite config on Node and the browser client, or several packages in a monorepo) should extract the schema with `type()` and pass it into each `arkenv()` call.
+
+## Shared `type()` definition
+
+```ts title="./env-schema.ts" twoslash
+import { type } from "@arkenv/core";
+
+export const Env = type({
+	HOST: "string.host = 'localhost'",
+	PORT: "number.port = 3000",
+	VITE_API_URL: "string",
+	DATABASE_URL: "string",
+});
+```
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+import { Env } from "./env-schema";
+
+export const env = arkenv(Env);
+```
+
+```ts title="./vite.config.ts"
+import { defineConfig, loadEnv } from "vite";
+import arkenvPlugin from "@arkenv/vite-plugin";
+import { Env } from "./env-schema";
+import arkenv from "@arkenv/core";
+
+const rootEnv = arkenv(Env, { env: loadEnv("development", process.cwd(), "") });
+
+export default defineConfig({
+	plugins: [arkenvPlugin(Env)],
+	server: { port: rootEnv.PORT },
+});
+```
+
+TypeScript keeps full inference on every call site. Keywords such as `string.host` and `number.port` work inside `type()` the same way they do inside `arkenv()`.
+
+## Extending schemas in frameworks
+
+Next.js and Nuxt strict layouts compose schemas with `extends` instead of object-spreading validators:
+
+```ts title="./env/server.ts"
+import arkenv from "@arkenv/nextjs/server";
+import { env as clientEnv } from "./client";
+
+export const env = arkenv(
+	{ DATABASE_URL: "string" },
+	{ extends: [clientEnv] },
+);
+```
+
+`extends` merges shared and client definitions into the server env object. See [client vs. server](/docs/validating-environment-variables/client-vs-server#strict-layout).
+
+## Monorepo packages
+
+Put the compiled schema in an internal package, then call the host `arkenv` (or plugin) from each app:
+
+```ts title="./packages/env/src/schema.ts"
+import { type } from "@arkenv/core";
+
+export const AppEnv = type({
+	DATABASE_URL: "string",
+	NEXT_PUBLIC_API_URL: "string",
+});
+```
+
+```ts title="./apps/web/env.ts"
+import arkenv from "@/generated/env.gen";
+import { AppEnv } from "@repo/env";
+
+export const env = arkenv(AppEnv);
+```
+
+Each app still owns its `env` export. Shared packages export schemas, not a process-wide singleton, so tests can pass a custom `{ env: ... }` per case.
+
+## Standard Schema maps
+
+With `@arkenv/standard`, reuse means exporting the same field map:
+
+```ts title="./env-schema.ts"
+import { z } from "zod";
+
+export const schema = {
+	PORT: z.coerce.number(),
+	HOST: z.string().default("localhost"),
+} as const;
+```
+
+```ts title="./env.ts"
+import arkenv from "@arkenv/standard";
+import { schema } from "./env-schema";
+
+export const env = arkenv(schema);
+```
+
+## Next steps
+
+Connect the schema to your bundler or framework with [framework integration](/docs/validating-environment-variables/framework-integration).

--- a/apps/www/content/docs/validating-environment-variables/reusing-schemas.mdx
+++ b/apps/www/content/docs/validating-environment-variables/reusing-schemas.mdx
@@ -7,7 +7,7 @@ Calling `arkenv({ ... })` defines the schema and parses the current environment 
 
 ## Shared `type()` definition
 
-```ts title="./env-schema.ts" twoslash
+```ts title="./env-schema.ts"
 import arkenv, { type } from "@arkenv/core";
 
 export const Env = type({

--- a/apps/www/content/docs/validating-environment-variables/reusing-schemas.mdx
+++ b/apps/www/content/docs/validating-environment-variables/reusing-schemas.mdx
@@ -8,7 +8,7 @@ Calling `arkenv({ ... })` defines the schema and parses the current environment 
 ## Shared `type()` definition
 
 ```ts title="./env-schema.ts" twoslash
-import { type } from "@arkenv/core";
+import arkenv, { type } from "@arkenv/core";
 
 export const Env = type({
 	HOST: "string.host = 'localhost'",
@@ -16,12 +16,8 @@ export const Env = type({
 	VITE_API_URL: "string",
 	DATABASE_URL: "string",
 });
-```
 
-```ts title="./env.ts" twoslash
-import arkenv from "@arkenv/core";
-import { Env } from "./env-schema";
-
+// Reuse the same compiled schema in every runtime
 export const env = arkenv(Env);
 ```
 

--- a/apps/www/content/docs/validating-environment-variables/structuring-your-schema.mdx
+++ b/apps/www/content/docs/validating-environment-variables/structuring-your-schema.mdx
@@ -15,7 +15,7 @@ pnpm add @arkenv/core arktype
 
 Create `env.ts` at the root of the app or package that boots first:
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 export const env = arkenv({
@@ -75,7 +75,7 @@ Keep `.env.example` in sync with the schema so new contributors know which keys 
 
 By default `arkenv()` reads `process.env`. Pass a custom record when the host injects env another way (tests, Cloudflare Workers, Vite `loadEnv`):
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -90,7 +90,7 @@ See [options](/docs/reference/options) for `coerce`, `arrayFormat`, `emptyAsUnde
 
 If the project already uses Zod, Valibot, or another [Standard Schema](https://standardschema.dev/) validator, swap the import:
 
-```ts title="./env.ts" twoslash
+```ts title="./env.ts"
 import arkenv from "@arkenv/standard";
 import { z } from "zod";
 

--- a/apps/www/content/docs/validating-environment-variables/structuring-your-schema.mdx
+++ b/apps/www/content/docs/validating-environment-variables/structuring-your-schema.mdx
@@ -34,10 +34,10 @@ console.log(`listening on ${env.HOST}:${env.PORT}`);
 ```
 
 <Callout type="info">
-	The validated `env` object is the product. Read `env.DATABASE_URL`, not
-	`process.env.DATABASE_URL` or `import.meta.env.DATABASE_URL`. Raw env maps stay
-	untyped strings; `env` is coerced, defaulted, and typed. That surface is
-	canonical across Node, Next.js, Nuxt, Vite, and Bun ([typesafety](/docs/core-concepts/typesafety)).
+  The validated `env` object is the product. Read `env.DATABASE_URL`, not
+  `process.env.DATABASE_URL` or `import.meta.env.DATABASE_URL`. Raw env maps stay
+  untyped strings; `env` is coerced, defaulted, and typed. That surface is
+  canonical across Node, Next.js, Nuxt, Vite, and Bun ([typesafety](/docs/core-concepts/typesafety)).
 </Callout>
 
 ## What belongs in the schema
@@ -56,14 +56,17 @@ Put every variable your process reads into the schema: secrets, public keys, tun
 A single `env.ts` is the default layout for ArkEnv (Node apps and [flat layout](/docs/validating-environment-variables/client-vs-server#flat-layout-recommended) frameworks):
 
 <Files>
-	<Folder name="my-app" defaultOpen>
-		<File name="env.ts" />
-		<File name=".env" />
-		<File name=".env.example" />
-		<Folder name="src">
-			<File name="index.ts" />
-		</Folder>
-	</Folder>
+  <Folder name="my-app" defaultOpen>
+    <File name="env.ts" />
+
+    <File name=".env" />
+
+    <File name=".env.example" />
+
+    <Folder name="src">
+      <File name="index.ts" />
+    </Folder>
+  </Folder>
 </Files>
 
 Keep `.env.example` in sync with the schema so new contributors know which keys to set.

--- a/apps/www/content/docs/validating-environment-variables/structuring-your-schema.mdx
+++ b/apps/www/content/docs/validating-environment-variables/structuring-your-schema.mdx
@@ -1,0 +1,103 @@
+---
+title: Structuring your schema
+description: Decide where env.ts lives and how you export a typed env object.
+---
+
+Define the schema once and import a typed `env` object everywhere else. This guide covers where that file lives and how to call `arkenv()`.
+
+## Getting started
+
+Install the core package and ArkType:
+
+```package-install
+pnpm add @arkenv/core arktype
+```
+
+Create `env.ts` at the root of the app or package that boots first:
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+	HOST: "string.host = 'localhost'",
+	PORT: "number.port = 3000",
+	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+});
+```
+
+Import that object from application code:
+
+```ts title="./src/server.ts"
+import { env } from "../env";
+
+console.log(`listening on ${env.HOST}:${env.PORT}`);
+```
+
+<Callout type="info">
+	Prefer importing `env` over reading `process.env` directly. The typed object
+	is the [canonical surface](/docs/core-concepts/typesafety) across Node, Next.js,
+	Nuxt, Vite, and Bun.
+</Callout>
+
+## What belongs in the schema
+
+Put every variable your process reads into the schema:
+
+- Required secrets (`DATABASE_URL`, `API_KEY`)
+- Tunables with defaults (`PORT`, `LOG_LEVEL`)
+- Framework public keys (`NEXT_PUBLIC_*`, `VITE_*`, `NUXT_PUBLIC_*`, `BUN_PUBLIC_*`)
+
+Leave host-injected platform variables to [hosting presets](/docs/validating-environment-variables/hosting-presets) when you scaffold with the CLI.
+
+## Single-file layout
+
+A single `env.ts` is the default for Node apps and for [flat](/docs/validating-environment-variables/client-vs-server#flat-layout) framework setups:
+
+<Files>
+	<Folder name="my-app" defaultOpen>
+		<File name="env.ts" />
+		<File name=".env" />
+		<File name=".env.example" />
+		<File name="package.json" />
+		<Folder name="src">
+			<File name="index.ts" />
+		</Folder>
+	</Folder>
+</Files>
+
+Keep `.env.example` in sync with the schema so new contributors know which keys to set. ArkEnv does not load `.env` files; your framework or a loader such as `dotenv` does that before `arkenv()` runs.
+
+## Custom env source
+
+By default `arkenv()` reads `process.env`. Pass a custom record when the host injects env another way (tests, Cloudflare Workers, Vite `loadEnv`):
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv(
+	{ PORT: "number.port" },
+	{ env: { PORT: "3000" } },
+);
+```
+
+See [options](/docs/reference/options) for `coerce`, `arrayFormat`, `emptyAsUndefined`, and `safe`.
+
+## Standard Schema alternative
+
+If the project already uses Zod, Valibot, or another [Standard Schema](https://standardschema.dev/) validator, swap the import:
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/standard";
+import { z } from "zod";
+
+export const env = arkenv({
+	PORT: z.coerce.number().int().min(0).max(65535),
+	HOST: z.string().default("localhost"),
+});
+```
+
+[`@arkenv/standard`](/docs/reference/standard) skips ArkType keywords and the ArkType DSL. Prefer `@arkenv/core` for new TypeScript projects.
+
+## Next steps
+
+With a file in place, [define the types](/docs/validating-environment-variables/defining-types) for each key.

--- a/apps/www/content/docs/validating-environment-variables/structuring-your-schema.mdx
+++ b/apps/www/content/docs/validating-environment-variables/structuring-your-schema.mdx
@@ -7,15 +7,15 @@ Define the schema once and import a typed `env` object everywhere else. This gui
 
 ## Getting started
 
-Install the core package and ArkType:
+Install the core package and ArkType (or skip ahead to [Standard Schema](#standard-schema-zod-valibot-etc) if you are on Zod/Valibot without ArkType):
 
 ```package-install
 pnpm add @arkenv/core arktype
 ```
 
-Create `env.ts` at the root of the app or package that boots first:
+Create `env.ts` next to the code that boots first. Root of the app or package is common; `src/env.ts` is fine when the rest of your entrypoints already live under `src/`:
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/core";
 
 export const env = arkenv({
@@ -34,48 +34,45 @@ console.log(`listening on ${env.HOST}:${env.PORT}`);
 ```
 
 <Callout type="info">
-  Prefer importing `env` over reading `process.env` directly. The typed object
-  is the [canonical surface](/docs/core-concepts/typesafety) across Node, Next.js,
-  Nuxt, Vite, and Bun.
+	The validated `env` object is the product. Read `env.DATABASE_URL`, not
+	`process.env.DATABASE_URL` or `import.meta.env.DATABASE_URL`. Raw env maps stay
+	untyped strings; `env` is coerced, defaulted, and typed. That surface is
+	canonical across Node, Next.js, Nuxt, Vite, and Bun ([typesafety](/docs/core-concepts/typesafety)).
 </Callout>
 
 ## What belongs in the schema
 
-Put every variable your process reads into the schema:
+Put every variable your process reads into the schema: secrets, public keys, tunables, and platform vars you rely on.
 
 - Required secrets (`DATABASE_URL`, `API_KEY`)
 - Tunables with defaults (`PORT`, `LOG_LEVEL`)
 - Framework public keys (`NEXT_PUBLIC_*`, `VITE_*`, `NUXT_PUBLIC_*`, `BUN_PUBLIC_*`)
+- Hosting provider system variables (`VERCEL_ENV`, `CONTEXT`, …) when you use them
 
-Leave host-injected platform variables to [hosting presets](/docs/validating-environment-variables/hosting-presets) when you scaffold with the CLI.
+[`arkenv init`](/docs/reference/init) and [hosting presets](/docs/validating-environment-variables/hosting-presets) can inject the provider fields for you. You can still declare them by hand.
 
 ## Single-file layout
 
-A single `env.ts` is the default for Node apps and for [flat](/docs/validating-environment-variables/client-vs-server#flat-layout) framework setups:
+A single `env.ts` is the default layout for ArkEnv (Node apps and [flat layout](/docs/validating-environment-variables/client-vs-server#flat-layout-recommended) frameworks):
 
 <Files>
-  <Folder name="my-app" defaultOpen>
-    <File name="env.ts" />
-
-    <File name=".env" />
-
-    <File name=".env.example" />
-
-    <File name="package.json" />
-
-    <Folder name="src">
-      <File name="index.ts" />
-    </Folder>
-  </Folder>
+	<Folder name="my-app" defaultOpen>
+		<File name="env.ts" />
+		<File name=".env" />
+		<File name=".env.example" />
+		<Folder name="src">
+			<File name="index.ts" />
+		</Folder>
+	</Folder>
 </Files>
 
-Keep `.env.example` in sync with the schema so new contributors know which keys to set. ArkEnv does not load `.env` files; your framework or a loader such as `dotenv` does that before `arkenv()` runs.
+Keep `.env.example` in sync with the schema so new contributors know which keys to set.
 
 ## Custom env source
 
-By default `arkenv()` reads `process.env`. Pass a custom record when the host injects env another way (tests, Cloudflare Workers, Vite `loadEnv`):
+By default `arkenv()` reads `process.env`. Pass a custom record for tests, Workers bindings, or any host that injects env outside `process.env`:
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/core";
 
 export const env = arkenv(
@@ -84,13 +81,13 @@ export const env = arkenv(
 );
 ```
 
-See [options](/docs/reference/options) for `coerce`, `arrayFormat`, `emptyAsUndefined`, and `safe`.
+Framework plugins (Next.js, Nuxt, Vite, Bun) wire the usual sources for you. See [options](/docs/reference/options) for `coerce`, `arrayFormat`, `emptyAsUndefined`, and `safe`.
 
-## Standard Schema alternative
+## Standard Schema (Zod, Valibot, etc.)
 
-If the project already uses Zod, Valibot, or another [Standard Schema](https://standardschema.dev/) validator, swap the import:
+Use [`@arkenv/standard`](/docs/reference/standard) when the project has no ArkType dependency and you want Zod, Valibot, or another [Standard Schema](https://standardschema.dev/) validator only. ArkType already implements Standard Schema; if you already depend on ArkType, stay on `@arkenv/core`.
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/standard";
 import { z } from "zod";
 
@@ -100,8 +97,6 @@ export const env = arkenv({
 });
 ```
 
-[`@arkenv/standard`](/docs/reference/standard) skips ArkType keywords and the ArkType DSL. Prefer `@arkenv/core` for new TypeScript projects.
-
 ## Next steps
 
-With a file in place, [define the types](/docs/validating-environment-variables/defining-types) for each key.
+Next: [define the types](/docs/validating-environment-variables/defining-types) for each key.

--- a/apps/www/content/docs/validating-environment-variables/structuring-your-schema.mdx
+++ b/apps/www/content/docs/validating-environment-variables/structuring-your-schema.mdx
@@ -34,9 +34,9 @@ console.log(`listening on ${env.HOST}:${env.PORT}`);
 ```
 
 <Callout type="info">
-	Prefer importing `env` over reading `process.env` directly. The typed object
-	is the [canonical surface](/docs/core-concepts/typesafety) across Node, Next.js,
-	Nuxt, Vite, and Bun.
+  Prefer importing `env` over reading `process.env` directly. The typed object
+  is the [canonical surface](/docs/core-concepts/typesafety) across Node, Next.js,
+  Nuxt, Vite, and Bun.
 </Callout>
 
 ## What belongs in the schema
@@ -54,15 +54,19 @@ Leave host-injected platform variables to [hosting presets](/docs/validating-env
 A single `env.ts` is the default for Node apps and for [flat](/docs/validating-environment-variables/client-vs-server#flat-layout) framework setups:
 
 <Files>
-	<Folder name="my-app" defaultOpen>
-		<File name="env.ts" />
-		<File name=".env" />
-		<File name=".env.example" />
-		<File name="package.json" />
-		<Folder name="src">
-			<File name="index.ts" />
-		</Folder>
-	</Folder>
+  <Folder name="my-app" defaultOpen>
+    <File name="env.ts" />
+
+    <File name=".env" />
+
+    <File name=".env.example" />
+
+    <File name="package.json" />
+
+    <Folder name="src">
+      <File name="index.ts" />
+    </Folder>
+  </Folder>
 </Files>
 
 Keep `.env.example` in sync with the schema so new contributors know which keys to set. ArkEnv does not load `.env` files; your framework or a loader such as `dotenv` does that before `arkenv()` runs.

--- a/apps/www/mdx-components.tsx
+++ b/apps/www/mdx-components.tsx
@@ -12,11 +12,10 @@ import {
 	CalloutDescription,
 	CalloutTitle,
 } from "fumadocs-ui/components/callout";
-import { Cards } from "fumadocs-ui/components/card";
+import { Card, Cards } from "fumadocs-ui/components/card";
 import { File, Files, Folder } from "fumadocs-ui/components/files";
 import type { MDXComponents } from "mdx/types";
 import { Button } from "~/components/ui/button";
-import { Card } from "~/components/ui/card";
 import { cn } from "~/lib/cn";
 
 const generator = createGenerator({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Populates the step-by-step guides under `/docs/validating-environment-variables/*` for the Simplify Docs stack (#1527).

Fixes #1520

## Pages

- Hub index with Turbo-style `Cards` navigation
- Structuring your schema
- Defining types (ArkType + Zod tabs)
- Client vs. server (flat layout recommended / strict callout)
- Coercion and parsing (twoslash restored)
- Error reporting (links #1558 for prefix inconsistency)
- Reusing schemas
- Framework integration
- Hosting presets

## Notes

- Voice aligned with Turborepo crafting guides; stop-slop pass after maintainer review edits
- Content drawn from v1 docs + current `@arkenv/core` / framework APIs
- Maintainer review feedback addressed in latest commits

## Test plan

- [x] `pnpm --filter=www run build` (production MDX/twoslash)
- [x] Local docs on http://localhost:1547
- [ ] Preview docs hub and each guide on the www preview
- [ ] Confirm Cards links and Next steps chain
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1098bdb9-42e8-474c-a0f8-2399ea50acd7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1098bdb9-42e8-474c-a0f8-2399ea50acd7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

