### PR TITLE
docs: fix legacy links and redirects for new IA (#1524)

### DIFF
--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -30,7 +30,7 @@ export default function HomePage() {
 					style={{ animationDelay: "40ms" }}
 				>
 					<AnnouncementBadge
-						href="/docs/validating-environment-variables/hosting-presets"
+						href="/docs/validating-environment-variables"
 						new
 					>
 						Next.js, Netlify presets

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -29,10 +29,7 @@ export default function HomePage() {
 					className="home-aurora__badge rise"
 					style={{ animationDelay: "40ms" }}
 				>
-					<AnnouncementBadge
-						href="/docs/validating-environment-variables"
-						new
-					>
+					<AnnouncementBadge href="/docs/validating-environment-variables" new>
 						Next.js, Netlify presets
 					</AnnouncementBadge>
 				</div>

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -29,7 +29,10 @@ export default function HomePage() {
 					className="home-aurora__badge rise"
 					style={{ animationDelay: "40ms" }}
 				>
-					<AnnouncementBadge href="docs/cli/hosting-presets" new>
+					<AnnouncementBadge
+						href="/docs/validating-environment-variables/hosting-presets"
+						new
+					>
 						Next.js, Netlify presets
 					</AnnouncementBadge>
 				</div>

--- a/apps/www/lib/docs-legacy-links.test.ts
+++ b/apps/www/lib/docs-legacy-links.test.ts
@@ -1,0 +1,60 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const WWW_ROOT = join(import.meta.dirname, "..");
+
+/** Legacy package-scoped docs trees removed in the Simplify Docs nav revamp. */
+const LEGACY_HREF =
+	/["'`](\/?docs\/(?:arkenv|cli|nextjs|nuxt|vite-plugin|bun-plugin)(?:\/[^"'`#?]*)?)["'`]/g;
+
+const SKIP_DIR_NAMES = new Set([
+	"node_modules",
+	".next",
+	".source",
+	"dist",
+	"coverage",
+]);
+
+function walk(dir: string): string[] {
+	const out: string[] = [];
+	for (const name of readdirSync(dir)) {
+		if (SKIP_DIR_NAMES.has(name)) continue;
+		const path = join(dir, name);
+		const stat = statSync(path);
+		if (stat.isDirectory()) {
+			out.push(...walk(path));
+			continue;
+		}
+		if (/\.(tsx?|mdx?|jsx?)$/.test(name) && name !== "next.config.ts") {
+			out.push(path);
+		}
+	}
+	return out;
+}
+
+describe("docs legacy links", () => {
+	it("does not href legacy package-scoped docs paths outside next.config redirects", () => {
+		const hits: string[] = [];
+		for (const file of walk(WWW_ROOT)) {
+			const text = readFileSync(file, "utf8");
+			for (const match of text.matchAll(LEGACY_HREF)) {
+				hits.push(`${relative(WWW_ROOT, file)}: ${match[1]}`);
+			}
+		}
+		expect(hits).toEqual([]);
+	});
+
+	it("does not use root-relative docs hrefs missing a leading slash", () => {
+		const hits: string[] = [];
+		const pattern = /\bhref=["']docs\//g;
+		for (const file of walk(WWW_ROOT)) {
+			const text = readFileSync(file, "utf8");
+			if (pattern.test(text)) {
+				hits.push(relative(WWW_ROOT, file));
+			}
+			pattern.lastIndex = 0;
+		}
+		expect(hits).toEqual([]);
+	});
+});

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -72,7 +72,7 @@ const config = {
 			},
 			{
 				source: "/docs/arkenv/comparison",
-				destination: "/docs/getting-started",
+				destination: "/docs/guides/migrating-from-t3-env",
 				permanent: true,
 			},
 			{
@@ -127,12 +127,13 @@ const config = {
 			},
 			{
 				source: "/docs/arkenv/how-to/reuse-schemas",
-				destination: "/docs/validating-environment-variables",
+				destination: "/docs/validating-environment-variables/reusing-schemas",
 				permanent: true,
 			},
 			{
 				source: "/docs/arkenv/how-to/load-environment-variables",
-				destination: "/docs/validating-environment-variables",
+				destination:
+					"/docs/validating-environment-variables/framework-integration",
 				permanent: true,
 			},
 			{
@@ -242,12 +243,12 @@ const config = {
 			},
 			{
 				source: "/docs/cli/hosting-presets",
-				destination: "/docs/validating-environment-variables",
+				destination: "/docs/validating-environment-variables/hosting-presets",
 				permanent: true,
 			},
 			{
 				source: "/docs/cli/machine-readable-output",
-				destination: "/docs/reference/validate",
+				destination: "/docs/reference/init",
 				permanent: true,
 			},
 			{

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -247,8 +247,10 @@ const config = {
 				permanent: true,
 			},
 			{
+				// `--json` / `--agent` are global CLI flags; land on the Terminal hub.
+				// `init` documents them in detail once the API reference content lands.
 				source: "/docs/cli/machine-readable-output",
-				destination: "/docs/reference/init",
+				destination: "/docs/reference",
 				permanent: true,
 			},
 			{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1524.

Stacked on `simplify-docs` (tracking [#1527](https://github.com/yamcodes/arkenv/pull/1527)).

## Summary

Audit and update links after the docs IA rewrite so marketing and redirects match the new tree.

## Changes

### Homepage

- Announcement badge: `docs/cli/hosting-presets` → `/docs/validating-environment-variables` (absolute path; hub until [#1547](https://github.com/yamcodes/arkenv/pull/1547) lands the hosting-presets leaf, so the hero does not 404 on preview).

### Redirects (`next.config.ts`)

Tighten several legacy → new targets:

| From | To |
|------|-----|
| `/docs/comparison` | `/docs/guides/migrating-from-t3-env` |
| `/docs/how-to/reuse-schemas` | `/docs/validating-environment-variables/reusing-schemas` |
| `/docs/how-to/load-environment-variables` | `/docs/validating-environment-variables/framework-integration` |
| `/docs/cli/hosting-presets` | `/docs/validating-environment-variables/hosting-presets` |
| `/docs/cli/machine-readable-output` | `/docs/reference` (`--json` / `--agent` are global CLI flags; Terminal hub is the landing page) |

### Regression test

`apps/www/lib/docs-legacy-links.test.ts` fails if:

- Source (outside `next.config.ts`) links to removed package-prefix paths (`/docs/arkenv`, `/docs/cli`, …)
- Any `href="docs/..."` is missing the leading `/`

## Merge order

Leaf redirect targets like hosting-presets and migrating-from-t3-env land with [#1547](https://github.com/yamcodes/arkenv/pull/1547) and [#1552](https://github.com/yamcodes/arkenv/pull/1552). Prefer merging those content PRs before or with this one so bookmark redirects do not 404 on preview. The homepage badge already uses the validating-env hub for that reason.

## Out of scope

- Populating stub MDX (other stack PRs)
- Mobile docs nav ([#1529](https://github.com/yamcodes/arkenv/issues/1529))
- Adding stub leaves on this branch (would conflict with content PRs)

## Validation

- `pnpm --filter=www test -- --run` — 111 passed
- `pnpm --filter=www exec tsc --noEmit` — clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67123bd4-151d-4b0f-879a-a8c3519b0e1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67123bd4-151d-4b0f-879a-a8c3519b0e1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

