### PR TITLE
docs: populate Getting started leaf pages (#1560)

### DIFF
--- a/apps/www/content/docs/getting-started/add-to-existing-repository.mdx
+++ b/apps/www/content/docs/getting-started/add-to-existing-repository.mdx
@@ -3,6 +3,147 @@ title: Add to an existing repository
 description: Add ArkEnv environment validation to an existing project.
 ---
 
-Stub guide for wiring ArkEnv into a repo that already has application code.
+You do not need a greenfield scaffold to adopt ArkEnv. When `arkenv init` finds a `package.json`, it runs the **existing-project flow**: detect your stack, read env keys already in use, generate schema files, and wire framework integrations.
 
-> Content TBD — Getting started leaf.
+## Before you start
+
+<Callout type="warn">
+  Commit or stash your work first. By default, `arkenv init` refuses to run when
+  the git working tree is dirty. Pass `--force` only when you accept overwriting
+  generated files and skipping that check.
+</Callout>
+
+ArkEnv works best with **TypeScript strict mode** enabled. The init wizard can offer to turn strict on when it is missing. Plain JavaScript works at runtime, but editor autocomplete and type checking are weaker — see [Editor integration](/docs/getting-started/editor-integration).
+
+Install the packages you need, or let init add them:
+
+```package-install
+pnpm add @arkenv/core
+pnpm add -D arkenv
+```
+
+## Run init
+
+From your project root:
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init
+```
+
+Init detects whether you are brownfield or greenfield:
+
+| Situation | Flow |
+| --------- | ---- |
+| Directory contains `package.json` | Existing-project wizard (this guide) |
+| Empty directory | New-project scaffold (pick an example or blank template) |
+| `--example` flag | Always new-project, even in a non-empty directory |
+
+Useful flags for existing repos:
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init --yes              # non-interactive; flat layout default for Next/Nuxt
+pnpm dlx arkenv@latest init --strict           # strict client/server file split for Next.js or Nuxt
+pnpm dlx arkenv@latest init --host-preset vercel
+pnpm dlx arkenv@latest init --agent            # --yes --quiet --json for AI agents
+```
+
+See [hosting presets](/docs/validating-environment-variables/hosting-presets) for provider values (`vercel`, `netlify`, `cloudflare`, `railway`, `render`, `fly`).
+
+## What init detects
+
+The wizard inspects your repo and asks targeted questions:
+
+1. **Framework** — Next.js, Nuxt, Vite, Bun fullstack, or vanilla Node from dependencies and config files.
+2. **Layout** — flat (default) or [strict](/docs/validating-environment-variables/client-vs-server#strict-layout) split for Next.js and Nuxt.
+3. **Existing schema** — whether to overwrite `env.ts` (or strict layout files).
+4. **Environment keys** — parsed from `.env.example`, or scanned from `process.env`, `import.meta.env`, and `env.*` usage in source when no example file exists.
+5. **Validator** — ArkType (default), Zod, or Valibot via `@arkenv/standard`.
+6. **Hosting preset** — optional provider system variables.
+
+When `.env.example` is present, init offers to seed the schema from its keys:
+
+```txt
+Detected .env.example with 12 keys. Use them for your schema?
+```
+
+When only source usage is found:
+
+```txt
+Detected 8 environment variables used in your project. Use them for your schema?
+```
+
+## What init generates
+
+Typical output for a Next.js flat layout:
+
+<Files>
+  <Folder name="my-app" defaultOpen>
+    <File name="env.ts" />
+    <File name=".env.example" />
+    <File name=".env" />
+    <Folder name="generated">
+      <File name="env.gen.ts" />
+    </Folder>
+    <File name="next.config.ts" />
+  </Folder>
+</Files>
+
+Depending on your stack, init may also:
+
+- Wrap `next.config.ts` with `withArkEnv` (Next.js codegen)
+- Scaffold `vite-env.d.ts` or `bun-env.d.ts` for framework env typing
+- Append `.env` and `.env.local` to `.gitignore` when missing
+- Create `.env` from `.env.example`, or create `.env.example` from `.env` with **values stripped** so secrets are not committed
+
+<Callout type="info">
+  ArkEnv does not load `.env` files itself. Your framework, Bun, or a tool like
+  `tsx --env-file` must populate `process.env` before `arkenv()` runs. See
+  [Framework integration — Loading .env files](/docs/validating-environment-variables/framework-integration#loading-env-files).
+</Callout>
+
+## After init
+
+1. Copy `.env.example` to `.env` if you still need local values:
+
+   ```bash title="Terminal"
+   cp .env.example .env
+   ```
+
+2. Import the validated object everywhere instead of raw env maps:
+
+   ```ts title="./src/server.ts"
+   import { env } from "../env";
+
+   console.log(env.DATABASE_URL);
+   ```
+
+3. Read [Client vs. server](/docs/validating-environment-variables/client-vs-server) to understand public prefixes (`NEXT_PUBLIC_*`, `VITE_*`, and friends).
+
+4. Follow the framework guide for your stack: [Next.js](/docs/guides/frameworks/nextjs), [Nuxt](/docs/guides/frameworks/nuxt), [Vite](/docs/guides/frameworks/vite), or [Bun](/docs/guides/frameworks/bun).
+
+## Non-interactive and CI
+
+For scripts, CI, or agent workflows, combine flags to skip prompts:
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init --yes --host-preset vercel --agent
+```
+
+`--agent` implies `--yes`, `--quiet`, and JSON output suitable for tooling.
+
+## Troubleshooting
+
+| Problem | Fix |
+| ------- | --- |
+| Git working tree is not clean | Commit, stash (`git stash -u` for untracked files), or use `--force` |
+| Technical requirements not met | Enable TypeScript strict mode, or use `--force` to bypass checks |
+| Non-empty directory without `package.json` | Run in a subdirectory, use `--example` for a new scaffold, or `--force` |
+| `--simple` flag | Deprecated — remove it; flat layout is the default |
+
+The deprecated `--simple` layout hard-fails on Next.js. Use flat layout (default) or `--strict` when you need a split schema.
+
+## Next steps
+
+- [Editor integration](/docs/getting-started/editor-integration) for autocomplete and IDE setup.
+- [Structuring your schema](/docs/validating-environment-variables/structuring-your-schema) for export patterns and Standard Schema.
+- [Start with an example](/docs/getting-started/examples) to compare against a known-good template.

--- a/apps/www/content/docs/getting-started/add-to-existing-repository.mdx
+++ b/apps/www/content/docs/getting-started/add-to-existing-repository.mdx
@@ -3,64 +3,51 @@ title: Add to an existing repository
 description: Add ArkEnv environment validation to an existing project.
 ---
 
-You do not need a greenfield scaffold to adopt ArkEnv. When `arkenv init` finds a `package.json`, it runs the **existing-project flow**: detect your stack, read env keys already in use, generate schema files, and wire framework integrations.
+When `arkenv init` finds a `package.json`, it runs the existing-project flow: detect your stack, read env keys already in use, generate schema files, and wire framework integrations.
 
-## Before you start
+## Adding ArkEnv to your repository
 
-<Callout type="warn">
-  Commit or stash your work first. By default, `arkenv init` refuses to run when
-  the git working tree is dirty. Pass `--force` only when you accept overwriting
-  generated files and skipping that check.
-</Callout>
+### 1. Commit or stash first
 
-ArkEnv works best with **TypeScript strict mode** enabled. The init wizard can offer to turn strict on when it is missing. Plain JavaScript works at runtime, but editor autocomplete and type checking are weaker — see [Editor integration](/docs/getting-started/editor-integration).
+By default, `arkenv init` refuses to run when the git working tree is dirty. Pass `--force` only when you accept overwriting generated files and skipping that check.
 
-Install the packages you need, or let init add them:
+TypeScript with `strict: true` is the supported path. The wizard can enable strict mode when it is missing.
 
-```package-install
-pnpm add @arkenv/core
-pnpm add -D arkenv
-```
-
-## Run init
-
-From your project root:
+### 2. Run init
 
 ```bash title="Terminal"
 pnpm dlx arkenv@latest init
 ```
 
-Init detects whether you are brownfield or greenfield:
+| Situation                         | Flow                                 |
+| --------------------------------- | ------------------------------------ |
+| Directory contains `package.json` | Existing-project wizard (this guide) |
+| Empty directory                   | New-project scaffold                 |
+| `--example` flag                  | Always new-project                   |
 
-| Situation                         | Flow                                                     |
-| --------------------------------- | -------------------------------------------------------- |
-| Directory contains `package.json` | Existing-project wizard (this guide)                     |
-| Empty directory                   | New-project scaffold (pick an example or blank template) |
-| `--example` flag                  | Always new-project, even in a non-empty directory        |
-
-Useful flags for existing repos:
+Common flags:
 
 ```bash title="Terminal"
-pnpm dlx arkenv@latest init --yes              # non-interactive; flat layout default for Next/Nuxt
-pnpm dlx arkenv@latest init --strict           # strict client/server file split for Next.js or Nuxt
+pnpm dlx arkenv@latest init --yes
+pnpm dlx arkenv@latest init --strict
 pnpm dlx arkenv@latest init --host-preset vercel
-pnpm dlx arkenv@latest init --agent            # --yes --quiet --json for AI agents
+pnpm dlx arkenv@latest init --agent
 ```
 
-See [hosting presets](/docs/validating-environment-variables/hosting-presets) for provider values (`vercel`, `netlify`, `cloudflare`, `railway`, `render`, `fly`).
+`--yes` skips prompts (flat layout default for Next/Nuxt). `--strict` uses the [strict client/server split](/docs/validating-environment-variables/client-vs-server#strict-layout). `--agent` implies `--yes`, `--quiet`, and JSON output. Hosting preset values are listed in [hosting presets](/docs/validating-environment-variables/hosting-presets).
 
-## What init detects
+### 3. Answer the wizard
 
-The wizard inspects your repo and asks targeted questions:
+Init inspects the repo and asks about:
 
-1. **Framework** — Next.js, Nuxt, Vite, Bun fullstack, or vanilla Node from dependencies and config files.
-2. **Layout** — flat (default) or [strict](/docs/validating-environment-variables/client-vs-server#strict-layout) split for Next.js and Nuxt.
-3. **Existing schema** — whether to overwrite `env.ts` (or strict layout files).
-4. **Environment keys** — parsed from `.env.example`, or scanned from `process.env`, `import.meta.env`, and `env.*` usage in source when no example file exists.
-5. **Validator** — ArkType (default), Zod, or Valibot via `@arkenv/standard`.
-6. **Hosting preset** — optional provider system variables.
+1. Framework (Next.js, Nuxt, Vite, Bun fullstack, or vanilla)
+2. Layout (flat or strict for Next.js / Nuxt)
+3. Overwriting an existing schema
+4. Env keys from `.env.example`, or from `process.env` / `import.meta.env` / `env.*` usage in source
+5. Validator (ArkType, Zod, or Valibot)
+6. Hosting preset
 
-When `.env.example` is present, init offers to seed the schema from its keys:
+When `.env.example` exists:
 
 ```txt
 Detected .env.example with 12 keys. Use them for your schema?
@@ -72,82 +59,49 @@ When only source usage is found:
 Detected 8 environment variables used in your project. Use them for your schema?
 ```
 
-## What init generates
+### 4. Review generated files
 
-Typical output for a Next.js flat layout:
+Typical Next.js flat layout:
 
 <Files>
   <Folder name="my-app" defaultOpen>
     <File name="env.ts" />
-
     <File name=".env.example" />
-
     <File name=".env" />
-
     <Folder name="generated">
       <File name="env.gen.ts" />
     </Folder>
-
     <File name="next.config.ts" />
   </Folder>
 </Files>
 
-Depending on your stack, init may also:
-
-- Wrap `next.config.ts` with `withArkEnv` (Next.js codegen)
-- Scaffold `vite-env.d.ts` or `bun-env.d.ts` for framework env typing
-- Append `.env` and `.env.local` to `.gitignore` when missing
-- Create `.env` from `.env.example`, or create `.env.example` from `.env` with **values stripped** so secrets are not committed
+Init may also wrap `next.config.ts` with `withArkEnv`, scaffold `vite-env.d.ts` or `bun-env.d.ts`, append `.env` / `.env.local` to `.gitignore`, create `.env` from `.env.example`, or create `.env.example` from `.env` with values stripped.
 
 <Callout type="info">
-  ArkEnv does not load `.env` files itself. Your framework, Bun, or a tool like
+  ArkEnv does not load `.env` files. Your framework, Bun, or a tool like
   `tsx --env-file` must populate `process.env` before `arkenv()` runs. See
-  [Framework integration — Loading .env files](/docs/validating-environment-variables/framework-integration#loading-env-files).
+  [Loading .env files](/docs/validating-environment-variables/framework-integration#loading-env-files).
 </Callout>
 
-## After init
-
-1. Copy `.env.example` to `.env` if you still need local values:
-
-   ```bash title="Terminal"
-   cp .env.example .env
-   ```
-
-2. Import the validated object everywhere instead of raw env maps:
-
-   ```ts title="./src/server.ts"
-   import { env } from "../env";
-
-   console.log(env.DATABASE_URL);
-   ```
-
-3. Read [Client vs. server](/docs/validating-environment-variables/client-vs-server) to understand public prefixes (`NEXT_PUBLIC_*`, `VITE_*`, and friends).
-
-4. Follow the framework guide for your stack: [Next.js](/docs/guides/frameworks/nextjs), [Nuxt](/docs/guides/frameworks/nuxt), [Vite](/docs/guides/frameworks/vite), or [Bun](/docs/guides/frameworks/bun).
-
-## Non-interactive and CI
-
-For scripts, CI, or agent workflows, combine flags to skip prompts:
+### 5. Use the validated `env` object
 
 ```bash title="Terminal"
-pnpm dlx arkenv@latest init --yes --host-preset vercel --agent
+cp .env.example .env
 ```
 
-`--agent` implies `--yes`, `--quiet`, and JSON output suitable for tooling.
+```ts title="./src/server.ts"
+import { env } from "../env";
+
+console.log(env.DATABASE_URL);
+```
+
+Read [Client vs. server](/docs/validating-environment-variables/client-vs-server) for public prefixes, then the guide for your stack: [Next.js](/docs/guides/frameworks/nextjs), [Nuxt](/docs/guides/frameworks/nuxt), [Vite](/docs/guides/frameworks/vite), or [Bun](/docs/guides/frameworks/bun).
 
 ## Troubleshooting
 
-| Problem                                    | Fix                                                                     |
-| ------------------------------------------ | ----------------------------------------------------------------------- |
-| Git working tree is not clean              | Commit, stash (`git stash -u` for untracked files), or use `--force`    |
-| Technical requirements not met             | Enable TypeScript strict mode, or use `--force` to bypass checks        |
-| Non-empty directory without `package.json` | Run in a subdirectory, use `--example` for a new scaffold, or `--force` |
-| `--simple` flag                            | Deprecated — remove it; flat layout is the default                      |
-
-The deprecated `--simple` layout hard-fails on Next.js. Use flat layout (default) or `--strict` when you need a split schema.
-
-## Next steps
-
-- [Editor integration](/docs/getting-started/editor-integration) for autocomplete and IDE setup.
-- [Structuring your schema](/docs/validating-environment-variables/structuring-your-schema) for export patterns and Standard Schema.
-- [Start with an example](/docs/getting-started/examples) to compare against a known-good template.
+| Problem                                    | Fix                                                     |
+| ------------------------------------------ | ------------------------------------------------------- |
+| Git working tree is not clean              | Commit, stash (`git stash -u`), or use `--force`        |
+| Technical requirements not met             | Enable TypeScript strict mode, or use `--force`         |
+| Non-empty directory without `package.json` | Use a subdirectory, `--example`, or `--force`           |
+| `--simple` flag                            | Deprecated; remove it. Flat layout is the default       |

--- a/apps/www/content/docs/getting-started/add-to-existing-repository.mdx
+++ b/apps/www/content/docs/getting-started/add-to-existing-repository.mdx
@@ -66,11 +66,15 @@ Typical Next.js flat layout:
 <Files>
   <Folder name="my-app" defaultOpen>
     <File name="env.ts" />
+
     <File name=".env.example" />
+
     <File name=".env" />
+
     <Folder name="generated">
       <File name="env.gen.ts" />
     </Folder>
+
     <File name="next.config.ts" />
   </Folder>
 </Files>
@@ -99,9 +103,9 @@ Read [Client vs. server](/docs/validating-environment-variables/client-vs-server
 
 ## Troubleshooting
 
-| Problem                                    | Fix                                                     |
-| ------------------------------------------ | ------------------------------------------------------- |
-| Git working tree is not clean              | Commit, stash (`git stash -u`), or use `--force`        |
-| Technical requirements not met             | Enable TypeScript strict mode, or use `--force`         |
-| Non-empty directory without `package.json` | Use a subdirectory, `--example`, or `--force`           |
-| `--simple` flag                            | Deprecated; remove it. Flat layout is the default       |
+| Problem                                    | Fix                                               |
+| ------------------------------------------ | ------------------------------------------------- |
+| Git working tree is not clean              | Commit, stash (`git stash -u`), or use `--force`  |
+| Technical requirements not met             | Enable TypeScript strict mode, or use `--force`   |
+| Non-empty directory without `package.json` | Use a subdirectory, `--example`, or `--force`     |
+| `--simple` flag                            | Deprecated; remove it. Flat layout is the default |

--- a/apps/www/content/docs/getting-started/add-to-existing-repository.mdx
+++ b/apps/www/content/docs/getting-started/add-to-existing-repository.mdx
@@ -32,11 +32,11 @@ pnpm dlx arkenv@latest init
 
 Init detects whether you are brownfield or greenfield:
 
-| Situation | Flow |
-| --------- | ---- |
-| Directory contains `package.json` | Existing-project wizard (this guide) |
-| Empty directory | New-project scaffold (pick an example or blank template) |
-| `--example` flag | Always new-project, even in a non-empty directory |
+| Situation                         | Flow                                                     |
+| --------------------------------- | -------------------------------------------------------- |
+| Directory contains `package.json` | Existing-project wizard (this guide)                     |
+| Empty directory                   | New-project scaffold (pick an example or blank template) |
+| `--example` flag                  | Always new-project, even in a non-empty directory        |
 
 Useful flags for existing repos:
 
@@ -79,11 +79,15 @@ Typical output for a Next.js flat layout:
 <Files>
   <Folder name="my-app" defaultOpen>
     <File name="env.ts" />
+
     <File name=".env.example" />
+
     <File name=".env" />
+
     <Folder name="generated">
       <File name="env.gen.ts" />
     </Folder>
+
     <File name="next.config.ts" />
   </Folder>
 </Files>
@@ -133,12 +137,12 @@ pnpm dlx arkenv@latest init --yes --host-preset vercel --agent
 
 ## Troubleshooting
 
-| Problem | Fix |
-| ------- | --- |
-| Git working tree is not clean | Commit, stash (`git stash -u` for untracked files), or use `--force` |
-| Technical requirements not met | Enable TypeScript strict mode, or use `--force` to bypass checks |
+| Problem                                    | Fix                                                                     |
+| ------------------------------------------ | ----------------------------------------------------------------------- |
+| Git working tree is not clean              | Commit, stash (`git stash -u` for untracked files), or use `--force`    |
+| Technical requirements not met             | Enable TypeScript strict mode, or use `--force` to bypass checks        |
 | Non-empty directory without `package.json` | Run in a subdirectory, use `--example` for a new scaffold, or `--force` |
-| `--simple` flag | Deprecated — remove it; flat layout is the default |
+| `--simple` flag                            | Deprecated — remove it; flat layout is the default                      |
 
 The deprecated `--simple` layout hard-fails on Next.js. Use flat layout (default) or `--strict` when you need a split schema.
 

--- a/apps/www/content/docs/getting-started/editor-integration.mdx
+++ b/apps/www/content/docs/getting-started/editor-integration.mdx
@@ -3,11 +3,25 @@ title: Editor integration
 description: Configure your editor for ArkEnv auto-imports and validation tooltips.
 ---
 
-ArkEnv's developer experience comes from TypeScript inference on the validated `env` object, optional framework type augmentation, and the ArkType VS Code extension for schema syntax highlighting. No separate ArkEnv IDE plugin exists — configure these pieces once and autocomplete follows your schema.
+ArkEnv leans on TypeScript inference and the ArkType VS Code extension. There is no separate ArkEnv IDE plugin.
 
-## Use TypeScript
+## ArkType VS Code extension
 
-TypeScript with `strict: true` is the supported path. The `arkenv init` wizard checks for strict mode and can enable it when missing.
+Install the [ArkType VS Code extension](https://marketplace.visualstudio.com/items?itemName=arktypeio.arkdark) (`arktypeio.arkdark`). It highlights ArkType schema strings when the import uses the default export name `arkenv`:
+
+```ts title="./env.ts"
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+  API_URL: "string.url",
+});
+```
+
+Keep that import name. Auto-import then picks up highlighting without a rename. See [ADR 0008](https://github.com/yamcodes/arkenv/blob/main/docs/adr/0008-default-export-and-function-naming.md).
+
+## Autocomplete on `env.*`
+
+TypeScript reads keys and types from the schema you pass to `arkenv()`:
 
 ```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/core";
@@ -19,50 +33,13 @@ export const env = arkenv({
 });
 ```
 
-Reading `env.PORT` gives a `number`. Reading `process.env.PORT` stays an untyped string. Import the validated object everywhere:
+Import `{ env }` in application code. `env.PORT` is a `number`; `process.env.PORT` stays an untyped string.
 
-<Callout type="info">
-  The validated `env` object is the product. Read `env.DATABASE_URL`, not
-  `process.env.DATABASE_URL`. That surface is typed, coerced, and defaulted —
-  raw env maps are not.
-</Callout>
+## Framework type augmentation
 
-Plain JavaScript works at runtime, but autocomplete and type checking depend on your editor and are not guaranteed. See the [basic-js example](https://github.com/yamcodes/arkenv/tree/main/examples/basic-js) for tradeoffs.
+Some hosts expose env through globals. `arkenv init` can scaffold these declaration files.
 
-## VS Code — ArkType extension
-
-Install the [ArkType VS Code extension](https://marketplace.visualstudio.com/items?itemName=arktypeio.arkdark) (`arktypeio.arkdark`). It highlights ArkType schema strings when your import uses the default export name `arkenv`:
-
-```ts title="./env.ts"
-import arkenv from "@arkenv/core";
-
-export const env = arkenv({
-  API_URL: "string.url",
-});
-```
-
-That naming is intentional: a default export named `arkenv` triggers syntax highlighting on auto-import without a manual rename. See [ADR 0008](https://github.com/yamcodes/arkenv/blob/main/docs/adr/0008-default-export-and-function-naming.md) for the rationale.
-
-## Autocomplete on `env.*`
-
-Once the schema is defined, your editor infers keys, types, and defaults on the exported object:
-
-```ts title="./src/server.ts"
-import { env } from "../env";
-
-console.log(env.HOST); // string
-console.log(env.PORT); // number
-```
-
-Typos and wrong types surface at compile time. At runtime, missing or invalid values throw before your app boots.
-
-## Framework-specific typings
-
-Some hosts expose env through globals (`import.meta.env`, augmented `process.env`). Init can scaffold the declaration files below; say yes when prompted during `arkenv init`.
-
-### Vite — `vite-env.d.ts`
-
-Augment `import.meta.env` so only client-safe keys autocomplete in browser code:
+### Vite: `vite-env.d.ts`
 
 ```ts title="./vite-env.d.ts"
 /// <reference types="vite/client" />
@@ -75,11 +52,9 @@ type ImportMetaEnvAugmented =
 interface ImportMetaEnv extends ImportMetaEnvAugmented {}
 ```
 
-With this file, `import.meta.env.VITE_*` keys are fully typed. Server-only keys (without the `VITE_` prefix) error in client code. See the [with-vite-react example](https://github.com/yamcodes/arkenv/tree/main/examples/with-vite-react) for a complete setup.
+`import.meta.env.VITE_*` keys autocomplete in client code. Keys without the `VITE_` prefix error there.
 
-### Bun fullstack — `bun-env.d.ts`
-
-Augment `process.env` for Bun bundler and fullstack apps:
+### Bun fullstack: `bun-env.d.ts`
 
 ```ts title="./bun-env.d.ts"
 /// <reference types="bun-types" />
@@ -93,41 +68,4 @@ declare namespace NodeJS {
 }
 ```
 
-### Next.js — codegen
-
-Next.js projects use `withArkEnv` and generated `env.gen.ts` for client/server boundaries. Init wraps `next.config.ts` and scaffolds the flat or strict layout. See [Client vs. server](/docs/validating-environment-variables/client-vs-server) for layout choice.
-
-## `.env.example` workflow
-
-Keep `.env.example` in version control as the **key catalog** for your team:
-
-- Lists every variable the schema expects, without secret values
-- Lets `arkenv init` seed a schema from detected keys on brownfield projects
-- Gives new contributors a copy-paste starting point
-
-Local development flow:
-
-```bash title="Terminal"
-cp .env.example .env
-# edit .env with real values (never commit .env)
-```
-
-When init finds `.env` but no `.env.example`, it generates an example file with values stripped so credentials do not leak into git.
-
-Pair the example file with your schema: when you add a key to `env.ts`, add a placeholder line to `.env.example` so teammates and tooling stay aligned.
-
-## Plain JavaScript
-
-<Callout type="warn">
-  Without TypeScript, you lose compile-time autocomplete and most static
-  guarantees. Runtime validation still works — missing keys still fail fast — but
-  prefer TypeScript for day-to-day development.
-</Callout>
-
-If you must stay on JavaScript, rely on runtime errors from ArkEnv and JSDoc where helpful. For predictable editor support, migrate to TypeScript or start from the [basic example](https://github.com/yamcodes/arkenv/tree/main/examples/basic).
-
-## Next steps
-
-- [Structuring your schema](/docs/validating-environment-variables/structuring-your-schema) — where `env.ts` lives and how to export it.
-- [Client vs. server](/docs/validating-environment-variables/client-vs-server) — public prefixes and strict layouts.
-- [Start with an example](/docs/getting-started/examples) — runnable templates with IDE setup already wired.
+Next.js uses `withArkEnv` codegen (`env.gen.ts`) for the same kind of boundary typing. See [Client vs. server](/docs/validating-environment-variables/client-vs-server).

--- a/apps/www/content/docs/getting-started/editor-integration.mdx
+++ b/apps/www/content/docs/getting-started/editor-integration.mdx
@@ -3,6 +3,131 @@ title: Editor integration
 description: Configure your editor for ArkEnv auto-imports and validation tooltips.
 ---
 
-Stub guide for editor/IDE setup (TypeScript, auto-imports, and schema feedback).
+ArkEnv's developer experience comes from TypeScript inference on the validated `env` object, optional framework type augmentation, and the ArkType VS Code extension for schema syntax highlighting. No separate ArkEnv IDE plugin exists — configure these pieces once and autocomplete follows your schema.
 
-> Content TBD — Getting started leaf.
+## Use TypeScript
+
+TypeScript with `strict: true` is the supported path. The `arkenv init` wizard checks for strict mode and can enable it when missing.
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+  HOST: "string.host = 'localhost'",
+  PORT: "number.port = 3000",
+  NODE_ENV: "'development' | 'production' | 'test' = 'development'",
+});
+```
+
+Reading `env.PORT` gives a `number`. Reading `process.env.PORT` stays an untyped string. Import the validated object everywhere:
+
+<Callout type="info">
+  The validated `env` object is the product. Read `env.DATABASE_URL`, not
+  `process.env.DATABASE_URL`. That surface is typed, coerced, and defaulted —
+  raw env maps are not.
+</Callout>
+
+Plain JavaScript works at runtime, but autocomplete and type checking depend on your editor and are not guaranteed. See the [basic-js example](https://github.com/yamcodes/arkenv/tree/main/examples/basic-js) for tradeoffs.
+
+## VS Code — ArkType extension
+
+Install the [ArkType VS Code extension](https://marketplace.visualstudio.com/items?itemName=arktypeio.arkdark) (`arktypeio.arkdark`). It highlights ArkType schema strings when your import uses the default export name `arkenv`:
+
+```ts title="./env.ts"
+import arkenv from "@arkenv/core";
+
+export const env = arkenv({
+  API_URL: "string.url",
+});
+```
+
+That naming is intentional: a default export named `arkenv` triggers syntax highlighting on auto-import without a manual rename. See [ADR 0008](https://github.com/yamcodes/arkenv/blob/main/docs/adr/0008-default-export-and-function-naming.md) for the rationale.
+
+## Autocomplete on `env.*`
+
+Once the schema is defined, your editor infers keys, types, and defaults on the exported object:
+
+```ts title="./src/server.ts"
+import { env } from "../env";
+
+console.log(env.HOST); // string
+console.log(env.PORT); // number
+```
+
+Typos and wrong types surface at compile time. At runtime, missing or invalid values throw before your app boots.
+
+## Framework-specific typings
+
+Some hosts expose env through globals (`import.meta.env`, augmented `process.env`). Init can scaffold the declaration files below; say yes when prompted during `arkenv init`.
+
+### Vite — `vite-env.d.ts`
+
+Augment `import.meta.env` so only client-safe keys autocomplete in browser code:
+
+```ts title="./vite-env.d.ts"
+/// <reference types="vite/client" />
+
+type ImportMetaEnvAugmented =
+  import("@arkenv/vite-plugin").ImportMetaEnvAugmented<
+    typeof import("./env").Env
+  >;
+
+interface ImportMetaEnv extends ImportMetaEnvAugmented {}
+```
+
+With this file, `import.meta.env.VITE_*` keys are fully typed. Server-only keys (without the `VITE_` prefix) error in client code. See the [with-vite-react example](https://github.com/yamcodes/arkenv/tree/main/examples/with-vite-react) for a complete setup.
+
+### Bun fullstack — `bun-env.d.ts`
+
+Augment `process.env` for Bun bundler and fullstack apps:
+
+```ts title="./bun-env.d.ts"
+/// <reference types="bun-types" />
+
+type ProcessEnvAugmented = import("@arkenv/bun-plugin").ProcessEnvAugmented<
+  typeof import("./env").Env
+>;
+
+declare namespace NodeJS {
+  interface ProcessEnv extends ProcessEnvAugmented {}
+}
+```
+
+### Next.js — codegen
+
+Next.js projects use `withArkEnv` and generated `env.gen.ts` for client/server boundaries. Init wraps `next.config.ts` and scaffolds the flat or strict layout. See [Client vs. server](/docs/validating-environment-variables/client-vs-server) for layout choice.
+
+## `.env.example` workflow
+
+Keep `.env.example` in version control as the **key catalog** for your team:
+
+- Lists every variable the schema expects, without secret values
+- Lets `arkenv init` seed a schema from detected keys on brownfield projects
+- Gives new contributors a copy-paste starting point
+
+Local development flow:
+
+```bash title="Terminal"
+cp .env.example .env
+# edit .env with real values (never commit .env)
+```
+
+When init finds `.env` but no `.env.example`, it generates an example file with values stripped so credentials do not leak into git.
+
+Pair the example file with your schema: when you add a key to `env.ts`, add a placeholder line to `.env.example` so teammates and tooling stay aligned.
+
+## Plain JavaScript
+
+<Callout type="warn">
+  Without TypeScript, you lose compile-time autocomplete and most static
+  guarantees. Runtime validation still works — missing keys still fail fast — but
+  prefer TypeScript for day-to-day development.
+</Callout>
+
+If you must stay on JavaScript, rely on runtime errors from ArkEnv and JSDoc where helpful. For predictable editor support, migrate to TypeScript or start from the [basic example](https://github.com/yamcodes/arkenv/tree/main/examples/basic).
+
+## Next steps
+
+- [Structuring your schema](/docs/validating-environment-variables/structuring-your-schema) — where `env.ts` lives and how to export it.
+- [Client vs. server](/docs/validating-environment-variables/client-vs-server) — public prefixes and strict layouts.
+- [Start with an example](/docs/getting-started/examples) — runnable templates with IDE setup already wired.

--- a/apps/www/content/docs/getting-started/examples.mdx
+++ b/apps/www/content/docs/getting-started/examples.mdx
@@ -3,65 +3,55 @@ title: Start with an example
 description: Explore playground templates and runnable ArkEnv examples.
 ---
 
-The [ArkEnv repository](https://github.com/yamcodes/arkenv) ships runnable examples under `examples/`. Each one is a standalone project that installs **published** packages from npm, so you can clone, install, and run without the monorepo.
-
-Inside the repo, `apps/playgrounds/` holds workspace sandboxes used for development and CI. Most examples are synced from those playgrounds; contributors edit the playground first, then run `pnpm sync:examples`.
-
-## Scaffold with the CLI
-
-The fastest way to start is `arkenv init --example`. It copies a verified template, installs dependencies, and writes starter files:
+Use `arkenv init --example` to bootstrap a project from a verified template:
 
 ```bash title="Terminal"
 pnpm dlx arkenv@latest init --example with-vite-react --name my-app
 pnpm dlx arkenv@latest init --example basic
 ```
 
-Run this in an **empty directory** (or pass `--force` when you mean to overwrite). The `--example` flag always triggers the new-project flow, even if the directory is not empty.
+Run this in an empty directory (or pass `--force` to overwrite). `--example` always uses the new-project flow.
 
-Available templates include `basic`, `with-nextjs`, `with-nextjs-strict`, `with-nuxt`, `with-vite-react`, `with-bun`, `with-bun-react`, `with-zod`, and `with-valibot`. See the full list in [`examples/registry.json`](https://github.com/yamcodes/arkenv/blob/main/examples/registry.json).
+Templates available to the CLI include `basic`, `with-nextjs`, `with-nextjs-strict`, `with-nuxt`, `with-vite-react`, `with-bun`, `with-bun-react`, `with-zod`, and `with-valibot`. See [`examples/registry.json`](https://github.com/yamcodes/arkenv/blob/main/examples/registry.json).
 
 <Callout type="info">
-  To wire ArkEnv into a repo that already has application code, skip `--example`
-  and follow [Add to an existing repository](/docs/getting-started/add-to-existing-repository).
+  For a repo that already has application code, skip `--example` and follow
+  [Add to an existing repository](/docs/getting-started/add-to-existing-repository).
 </Callout>
 
-## Browse examples
+## Examples
+
+Each example under [`examples/`](https://github.com/yamcodes/arkenv/tree/main/examples) is a standalone project that installs published packages from npm. Open the README in the example for setup steps.
 
 <Cards>
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/basic" title="basic" description="Minimal Node.js app with ArkType — defaults, coercion, and the .env.example workflow." />
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/basic" title="basic" description="Minimal Node.js app with ArkType." />
 
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/basic-js" title="basic-js" description="Same fundamentals in plain JavaScript. Weaker editor guarantees; see editor integration." />
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/basic-js" title="basic-js" description="Same fundamentals in plain JavaScript." />
 
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-zod" title="with-zod" description="Node.js with @arkenv/standard and Zod instead of ArkType." />
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-zod" title="with-zod" description="Node.js with @arkenv/standard and Zod." />
 
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-valibot" title="with-valibot" description="Node.js with @arkenv/standard and Valibot instead of ArkType." />
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-valibot" title="with-valibot" description="Node.js with @arkenv/standard and Valibot." />
 
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-standard-schema" title="with-standard-schema" description="Mix ArkType with Standard Schema validators like Zod in one schema." />
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-standard-schema" title="with-standard-schema" description="Mix ArkType with Standard Schema validators." />
 
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nextjs" title="with-nextjs" description="Next.js flat layout with withArkEnv and client/server boundaries." />
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nextjs" title="with-nextjs" description="Next.js flat layout with withArkEnv." />
 
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nextjs-strict" title="with-nextjs-strict" description="Next.js strict split layout — separate client, server, and shared modules." />
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nextjs-strict" title="with-nextjs-strict" description="Next.js strict client/server split." />
 
   <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nuxt" title="with-nuxt" description="Nuxt flat layout with @arkenv/nuxt." />
 
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nuxt-strict" title="with-nuxt-strict" description="Nuxt strict layout with auto-extended client and server entrypoints." />
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nuxt-strict" title="with-nuxt-strict" description="Nuxt strict client/server split." />
 
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-vite-react" title="with-vite-react" description="Vite + React with @arkenv/vite-plugin and typesafe import.meta.env." />
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-vite-react" title="with-vite-react" description="Vite + React with @arkenv/vite-plugin." />
 
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-solid-start" title="with-solid-start" description="SolidStart with the Vite plugin and SSR/client env split." />
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-solid-start" title="with-solid-start" description="SolidStart with the Vite plugin." />
 
   <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-bun" title="with-bun" description="Minimal Bun runtime project." />
 
   <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-bun-react" title="with-bun-react" description="Bun fullstack + React with @arkenv/bun-plugin." />
 </Cards>
 
-Each example includes a `README.md` with setup steps. TypeScript is the recommended path; see [basic-js](https://github.com/yamcodes/arkenv/tree/main/examples/basic-js) for plain JavaScript tradeoffs.
-
-## Run an example locally
-
-1. Clone or download the example directory.
-2. Copy `.env.example` to `.env` when the example ships one.
-3. Install dependencies and start the dev script.
+You can also clone an example and run it locally:
 
 ```bash title="Terminal"
 git clone https://github.com/yamcodes/arkenv.git
@@ -71,47 +61,10 @@ npm install
 npm run dev
 ```
 
-Framework examples typically use `pnpm dev` / `pnpm build`. Bun examples use `bun dev` or `bun run index.ts`. Check the example's `package.json` scripts when in doubt.
+Or try the [StackBlitz demo](https://stackblitz.com/github/yamcodes/arkenv/tree/main/examples/stackblitz?file=index.ts) in the browser. That template is adapted for WebContainer, so prefer the standalone examples when you want the exact production stack.
 
-| Example                                                                | Typical commands                           |
-| ---------------------------------------------------------------------- | ------------------------------------------ |
-| `basic`, `basic-js`, `with-zod`, `with-valibot`                        | `npm install` → `npm run dev`              |
-| `with-nextjs`, `with-nextjs-strict`                                    | `pnpm install` → `pnpm dev`                |
-| `with-nuxt`, `with-nuxt-strict`, `with-vite-react`, `with-solid-start` | `pnpm install` → `pnpm dev` / `pnpm build` |
-| `with-bun`, `with-bun-react`                                           | `bun install` → `bun dev`                  |
-
-## Try in the browser
-
-Open the [StackBlitz demo](https://stackblitz.com/github/yamcodes/arkenv/tree/main/examples/stackblitz?file=index.ts) to explore ArkEnv without a local install. That template is adapted for WebContainer (for example, it uses `ts-node` instead of `tsx`), so prefer the standalone examples above when you want the exact production stack.
-
-## Monorepo playgrounds (contributors)
-
-If you are working inside the ArkEnv repo, playgrounds under `apps/playgrounds/` consume `workspace:*` packages so you can test local changes:
-
-```bash title="Terminal"
-cd apps/playgrounds/node
-cp .env.example .env
-pnpm start
-```
-
-| Example                | Playground source                  |
-| ---------------------- | ---------------------------------- |
-| `basic`                | `apps/playgrounds/node`            |
-| `basic-js`             | `apps/playgrounds/js`              |
-| `with-nextjs`          | `apps/playgrounds/nextjs`          |
-| `with-nextjs-strict`   | `apps/playgrounds/nextjs-strict`   |
-| `with-nuxt`            | `apps/playgrounds/nuxt`            |
-| `with-nuxt-strict`     | `apps/playgrounds/nuxt-strict`     |
-| `with-vite-react`      | `apps/playgrounds/vite`            |
-| `with-bun`             | `apps/playgrounds/bun`             |
-| `with-bun-react`       | `apps/playgrounds/bun-react`       |
-| `with-solid-start`     | `apps/playgrounds/solid-start`     |
-| `with-standard-schema` | `apps/playgrounds/standard-schema` |
-
-Edit the playground, run `pnpm sync:examples`, then commit both directories.
-
-## Next steps
-
-- [Add to an existing repository](/docs/getting-started/add-to-existing-repository) when you already have a project.
-- [Structuring your schema](/docs/validating-environment-variables/structuring-your-schema) to understand `env.ts` layout.
-- [Framework integration](/docs/validating-environment-variables/framework-integration) for Next.js, Nuxt, Vite, and Bun specifics.
+<Callout type="info">
+  Contributors: examples sync from `apps/playgrounds/` via `pnpm sync:examples`.
+  Edit the playground, sync, then commit both directories. Mapping lives in
+  [`examples/README.md`](https://github.com/yamcodes/arkenv/blob/main/examples/README.md).
+</Callout>

--- a/apps/www/content/docs/getting-started/examples.mdx
+++ b/apps/www/content/docs/getting-started/examples.mdx
@@ -28,71 +28,31 @@ Available templates include `basic`, `with-nextjs`, `with-nextjs-strict`, `with-
 ## Browse examples
 
 <Cards>
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/basic"
-    title="basic"
-    description="Minimal Node.js app with ArkType — defaults, coercion, and the .env.example workflow."
-  />
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/basic-js"
-    title="basic-js"
-    description="Same fundamentals in plain JavaScript. Weaker editor guarantees; see editor integration."
-  />
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-zod"
-    title="with-zod"
-    description="Node.js with @arkenv/standard and Zod instead of ArkType."
-  />
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-valibot"
-    title="with-valibot"
-    description="Node.js with @arkenv/standard and Valibot instead of ArkType."
-  />
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-standard-schema"
-    title="with-standard-schema"
-    description="Mix ArkType with Standard Schema validators like Zod in one schema."
-  />
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nextjs"
-    title="with-nextjs"
-    description="Next.js flat layout with withArkEnv and client/server boundaries."
-  />
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nextjs-strict"
-    title="with-nextjs-strict"
-    description="Next.js strict split layout — separate client, server, and shared modules."
-  />
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nuxt"
-    title="with-nuxt"
-    description="Nuxt flat layout with @arkenv/nuxt."
-  />
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nuxt-strict"
-    title="with-nuxt-strict"
-    description="Nuxt strict layout with auto-extended client and server entrypoints."
-  />
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-vite-react"
-    title="with-vite-react"
-    description="Vite + React with @arkenv/vite-plugin and typesafe import.meta.env."
-  />
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-solid-start"
-    title="with-solid-start"
-    description="SolidStart with the Vite plugin and SSR/client env split."
-  />
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-bun"
-    title="with-bun"
-    description="Minimal Bun runtime project."
-  />
-  <Card
-    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-bun-react"
-    title="with-bun-react"
-    description="Bun fullstack + React with @arkenv/bun-plugin."
-  />
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/basic" title="basic" description="Minimal Node.js app with ArkType — defaults, coercion, and the .env.example workflow." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/basic-js" title="basic-js" description="Same fundamentals in plain JavaScript. Weaker editor guarantees; see editor integration." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-zod" title="with-zod" description="Node.js with @arkenv/standard and Zod instead of ArkType." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-valibot" title="with-valibot" description="Node.js with @arkenv/standard and Valibot instead of ArkType." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-standard-schema" title="with-standard-schema" description="Mix ArkType with Standard Schema validators like Zod in one schema." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nextjs" title="with-nextjs" description="Next.js flat layout with withArkEnv and client/server boundaries." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nextjs-strict" title="with-nextjs-strict" description="Next.js strict split layout — separate client, server, and shared modules." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nuxt" title="with-nuxt" description="Nuxt flat layout with @arkenv/nuxt." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nuxt-strict" title="with-nuxt-strict" description="Nuxt strict layout with auto-extended client and server entrypoints." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-vite-react" title="with-vite-react" description="Vite + React with @arkenv/vite-plugin and typesafe import.meta.env." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-solid-start" title="with-solid-start" description="SolidStart with the Vite plugin and SSR/client env split." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-bun" title="with-bun" description="Minimal Bun runtime project." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-bun-react" title="with-bun-react" description="Bun fullstack + React with @arkenv/bun-plugin." />
 </Cards>
 
 Each example includes a `README.md` with setup steps. TypeScript is the recommended path; see [basic-js](https://github.com/yamcodes/arkenv/tree/main/examples/basic-js) for plain JavaScript tradeoffs.
@@ -113,12 +73,12 @@ npm run dev
 
 Framework examples typically use `pnpm dev` / `pnpm build`. Bun examples use `bun dev` or `bun run index.ts`. Check the example's `package.json` scripts when in doubt.
 
-| Example | Typical commands |
-| ------- | ---------------- |
-| `basic`, `basic-js`, `with-zod`, `with-valibot` | `npm install` → `npm run dev` |
-| `with-nextjs`, `with-nextjs-strict` | `pnpm install` → `pnpm dev` |
+| Example                                                                | Typical commands                           |
+| ---------------------------------------------------------------------- | ------------------------------------------ |
+| `basic`, `basic-js`, `with-zod`, `with-valibot`                        | `npm install` → `npm run dev`              |
+| `with-nextjs`, `with-nextjs-strict`                                    | `pnpm install` → `pnpm dev`                |
 | `with-nuxt`, `with-nuxt-strict`, `with-vite-react`, `with-solid-start` | `pnpm install` → `pnpm dev` / `pnpm build` |
-| `with-bun`, `with-bun-react` | `bun install` → `bun dev` |
+| `with-bun`, `with-bun-react`                                           | `bun install` → `bun dev`                  |
 
 ## Try in the browser
 
@@ -134,18 +94,18 @@ cp .env.example .env
 pnpm start
 ```
 
-| Example | Playground source |
-| ------- | ----------------- |
-| `basic` | `apps/playgrounds/node` |
-| `basic-js` | `apps/playgrounds/js` |
-| `with-nextjs` | `apps/playgrounds/nextjs` |
-| `with-nextjs-strict` | `apps/playgrounds/nextjs-strict` |
-| `with-nuxt` | `apps/playgrounds/nuxt` |
-| `with-nuxt-strict` | `apps/playgrounds/nuxt-strict` |
-| `with-vite-react` | `apps/playgrounds/vite` |
-| `with-bun` | `apps/playgrounds/bun` |
-| `with-bun-react` | `apps/playgrounds/bun-react` |
-| `with-solid-start` | `apps/playgrounds/solid-start` |
+| Example                | Playground source                  |
+| ---------------------- | ---------------------------------- |
+| `basic`                | `apps/playgrounds/node`            |
+| `basic-js`             | `apps/playgrounds/js`              |
+| `with-nextjs`          | `apps/playgrounds/nextjs`          |
+| `with-nextjs-strict`   | `apps/playgrounds/nextjs-strict`   |
+| `with-nuxt`            | `apps/playgrounds/nuxt`            |
+| `with-nuxt-strict`     | `apps/playgrounds/nuxt-strict`     |
+| `with-vite-react`      | `apps/playgrounds/vite`            |
+| `with-bun`             | `apps/playgrounds/bun`             |
+| `with-bun-react`       | `apps/playgrounds/bun-react`       |
+| `with-solid-start`     | `apps/playgrounds/solid-start`     |
 | `with-standard-schema` | `apps/playgrounds/standard-schema` |
 
 Edit the playground, run `pnpm sync:examples`, then commit both directories.

--- a/apps/www/content/docs/getting-started/examples.mdx
+++ b/apps/www/content/docs/getting-started/examples.mdx
@@ -3,6 +3,155 @@ title: Start with an example
 description: Explore playground templates and runnable ArkEnv examples.
 ---
 
-Stub guide for cloning or browsing starter templates and playgrounds.
+The [ArkEnv repository](https://github.com/yamcodes/arkenv) ships runnable examples under `examples/`. Each one is a standalone project that installs **published** packages from npm, so you can clone, install, and run without the monorepo.
 
-> Content TBD — Getting started leaf.
+Inside the repo, `apps/playgrounds/` holds workspace sandboxes used for development and CI. Most examples are synced from those playgrounds; contributors edit the playground first, then run `pnpm sync:examples`.
+
+## Scaffold with the CLI
+
+The fastest way to start is `arkenv init --example`. It copies a verified template, installs dependencies, and writes starter files:
+
+```bash title="Terminal"
+pnpm dlx arkenv@latest init --example with-vite-react --name my-app
+pnpm dlx arkenv@latest init --example basic
+```
+
+Run this in an **empty directory** (or pass `--force` when you mean to overwrite). The `--example` flag always triggers the new-project flow, even if the directory is not empty.
+
+Available templates include `basic`, `with-nextjs`, `with-nextjs-strict`, `with-nuxt`, `with-vite-react`, `with-bun`, `with-bun-react`, `with-zod`, and `with-valibot`. See the full list in [`examples/registry.json`](https://github.com/yamcodes/arkenv/blob/main/examples/registry.json).
+
+<Callout type="info">
+  To wire ArkEnv into a repo that already has application code, skip `--example`
+  and follow [Add to an existing repository](/docs/getting-started/add-to-existing-repository).
+</Callout>
+
+## Browse examples
+
+<Cards>
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/basic"
+    title="basic"
+    description="Minimal Node.js app with ArkType — defaults, coercion, and the .env.example workflow."
+  />
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/basic-js"
+    title="basic-js"
+    description="Same fundamentals in plain JavaScript. Weaker editor guarantees; see editor integration."
+  />
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-zod"
+    title="with-zod"
+    description="Node.js with @arkenv/standard and Zod instead of ArkType."
+  />
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-valibot"
+    title="with-valibot"
+    description="Node.js with @arkenv/standard and Valibot instead of ArkType."
+  />
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-standard-schema"
+    title="with-standard-schema"
+    description="Mix ArkType with Standard Schema validators like Zod in one schema."
+  />
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nextjs"
+    title="with-nextjs"
+    description="Next.js flat layout with withArkEnv and client/server boundaries."
+  />
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nextjs-strict"
+    title="with-nextjs-strict"
+    description="Next.js strict split layout — separate client, server, and shared modules."
+  />
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nuxt"
+    title="with-nuxt"
+    description="Nuxt flat layout with @arkenv/nuxt."
+  />
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nuxt-strict"
+    title="with-nuxt-strict"
+    description="Nuxt strict layout with auto-extended client and server entrypoints."
+  />
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-vite-react"
+    title="with-vite-react"
+    description="Vite + React with @arkenv/vite-plugin and typesafe import.meta.env."
+  />
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-solid-start"
+    title="with-solid-start"
+    description="SolidStart with the Vite plugin and SSR/client env split."
+  />
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-bun"
+    title="with-bun"
+    description="Minimal Bun runtime project."
+  />
+  <Card
+    href="https://github.com/yamcodes/arkenv/tree/main/examples/with-bun-react"
+    title="with-bun-react"
+    description="Bun fullstack + React with @arkenv/bun-plugin."
+  />
+</Cards>
+
+Each example includes a `README.md` with setup steps. TypeScript is the recommended path; see [basic-js](https://github.com/yamcodes/arkenv/tree/main/examples/basic-js) for plain JavaScript tradeoffs.
+
+## Run an example locally
+
+1. Clone or download the example directory.
+2. Copy `.env.example` to `.env` when the example ships one.
+3. Install dependencies and start the dev script.
+
+```bash title="Terminal"
+git clone https://github.com/yamcodes/arkenv.git
+cd arkenv/examples/basic
+cp .env.example .env
+npm install
+npm run dev
+```
+
+Framework examples typically use `pnpm dev` / `pnpm build`. Bun examples use `bun dev` or `bun run index.ts`. Check the example's `package.json` scripts when in doubt.
+
+| Example | Typical commands |
+| ------- | ---------------- |
+| `basic`, `basic-js`, `with-zod`, `with-valibot` | `npm install` → `npm run dev` |
+| `with-nextjs`, `with-nextjs-strict` | `pnpm install` → `pnpm dev` |
+| `with-nuxt`, `with-nuxt-strict`, `with-vite-react`, `with-solid-start` | `pnpm install` → `pnpm dev` / `pnpm build` |
+| `with-bun`, `with-bun-react` | `bun install` → `bun dev` |
+
+## Try in the browser
+
+Open the [StackBlitz demo](https://stackblitz.com/github/yamcodes/arkenv/tree/main/examples/stackblitz?file=index.ts) to explore ArkEnv without a local install. That template is adapted for WebContainer (for example, it uses `ts-node` instead of `tsx`), so prefer the standalone examples above when you want the exact production stack.
+
+## Monorepo playgrounds (contributors)
+
+If you are working inside the ArkEnv repo, playgrounds under `apps/playgrounds/` consume `workspace:*` packages so you can test local changes:
+
+```bash title="Terminal"
+cd apps/playgrounds/node
+cp .env.example .env
+pnpm start
+```
+
+| Example | Playground source |
+| ------- | ----------------- |
+| `basic` | `apps/playgrounds/node` |
+| `basic-js` | `apps/playgrounds/js` |
+| `with-nextjs` | `apps/playgrounds/nextjs` |
+| `with-nextjs-strict` | `apps/playgrounds/nextjs-strict` |
+| `with-nuxt` | `apps/playgrounds/nuxt` |
+| `with-nuxt-strict` | `apps/playgrounds/nuxt-strict` |
+| `with-vite-react` | `apps/playgrounds/vite` |
+| `with-bun` | `apps/playgrounds/bun` |
+| `with-bun-react` | `apps/playgrounds/bun-react` |
+| `with-solid-start` | `apps/playgrounds/solid-start` |
+| `with-standard-schema` | `apps/playgrounds/standard-schema` |
+
+Edit the playground, run `pnpm sync:examples`, then commit both directories.
+
+## Next steps
+
+- [Add to an existing repository](/docs/getting-started/add-to-existing-repository) when you already have a project.
+- [Structuring your schema](/docs/validating-environment-variables/structuring-your-schema) to understand `env.ts` layout.
+- [Framework integration](/docs/validating-environment-variables/framework-integration) for Next.js, Nuxt, Vite, and Bun specifics.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1560.

Populates the three remaining Getting started stubs on `simplify-docs`, then tightened per review to match Turborepo getting-started structure and stop-slop prose:

- **examples** — CLI `--example` scaffold, curated Cards, local clone snippet, StackBlitz link; contributor playground sync reduced to a Callout (no duplicate directory map)
- **add-to-existing-repository** — numbered brownfield `arkenv init` steps, detection/flags, generated files, troubleshooting
- **editor-integration** — editor-only: ArkType VS Code extension, `env.*` autocomplete, Vite/Bun type augmentation (dropped unrelated onboarding content)

## Verification

- `pnpm twoslash content/docs/getting-started/editor-integration.mdx` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f391f2f-e709-4ba1-bc85-c571dc29206d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f391f2f-e709-4ba1-bc85-c571dc29206d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

