### PR TITLE
docs(www): populate Framework guides and AI recipes

### DIFF
--- a/apps/www/content/docs/guides/ai.mdx
+++ b/apps/www/content/docs/guides/ai.mdx
@@ -75,10 +75,10 @@ Parse `status: "success"` and use fields such as the scaffolded schema path.
 
 ```json
 {
-	"status": "error",
-	"code": "GIT_TREE_DIRTY",
-	"message": "Git working tree is not clean.",
-	"retryWith": ["--force"]
+  "status": "error",
+  "code": "GIT_TREE_DIRTY",
+  "message": "Git working tree is not clean.",
+  "retryWith": ["--force"]
 }
 ```
 
@@ -100,16 +100,16 @@ Tell assistants explicitly: **sync schema, `.env.example`, and docs together** w
 
 Treat these as hard rules unless a human overrides them:
 
-| Rule | Why |
-| ---- | --- |
-| Run `init --agent` (or `add host … --agent`) for setup | Avoids drift from hand-scaffolded config |
-| Validate through `arkenv()` from `@arkenv/core` or a framework entry | The `arkenv` npm package is the CLI, not the runtime |
-| Use framework public prefixes for client-exposed keys | `NEXT_PUBLIC_*`, `NUXT_PUBLIC_*`, `VITE_*`, `BUN_PUBLIC_*` |
-| Never put secrets in client-prefixed keys | Client bundles and flat layouts still leak key names |
-| Do not reintroduce T3-style `runtimeEnv` maps | `withArkEnv` codegen owns the mapping in Next.js |
-| Do not skip validation or read `process.env` ad hoc after setup | Defeats the typed `env` object |
-| Respect `--agent` refusals | Dirty trees and requirement failures are intentional |
-| Commit `.env.example`, not `.env` | Local secrets stay local |
+| Rule                                                                 | Why                                                        |
+| -------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Run `init --agent` (or `add host … --agent`) for setup               | Avoids drift from hand-scaffolded config                   |
+| Validate through `arkenv()` from `@arkenv/core` or a framework entry | The `arkenv` npm package is the CLI, not the runtime       |
+| Use framework public prefixes for client-exposed keys                | `NEXT_PUBLIC_*`, `NUXT_PUBLIC_*`, `VITE_*`, `BUN_PUBLIC_*` |
+| Never put secrets in client-prefixed keys                            | Client bundles and flat layouts still leak key names       |
+| Do not reintroduce T3-style `runtimeEnv` maps                        | `withArkEnv` codegen owns the mapping in Next.js           |
+| Do not skip validation or read `process.env` ad hoc after setup      | Defeats the typed `env` object                             |
+| Respect `--agent` refusals                                           | Dirty trees and requirement failures are intentional       |
+| Commit `.env.example`, not `.env`                                    | Local secrets stay local                                   |
 
 For layout and client/server tradeoffs, link assistants to [Client vs. server](/docs/validating-environment-variables/client-vs-server) instead of inventing a third layout.
 

--- a/apps/www/content/docs/guides/ai.mdx
+++ b/apps/www/content/docs/guides/ai.mdx
@@ -1,9 +1,9 @@
 ---
 title: Using AI with ArkEnv
-description: Pair ArkEnv with AI coding assistants via skills and --agent init.
+description: Pair ArkEnv with AI coding assistants via skills, prompts, .env.example, and guardrails.
 ---
 
-AI assistants write better ArkEnv code when they have the project skill and when setup goes through the CLI's machine-readable agent mode.
+AI assistants write better ArkEnv code when they have the project skill, when setup goes through the CLI's machine-readable agent mode, and when you give them explicit constraints about env files and client boundaries.
 
 ## Install the skill
 
