### PR TITLE
fix(www): force dark mode while theme toggle is off

### DIFF
--- a/apps/playwright-www/tests/theme-switching.test.ts
+++ b/apps/playwright-www/tests/theme-switching.test.ts
@@ -22,4 +22,19 @@ test.describe("Theme Switching", () => {
 
 		expect(hydrationErrors).toHaveLength(0);
 	});
+
+	test("should stay dark when system prefers light and storage says light", async ({
+		page,
+	}) => {
+		await page.emulateMedia({ colorScheme: "light" });
+		await page.addInitScript(() => {
+			localStorage.setItem("theme", "light");
+		});
+
+		await page.goto("/docs");
+		await page.waitForLoadState("domcontentloaded");
+
+		await expect(page.locator("html")).toHaveClass(/dark/);
+		await expect(page.locator("html")).toHaveCSS("color-scheme", "dark");
+	});
 });

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -33,7 +33,7 @@ export default function Layout({ children }: { children: ReactNode }) {
 	return (
 		<html
 			lang="en"
-			className={`${GeistSans.className} ${GeistSans.variable} ${GeistMono.variable} ${GeistPixelGrid.variable}`}
+			className={`dark ${GeistSans.className} ${GeistSans.variable} ${GeistMono.variable} ${GeistPixelGrid.variable}`}
 			suppressHydrationWarning
 			data-scroll-behavior="smooth"
 		>

--- a/apps/www/components/providers/app-root-provider.tsx
+++ b/apps/www/components/providers/app-root-provider.tsx
@@ -9,6 +9,11 @@ import ArkenvSearchDialog from "~/components/search/arkenv-search-dialog";
  * hydration. next-themes injects a FOUC `<script>`; React 19 warns when that
  * tag is reconciled on the client. Keep JS on the server (runs in HTML), mark
  * it as a data block on the client (script already ran; suppresses the warn).
+ *
+ * Light/system themes are disabled while the PostHog `theme-toggle` flag is
+ * off — force dark so stored localStorage / prefers-color-scheme cannot flip
+ * the site to light. When re-enabling the toggle, drop `forcedTheme` and
+ * restore `enableSystem` + the light/system theme entries.
  */
 export function AppRootProvider({ children }: { children: ReactNode }) {
 	return (
@@ -21,9 +26,10 @@ export function AppRootProvider({ children }: { children: ReactNode }) {
 			}}
 			theme={{
 				enableColorScheme: true,
-				enableSystem: true,
+				enableSystem: false,
 				defaultTheme: "dark",
-				themes: ["system", "light", "dark"],
+				forcedTheme: "dark",
+				themes: ["dark"],
 				scriptProps:
 					typeof window === "undefined"
 						? undefined

--- a/apps/www/lib/posthog/feature-flags.ts
+++ b/apps/www/lib/posthog/feature-flags.ts
@@ -3,6 +3,10 @@
  * Keep each flag consumed in as few places as possible.
  */
 export enum FeatureFlag {
-	/** When true, show the light/dark/system theme switcher. Default: off. */
+	/**
+	 * When true, show the light/dark/system theme switcher. Default: off.
+	 * While off, `AppRootProvider` forces dark via `forcedTheme` — remove that
+	 * when turning this flag on so light/system can take effect again.
+	 */
 	THEME_TOGGLE = "theme-toggle",
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs (and the rest of www) could still render in light mode in Chrome and other browsers even though the theme toggle is feature-flagged off. Hiding the switcher did not stop `next-themes` from applying a stored `light`/`system` preference or following `prefers-color-scheme`.

## Fix

- Force dark in `AppRootProvider` via `forcedTheme: "dark"`, disable system theme, and only register the `dark` theme.
- Add a static `dark` class on `<html>` so SSR/first paint is dark too.
- Extend the Playwright theme test to assert dark mode wins over light system preference + `localStorage.theme = "light"`.

When re-enabling PostHog `theme-toggle`, remove `forcedTheme` and restore light/system theme options in the provider.

## Verification

Manual Chrome checks on `/docs` and `/docs/getting-started`: stays dark with `prefers-color-scheme: light` and with `localStorage.theme = "light"`.

[Docs intro in dark mode](https://cursor.com/agents/bc-0739c241-cb60-4a9f-8b46-5369a1cd0853/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocs-dark-intro.webp)
[Still dark with prefers-color-scheme light](https://cursor.com/agents/bc-0739c241-cb60-4a9f-8b46-5369a1cd0853/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocs-dark-prefers-light.webp)
[Still dark after localStorage theme=light](https://cursor.com/agents/bc-0739c241-cb60-4a9f-8b46-5369a1cd0853/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocs-dark-localstorage-light.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0739c241-cb60-4a9f-8b46-5369a1cd0853?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0739c241-cb60-4a9f-8b46-5369a1cd0853&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

