### PR TITLE
ci: run www previews for PRs targeting any base branch

### DIFF
--- a/.github/workflows/preview-www-default.yml
+++ b/.github/workflows/preview-www-default.yml
@@ -3,11 +3,10 @@ name: Preview www (Default Events)
 on:
   # pull_request_target so fork PRs receive repository secrets (VERCEL_*).
   # Workflow YAML is taken from the base branch; we checkout PR HEAD in the reusable job.
+  # No base-branch filter: collective targets (e.g. simplify-docs) must get previews too.
+  # Spam control is the `preview` label (triage+), not the base ref.
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
-    branches:
-      - dev
-      - v1
   push:
     branches:
       - dev
@@ -20,7 +19,8 @@ concurrency:
 jobs:
   Deploy-Preview:
     # Branch previews (push to dev/v1) always deploy. PR previews are opt-in:
-    # they only deploy when the PR carries the `preview` label, regardless of draft state.
+    # they only deploy when the PR carries the `preview` label, regardless of draft state
+    # or which branch the PR targets.
     # Fork authors cannot apply labels (triage+ required), so this is not self-serve spamable.
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'preview')
     uses: ./.github/workflows/preview-www-reusable.yml

--- a/.github/workflows/preview-www-labeled.yml
+++ b/.github/workflows/preview-www-labeled.yml
@@ -2,11 +2,9 @@ name: Preview www (Label Triggered)
 
 on:
   # pull_request_target so fork PRs receive repository secrets when a maintainer applies `preview`.
+  # No base-branch filter — same as preview-www-default (collective targets included).
   pull_request_target:
     types: [labeled]
-    branches:
-      - dev
-      - v1
 
 concurrency:
   group: preview-www-labeled-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Remove the accidental `dev`/`v1` base-branch filter from `pull_request_target` on the preview workflows
- Keep the `push` filter so rolling branch domains (`arkenv-dev` / `arkenv-v1`) stay scoped
- Opt-in remains the maintainer `preview` label (triage+)

Without this, labeled PRs into collective bases like `simplify-docs` never schedule a preview.

## Test plan
- [ ] Merge, then on a PR into a non-`dev`/`v1` base (e.g. `simplify-docs`), toggle the `preview` label and confirm `Preview www (Label Triggered)` runs
- [ ] Confirm unlabeled PRs still skip deploy
- [ ] Confirm pushes to `dev`/`v1` still deploy and alias branch domains


Made with [Cursor](https://cursor.com)