### PR TITLE
fix(fumadocs-ui): keep underlines visible on linked inline code

### DIFF
--- a/.changeset/linked-code-underline.md
+++ b/.changeset/linked-code-underline.md
@@ -1,0 +1,5 @@
+---
+"@arkenv/fumadocs-ui": patch
+---
+
+Fix link underlines when the link wraps only an inline code chip (e.g. `` [`number.port`](/docs/...) ``). The chip background no longer clips the underline; the underline is painted under the chip instead.

--- a/.changeset/linked-code-underline.md
+++ b/.changeset/linked-code-underline.md
@@ -2,4 +2,4 @@
 "@arkenv/fumadocs-ui": patch
 ---
 
-Fix link underlines when the link wraps only an inline code chip (e.g. `` [`number.port`](/docs/...) ``). The chip background no longer clips the underline; the underline is painted under the chip instead.
+Fix link underlines when a docs link includes inline code (code-only or mixed with text). Use a continuous `text-decoration` underline so the line runs through plain text and inside the code chip at the same baseline, instead of a `border-bottom` that the chip background covers.

--- a/.changeset/linked-code-underline.md
+++ b/.changeset/linked-code-underline.md
@@ -2,4 +2,14 @@
 "@arkenv/fumadocs-ui": patch
 ---
 
-Fix link underlines when a docs link includes inline code (code-only or mixed with text). Use a continuous `text-decoration` underline so the line runs through plain text and inside the code chip at the same baseline, instead of a `border-bottom` that the chip background covers.
+#### Fix continuous underlines for docs links that include inline code
+
+Links that wrap only a code chip or mix plain text with code now keep one continuous underline through the text and inside the code chip, instead of losing the line under the chip background.
+
+Affected markdown patterns:
+
+```md
+[`number.port`](/docs/reference/keywords)
+
+[see the `number.port` keyword](/docs/reference/keywords)
+```

--- a/packages/fumadocs-ui/css/theme.css
+++ b/packages/fumadocs-ui/css/theme.css
@@ -137,30 +137,38 @@ article a:not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not(
 }
 
 /*
- * Linked-only inline code (`[`foo`](url)`): the code chip background sits flush
- * against the anchor border-bottom and clips it. Paint the underline under the
- * chip with box-shadow instead.
+ * Links that include inline code (code-only or mixed with text): use a continuous
+ * text underline so the line runs through plain text and inside the code chip at
+ * the same baseline (border-bottom on the <a> is covered by the chip background).
  */
-article a:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]),
-[data-external-link]:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]) {
+article a:has(code):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]),
+[data-external-link]:has(code):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]) {
 	border-bottom: none;
 	padding-bottom: 0;
+	text-decoration: underline;
+	text-decoration-color: currentColor;
+	text-decoration-thickness: 2px;
+	text-underline-offset: 0.18em;
+	text-decoration-skip-ink: none;
+	transition:
+		text-decoration-thickness 0.1s ease,
+		text-underline-offset 0.1s ease;
 }
 
-article a:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]):hover,
-[data-external-link]:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]):hover {
+article a:has(code):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]):hover,
+[data-external-link]:has(code):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]):hover {
 	border-bottom-width: 0;
+	text-decoration-thickness: 3px;
 }
 
-article a:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]) > code,
-[data-external-link]:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]) > code {
-	box-shadow: 0 2px 0 0 currentColor;
-	transition: box-shadow 0.1s ease;
-}
-
-article a:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]):hover > code,
-[data-external-link]:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]):hover > code {
-	box-shadow: 0 3px 0 0 currentColor;
+/* Paint the underline on the chip too so it sits above the code background */
+article a:has(code):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]) code,
+[data-external-link]:has(code):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]) code {
+	text-decoration: underline;
+	text-decoration-color: currentColor;
+	text-decoration-thickness: inherit;
+	text-underline-offset: inherit;
+	text-decoration-skip-ink: none;
 }
 
 /* External links in documentation */