@@ -14,6 +14,42 @@ pnpm dlx skills add yamcodes/arkenv
 That installs the ArkEnv skill into the project (see [skills.sh](https://skills.sh)). Assistants that support skills load it when they see `env.ts`, ArkEnv imports, or env-validation questions.
 
 The skill covers schema definition (ArkType and Standard Schema), framework wiring, and CLI init patterns.
+
+## Prompts that work well
+
+Copy these into your assistant when you want predictable output:
+
+**Greenfield setup**
+
+```text
+Add ArkEnv to this repo. Run `pnpm dlx arkenv@latest init --agent`, parse the JSON on stdout, and only retry with flags from `retryWith` if a refusal is safe to bypass. Do not hand-write next.config or env.ts unless init fails.
+```
+
+**Existing keys**
+
+```text
+We already have a .env.example. Run `arkenv init --agent` and accept the detected keys for the schema. Keep .env.example values empty or placeholder-only; never copy secrets from .env into git.
+```
+
+**Migrate raw process.env usage**
+
+```text
+Find direct `process.env` / `import.meta.env` reads and route them through the typed `env` export from env.ts (or strict env/client.ts and env/server.ts). Do not add a runtimeEnv map. Match the framework public prefix (NEXT_PUBLIC_, NUXT_PUBLIC_, VITE_, BUN_PUBLIC_).
+```
+
+**Add a variable**
+
+```text
+Add DATABASE_URL to the ArkEnv schema with the right type, update .env.example with an empty value, and document the key in a comment if it is non-obvious. Do not expose server keys on the client.
+```
+
+**Hosting preset**
+
+```text
+Add the Vercel hosting preset with `pnpm dlx arkenv@latest add host vercel --agent` and merge any new system vars into the schema.
+```
+
+Point the assistant at this page and [Framework integration](/docs/validating-environment-variables/framework-integration) when it needs host context.
 
 ## Scaffold with `--agent`
 
@@ -50,6 +86,33 @@ Run without `--force` first. Only re-run with flags from `retryWith` after you d
 
 Full flag list: [init](/docs/reference/init).
 
+## Keep `.env.example` honest
+
+The CLI treats `.env.example` as the onboarding contract:
+
+- **Init on an existing repo**: if `.env.example` exists, init can detect keys and offer them for the schema (see [structuring your schema](/docs/validating-environment-variables/structuring-your-schema)).
+- **Missing files**: init may create `.env` and `.env.example` with framework defaults, copy `.env.example` to `.env` when only the template exists, or strip values from `.env` into a new `.env.example` so secrets do not land in git.
+- **After schema changes**: add new keys to `.env.example` with empty or placeholder values. Commit the template; keep `.env` and `.env.local` gitignored.
+
+Tell assistants explicitly: **sync schema, `.env.example`, and docs together** when adding or renaming variables.
+
+## Guardrails for assistants
+
+Treat these as hard rules unless a human overrides them:
+
+| Rule | Why |
+| ---- | --- |
+| Run `init --agent` (or `add host … --agent`) for setup | Avoids drift from hand-scaffolded config |
+| Validate through `arkenv()` from `@arkenv/core` or a framework entry | The `arkenv` npm package is the CLI, not the runtime |
+| Use framework public prefixes for client-exposed keys | `NEXT_PUBLIC_*`, `NUXT_PUBLIC_*`, `VITE_*`, `BUN_PUBLIC_*` |
+| Never put secrets in client-prefixed keys | Client bundles and flat layouts still leak key names |
+| Do not reintroduce T3-style `runtimeEnv` maps | `withArkEnv` codegen owns the mapping in Next.js |
+| Do not skip validation or read `process.env` ad hoc after setup | Defeats the typed `env` object |
+| Respect `--agent` refusals | Dirty trees and requirement failures are intentional |
+| Commit `.env.example`, not `.env` | Local secrets stay local |
+
+For layout and client/server tradeoffs, link assistants to [Client vs. server](/docs/validating-environment-variables/client-vs-server) instead of inventing a third layout.
+
 ## Patterns the skill enforces
 
 - Export a single `env` object from `env.ts` (or the strict `env/` tree)
@@ -66,5 +129,5 @@ pnpm dlx arkenv@latest add host vercel --agent
 ## Next steps
 
 - [Framework guides](/docs/guides/frameworks)
-- [Validating environment variables](/docs/validating-environment-variables)
+- [Framework integration](/docs/validating-environment-variables/framework-integration)
 - [skills.sh](https://skills.sh)

--- a/apps/www/content/docs/guides/ai.mdx
+++ b/apps/www/content/docs/guides/ai.mdx
@@ -1,8 +1,70 @@
 ---
 title: Using AI with ArkEnv
-description: Use AI coding assistants with ArkEnv schemas and tooling.
+description: Pair ArkEnv with AI coding assistants via skills and --agent init.
 ---
 
-Stub guide for pairing ArkEnv with AI coding assistants (CLI agent mode, schemas, and recipes).
+AI assistants write better ArkEnv code when they have the project skill and when setup goes through the CLI's machine-readable agent mode.
 
-> Content TBD — Guides section leaf.
+## Install the skill
+
+```bash title="Terminal"
+pnpm dlx skills add yamcodes/arkenv
+```
+
+That installs the ArkEnv skill into the project (see [skills.sh](https://skills.sh)). Assistants that support skills load it when they see `env.ts`, ArkEnv imports, or env-validation questions.
+
+The skill covers schema definition (ArkType and Standard Schema), framework wiring, and CLI init patterns.
+
+## Scaffold with `--agent`
+
+Agents should initialize projects through the CLI instead of hand-writing config:
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init --agent
+pnpm dlx arkenv@latest init --agent --flat
+pnpm dlx arkenv@latest init --agent --strict -H vercel
+```
+
+`--agent` implies `--yes --quiet --json`. It does **not** imply `--force`.
+
+Success and refusal payloads land on stdout as JSON. Other logs go to stderr.
+
+### Success
+
+Parse `status: "success"` and use fields such as the scaffolded schema path.
+
+### Refusals
+
+`--agent` still honors safety checks (dirty git tree, unmet requirements). A refusal looks like:
+
+```json
+{
+	"status": "error",
+	"code": "GIT_TREE_DIRTY",
+	"message": "Git working tree is not clean.",
+	"retryWith": ["--force"]
+}
+```
+
+Run without `--force` first. Only re-run with flags from `retryWith` after you decide the bypass is safe. An empty `retryWith` means the refusal is not bypassable. `code: "INTERNAL"` means the CLI failed; retry flags will not help.
+
+Full flag list: [init](/docs/reference/init).
+
+## Patterns the skill enforces
+
+- Export a single `env` object from `env.ts` (or the strict `env/` tree)
+- Prefer ArkType strings in `@arkenv/core` when the project already uses ArkType
+- Keep secrets out of client schemas; use framework public prefixes
+- Load `.env` via the framework or dotenv; ArkEnv only validates
+
+## Add a hosting preset later
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest add host vercel --agent
+```
+
+## Next steps
+
+- [Framework guides](/docs/guides/frameworks)
+- [Validating environment variables](/docs/validating-environment-variables)
+- [skills.sh](https://skills.sh)

--- a/apps/www/content/docs/guides/frameworks/bun.mdx
+++ b/apps/www/content/docs/guides/frameworks/bun.mdx
@@ -1,8 +1,87 @@
 ---
 title: Bun
-description: Use ArkEnv with Bun.
+description: Validate Bun bundler env vars with @arkenv/bun-plugin.
 ---
 
-Stub guide for `@arkenv/bun-plugin` setup and Bun runtime validation.
+Use `@arkenv/bun-plugin` when Bun builds or serves a client bundle that inlines public env (`BUN_PUBLIC_*` by default). Plain Bun **backends** can call [`@arkenv/core`](/docs/reference/core) directly without the plugin.
 
-> Content TBD — Nested Folder leaf (`/docs/guides/frameworks/bun`).
+## Quickstart
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init
+```
+
+## Manual install
+
+```package-install
+pnpm add @arkenv/core arktype
+pnpm add -D @arkenv/bun-plugin
+```
+
+```package-install
+pnpm add @arkenv/standard zod
+pnpm add -D @arkenv/bun-plugin
+```
+
+Standard Schema plugin entry: `@arkenv/bun-plugin/standard`.
+
+### Schema module
+
+```ts title="./src/env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+	DATABASE_URL: "string",
+	BUN_PUBLIC_API_URL: "string",
+	BUN_PUBLIC_DEBUG: "boolean = false",
+});
+```
+
+### Bun.serve (dev)
+
+```toml title="./bunfig.toml"
+[serve.static]
+plugins = ["@arkenv/bun-plugin"]
+```
+
+### Bun.build
+
+```ts title="./build.ts"
+import arkenv from "@arkenv/bun-plugin";
+
+await Bun.build({
+	entrypoints: ["./src/index.tsx"],
+	outdir: "./dist",
+	plugins: [arkenv()],
+});
+```
+
+Import `{ env } from "./env"` in application code. Transform mode rewrites the client graph the same way the Vite plugin does.
+
+## Backend-only Bun
+
+Skip the plugin:
+
+```ts title="./src/env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+	DATABASE_URL: "string",
+	PORT: "number.port = 3000",
+});
+```
+
+## Types
+
+Optional ambient helper for accessor-style SPAs:
+
+```ts
+import type { ProcessEnvAugmented } from "@arkenv/bun-plugin";
+```
+
+Prefer the exported `env` object for fullstack apps. See [`@arkenv/bun-plugin`](/docs/reference/bun-plugin).
+
+## Next steps
+
+- [Client vs. server](/docs/validating-environment-variables/client-vs-server)
+- [Bun fullstack bundler](https://bun.sh/docs/bundler/fullstack) docs

--- a/apps/www/content/docs/guides/frameworks/bun.mdx
+++ b/apps/www/content/docs/guides/frameworks/bun.mdx
@@ -83,5 +83,5 @@ Prefer the exported `env` object for fullstack apps. See [`@arkenv/bun-plugin`](
 
 ## Next steps
 
-- [Client vs. server](/docs/validating-environment-variables/client-vs-server)
+- [Client vs. server](/docs/validating-environment-variables)
 - [Bun fullstack bundler](https://bun.sh/docs/bundler/fullstack) docs

--- a/apps/www/content/docs/guides/frameworks/bun.mdx
+++ b/apps/www/content/docs/guides/frameworks/bun.mdx
@@ -3,6 +3,8 @@ title: Bun
 description: Validate Bun bundler env vars with @arkenv/bun-plugin.
 ---
 
+Recipe for Bun bundler / fullstack apps. Overview: [Framework integration](/docs/validating-environment-variables/framework-integration).
+
 Use `@arkenv/bun-plugin` when Bun builds or serves a client bundle that inlines public env (`BUN_PUBLIC_*` by default). Plain Bun **backends** can call [`@arkenv/core`](/docs/reference/core) directly without the plugin.
 
 ## Quickstart
@@ -83,5 +85,5 @@ Prefer the exported `env` object for fullstack apps. See [`@arkenv/bun-plugin`](
 
 ## Next steps
 
-- [Client vs. server](/docs/validating-environment-variables)
+- [Client vs. server](/docs/validating-environment-variables/client-vs-server)
 - [Bun fullstack bundler](https://bun.sh/docs/bundler/fullstack) docs

--- a/apps/www/content/docs/guides/frameworks/bun.mdx
+++ b/apps/www/content/docs/guides/frameworks/bun.mdx
@@ -33,9 +33,9 @@ Standard Schema plugin entry: `@arkenv/bun-plugin/standard`.
 import arkenv from "@arkenv/core";
 
 export const env = arkenv({
-	DATABASE_URL: "string",
-	BUN_PUBLIC_API_URL: "string",
-	BUN_PUBLIC_DEBUG: "boolean = false",
+  DATABASE_URL: "string",
+  BUN_PUBLIC_API_URL: "string",
+  BUN_PUBLIC_DEBUG: "boolean = false",
 });
 ```
 
@@ -52,9 +52,9 @@ plugins = ["@arkenv/bun-plugin"]
 import arkenv from "@arkenv/bun-plugin";
 
 await Bun.build({
-	entrypoints: ["./src/index.tsx"],
-	outdir: "./dist",
-	plugins: [arkenv()],
+  entrypoints: ["./src/index.tsx"],
+  outdir: "./dist",
+  plugins: [arkenv()],
 });
 ```
 
@@ -68,8 +68,8 @@ Skip the plugin:
 import arkenv from "@arkenv/core";
 
 export const env = arkenv({
-	DATABASE_URL: "string",
-	PORT: "number.port = 3000",
+  DATABASE_URL: "string",
+  PORT: "number.port = 3000",
 });
 ```
 

--- a/apps/www/content/docs/guides/frameworks/bun.mdx
+++ b/apps/www/content/docs/guides/frameworks/bun.mdx
@@ -48,7 +48,7 @@ plugins = ["@arkenv/bun-plugin"]
 
 ### Bun.build
 
-```ts title="./build.ts"
+```ts title="./build.ts" twoslash
 import arkenv from "@arkenv/bun-plugin";
 
 await Bun.build({
@@ -77,8 +77,17 @@ export const env = arkenv({
 
 Optional ambient helper for accessor-style SPAs:
 
-```ts
+```ts title="./src/env.d.ts" twoslash
 import type { ProcessEnvAugmented } from "@arkenv/bun-plugin";
+import { type } from "@arkenv/core";
+
+export const Env = type({
+	BUN_PUBLIC_API_URL: "string",
+});
+
+declare namespace NodeJS {
+	interface ProcessEnv extends ProcessEnvAugmented<typeof Env> {}
+}
 ```
 
 Prefer the exported `env` object for fullstack apps. See [`@arkenv/bun-plugin`](/docs/reference/bun-plugin).

--- a/apps/www/content/docs/guides/frameworks/index.mdx
+++ b/apps/www/content/docs/guides/frameworks/index.mdx
@@ -3,7 +3,7 @@ title: Frameworks
 description: Wire ArkEnv into Next.js, Nuxt, Vite, or Bun.
 ---
 
-Each guide is a short recipe: install, scaffold or hand-wire, then import `env`. Deeper option lists live under [API reference](/docs/reference). Client/server boundaries are covered in [Client vs. server](/docs/validating-environment-variables/client-vs-server).
+Each guide is a short recipe: install, scaffold or hand-wire, then import `env`. Deeper option lists live under [API reference](/docs/reference). Client/server boundaries are covered in [Client vs. server](/docs/validating-environment-variables).
 
 <Cards>
   <Card href="/docs/guides/frameworks/nextjs" title="Next.js" description="@arkenv/nextjs, withArkEnv, and env.gen codegen." />

--- a/apps/www/content/docs/guides/frameworks/index.mdx
+++ b/apps/www/content/docs/guides/frameworks/index.mdx
@@ -6,24 +6,11 @@ description: Wire ArkEnv into Next.js, Nuxt, Vite, or Bun.
 Each guide is a short recipe: install, scaffold or hand-wire, then import `env`. Deeper option lists live under [API reference](/docs/reference). Client/server boundaries are covered in [Client vs. server](/docs/validating-environment-variables/client-vs-server).
 
 <Cards>
-	<Card
-		href="/docs/guides/frameworks/nextjs"
-		title="Next.js"
-		description="@arkenv/nextjs, withArkEnv, and env.gen codegen."
-	/>
-	<Card
-		href="/docs/guides/frameworks/nuxt"
-		title="Nuxt"
-		description="@arkenv/nuxt module and NUXT_PUBLIC_ keys."
-	/>
-	<Card
-		href="/docs/guides/frameworks/vite"
-		title="Vite"
-		description="@arkenv/vite-plugin transform mode and VITE_ keys."
-	/>
-	<Card
-		href="/docs/guides/frameworks/bun"
-		title="Bun"
-		description="@arkenv/bun-plugin for Bun bundler / fullstack apps."
-	/>
+  <Card href="/docs/guides/frameworks/nextjs" title="Next.js" description="@arkenv/nextjs, withArkEnv, and env.gen codegen." />
+
+  <Card href="/docs/guides/frameworks/nuxt" title="Nuxt" description="@arkenv/nuxt module and NUXT_PUBLIC_ keys." />
+
+  <Card href="/docs/guides/frameworks/vite" title="Vite" description="@arkenv/vite-plugin transform mode and VITE_ keys." />
+
+  <Card href="/docs/guides/frameworks/bun" title="Bun" description="@arkenv/bun-plugin for Bun bundler / fullstack apps." />
 </Cards>

--- a/apps/www/content/docs/guides/frameworks/index.mdx
+++ b/apps/www/content/docs/guides/frameworks/index.mdx
@@ -3,7 +3,7 @@ title: Frameworks
 description: Wire ArkEnv into Next.js, Nuxt, Vite, or Bun.
 ---
 
-Each guide is a short recipe: install, scaffold or hand-wire, then import `env`. Deeper option lists live under [API reference](/docs/reference). Client/server boundaries are covered in [Client vs. server](/docs/validating-environment-variables).
+Each guide is a short recipe: install, scaffold or hand-wire, then import `env`. For how integrations fit together (prefixes, `.env` loading, stack choice), see [Framework integration](/docs/validating-environment-variables/framework-integration). Option lists live under [API reference](/docs/reference). Client/server boundaries: [Client vs. server](/docs/validating-environment-variables/client-vs-server).
 
 <Cards>
   <Card href="/docs/guides/frameworks/nextjs" title="Next.js" description="@arkenv/nextjs, withArkEnv, and env.gen codegen." />

--- a/apps/www/content/docs/guides/frameworks/index.mdx
+++ b/apps/www/content/docs/guides/frameworks/index.mdx
@@ -1,8 +1,29 @@
 ---
 title: Frameworks
-description: Use ArkEnv with your framework of choice.
+description: Wire ArkEnv into Next.js, Nuxt, Vite, or Bun.
 ---
 
-Guides for integrating ArkEnv with popular frameworks.
+Each guide is a short recipe: install, scaffold or hand-wire, then import `env`. Deeper option lists live under [API reference](/docs/reference). Client/server boundaries are covered in [Client vs. server](/docs/validating-environment-variables/client-vs-server).
 
-> Nested Folder overview — children are true n=2 leaves (`/docs/guides/frameworks/nextjs`).
+<Cards>
+	<Card
+		href="/docs/guides/frameworks/nextjs"
+		title="Next.js"
+		description="@arkenv/nextjs, withArkEnv, and env.gen codegen."
+	/>
+	<Card
+		href="/docs/guides/frameworks/nuxt"
+		title="Nuxt"
+		description="@arkenv/nuxt module and NUXT_PUBLIC_ keys."
+	/>
+	<Card
+		href="/docs/guides/frameworks/vite"
+		title="Vite"
+		description="@arkenv/vite-plugin transform mode and VITE_ keys."
+	/>
+	<Card
+		href="/docs/guides/frameworks/bun"
+		title="Bun"
+		description="@arkenv/bun-plugin for Bun bundler / fullstack apps."
+	/>
+</Cards>

--- a/apps/www/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/www/content/docs/guides/frameworks/nextjs.mdx
@@ -44,9 +44,9 @@ export default withArkEnv(nextConfig);
 import arkenv from "@/generated/env.gen";
 
 export const env = arkenv({
-	DATABASE_URL: "string",
-	NEXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
-	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+  DATABASE_URL: "string",
+  NEXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
+  NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });
 ```
 

--- a/apps/www/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/www/content/docs/guides/frameworks/nextjs.mdx
@@ -56,7 +56,7 @@ Import `env` in Server Components, Route Handlers, and Client Components. Readin
 pnpm dlx arkenv@latest init --strict
 ```
 
-Splits `env/client.ts`, `env/server.ts`, and `env/internal/shared.ts` so the server schema never enters the client module graph. See [Client vs. server](/docs/validating-environment-variables/client-vs-server).
+Splits `env/client.ts`, `env/server.ts`, and `env/internal/shared.ts` so the server schema never enters the client module graph. See [Client vs. server](/docs/validating-environment-variables).
 
 ## Standard Schema
 
@@ -71,5 +71,5 @@ Use `@arkenv/standard` validators in the schema. Details: [`@arkenv/nextjs`](/do
 ## Next steps
 
 - [codegen](/docs/reference/codegen) for `env.gen.ts` options
-- [Hosting presets](/docs/validating-environment-variables/hosting-presets) for Vercel system vars
+- [Hosting presets](/docs/validating-environment-variables) for Vercel system vars
 - Official [Next.js environment variables](https://nextjs.org/docs/app/guides/environment-variables) guide

--- a/apps/www/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/www/content/docs/guides/frameworks/nextjs.mdx
@@ -3,6 +3,8 @@ title: Next.js
 description: Validate Next.js env vars with @arkenv/nextjs and withArkEnv.
 ---
 
+Recipe for Next.js. Overview and stack comparison: [Framework integration](/docs/validating-environment-variables/framework-integration).
+
 `@arkenv/nextjs` validates server and client environment variables, generates a typed factory, and blocks server secrets from Client Components.
 
 ## Quickstart
@@ -56,7 +58,7 @@ Import `env` in Server Components, Route Handlers, and Client Components. Readin
 pnpm dlx arkenv@latest init --strict
 ```
 
-Splits `env/client.ts`, `env/server.ts`, and `env/internal/shared.ts` so the server schema never enters the client module graph. See [Client vs. server](/docs/validating-environment-variables).
+Splits `env/client.ts`, `env/server.ts`, and `env/internal/shared.ts` so the server schema never enters the client module graph. See [Client vs. server](/docs/validating-environment-variables/client-vs-server).
 
 ## Standard Schema
 
@@ -71,5 +73,5 @@ Use `@arkenv/standard` validators in the schema. Details: [`@arkenv/nextjs`](/do
 ## Next steps
 
 - [codegen](/docs/reference/codegen) for `env.gen.ts` options
-- [Hosting presets](/docs/validating-environment-variables) for Vercel system vars
+- [Hosting presets](/docs/validating-environment-variables/hosting-presets) for Vercel system vars
 - Official [Next.js environment variables](https://nextjs.org/docs/app/guides/environment-variables) guide

--- a/apps/www/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/www/content/docs/guides/frameworks/nextjs.mdx
@@ -29,7 +29,7 @@ pnpm add @arkenv/standard @arkenv/nextjs zod
 
 ### Wrap the Next.js config
 
-```ts title="./next.config.ts"
+```ts title="./next.config.ts" twoslash
 import type { NextConfig } from "next";
 import { withArkEnv } from "@arkenv/nextjs/config";
 
@@ -40,7 +40,7 @@ export default withArkEnv(nextConfig);
 
 ### Flat schema (default)
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@/generated/env.gen";
 
 export const env = arkenv({
@@ -62,8 +62,11 @@ Splits `env/client.ts`, `env/server.ts`, and `env/internal/shared.ts` so the ser
 
 ## Standard Schema
 
-```ts title="./next.config.ts"
+```ts title="./next.config.ts" twoslash
+import type { NextConfig } from "next";
 import { withArkEnv } from "@arkenv/nextjs/standard/config";
+
+const nextConfig: NextConfig = {};
 
 export default withArkEnv(nextConfig);
 ```

--- a/apps/www/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/www/content/docs/guides/frameworks/nextjs.mdx
@@ -1,8 +1,75 @@
 ---
 title: Next.js
-description: Use ArkEnv with Next.js.
+description: Validate Next.js env vars with @arkenv/nextjs and withArkEnv.
 ---
 
-Stub guide for `@arkenv/nextjs` setup, `withArkEnv`, and codegen.
+`@arkenv/nextjs` validates server and client environment variables, generates a typed factory, and blocks server secrets from Client Components.
 
-> Content TBD — Nested Folder leaf (`/docs/guides/frameworks/nextjs`).
+## Quickstart
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init
+```
+
+The CLI detects Next.js, installs packages, wraps `next.config` with `withArkEnv`, and scaffolds a flat `env.ts` (or `--strict` split files).
+
+## Manual install
+
+Choose one engine:
+
+```package-install
+pnpm add @arkenv/core @arkenv/nextjs arktype
+```
+
+```package-install
+pnpm add @arkenv/standard @arkenv/nextjs zod
+```
+
+### Wrap the Next.js config
+
+```ts title="./next.config.ts"
+import type { NextConfig } from "next";
+import { withArkEnv } from "@arkenv/nextjs/config";
+
+const nextConfig: NextConfig = {};
+
+export default withArkEnv(nextConfig);
+```
+
+### Flat schema (default)
+
+```ts title="./env.ts"
+import arkenv from "@/generated/env.gen";
+
+export const env = arkenv({
+	DATABASE_URL: "string",
+	NEXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
+	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+});
+```
+
+Import `env` in Server Components, Route Handlers, and Client Components. Reading `DATABASE_URL` on the client throws at runtime.
+
+### Strict layout
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init --strict
+```
+
+Splits `env/client.ts`, `env/server.ts`, and `env/internal/shared.ts` so the server schema never enters the client module graph. See [Client vs. server](/docs/validating-environment-variables/client-vs-server).
+
+## Standard Schema
+
+```ts title="./next.config.ts"
+import { withArkEnv } from "@arkenv/nextjs/standard/config";
+
+export default withArkEnv(nextConfig);
+```
+
+Use `@arkenv/standard` validators in the schema. Details: [`@arkenv/nextjs`](/docs/reference/nextjs).
+
+## Next steps
+
+- [codegen](/docs/reference/codegen) for `env.gen.ts` options
+- [Hosting presets](/docs/validating-environment-variables/hosting-presets) for Vercel system vars
+- Official [Next.js environment variables](https://nextjs.org/docs/app/guides/environment-variables) guide

--- a/apps/www/content/docs/guides/frameworks/nuxt.mdx
+++ b/apps/www/content/docs/guides/frameworks/nuxt.mdx
@@ -3,6 +3,8 @@ title: Nuxt
 description: Validate Nuxt env vars with @arkenv/nuxt.
 ---
 
+Recipe for Nuxt. Overview: [Framework integration](/docs/validating-environment-variables/framework-integration).
+
 `@arkenv/nuxt` validates environment variables for server and browser, maps public keys through Nuxt runtime config, and keeps server secrets off the client.
 
 ## Quickstart
@@ -54,7 +56,7 @@ Public keys use the `NUXT_PUBLIC_` prefix. Nuxt does not emit `env.gen.ts`; this
 pnpm dlx arkenv@latest init --strict
 ```
 
-Use `@arkenv/nuxt/client` and `@arkenv/nuxt/server`. Shared/client schemas can auto-merge via Nuxt virtual aliases when you omit `extends`. See [Client vs. server](/docs/validating-environment-variables).
+Use `@arkenv/nuxt/client` and `@arkenv/nuxt/server`. Shared/client schemas can auto-merge via Nuxt virtual aliases when you omit `extends`. See [Client vs. server](/docs/validating-environment-variables/client-vs-server).
 
 ## Standard Schema
 
@@ -63,5 +65,5 @@ Point the module at a Standard Schema entry and import from `@arkenv/nuxt/standa
 ## Next steps
 
 - Module options under [`@arkenv/nuxt`](/docs/reference/nuxt)
-- [Hosting presets](/docs/validating-environment-variables)
+- [Hosting presets](/docs/validating-environment-variables/hosting-presets)
 - Official [Nuxt configuration](https://nuxt.com/docs/getting-started/configuration) docs

--- a/apps/www/content/docs/guides/frameworks/nuxt.mdx
+++ b/apps/www/content/docs/guides/frameworks/nuxt.mdx
@@ -38,7 +38,7 @@ export default defineNuxtConfig({
 
 ### Flat schema
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/nuxt";
 
 export const env = arkenv({

--- a/apps/www/content/docs/guides/frameworks/nuxt.mdx
+++ b/apps/www/content/docs/guides/frameworks/nuxt.mdx
@@ -29,10 +29,10 @@ pnpm add @arkenv/standard @arkenv/nuxt zod
 
 ```ts title="./nuxt.config.ts"
 export default defineNuxtConfig({
-	modules: ["@arkenv/nuxt/module"],
-	arkenv: {
-		layout: "flat",
-	},
+  modules: ["@arkenv/nuxt/module"],
+  arkenv: {
+    layout: "flat",
+  },
 });
 ```
 
@@ -42,9 +42,9 @@ export default defineNuxtConfig({
 import arkenv from "@arkenv/nuxt";
 
 export const env = arkenv({
-	DATABASE_URL: "string",
-	NUXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
-	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+  DATABASE_URL: "string",
+  NUXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
+  NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });
 ```
 

--- a/apps/www/content/docs/guides/frameworks/nuxt.mdx
+++ b/apps/www/content/docs/guides/frameworks/nuxt.mdx
@@ -1,8 +1,67 @@
 ---
 title: Nuxt
-description: Use ArkEnv with Nuxt.
+description: Validate Nuxt env vars with @arkenv/nuxt.
 ---
 
-Stub guide for `@arkenv/nuxt` setup and Nuxt-specific env wiring.
+`@arkenv/nuxt` validates environment variables for server and browser, maps public keys through Nuxt runtime config, and keeps server secrets off the client.
 
-> Content TBD — Nested Folder leaf (`/docs/guides/frameworks/nuxt`).
+## Quickstart
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init
+```
+
+The CLI registers `@arkenv/nuxt/module` and scaffolds a flat `env.ts` (or `--strict` files).
+
+## Manual install
+
+```package-install
+pnpm add @arkenv/core @arkenv/nuxt arktype
+```
+
+```package-install
+pnpm add @arkenv/standard @arkenv/nuxt zod
+```
+
+### Register the module
+
+```ts title="./nuxt.config.ts"
+export default defineNuxtConfig({
+	modules: ["@arkenv/nuxt/module"],
+	arkenv: {
+		layout: "flat",
+	},
+});
+```
+
+### Flat schema
+
+```ts title="./env.ts"
+import arkenv from "@arkenv/nuxt";
+
+export const env = arkenv({
+	DATABASE_URL: "string",
+	NUXT_PUBLIC_API_URL: "string = 'https://api.example.com'",
+	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+});
+```
+
+Public keys use the `NUXT_PUBLIC_` prefix. Nuxt does not emit `env.gen.ts`; this module is the surface.
+
+### Strict layout
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init --strict
+```
+
+Use `@arkenv/nuxt/client` and `@arkenv/nuxt/server`. Shared/client schemas can auto-merge via Nuxt virtual aliases when you omit `extends`. See [Client vs. server](/docs/validating-environment-variables/client-vs-server).
+
+## Standard Schema
+
+Point the module at a Standard Schema entry and import from `@arkenv/nuxt/standard` (or the `/standard/module` path). Package map: [`@arkenv/nuxt`](/docs/reference/nuxt).
+
+## Next steps
+
+- Module options under [`@arkenv/nuxt`](/docs/reference/nuxt)
+- [Hosting presets](/docs/validating-environment-variables/hosting-presets)
+- Official [Nuxt configuration](https://nuxt.com/docs/getting-started/configuration) docs

--- a/apps/www/content/docs/guides/frameworks/nuxt.mdx
+++ b/apps/www/content/docs/guides/frameworks/nuxt.mdx
@@ -54,7 +54,7 @@ Public keys use the `NUXT_PUBLIC_` prefix. Nuxt does not emit `env.gen.ts`; this
 pnpm dlx arkenv@latest init --strict
 ```
 
-Use `@arkenv/nuxt/client` and `@arkenv/nuxt/server`. Shared/client schemas can auto-merge via Nuxt virtual aliases when you omit `extends`. See [Client vs. server](/docs/validating-environment-variables/client-vs-server).
+Use `@arkenv/nuxt/client` and `@arkenv/nuxt/server`. Shared/client schemas can auto-merge via Nuxt virtual aliases when you omit `extends`. See [Client vs. server](/docs/validating-environment-variables).
 
 ## Standard Schema
 
@@ -63,5 +63,5 @@ Point the module at a Standard Schema entry and import from `@arkenv/nuxt/standa
 ## Next steps
 
 - Module options under [`@arkenv/nuxt`](/docs/reference/nuxt)
-- [Hosting presets](/docs/validating-environment-variables/hosting-presets)
+- [Hosting presets](/docs/validating-environment-variables)
 - Official [Nuxt configuration](https://nuxt.com/docs/getting-started/configuration) docs

--- a/apps/www/content/docs/guides/frameworks/vite.mdx
+++ b/apps/www/content/docs/guides/frameworks/vite.mdx
@@ -74,7 +74,7 @@ export default defineConfig(({ mode }) => {
 });
 ```
 
-See [Reusing schemas](/docs/validating-environment-variables/reusing-schemas).
+See [Reusing schemas](/docs/validating-environment-variables).
 
 ## SPA accessor mode
 
@@ -83,4 +83,4 @@ Client-only apps can still augment `import.meta.env` with `ImportMetaEnvAugmente
 ## Next steps
 
 - Plugin modes and options: [`@arkenv/vite-plugin`](/docs/reference/vite-plugin)
-- [Client vs. server](/docs/validating-environment-variables/client-vs-server)
+- [Client vs. server](/docs/validating-environment-variables)

--- a/apps/www/content/docs/guides/frameworks/vite.mdx
+++ b/apps/www/content/docs/guides/frameworks/vite.mdx
@@ -1,8 +1,86 @@
 ---
 title: Vite
-description: Use ArkEnv with Vite.
+description: Validate Vite env vars with @arkenv/vite-plugin.
 ---
 
-Stub guide for `@arkenv/vite-plugin` setup and `import.meta.env` typing.
+`@arkenv/vite-plugin` validates environment variables in Vite dev and build. The canonical setup is an `env.ts` module plus transform mode: the client graph only receives public keys (default `VITE_*`).
 
-> Content TBD — Nested Folder leaf (`/docs/guides/frameworks/vite`).
+## Quickstart
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init
+```
+
+## Manual install
+
+```package-install
+pnpm add @arkenv/core arktype
+pnpm add -D @arkenv/vite-plugin
+```
+
+```package-install
+pnpm add @arkenv/standard zod
+pnpm add -D @arkenv/vite-plugin
+```
+
+For Standard Schema, import the plugin from `@arkenv/vite-plugin/standard`.
+
+### Schema module
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+	DATABASE_URL: "string",
+	VITE_API_URL: "string",
+	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+});
+```
+
+### Transform plugin
+
+```ts title="./vite.config.ts"
+import { defineConfig } from "vite";
+import arkenv from "@arkenv/vite-plugin";
+
+export default defineConfig({
+	plugins: [arkenv()],
+});
+```
+
+Import `{ env } from "./env"` in app code. Server code runs the real module (boot-time validation). The client bundle gets a rewritten module with public keys inlined and server keys guarded.
+
+### Reuse the schema in `vite.config.ts`
+
+When the config file needs typed values (for example `server.port`), share a compiled `type()`:
+
+```ts title="./vite.config.ts"
+import { defineConfig, loadEnv } from "vite";
+import arkenvPlugin from "@arkenv/vite-plugin";
+import arkenv, { type } from "@arkenv/core";
+
+export const Env = type({
+	PORT: "number.port = 5173",
+	VITE_API_URL: "string",
+	DATABASE_URL: "string",
+});
+
+export default defineConfig(({ mode }) => {
+	const env = arkenv(Env, { env: loadEnv(mode, process.cwd(), "") });
+	return {
+		plugins: [arkenvPlugin(Env)],
+		server: { port: env.PORT },
+	};
+});
+```
+
+See [Reusing schemas](/docs/validating-environment-variables/reusing-schemas).
+
+## SPA accessor mode
+
+Client-only apps can still augment `import.meta.env` with `ImportMetaEnvAugmented` and rely on static access. Prefer the `env` object for fullstack apps so server secrets validate at boot. Types: [`@arkenv/vite-plugin`](/docs/reference/vite-plugin).
+
+## Next steps
+
+- Plugin modes and options: [`@arkenv/vite-plugin`](/docs/reference/vite-plugin)
+- [Client vs. server](/docs/validating-environment-variables/client-vs-server)

--- a/apps/www/content/docs/guides/frameworks/vite.mdx
+++ b/apps/www/content/docs/guides/frameworks/vite.mdx
@@ -41,7 +41,7 @@ export const env = arkenv({
 
 ### Transform plugin
 
-```ts title="./vite.config.ts"
+```ts title="./vite.config.ts" twoslash
 import { defineConfig } from "vite";
 import arkenv from "@arkenv/vite-plugin";
 
@@ -56,7 +56,7 @@ Import `{ env } from "./env"` in app code. Server code runs the real module (boo
 
 When the config file needs typed values (for example `server.port`), share a compiled `type()`:
 
-```ts title="./vite.config.ts"
+```ts title="./vite.config.ts" twoslash
 import { defineConfig, loadEnv } from "vite";
 import arkenvPlugin from "@arkenv/vite-plugin";
 import arkenv, { type } from "@arkenv/core";

--- a/apps/www/content/docs/guides/frameworks/vite.mdx
+++ b/apps/www/content/docs/guides/frameworks/vite.mdx
@@ -33,9 +33,9 @@ For Standard Schema, import the plugin from `@arkenv/vite-plugin/standard`.
 import arkenv from "@arkenv/core";
 
 export const env = arkenv({
-	DATABASE_URL: "string",
-	VITE_API_URL: "string",
-	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+  DATABASE_URL: "string",
+  VITE_API_URL: "string",
+  NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });
 ```
 
@@ -46,7 +46,7 @@ import { defineConfig } from "vite";
 import arkenv from "@arkenv/vite-plugin";
 
 export default defineConfig({
-	plugins: [arkenv()],
+  plugins: [arkenv()],
 });
 ```
 
@@ -62,17 +62,17 @@ import arkenvPlugin from "@arkenv/vite-plugin";
 import arkenv, { type } from "@arkenv/core";
 
 export const Env = type({
-	PORT: "number.port = 5173",
-	VITE_API_URL: "string",
-	DATABASE_URL: "string",
+  PORT: "number.port = 5173",
+  VITE_API_URL: "string",
+  DATABASE_URL: "string",
 });
 
 export default defineConfig(({ mode }) => {
-	const env = arkenv(Env, { env: loadEnv(mode, process.cwd(), "") });
-	return {
-		plugins: [arkenvPlugin(Env)],
-		server: { port: env.PORT },
-	};
+  const env = arkenv(Env, { env: loadEnv(mode, process.cwd(), "") });
+  return {
+    plugins: [arkenvPlugin(Env)],
+    server: { port: env.PORT },
+  };
 });
 ```
 

--- a/apps/www/content/docs/guides/frameworks/vite.mdx
+++ b/apps/www/content/docs/guides/frameworks/vite.mdx
@@ -3,6 +3,8 @@ title: Vite
 description: Validate Vite env vars with @arkenv/vite-plugin.
 ---
 
+Recipe for Vite. Overview: [Framework integration](/docs/validating-environment-variables/framework-integration).
+
 `@arkenv/vite-plugin` validates environment variables in Vite dev and build. The canonical setup is an `env.ts` module plus transform mode: the client graph only receives public keys (default `VITE_*`).
 
 ## Quickstart
@@ -74,7 +76,7 @@ export default defineConfig(({ mode }) => {
 });
 ```
 
-See [Reusing schemas](/docs/validating-environment-variables).
+See [Reusing schemas](/docs/validating-environment-variables/reusing-schemas).
 
 ## SPA accessor mode
 
@@ -83,4 +85,4 @@ Client-only apps can still augment `import.meta.env` with `ImportMetaEnvAugmente
 ## Next steps
 
 - Plugin modes and options: [`@arkenv/vite-plugin`](/docs/reference/vite-plugin)
-- [Client vs. server](/docs/validating-environment-variables)
+- [Client vs. server](/docs/validating-environment-variables/client-vs-server)

--- a/apps/www/content/docs/guides/index.mdx
+++ b/apps/www/content/docs/guides/index.mdx
@@ -6,7 +6,7 @@ description: Practical recipes for frameworks, AI assistants, and migrations.
 Short, copy-pasteable recipes. For concepts, see [Core concepts](/docs/core-concepts). For option lookups, see the [API reference](/docs/reference).
 
 <Cards>
-  <Card href="/docs/guides/ai" title="Using AI with ArkEnv" description="Install the ArkEnv skill and drive init with --agent." />
+  <Card href="/docs/guides/ai" title="Using AI with ArkEnv" description="Skills, prompts, .env.example sync, and assistant guardrails." />
 
   <Card href="/docs/guides/frameworks" title="Frameworks" description="Next.js, Nuxt, Vite, and Bun integrations." />
 

--- a/apps/www/content/docs/guides/index.mdx
+++ b/apps/www/content/docs/guides/index.mdx
@@ -1,6 +1,24 @@
 ---
 title: Guides
-description: Practical guides for using ArkEnv.
+description: Practical recipes for frameworks, AI assistants, and migrations.
 ---
 
-Practical guides for adopting and extending ArkEnv.
+Short, copy-pasteable recipes. For concepts, see [Core concepts](/docs/core-concepts). For option lookups, see the [API reference](/docs/reference).
+
+<Cards>
+	<Card
+		href="/docs/guides/ai"
+		title="Using AI with ArkEnv"
+		description="Install the ArkEnv skill and drive init with --agent."
+	/>
+	<Card
+		href="/docs/guides/frameworks"
+		title="Frameworks"
+		description="Next.js, Nuxt, Vite, and Bun integrations."
+	/>
+	<Card
+		href="/docs/guides/migrating-from-t3-env"
+		title="Migrating from T3 Env"
+		description="Move createEnv and runtimeEnv setups to ArkEnv."
+	/>
+</Cards>

--- a/apps/www/content/docs/guides/index.mdx
+++ b/apps/www/content/docs/guides/index.mdx
@@ -6,19 +6,9 @@ description: Practical recipes for frameworks, AI assistants, and migrations.
 Short, copy-pasteable recipes. For concepts, see [Core concepts](/docs/core-concepts). For option lookups, see the [API reference](/docs/reference).
 
 <Cards>
-	<Card
-		href="/docs/guides/ai"
-		title="Using AI with ArkEnv"
-		description="Install the ArkEnv skill and drive init with --agent."
-	/>
-	<Card
-		href="/docs/guides/frameworks"
-		title="Frameworks"
-		description="Next.js, Nuxt, Vite, and Bun integrations."
-	/>
-	<Card
-		href="/docs/guides/migrating-from-t3-env"
-		title="Migrating from T3 Env"
-		description="Move createEnv and runtimeEnv setups to ArkEnv."
-	/>
+  <Card href="/docs/guides/ai" title="Using AI with ArkEnv" description="Install the ArkEnv skill and drive init with --agent." />
+
+  <Card href="/docs/guides/frameworks" title="Frameworks" description="Next.js, Nuxt, Vite, and Bun integrations." />
+
+  <Card href="/docs/guides/migrating-from-t3-env" title="Migrating from T3 Env" description="Move createEnv and runtimeEnv setups to ArkEnv." />
 </Cards>

--- a/apps/www/content/docs/guides/migrating-from-t3-env.mdx
+++ b/apps/www/content/docs/guides/migrating-from-t3-env.mdx
@@ -33,7 +33,7 @@ pnpm remove @t3-oss/env-nextjs
 
 ### 2. Wrap the config
 
-```ts title="./next.config.ts"
+```ts title="./next.config.ts" twoslash
 import type { NextConfig } from "next";
 import { withArkEnv } from "@arkenv/nextjs/config";
 
@@ -68,7 +68,7 @@ export const env = createEnv({
 
 After (ArkEnv flat + ArkType):
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@/generated/env.gen";
 
 export const env = arkenv({
@@ -79,7 +79,7 @@ export const env = arkenv({
 
 After (ArkEnv flat + Zod):
 
-```ts title="./env.ts"
+```ts title="./env.ts" twoslash
 import arkenv from "@/generated/env.gen";
 import { z } from "zod";
 

--- a/apps/www/content/docs/guides/migrating-from-t3-env.mdx
+++ b/apps/www/content/docs/guides/migrating-from-t3-env.mdx
@@ -103,7 +103,7 @@ If you relied on separate server/client modules for compile-time isolation:
 pnpm dlx arkenv@latest init --strict
 ```
 
-Then move keys into `env/server.ts` and `env/client.ts` as in [Client vs. server](/docs/validating-environment-variables).
+Then move keys into `env/server.ts` and `env/client.ts` as in [Client vs. server](/docs/validating-environment-variables/client-vs-server).
 
 ## Nuxt and other hosts
 
@@ -113,4 +113,4 @@ Same idea: flat schema, framework public prefix, no `runtimeEnv`. Use [`@arkenv/
 
 - [Next.js guide](/docs/guides/frameworks/nextjs)
 - [`@arkenv/standard`](/docs/reference/standard) if you stay on Zod
-- [Hosting presets](/docs/validating-environment-variables)
+- [Hosting presets](/docs/validating-environment-variables/hosting-presets)

--- a/apps/www/content/docs/guides/migrating-from-t3-env.mdx
+++ b/apps/www/content/docs/guides/migrating-from-t3-env.mdx
@@ -103,7 +103,7 @@ If you relied on separate server/client modules for compile-time isolation:
 pnpm dlx arkenv@latest init --strict
 ```
 
-Then move keys into `env/server.ts` and `env/client.ts` as in [Client vs. server](/docs/validating-environment-variables/client-vs-server).
+Then move keys into `env/server.ts` and `env/client.ts` as in [Client vs. server](/docs/validating-environment-variables).
 
 ## Nuxt and other hosts
 
@@ -113,4 +113,4 @@ Same idea: flat schema, framework public prefix, no `runtimeEnv`. Use [`@arkenv/
 
 - [Next.js guide](/docs/guides/frameworks/nextjs)
 - [`@arkenv/standard`](/docs/reference/standard) if you stay on Zod
-- [Hosting presets](/docs/validating-environment-variables/hosting-presets)
+- [Hosting presets](/docs/validating-environment-variables)

--- a/apps/www/content/docs/guides/migrating-from-t3-env.mdx
+++ b/apps/www/content/docs/guides/migrating-from-t3-env.mdx
@@ -7,12 +7,12 @@ description: Move a T3 Env project to ArkEnv without keeping runtimeEnv sync.
 
 ## What changes
 
-| T3 Env | ArkEnv |
-| --- | --- |
-| `createEnv` from `@t3-oss/env-nextjs` (or `/core`) | `arkenv` from `@arkenv/nextjs` codegen or `@arkenv/core` |
-| Nested `{ server, client, runtimeEnv }` | Flat schema (default) or strict file split |
-| Hand-maintained `runtimeEnv` inlining | `withArkEnv` codegen writes the mapping |
-| Zod (usual) | Zod via `@arkenv/standard`, or ArkType via `@arkenv/core` |
+| T3 Env                                             | ArkEnv                                                    |
+| -------------------------------------------------- | --------------------------------------------------------- |
+| `createEnv` from `@t3-oss/env-nextjs` (or `/core`) | `arkenv` from `@arkenv/nextjs` codegen or `@arkenv/core`  |
+| Nested `{ server, client, runtimeEnv }`            | Flat schema (default) or strict file split                |
+| Hand-maintained `runtimeEnv` inlining              | `withArkEnv` codegen writes the mapping                   |
+| Zod (usual)                                        | Zod via `@arkenv/standard`, or ArkType via `@arkenv/core` |
 
 Flat ArkEnv matches T3 Env single-file security: full inference plus a runtime Proxy that throws on server-key access in the client. Schema **names** still ship to the client in flat mode; use `--strict` if names must stay out of the client graph.
 

--- a/apps/www/content/docs/guides/migrating-from-t3-env.mdx
+++ b/apps/www/content/docs/guides/migrating-from-t3-env.mdx
@@ -1,8 +1,116 @@
 ---
 title: Migrating from T3 Env
-description: Move an existing T3 Env setup to ArkEnv.
+description: Move a T3 Env project to ArkEnv without keeping runtimeEnv sync.
 ---
 
-Stub guide for migrating schemas, config, and framework wiring from T3 Env to ArkEnv.
+[T3 Env](https://env.t3.gg) inspired ArkEnv's Next.js security model. Migration drops the manual `runtimeEnv` map and the required `server` / `client` blocks for most apps.
 
-> Content TBD — Guides section leaf.
+## What changes
+
+| T3 Env | ArkEnv |
+| --- | --- |
+| `createEnv` from `@t3-oss/env-nextjs` (or `/core`) | `arkenv` from `@arkenv/nextjs` codegen or `@arkenv/core` |
+| Nested `{ server, client, runtimeEnv }` | Flat schema (default) or strict file split |
+| Hand-maintained `runtimeEnv` inlining | `withArkEnv` codegen writes the mapping |
+| Zod (usual) | Zod via `@arkenv/standard`, or ArkType via `@arkenv/core` |
+
+Flat ArkEnv matches T3 Env single-file security: full inference plus a runtime Proxy that throws on server-key access in the client. Schema **names** still ship to the client in flat mode; use `--strict` if names must stay out of the client graph.
+
+## Next.js migration
+
+### 1. Install ArkEnv
+
+```package-install
+pnpm add @arkenv/core @arkenv/nextjs arktype
+```
+
+Or keep Zod:
+
+```package-install
+pnpm add @arkenv/standard @arkenv/nextjs zod
+pnpm remove @t3-oss/env-nextjs
+```
+
+### 2. Wrap the config
+
+```ts title="./next.config.ts"
+import type { NextConfig } from "next";
+import { withArkEnv } from "@arkenv/nextjs/config";
+
+const nextConfig: NextConfig = {};
+
+export default withArkEnv(nextConfig);
+```
+
+For Zod, import `withArkEnv` from `@arkenv/nextjs/standard/config`.
+
+### 3. Replace the schema
+
+Before (T3 Env sketch):
+
+```ts title="./src/env.js"
+import { createEnv } from "@t3-oss/env-nextjs";
+import { z } from "zod";
+
+export const env = createEnv({
+	server: {
+		DATABASE_URL: z.string().url(),
+	},
+	client: {
+		NEXT_PUBLIC_APP_URL: z.string().url(),
+	},
+	runtimeEnv: {
+		DATABASE_URL: process.env.DATABASE_URL,
+		NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+	},
+});
+```
+
+After (ArkEnv flat + ArkType):
+
+```ts title="./env.ts"
+import arkenv from "@/generated/env.gen";
+
+export const env = arkenv({
+	DATABASE_URL: "string.url",
+	NEXT_PUBLIC_APP_URL: "string.url",
+});
+```
+
+After (ArkEnv flat + Zod):
+
+```ts title="./env.ts"
+import arkenv from "@/generated/env.gen";
+import { z } from "zod";
+
+export const env = arkenv({
+	DATABASE_URL: z.string().url(),
+	NEXT_PUBLIC_APP_URL: z.string().url(),
+});
+```
+
+Delete `runtimeEnv`. Prefixes (`NEXT_PUBLIC_*`) decide the client bucket.
+
+### 4. Update imports
+
+Point every `import { env } from "~/env"` (or similar) at the new module. Remove `@t3-oss/env-*` packages when nothing imports them.
+
+### 5. Optional: strict layout
+
+If you relied on separate server/client modules for compile-time isolation:
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init --strict
+```
+
+Then move keys into `env/server.ts` and `env/client.ts` as in [Client vs. server](/docs/validating-environment-variables/client-vs-server).
+
+## Nuxt and other hosts
+
+Same idea: flat schema, framework public prefix, no `runtimeEnv`. Use [`@arkenv/nuxt`](/docs/guides/frameworks/nuxt) or the matching Vite/Bun guide.
+
+## Next steps
+
+- [Next.js guide](/docs/guides/frameworks/nextjs)
+- [`@arkenv/standard`](/docs/reference/standard) if you stay on Zod
+- [Hosting presets](/docs/validating-environment-variables/hosting-presets)

--- a/apps/www/content/docs/guides/migrating-from-t3-env.mdx
+++ b/apps/www/content/docs/guides/migrating-from-t3-env.mdx
@@ -53,16 +53,16 @@ import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
 export const env = createEnv({
-	server: {
-		DATABASE_URL: z.string().url(),
-	},
-	client: {
-		NEXT_PUBLIC_APP_URL: z.string().url(),
-	},
-	runtimeEnv: {
-		DATABASE_URL: process.env.DATABASE_URL,
-		NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
-	},
+  server: {
+    DATABASE_URL: z.string().url(),
+  },
+  client: {
+    NEXT_PUBLIC_APP_URL: z.string().url(),
+  },
+  runtimeEnv: {
+    DATABASE_URL: process.env.DATABASE_URL,
+    NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+  },
 });
 ```
 
@@ -72,8 +72,8 @@ After (ArkEnv flat + ArkType):
 import arkenv from "@/generated/env.gen";
 
 export const env = arkenv({
-	DATABASE_URL: "string.url",
-	NEXT_PUBLIC_APP_URL: "string.url",
+  DATABASE_URL: "string.url",
+  NEXT_PUBLIC_APP_URL: "string.url",
 });
 ```
 
@@ -84,8 +84,8 @@ import arkenv from "@/generated/env.gen";
 import { z } from "zod";
 
 export const env = arkenv({
-	DATABASE_URL: z.string().url(),
-	NEXT_PUBLIC_APP_URL: z.string().url(),
+  DATABASE_URL: z.string().url(),
+  NEXT_PUBLIC_APP_URL: z.string().url(),
 });
 ```
 

--- a/apps/www/lib/twoslash-options.ts
+++ b/apps/www/lib/twoslash-options.ts
@@ -56,6 +56,9 @@ export const arktypeTwoslashOptions: ArkTypeTwoslashOptions = {
 				"@arkenv/nextjs/client": [
 					path.join(root, "packages/nextjs/src/client.ts"),
 				],
+				"@arkenv/nextjs/config": [
+					path.join(root, "packages/nextjs/src/config/index.ts"),
+				],
 				"@arkenv/nextjs/standard": [
 					path.join(root, "packages/nextjs/src/standard/index.ts"),
 				],
@@ -70,6 +73,9 @@ export const arktypeTwoslashOptions: ArkTypeTwoslashOptions = {
 				],
 				"@arkenv/nextjs/standard/config": [
 					path.join(root, "packages/nextjs/src/standard/config.ts"),
+				],
+				"@/generated/env.gen": [
+					path.join(root, "packages/nextjs/src/index.ts"),
 				],
 				"@arkenv/vite-plugin": [
 					path.join(root, "packages/vite-plugin/src/index.ts"),

--- a/apps/www/mdx-components.tsx
+++ b/apps/www/mdx-components.tsx
@@ -12,11 +12,10 @@ import {
 	CalloutDescription,
 	CalloutTitle,
 } from "fumadocs-ui/components/callout";
-import { Cards } from "fumadocs-ui/components/card";
+import { Card, Cards } from "fumadocs-ui/components/card";
 import { File, Files, Folder } from "fumadocs-ui/components/files";
 import type { MDXComponents } from "mdx/types";
 import { Button } from "~/components/ui/button";
-import { Card } from "~/components/ui/card";
 import { cn } from "~/lib/cn";
 
 const generator = createGenerator({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Populates `/docs/guides/*` for the Simplify Docs stack (#1527).

Fixes #1523

## Pages

- Guides hub (already populated; leaves only in this ticket)
- **Using AI with ArkEnv** — skills, copy-paste prompts, `.env.example` sync, assistant guardrails, and `--agent` init refusals
- **Frameworks hub** + Next.js / Nuxt / Vite / Bun recipes (complement [Framework integration](/docs/validating-environment-variables/framework-integration) and package reference pages)
- **Migrating from T3 Env** — concrete `runtimeEnv` → flat schema steps

## Notes

- Recipe tone aligned with Turbo framework guides; framework leaves link to framework-integration for stack context and to reference pages for options
- Vite/Bun prefer the canonical `env` object + transform plugin (ADR 0021); SPA accessor mode noted as optional
- Merged latest `simplify-docs` (#1547 validating-env guides, #1524 link fixes); deep links to validating-env subpages restored
- **Twoslash** on TypeScript snippets wherever the docs VFS can resolve them (`next.config`, `env.ts`, Vite/Bun plugin configs, migration after-examples). Nuxt `defineNuxtConfig` and T3 “before” sketches stay plain (host globals / external package). Docs VFS maps `@arkenv/nextjs/config` and `@/generated/env.gen`.
- Stop-slop pass on prose

## Test plan

- [x] `pnpm --filter=www run build`
- [x] Deep links to validating-env subpages resolve after merge from `simplify-docs`
- [x] Twoslash-enabled guide snippets typecheck in www build
- [ ] Preview guides hub and framework leaves
- [ ] Spot-check AI `--agent` JSON example against current CLI help

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fa80fe5-6cb1-40d8-b9f9-9976871c1c43?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fa80fe5-6cb1-40d8-b9f9-9976871c1c43&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