--- a/packages/fumadocs-ui/css/theme.css
+++ b/packages/fumadocs-ui/css/theme.css
@@ -136,6 +136,33 @@ article a:not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not(
 	border-bottom-width: 3px;
 }
 
+/*
+ * Linked-only inline code (`[`foo`](url)`): the code chip background sits flush
+ * against the anchor border-bottom and clips it. Paint the underline under the
+ * chip with box-shadow instead.
+ */
+article a:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]),
+[data-external-link]:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]) {
+	border-bottom: none;
+	padding-bottom: 0;
+}
+
+article a:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]):hover,
+[data-external-link]:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]):hover {
+	border-bottom-width: 0;
+}
+
+article a:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]) > code,
+[data-external-link]:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]) > code {
+	box-shadow: 0 2px 0 0 currentColor;
+	transition: box-shadow 0.1s ease;
+}
+
+article a:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]):hover > code,
+[data-external-link]:has(> code:only-child):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]):hover > code {
+	box-shadow: 0 3px 0 0 currentColor;
+}
+
 /* External links in documentation */
 article a[rel*="noopener"][target="_blank"]:not(.fd-card):not([data-card]):not([data-no-arrow]):not(:has(img)),
 [data-external-link]:not(.fd-card):not([data-card]):not([data-no-arrow]):not(:has(img)) {

--- a/packages/fumadocs-ui/css/theme.css
+++ b/packages/fumadocs-ui/css/theme.css
@@ -150,9 +150,7 @@ article a:has(code):not(:has(img)):not(.fd-card):not([data-card]):not([class*="f
 	text-decoration-thickness: 2px;
 	text-underline-offset: 0.18em;
 	text-decoration-skip-ink: none;
-	transition:
-		text-decoration-thickness 0.1s ease,
-		text-underline-offset 0.1s ease;
+	transition: text-decoration-thickness 0.1s ease;
 }
 
 article a:has(code):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]):hover,
@@ -165,10 +163,12 @@ article a:has(code):not(:has(img)):not(.fd-card):not([data-card]):not([class*="f
 article a:has(code):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]) code,
 [data-external-link]:has(code):not(:has(img)):not(.fd-card):not([data-card]):not([class*="fd-"]):not([data-no-underline]) code {
 	text-decoration: underline;
-	text-decoration-color: currentColor;
+	/* Inherit the link color so chip underlines stay in sync if code text color diverges */
+	text-decoration-color: inherit;
 	text-decoration-thickness: inherit;
 	text-underline-offset: inherit;
 	text-decoration-skip-ink: none;
+	transition: text-decoration-thickness 0.1s ease;
 }
 
 /* External links in documentation */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Docs links that include inline code (code-only like `` [`number.port`](/docs/...) ``, or mixed like `` [see the `number.port` keyword](...) ``) used `border-bottom` on the `<a>`, which the code chip background covered.
- For those links, switch to a continuous `text-decoration` underline so the line runs through plain text **and inside** the code chip on one baseline. Hover still thickens 2px → 3px.
- Review polish: chip underline inherits the link decoration color; matching thickness transition on `code`; drop unused offset transition.
- Plain text-only links keep the existing `border-bottom` treatment.

## Test plan
- [x] Code-only linked chip: underline visible inside the chip
- [x] Mixed text+code link: one continuous underline across plain text and through the chip
- [x] Hover thickens the underline (plain text + chip in sync)
- [x] Plain text links unchanged (`border-bottom`)
- [ ] External linked-code still shows the external-link icon

### Screenshots
[Mixed text+code continuous underline](https://cursor.com/agents/bc-95206b52-351b-4e4b-a4b4-a2fef4a95cb8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmixed-link-crop.png)
[Code-only linked chip underline](https://cursor.com/agents/bc-95206b52-351b-4e4b-a4b4-a2fef4a95cb8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcode-only-el.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95206b52-351b-4e4b-a4b4-a2fef4a95cb8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95206b52-351b-4e4b-a4b4-a2fef4a95cb8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

