### PR TITLE
feat(standard): optional `toJsonSchema` coercion escape hatch (#1564)

### DIFF
--- a/.changeset/to-json-schema-escape-hatch.md
+++ b/.changeset/to-json-schema-escape-hatch.md
@@ -11,3 +11,4 @@
 - Throwing or returning a non-plain object fails the parse with `ArkEnvError` (`INVALID_SCHEMA`) for that key
 - Zod and other Standard JSON Schema validators are unchanged (callback is not invoked when probes succeed)
 - No new package dependencies on `@arkenv/standard`
+- Bundle size budget for `@arkenv/standard` raised from 3.6 kB to 3.7 kB for the callback path

--- a/.changeset/to-json-schema-escape-hatch.md
+++ b/.changeset/to-json-schema-escape-hatch.md
@@ -5,10 +5,10 @@
 
 #### Add optional `toJsonSchema` coercion escape hatch
 
-`@arkenv/standard` gains an optional `toJsonSchema` config callback used as a **fallback** after built-in Standard JSON Schema probes fail for a key. This lets Valibot users wire `@valibot/to-json-schema` once and get ArkEnv pre-coercion for `v.number()` / `v.boolean()` without per-key wrappers.
+`@arkenv/standard` gains an optional `toJsonSchema` config callback used as a **fallback** when a key has no Standard JSON Schema on the value. This lets Valibot users wire `@valibot/to-json-schema` once and get ArkEnv pre-coercion for `v.number()` / `v.boolean()` without per-key wrappers.
 
 - Return a plain object to coerce that key; return `undefined` to skip only that key
 - Throwing or returning a non-plain object fails the parse with `ArkEnvError` (`INVALID_SCHEMA`) for that key
-- Zod and other Standard JSON Schema validators are unchanged (callback is not invoked when probes succeed)
+- Zod and other Standard JSON Schema validators are unchanged (callback is not invoked when JSON Schema is already on the value)
 - No new package dependencies on `@arkenv/standard`
 - Bundle size budget for `@arkenv/standard` raised from 3.6 kB to 3.7 kB for the callback path

--- a/.changeset/to-json-schema-escape-hatch.md
+++ b/.changeset/to-json-schema-escape-hatch.md
@@ -1,0 +1,13 @@
+---
+"@arkenv/standard": minor
+"@arkenv/core": minor
+---
+
+#### Add optional `toJsonSchema` coercion escape hatch
+
+`@arkenv/standard` gains an optional `toJsonSchema` config callback used as a **fallback** after built-in Standard JSON Schema probes fail for a key. This lets Valibot users wire `@valibot/to-json-schema` once and get ArkEnv pre-coercion for `v.number()` / `v.boolean()` without per-key wrappers.
+
+- Return a plain object to coerce that key; return `undefined` to skip only that key
+- Throwing or returning a non-plain object fails the parse with `ArkEnvError` (`INVALID_SCHEMA`) for that key
+- Zod and other Standard JSON Schema validators are unchanged (callback is not invoked when probes succeed)
+- No new package dependencies on `@arkenv/standard`

--- a/apps/www/content/docs/arkenv/coercion.mdx
+++ b/apps/www/content/docs/arkenv/coercion.mdx
@@ -129,9 +129,9 @@ export const env = arkenv(
 );
 ```
 
-- `target: "draft-07"` matches ArkEnv's built-in probes.
+- `target: "draft-07"` matches the JSON Schema draft ArkEnv expects.
 - `typeMode: "input"` coerces env strings toward the schema's input type. Do **not** pass a bare `{ toJsonSchema }` function reference — Valibot's default `typeMode` is `"ignore"`, which can silently mis-coerce piped schemas.
-- The callback runs **only** as a fallback after Standard JSON Schema probes fail for that key. Zod fields in a hybrid schema still coerce without it.
+- ArkEnv calls the callback when a key has no Standard JSON Schema on the value. Zod fields in a hybrid schema still coerce without it.
 - Install `@valibot/to-json-schema` yourself; `@arkenv/standard` does not depend on it.
 
 ## Performance

--- a/apps/www/content/docs/arkenv/coercion.mdx
+++ b/apps/www/content/docs/arkenv/coercion.mdx
@@ -6,13 +6,14 @@ description: Environment variables are auto-morphed into typesafe numbers, boole
 Traditionally, environment variables are always strings by default. ArkEnv **coerces** these strings into their target types based on your schema, so you only have to think about the types you want.
 
 :::note
-Coercion in [@arkenv/standard](/docs/arkenv/standard) only works with:
+Coercion in [@arkenv/standard](/docs/arkenv/standard) prefers validators that expose [Standard JSON Schema](https://standardschema.dev/json-schema) on the value itself:
 
 - [Zod](https://zod.dev) (v4.2+)
-- [Valibot](https://valibot.dev) (v1.2+ via `@valibot/to-json-schema`)
 - [Zod Mini](https://zod.dev/packages/mini)
 - [VineJS](https://vinejs.dev/) (v4.3.0+)
 - Any validator compliant with [Standard JSON Schema v1](https://standardschema.dev/json-schema#what-schema-libraries-support-this-spec)
+
+[Valibot](https://valibot.dev) (v1.2+) keeps JSON Schema conversion in [`@valibot/to-json-schema`](https://valibot.dev/guides/json-schema/) rather than on the schema. Wire ArkEnv's optional `toJsonSchema` escape hatch — see [Valibot](#valibot-tojsonschema).
   :::
 
 ## Numbers
@@ -102,10 +103,36 @@ Coercion works recursively: even variables inside a JSON object are coerced to t
 
 ArkEnv uses a unified pre-coercion model shared across both `@arkenv/core` and `@arkenv/standard`. When you call `arkenv()`:
 
-1. **Introspection**: ArkEnv extracts the JSON Schema of your defined schema. For `@arkenv/core` (ArkType), it introspects the schema (with a fallback to handle unjsonifiable parts of the schema like custom morphs or predicates). For `@arkenv/standard` (e.g., Zod, Valibot), it extracts JSON Schema using the validator's standard metadata.
+1. **Introspection**: ArkEnv extracts the JSON Schema of your defined schema. For `@arkenv/core` (ArkType), it introspects the schema (with a fallback to handle unjsonifiable parts of the schema like custom morphs or predicates). For `@arkenv/standard` (e.g., Zod), it extracts JSON Schema using the validator's standard metadata. When a key has no Standard JSON Schema on the value, an optional [`toJsonSchema`](#valibot-tojsonschema) callback can supply one.
 2. **Paths Identification**: It computes the exact paths requiring coercion (using `findCoercionPaths`) to identify target non-string types like numbers, booleans, arrays, or objects.
 3. **Pre-Coercion**: ArkEnv creates a shallow copy of the input environment object and applies coercion to it directly (using `applyCoercion`), preventing any mutation of the original `process.env`.
 4. **Validation**: Finally, the pre-coerced copy is passed to the original, unmodified schema for validation.
+
+## Valibot (`toJsonSchema`)
+
+Valibot implements Standard Schema validation but intentionally does **not** embed Standard JSON Schema on each schema value. Conversion lives in [`@valibot/to-json-schema`](https://valibot.dev/guides/json-schema/). Pass a `toJsonSchema` callback so ArkEnv can coerce env strings toward types like `v.number()` and `v.boolean()`:
+
+```ts
+import arkenv from "@arkenv/standard";
+import * as v from "valibot";
+import { toJsonSchema } from "@valibot/to-json-schema";
+
+export const env = arkenv(
+  { PORT: v.number(), DEBUG: v.boolean() },
+  {
+    toJsonSchema: (schema) =>
+      toJsonSchema(schema as v.GenericSchema, {
+        typeMode: "input",
+        target: "draft-07",
+      }),
+  },
+);
+```
+
+- `target: "draft-07"` matches ArkEnv's built-in probes.
+- `typeMode: "input"` coerces env strings toward the schema's input type. Do **not** pass a bare `{ toJsonSchema }` function reference — Valibot's default `typeMode` is `"ignore"`, which can silently mis-coerce piped schemas.
+- The callback runs **only** as a fallback after Standard JSON Schema probes fail for that key. Zod fields in a hybrid schema still coerce without it.
+- Install `@valibot/to-json-schema` yourself; `@arkenv/standard` does not depend on it.
 
 ## Performance
 

--- a/apps/www/content/docs/arkenv/coercion.mdx
+++ b/apps/www/content/docs/arkenv/coercion.mdx
@@ -14,7 +14,7 @@ Coercion in [@arkenv/standard](/docs/arkenv/standard) prefers validators that ex
 - Any validator compliant with [Standard JSON Schema v1](https://standardschema.dev/json-schema#what-schema-libraries-support-this-spec)
 
 [Valibot](https://valibot.dev) (v1.2+) keeps JSON Schema conversion in [`@valibot/to-json-schema`](https://valibot.dev/guides/json-schema/) rather than on the schema. Wire ArkEnv's optional `toJsonSchema` escape hatch — see [Valibot](#valibot-tojsonschema).
-  :::
+:::
 
 ## Numbers
 

--- a/apps/www/content/docs/arkenv/coercion.mdx
+++ b/apps/www/content/docs/arkenv/coercion.mdx
@@ -120,7 +120,7 @@ import { toJsonSchema } from "@valibot/to-json-schema";
 export const env = arkenv(
   { PORT: v.number(), DEBUG: v.boolean() },
   {
-    toJsonSchema: (schema) =>
+    toJsonSchema: (schema: unknown) =>
       toJsonSchema(schema as v.GenericSchema, {
         typeMode: "input",
         target: "draft-07",

--- a/apps/www/content/docs/arkenv/options.mdx
+++ b/apps/www/content/docs/arkenv/options.mdx
@@ -6,7 +6,7 @@ description: Configuration options for the arkenv() function.
 The second argument to `arkenv()` is an optional configuration object.
 
 :::note
-All options listed below apply to both `@arkenv/core` (ArkType mode) and `@arkenv/standard` (Standard Schema mode).
+Most options listed below apply to both `@arkenv/core` (ArkType mode) and `@arkenv/standard` (Standard Schema mode). `toJsonSchema` is **standard-mode only** — see [Coercion → Valibot](/docs/arkenv/coercion#valibot-tojsonschema).
 :::
 
 ## Configuration options
@@ -80,6 +80,12 @@ const env = arkenv(
 // env.PORT  → 3000 (default applied)
 // env.DEBUG → false (default applied)
 ```
+
+### `toJsonSchema` (standard mode only)
+
+When a Standard Schema validator does not expose JSON Schema on the value (notably Valibot), pass a fallback converter. See [Coercion → Valibot](/docs/arkenv/coercion#valibot-tojsonschema) for the full wiring example.
+
+This option does **not** apply to `@arkenv/core` / ArkType `ArkEnvConfig`.
 
 ## `safe`
 

--- a/apps/www/content/docs/arkenv/standard.mdx
+++ b/apps/www/content/docs/arkenv/standard.mdx
@@ -22,7 +22,7 @@ Already using ArkType? You can still use Zod, Valibot, and other Standard Schema
 
 ¹ ArkEnv extends ArkType with custom keywords like `string.host` and `number.port` - see [keywords](/docs/arkenv/keywords)
 
-² Only works with Standard JSON Schema validators like Zod 4, Zod Mini and Valibot - see [Coercion](/docs/arkenv/coercion)
+² Automatic coercion works with Standard JSON Schema validators like Zod 4 and Zod Mini. For Valibot, wire the optional `toJsonSchema` escape hatch — see [Coercion](/docs/arkenv/coercion#valibot-tojsonschema).
 
 ✅ Built-in / first-class support
 

--- a/examples/with-bun-react/package.json
+++ b/examples/with-bun-react/package.json
@@ -11,7 +11,7 @@
 		"clean": "rimraf dist node_modules"
 	},
 	"dependencies": {
-		"@arkenv/bun-plugin": "1.0.0-alpha.6",
+		"@arkenv/bun-plugin": "1.0.0-alpha.8",
 		"@arkenv/core": "1.0.0-alpha.4",
 		"arktype": "^2.2.0",
 		"react": "^19.2.5",

--- a/examples/with-nextjs-strict/package.json
+++ b/examples/with-nextjs-strict/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"@arkenv/core": "1.0.0-alpha.4",
-		"@arkenv/nextjs": "1.0.0-alpha.8",
+		"@arkenv/nextjs": "1.0.0-alpha.9",
 		"arktype": "^2.2.0",
 		"next": "^16.2.6",
 		"react": "^19.2.5",

--- a/examples/with-nextjs/package.json
+++ b/examples/with-nextjs/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"@arkenv/core": "1.0.0-alpha.4",
-		"@arkenv/nextjs": "1.0.0-alpha.8",
+		"@arkenv/nextjs": "1.0.0-alpha.9",
 		"arktype": "^2.2.0",
 		"next": "^16.2.6",
 		"react": "^19.2.5",

--- a/examples/with-nuxt-strict/package.json
+++ b/examples/with-nuxt-strict/package.json
@@ -11,7 +11,7 @@
 	},
 	"dependencies": {
 		"@arkenv/core": "1.0.0-alpha.4",
-		"@arkenv/nuxt": "1.0.0-alpha.9",
+		"@arkenv/nuxt": "1.0.0-alpha.11",
 		"arktype": "^2.2.0",
 		"nuxt": "^4.4.8"
 	},

--- a/examples/with-nuxt/package.json
+++ b/examples/with-nuxt/package.json
@@ -11,7 +11,7 @@
 	},
 	"dependencies": {
 		"@arkenv/core": "1.0.0-alpha.4",
-		"@arkenv/nuxt": "1.0.0-alpha.9",
+		"@arkenv/nuxt": "1.0.0-alpha.11",
 		"arktype": "^2.2.0",
 		"nuxt": "^4.4.8"
 	},

--- a/examples/with-solid-start/package.json
+++ b/examples/with-solid-start/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"@arkenv/core": "1.0.0-alpha.4",
-		"@arkenv/vite-plugin": "1.0.0-alpha.6",
+		"@arkenv/vite-plugin": "1.0.0-alpha.8",
 		"@solidjs/start": "1.3.2",
 		"arktype": "^2.2.0",
 		"solid-js": "1.9.12",

--- a/examples/with-valibot/.env.example
+++ b/examples/with-valibot/.env.example
@@ -1,0 +1,4 @@
+HOST=localhost
+PORT=3000
+TEST_VALUE=https://example.com
+DEBUG=true

--- a/examples/with-valibot/README.md
+++ b/examples/with-valibot/README.md
@@ -2,12 +2,13 @@
 
 This example demonstrates how to use ArkEnv with [Valibot](https://valibot.dev/) for validation, without ArkType.
 
-Because Valibot implements the [Standard Schema](https://standardschema.dev/) specification, its schemas can be passed straight to ArkEnv via the `@arkenv/standard` package.
+Because Valibot implements the [Standard Schema](https://standardschema.dev/) specification, its schemas can be passed straight to ArkEnv via the `@arkenv/standard` package. Valibot keeps JSON Schema conversion in [`@valibot/to-json-schema`](https://valibot.dev/guides/json-schema/) rather than on the schema itself, so this example wires ArkEnv's optional `toJsonSchema` escape hatch for automatic coercion.
 
 ## What's inside?
 
 - Pure Valibot usage via `@arkenv/standard` (no ArkType dependency)
-- A minimal schema validating a URL, a coerced number, and a hostname
+- ArkEnv coercion for `v.number()` / `v.boolean()` via `toJsonSchema` + `@valibot/to-json-schema`
+- A minimal schema validating a URL, a port number, a hostname, and a boolean
 - Full TypeScript type inference for the validated environment
 
 ## Getting started
@@ -30,6 +31,7 @@ Make sure you have [Node.js](https://nodejs.org) installed. We recommend using [
    HOST=localhost
    PORT=3000
    TEST_VALUE=https://example.com
+   DEBUG=true
    ```
 
 3. #### Start the development server with hot reloading enabled
@@ -43,8 +45,9 @@ Make sure you have [Node.js](https://nodejs.org) installed. We recommend using [
 ## Environment Variables
 
 - `TEST_VALUE` - A URL (validated by Valibot)
-- `PORT` - A port number (coerced from string to number)
+- `PORT` - A port number (coerced from string to number via ArkEnv)
 - `HOST` - `localhost` or a hostname
+- `DEBUG` - A boolean (coerced from `"true"` / `"false"` via ArkEnv)
 
 ## Next steps
 

--- a/examples/with-valibot/package.json
+++ b/examples/with-valibot/package.json
@@ -18,7 +18,7 @@
 	},
 	"dependencies": {
 		"@arkenv/standard": "^1.0.0-alpha.2",
-		"@valibot/to-json-schema": "^1.3.0",
+		"@valibot/to-json-schema": "^1.6.0",
 		"valibot": "^1.3.1"
 	},
 	"engines": {

--- a/examples/with-valibot/package.json
+++ b/examples/with-valibot/package.json
@@ -18,6 +18,7 @@
 	},
 	"dependencies": {
 		"@arkenv/standard": "^1.0.0-alpha.2",
+		"@valibot/to-json-schema": "^1.3.0",
 		"valibot": "^1.3.1"
 	},
 	"engines": {

--- a/examples/with-valibot/src/index.ts
+++ b/examples/with-valibot/src/index.ts
@@ -13,7 +13,7 @@ const env = arkenv(
 		DEBUG: v.boolean(),
 	},
 	{
-		toJsonSchema: (schema) =>
+		toJsonSchema: (schema: unknown) =>
 			toJsonSchema(schema as v.GenericSchema, {
 				typeMode: "input",
 				target: "draft-07",

--- a/examples/with-valibot/src/index.ts
+++ b/examples/with-valibot/src/index.ts
@@ -8,7 +8,7 @@ const env = arkenv(
 		PORT: v.number(),
 		HOST: v.union([
 			v.literal("localhost"),
-			v.pipe(v.string(), v.regex(/^[a-z0-9.-]+$/i)),
+			v.pipe(v.string(), v.regex(/^[a-zA-Z0-9.-]+$/)),
 		]),
 		DEBUG: v.boolean(),
 	},

--- a/examples/with-valibot/src/index.ts
+++ b/examples/with-valibot/src/index.ts
@@ -1,14 +1,25 @@
 import arkenv from "@arkenv/standard";
+import { toJsonSchema } from "@valibot/to-json-schema";
 import * as v from "valibot";
 
-const env = arkenv({
-	TEST_VALUE: v.pipe(v.string(), v.url()),
-	PORT: v.pipe(v.string(), v.transform(Number), v.number()),
-	HOST: v.union([
-		v.literal("localhost"),
-		v.pipe(v.string(), v.regex(/^[a-z0-9.-]+$/i)),
-	]),
-});
+const env = arkenv(
+	{
+		TEST_VALUE: v.pipe(v.string(), v.url()),
+		PORT: v.number(),
+		HOST: v.union([
+			v.literal("localhost"),
+			v.pipe(v.string(), v.regex(/^[a-z0-9.-]+$/i)),
+		]),
+		DEBUG: v.boolean(),
+	},
+	{
+		toJsonSchema: (schema) =>
+			toJsonSchema(schema as v.GenericSchema, {
+				typeMode: "input",
+				target: "draft-07",
+			}),
+	},
+);
 
 console.log(`Value: ${String(env.TEST_VALUE)}`);
 console.log(`Type: ${typeof env.TEST_VALUE}`);

--- a/examples/with-vite-react/package.json
+++ b/examples/with-vite-react/package.json
@@ -12,7 +12,7 @@
 	},
 	"dependencies": {
 		"@arkenv/core": "1.0.0-alpha.4",
-		"@arkenv/vite-plugin": "1.0.0-alpha.6",
+		"@arkenv/vite-plugin": "1.0.0-alpha.8",
 		"arktype": "^2.2.0",
 		"react": "^19.2.5",
 		"react-dom": "^19.2.5"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,13 +62,11 @@
 		"@size-limit/esbuild-why": "catalog:",
 		"@size-limit/preset-small-lib": "catalog:",
 		"@types/node": "catalog:",
-		"@valibot/to-json-schema": "1.6.0",
 		"arktype": "catalog:",
 		"rimraf": "catalog:",
 		"size-limit": "catalog:",
 		"tsdown": "catalog:",
 		"typescript": "catalog:",
-		"valibot": "catalog:",
 		"vitest": "catalog:",
 		"zod": "catalog:"
 	},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,7 @@
 		"@size-limit/esbuild-why": "catalog:",
 		"@size-limit/preset-small-lib": "catalog:",
 		"@types/node": "catalog:",
-		"@valibot/to-json-schema": "1.3.0",
+		"@valibot/to-json-schema": "1.6.0",
 		"arktype": "catalog:",
 		"rimraf": "catalog:",
 		"size-limit": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,11 +62,13 @@
 		"@size-limit/esbuild-why": "catalog:",
 		"@size-limit/preset-small-lib": "catalog:",
 		"@types/node": "catalog:",
+		"@valibot/to-json-schema": "1.3.0",
 		"arktype": "catalog:",
 		"rimraf": "catalog:",
 		"size-limit": "catalog:",
 		"tsdown": "catalog:",
 		"typescript": "catalog:",
+		"valibot": "catalog:",
 		"vitest": "catalog:",
 		"zod": "catalog:"
 	},

--- a/packages/core/src/standard-mode.test.ts
+++ b/packages/core/src/standard-mode.test.ts
@@ -301,6 +301,271 @@ describe("Standard Mode Coercion", () => {
 	});
 });
 
+describe("Standard Mode toJsonSchema", () => {
+	const createMockWithoutJsonSchema = <TOutput>(
+		validate: (value: unknown) =>
+			| { value: TOutput }
+			| { issues: { message: string }[] },
+	) => ({
+		"~standard": {
+			version: 1 as const,
+			vendor: "mock",
+			types: {} as { input: unknown; output: TOutput },
+			validate,
+		},
+	});
+
+	it("coerces via toJsonSchema when built-in probes miss", () => {
+		vi.stubEnv("PORT", "3000");
+		vi.stubEnv("DEBUG", "true");
+
+		const portSchema = createMockWithoutJsonSchema((value) =>
+			typeof value === "number"
+				? { value }
+				: {
+						issues: [{ message: `Expected number, received ${typeof value}` }],
+					},
+		);
+		const debugSchema = createMockWithoutJsonSchema((value) =>
+			typeof value === "boolean"
+				? { value }
+				: {
+						issues: [
+							{ message: `Expected boolean, received ${typeof value}` },
+						],
+					},
+		);
+
+		const env = arkenv(
+			{
+				PORT: portSchema,
+				DEBUG: debugSchema,
+			},
+			{
+				toJsonSchema: (schema) => {
+					if (schema === portSchema) return { type: "number" };
+					if (schema === debugSchema) return { type: "boolean" };
+					return undefined;
+				},
+			},
+		);
+
+		expect(env.PORT).toBe(3000);
+		expect(env.DEBUG).toBe(true);
+	});
+
+	it("coerces Valibot number/boolean fields via toJsonSchema", async () => {
+		const v = await import("valibot");
+		const { toJsonSchema } = await import("@valibot/to-json-schema");
+
+		vi.stubEnv("PORT", "3000");
+		vi.stubEnv("DEBUG", "true");
+
+		const env = arkenv(
+			{
+				PORT: v.number(),
+				DEBUG: v.boolean(),
+			},
+			{
+				toJsonSchema: (schema) =>
+					toJsonSchema(schema as v.GenericSchema, {
+						typeMode: "input",
+						target: "draft-07",
+					}),
+			},
+		);
+
+		expect(env.PORT).toBe(3000);
+		expect(env.DEBUG).toBe(true);
+	});
+
+	it("coerces hybrid Zod + Valibot schemas when toJsonSchema is provided", async () => {
+		const { z } = await import("zod");
+		const v = await import("valibot");
+		const { toJsonSchema } = await import("@valibot/to-json-schema");
+
+		vi.stubEnv("ZOD_PORT", "8080");
+		vi.stubEnv("VALIBOT_DEBUG", "false");
+
+		const env = arkenv(
+			{
+				ZOD_PORT: z.number(),
+				VALIBOT_DEBUG: v.boolean(),
+			},
+			{
+				toJsonSchema: (schema) =>
+					toJsonSchema(schema as v.GenericSchema, {
+						typeMode: "input",
+						target: "draft-07",
+					}),
+			},
+		);
+
+		expect(env.ZOD_PORT).toBe(8080);
+		expect(env.VALIBOT_DEBUG).toBe(false);
+	});
+
+	it("does not invoke toJsonSchema for keys with Standard JSON Schema", () => {
+		vi.stubEnv("NUMBER_VAR", "42");
+		const toJsonSchema = vi.fn(() => ({ type: "number" }));
+
+		const env = arkenv(
+			{
+				NUMBER_VAR: createMockStandardJSONSchema(42, { type: "number" }),
+			},
+			{ toJsonSchema },
+		);
+
+		expect(env.NUMBER_VAR).toBe(42);
+		expect(toJsonSchema).not.toHaveBeenCalled();
+	});
+
+	it("does not invoke toJsonSchema when coerce is false", () => {
+		vi.stubEnv("NUMBER_VAR", "42");
+		const toJsonSchema = vi.fn(() => ({ type: "number" }));
+
+		expect(() =>
+			arkenv(
+				{
+					NUMBER_VAR: createMockWithoutJsonSchema((value) =>
+						typeof value === "number"
+							? { value }
+							: {
+									issues: [
+										{ message: `Expected number, received ${typeof value}` },
+									],
+								},
+					),
+				},
+				{ coerce: false, toJsonSchema },
+			),
+		).toThrow(/Expected number, received string/);
+
+		expect(toJsonSchema).not.toHaveBeenCalled();
+	});
+
+	it("leaves behavior unchanged when toJsonSchema is omitted", () => {
+		vi.stubEnv("NUMBER_VAR", "42");
+
+		expect(() =>
+			arkenv({
+				NUMBER_VAR: createMockWithoutJsonSchema(() => ({
+					issues: [{ message: "Expected number, received string" }],
+				})),
+			}),
+		).toThrow(
+			/Hint: coercion is enabled by default, but the validator for 'NUMBER_VAR' lacks Standard JSON Schema support/,
+		);
+	});
+
+	it("throws ArkEnvError when toJsonSchema throws for a key", () => {
+		vi.stubEnv("BAD_VAR", "1");
+
+		try {
+			arkenv(
+				{
+					BAD_VAR: createMockWithoutJsonSchema((value) => ({
+						value: value as number,
+					})),
+				},
+				{
+					toJsonSchema: () => {
+						throw new Error("converter exploded");
+					},
+				},
+			);
+			expect.fail("Should throw");
+		} catch (error: any) {
+			expect(error).toBeInstanceOf(ArkEnvError);
+			expect(error.issues[0].path).toBe("BAD_VAR");
+			expect(error.issues[0].code).toBe("INVALID_SCHEMA");
+			expect(error.issues[0].message).toContain("toJsonSchema failed");
+			expect(error.issues[0].message).toContain("converter exploded");
+		}
+	});
+
+	it("skips only the key when toJsonSchema returns undefined", () => {
+		const skipSchema = createMockWithoutJsonSchema((value) =>
+			typeof value === "number"
+				? { value }
+				: {
+						issues: [{ message: `Expected number, received ${typeof value}` }],
+					},
+		);
+		const coerceSchema = createMockWithoutJsonSchema((value) =>
+			typeof value === "boolean"
+				? { value }
+				: {
+						issues: [
+							{ message: `Expected boolean, received ${typeof value}` },
+						],
+					},
+		);
+		const passThroughSchema = createMockWithoutJsonSchema(
+			(value) => ({ value: value as string }),
+		);
+
+		expect(() =>
+			arkenv(
+				{
+					SKIP_VAR: skipSchema,
+					COERCE_VAR: coerceSchema,
+				},
+				{
+					env: { SKIP_VAR: "42", COERCE_VAR: "true" },
+					toJsonSchema: (schema) => {
+						if (schema === skipSchema) return undefined;
+						return { type: "boolean" };
+					},
+				},
+			),
+		).toThrow(
+			/Hint: coercion is enabled by default, but the validator for 'SKIP_VAR' lacks Standard JSON Schema support/,
+		);
+
+		const env = arkenv(
+			{
+				COERCE_VAR: coerceSchema,
+				PASS_VAR: passThroughSchema,
+			},
+			{
+				env: { COERCE_VAR: "true", PASS_VAR: "hello" },
+				toJsonSchema: (schema) => {
+					if (schema === passThroughSchema) return undefined;
+					return { type: "boolean" };
+				},
+			},
+		);
+		expect(env.COERCE_VAR).toBe(true);
+		expect(env.PASS_VAR).toBe("hello");
+	});
+
+	it("throws ArkEnvError when toJsonSchema returns a non-plain object", () => {
+		vi.stubEnv("DATE_SCHEMA", "1");
+
+		for (const bad of [new Date(), ["array"], () => ({})]) {
+			try {
+				arkenv(
+					{
+						DATE_SCHEMA: createMockWithoutJsonSchema((value) => ({
+							value: value as number,
+						})),
+					},
+					{
+						toJsonSchema: () => bad as object,
+					},
+				);
+				expect.fail(`Should throw for ${Object.prototype.toString.call(bad)}`);
+			} catch (error: any) {
+				expect(error).toBeInstanceOf(ArkEnvError);
+				expect(error.issues[0].path).toBe("DATE_SCHEMA");
+				expect(error.issues[0].code).toBe("INVALID_SCHEMA");
+				expect(error.issues[0].message).toMatch(/plain object/);
+			}
+		}
+	});
+});
+
 describe("Standard Mode emptyAsUndefined", () => {
 	it("should treat empty strings as undefined when enabled", () => {
 		vi.stubEnv("STRING_VAR", "");

--- a/packages/core/src/standard-mode.test.ts
+++ b/packages/core/src/standard-mode.test.ts
@@ -303,9 +303,9 @@ describe("Standard Mode Coercion", () => {
 
 describe("Standard Mode toJsonSchema", () => {
 	const createMockWithoutJsonSchema = <TOutput>(
-		validate: (value: unknown) =>
-			| { value: TOutput }
-			| { issues: { message: string }[] },
+		validate: (
+			value: unknown,
+		) => { value: TOutput } | { issues: { message: string }[] },
 	) => ({
 		"~standard": {
 			version: 1 as const,
@@ -330,9 +330,7 @@ describe("Standard Mode toJsonSchema", () => {
 			typeof value === "boolean"
 				? { value }
 				: {
-						issues: [
-							{ message: `Expected boolean, received ${typeof value}` },
-						],
+						issues: [{ message: `Expected boolean, received ${typeof value}` }],
 					},
 		);
 
@@ -496,14 +494,12 @@ describe("Standard Mode toJsonSchema", () => {
 			typeof value === "boolean"
 				? { value }
 				: {
-						issues: [
-							{ message: `Expected boolean, received ${typeof value}` },
-						],
+						issues: [{ message: `Expected boolean, received ${typeof value}` }],
 					},
 		);
-		const passThroughSchema = createMockWithoutJsonSchema(
-			(value) => ({ value: value as string }),
-		);
+		const passThroughSchema = createMockWithoutJsonSchema((value) => ({
+			value: value as string,
+		}));
 
 		expect(() =>
 			arkenv(

--- a/packages/core/src/standard-mode.test.ts
+++ b/packages/core/src/standard-mode.test.ts
@@ -1,5 +1,9 @@
 import { ArkEnvError, arkenv } from "@arkenv/standard";
+import { toJsonSchema } from "@valibot/to-json-schema";
+import type { GenericSchema } from "valibot";
+import * as v from "valibot";
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import { z } from "zod";
 
 // Mock Standard Schema validators for testing
 const createMockStandardSchema = <TOutput>(outputValue: TOutput) => ({
@@ -352,10 +356,7 @@ describe("Standard Mode toJsonSchema", () => {
 		expect(env.DEBUG).toBe(true);
 	});
 
-	it("coerces Valibot number/boolean fields via toJsonSchema", async () => {
-		const v = await import("valibot");
-		const { toJsonSchema } = await import("@valibot/to-json-schema");
-
+	it("coerces Valibot number/boolean fields via toJsonSchema", () => {
 		vi.stubEnv("PORT", "3000");
 		vi.stubEnv("DEBUG", "true");
 
@@ -366,7 +367,7 @@ describe("Standard Mode toJsonSchema", () => {
 			},
 			{
 				toJsonSchema: (schema) =>
-					toJsonSchema(schema as v.GenericSchema, {
+					toJsonSchema(schema as GenericSchema, {
 						typeMode: "input",
 						target: "draft-07",
 					}),
@@ -377,11 +378,7 @@ describe("Standard Mode toJsonSchema", () => {
 		expect(env.DEBUG).toBe(true);
 	});
 
-	it("coerces hybrid Zod + Valibot schemas when toJsonSchema is provided", async () => {
-		const { z } = await import("zod");
-		const v = await import("valibot");
-		const { toJsonSchema } = await import("@valibot/to-json-schema");
-
+	it("coerces hybrid Zod + Valibot schemas when toJsonSchema is provided", () => {
 		vi.stubEnv("ZOD_PORT", "8080");
 		vi.stubEnv("VALIBOT_DEBUG", "false");
 
@@ -392,7 +389,7 @@ describe("Standard Mode toJsonSchema", () => {
 			},
 			{
 				toJsonSchema: (schema) =>
-					toJsonSchema(schema as v.GenericSchema, {
+					toJsonSchema(schema as GenericSchema, {
 						typeMode: "input",
 						target: "draft-07",
 					}),

--- a/packages/internal/utils/src/parse-standard.ts
+++ b/packages/internal/utils/src/parse-standard.ts
@@ -63,13 +63,46 @@ export type ParseStandardConfig = {
 
 	/**
 	 * Whether to perform best-effort coercion on the environment variables.
-	 * Coercion requires validators that implement the StandardJSONSchemaV1 spec
-	 * (e.g. Zod, Valibot).
+	 * Coercion prefers validators that expose Standard JSON Schema on the value
+	 * itself (e.g. Zod). For converters that live outside the schema (e.g. Valibot
+	 * via `@valibot/to-json-schema`), pass {@link toJsonSchema}.
 	 *
 	 * @see https://standard-schema.dev
 	 * @default true
 	 */
 	coerce?: boolean;
+
+	/**
+	 * Optional fallback that converts a Standard Schema validator to JSON Schema
+	 * for ArkEnv pre-coercion when built-in Standard JSON Schema probes fail for
+	 * that key.
+	 *
+	 * Invoked per key only after probes miss. Not called when omitted, when
+	 * `coerce` is `false`, or when a built-in probe already produced a schema.
+	 *
+	 * - Return a plain object to use as that key's JSON Schema.
+	 * - Return `undefined` to skip coercion for that key only.
+	 * - Throwing or returning a non-plain object fails the parse with
+	 *   {@link ArkEnvError} for that key (`INVALID_SCHEMA`).
+	 *
+	 * @example Valibot wiring
+	 * ```ts
+	 * import { toJsonSchema } from "@valibot/to-json-schema";
+	 * import * as v from "valibot";
+	 *
+	 * arkenv(
+	 *   { PORT: v.number() },
+	 *   {
+	 *     toJsonSchema: (schema) =>
+	 *       toJsonSchema(schema as v.GenericSchema, {
+	 *         typeMode: "input",
+	 *         target: "draft-07",
+	 *       }),
+	 *   },
+	 * );
+	 * ```
+	 */
+	toJsonSchema?: (schema: StandardSchemaV1) => object | undefined;
 
 	/**
 	 * The format to use for array parsing when coercion is enabled.
@@ -120,6 +153,7 @@ export function parseStandard(
 		coerce = true,
 		arrayFormat = "comma",
 		emptyAsUndefined = false,
+		toJsonSchema,
 	} = config;
 	const output: Record<string, unknown> = {};
 	const errors: EnvIssue[] = [];
@@ -135,7 +169,7 @@ export function parseStandard(
 		coerce
 			? () => {
 					const { jsonSchema, hasJsonSchema, missingKeys } =
-						extractJsonSchema(def);
+						extractJsonSchema(def, toJsonSchema);
 					return {
 						schema: jsonSchema,
 						hasSchema: hasJsonSchema,

--- a/packages/internal/utils/src/parse-standard.ts
+++ b/packages/internal/utils/src/parse-standard.ts
@@ -92,7 +92,7 @@ export type ParseStandardConfig = {
 	 * arkenv(
 	 *   { PORT: v.number() },
 	 *   {
-	 *     toJsonSchema: (schema) =>
+	 *     toJsonSchema: (schema: unknown) =>
 	 *       toJsonSchema(schema as v.GenericSchema, {
 	 *         typeMode: "input",
 	 *         target: "draft-07",

--- a/packages/internal/utils/src/parse-standard.ts
+++ b/packages/internal/utils/src/parse-standard.ts
@@ -168,8 +168,10 @@ export function parseStandard(
 		arrayFormat,
 		coerce
 			? () => {
-					const { jsonSchema, hasJsonSchema, missingKeys } =
-						extractJsonSchema(def, toJsonSchema);
+					const { jsonSchema, hasJsonSchema, missingKeys } = extractJsonSchema(
+						def,
+						toJsonSchema,
+					);
 					return {
 						schema: jsonSchema,
 						hasSchema: hasJsonSchema,

--- a/packages/internal/utils/src/parse-standard.ts
+++ b/packages/internal/utils/src/parse-standard.ts
@@ -74,11 +74,10 @@ export type ParseStandardConfig = {
 
 	/**
 	 * Optional fallback that converts a Standard Schema validator to JSON Schema
-	 * for ArkEnv pre-coercion when built-in Standard JSON Schema probes fail for
-	 * that key.
+	 * for ArkEnv pre-coercion when a key has no Standard JSON Schema on the value.
 	 *
-	 * Invoked per key only after probes miss. Not called when omitted, when
-	 * `coerce` is `false`, or when a built-in probe already produced a schema.
+	 * Called per key only in that case. Not called when omitted, when `coerce` is
+	 * `false`, or when JSON Schema was already read from the value.
 	 *
 	 * - Return a plain object to use as that key's JSON Schema.
 	 * - Return `undefined` to skip coercion for that key only.

--- a/packages/internal/utils/src/utils/standard-helpers.ts
+++ b/packages/internal/utils/src/utils/standard-helpers.ts
@@ -94,8 +94,7 @@ export function extractJsonSchema(
 			try {
 				converted = toJsonSchema(validator as StandardSchemaV1);
 			} catch (error) {
-				const detail =
-					error instanceof Error ? error.message : String(error);
+				const detail = error instanceof Error ? error.message : String(error);
 				throw new ArkEnvError([
 					buildEnvIssue(
 						key,

--- a/packages/internal/utils/src/utils/standard-helpers.ts
+++ b/packages/internal/utils/src/utils/standard-helpers.ts
@@ -15,7 +15,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * Extract JSON Schema definitions from standard schema validators.
  *
  * @param def The schema dictionary mapping keys to validators
- * @param toJsonSchema Optional fallback converter when built-in Standard JSON Schema probes fail
+ * @param toJsonSchema Optional fallback converter when a key has no Standard JSON Schema on the value
  * @returns The generated JSON Schema, a flag indicating if any JSON Schema was found,
  *          and a list of keys that do not support JSON Schema
  * @throws {ArkEnvError} When `toJsonSchema` throws or returns a non-plain object for a key

--- a/packages/internal/utils/src/utils/standard-helpers.ts
+++ b/packages/internal/utils/src/utils/standard-helpers.ts
@@ -1,5 +1,5 @@
 import type { StandardSchemaV1 } from "@repo/types";
-import { ArkEnvError } from "../core";
+import { ArkEnvError } from "@/core";
 import { buildEnvIssue } from "./errors";
 
 /**

--- a/packages/internal/utils/src/utils/standard-helpers.ts
+++ b/packages/internal/utils/src/utils/standard-helpers.ts
@@ -1,11 +1,29 @@
+import type { StandardSchemaV1 } from "@repo/types";
+import { ArkEnvError } from "../core";
+import { buildEnvIssue } from "./errors";
+
+/**
+ * Whether `value` is a plain object (`{}` / Object.create(null) style).
+ * Rejects arrays, `Date`, functions, boxed primitives, etc.
+ * @internal
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return Object.prototype.toString.call(value) === "[object Object]";
+}
+
 /**
  * Extract JSON Schema definitions from standard schema validators.
  *
  * @param def The schema dictionary mapping keys to validators
+ * @param toJsonSchema Optional fallback converter when built-in Standard JSON Schema probes fail
  * @returns The generated JSON Schema, a flag indicating if any JSON Schema was found,
  *          and a list of keys that do not support JSON Schema
+ * @throws {ArkEnvError} When `toJsonSchema` throws or returns a non-plain object for a key
  */
-export function extractJsonSchema(def: Record<string, unknown>): {
+export function extractJsonSchema(
+	def: Record<string, unknown>,
+	toJsonSchema?: (schema: StandardSchemaV1) => object | undefined,
+): {
 	jsonSchema: Record<string, any>;
 	hasJsonSchema: boolean;
 	missingKeys: string[];
@@ -68,6 +86,44 @@ export function extractJsonSchema(def: Record<string, unknown>): {
 					continue;
 				}
 			} catch {}
+		}
+
+		// 5. Optional user-supplied converter (e.g. Valibot via @valibot/to-json-schema)
+		if (toJsonSchema) {
+			let converted: object | undefined;
+			try {
+				converted = toJsonSchema(validator as StandardSchemaV1);
+			} catch (error) {
+				const detail =
+					error instanceof Error ? error.message : String(error);
+				throw new ArkEnvError([
+					buildEnvIssue(
+						key,
+						`toJsonSchema failed for '${key}': ${detail}`,
+						"INVALID_SCHEMA",
+					),
+				]);
+			}
+
+			// undefined / falsy → skip this key only (siblings still coerce)
+			if (!converted) {
+				missingKeys.push(key);
+				continue;
+			}
+
+			if (!isPlainObject(converted)) {
+				throw new ArkEnvError([
+					buildEnvIssue(
+						key,
+						`toJsonSchema must return a plain object or undefined for '${key}'.`,
+						"INVALID_SCHEMA",
+					),
+				]);
+			}
+
+			jsonSchema.properties[key] = converted;
+			hasJsonSchema = true;
+			continue;
 		}
 
 		missingKeys.push(key);

--- a/packages/standard/package.json
+++ b/packages/standard/package.json
@@ -62,7 +62,7 @@
 		{
 			"name": "@arkenv/standard",
 			"path": "dist/index.js",
-			"limit": "3.6 kB",
+			"limit": "3.7 kB",
 			"import": "*"
 		}
 	]

--- a/packages/standard/package.json
+++ b/packages/standard/package.json
@@ -16,6 +16,8 @@
 	"scripts": {
 		"build": "tsdown",
 		"size": "size-limit --json > .size-limit.json",
+		"test": "vitest",
+		"test:once": "vitest run",
 		"typecheck": "tsc --noEmit",
 		"clean": "rimraf dist node_modules",
 		"fix": "pnpm -w run fix"
@@ -53,10 +55,14 @@
 		"@size-limit/esbuild-why": "catalog:",
 		"@size-limit/preset-small-lib": "catalog:",
 		"@types/node": "catalog:",
+		"@valibot/to-json-schema": "1.6.0",
 		"rimraf": "catalog:",
 		"size-limit": "catalog:",
 		"tsdown": "catalog:",
-		"typescript": "catalog:"
+		"typescript": "catalog:",
+		"valibot": "catalog:",
+		"vitest": "catalog:",
+		"zod": "catalog:"
 	},
 	"size-limit": [
 		{

--- a/packages/standard/src/standard-mode.test.ts
+++ b/packages/standard/src/standard-mode.test.ts
@@ -319,7 +319,7 @@ describe("Standard Mode toJsonSchema", () => {
 		},
 	});
 
-	it("coerces via toJsonSchema when built-in probes miss", () => {
+	it("coerces via toJsonSchema when the value has no JSON Schema", () => {
 		vi.stubEnv("PORT", "3000");
 		vi.stubEnv("DEBUG", "true");
 

--- a/packages/standard/src/standard-mode.test.ts
+++ b/packages/standard/src/standard-mode.test.ts
@@ -1,9 +1,9 @@
-import { ArkEnvError, arkenv } from "@arkenv/standard";
 import { toJsonSchema } from "@valibot/to-json-schema";
 import type { GenericSchema } from "valibot";
 import * as v from "valibot";
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { z } from "zod";
+import { ArkEnvError, arkenv } from "./index";
 
 // Mock Standard Schema validators for testing
 const createMockStandardSchema = <TOutput>(outputValue: TOutput) => ({

--- a/packages/standard/vitest.config.ts
+++ b/packages/standard/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+	test: {
+		name: "@arkenv/standard",
+		include: ["**/*.{test,spec,test-d}.?(c|m)[jt]s?(x)"],
+		unstubEnvs: true,
+		restoreMocks: true,
+		unstubGlobals: true,
+	},
+	resolve: {
+		tsconfigPaths: true,
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -969,6 +969,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
+      '@valibot/to-json-schema':
+        specifier: 1.3.0
+        version: 1.3.0(valibot@1.3.1(typescript@6.0.3))
       arktype:
         specifier: 'catalog:'
         version: 2.2.0
@@ -984,6 +987,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      valibot:
+        specifier: 'catalog:'
+        version: 1.3.1(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -1002,7 +1008,7 @@ importers:
     devDependencies:
       '@fumadocs/ui':
         specifier: 16.5.0
-        version: 16.5.0(@types/react@19.2.14)(fumadocs-core@16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)
+        version: 16.5.0(@types/react@19.2.14)(fumadocs-core@16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)
       '@radix-ui/react-collapsible':
         specifier: 1.1.12
         version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1017,10 +1023,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       fumadocs-core:
         specifier: 16.8.7
-        version: 16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
+        version: 16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
       fumadocs-ui:
         specifier: 16.8.7
-        version: 16.8.7(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)
+        version: 16.8.7(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)
       lucide-react:
         specifier: 1.14.0
         version: 1.14.0(react@19.2.5)
@@ -5906,6 +5912,11 @@ packages:
     resolution: {integrity: sha512-SSByXfEjhzPn8gXdEdgpYqpLMPSkLUH2HVE0GxZfOtNsJ0GgOHQs0g9T67ZZ1z0kTELLKdtOtYrzrbv9+ffF7g==}
     peerDependencies:
       vue: '>=3.5.18'
+
+  '@valibot/to-json-schema@1.3.0':
+    resolution: {integrity: sha512-82Vv6x7sOYhv5YmTRgSppSqj1nn2pMCk5BqCMGWYp0V/fq+qirrbGncqZAtZ09/lrO40ne/7z8ejwE728aVreg==}
+    peerDependencies:
+      valibot: ^1.1.0
 
   '@vercel/analytics@2.0.1':
     resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
@@ -12723,9 +12734,9 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
 
-  '@fumadocs/ui@16.5.0(@types/react@19.2.14)(fumadocs-core@16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)':
+  '@fumadocs/ui@16.5.0(@types/react@19.2.14)(fumadocs-core@16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)':
     dependencies:
-      fumadocs-core: 16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
+      fumadocs-core: 16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
       next-themes: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       postcss-selector-parser: 7.1.1
       react: 19.2.5
@@ -16515,6 +16526,10 @@ snapshots:
       unhead: 2.1.15
       vue: 3.5.35(typescript@6.0.3)
 
+  '@valibot/to-json-schema@1.3.0(valibot@1.3.1(typescript@6.0.3))':
+    dependencies:
+      valibot: 1.3.1(typescript@6.0.3)
+
   '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@biomejs/biome@2.4.14)(@parcel/watcher@2.5.6)(@types/node@25.6.0)(@vercel/blob@2.3.3)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.2))(rollup@4.60.2)(terser@5.47.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))(yaml@2.9.0))(react@19.2.5)(vue-router@4.6.4(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -18420,7 +18435,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-core@16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3):
+  fumadocs-core@16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -18564,7 +18579,7 @@ snapshots:
       - '@types/react-dom'
       - tailwindcss
 
-  fumadocs-ui@16.8.7(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4):
+  fumadocs-ui@16.8.7(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4):
     dependencies:
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.2.4)(tailwindcss@4.2.4)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -18578,7 +18593,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
+      fumadocs-core: 16.8.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
       lucide-react: 1.14.0(react@19.2.5)
       motion: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -970,8 +970,8 @@ importers:
         specifier: 'catalog:'
         version: 24.12.2
       '@valibot/to-json-schema':
-        specifier: 1.3.0
-        version: 1.3.0(valibot@1.3.1(typescript@6.0.3))
+        specifier: 1.6.0
+        version: 1.6.0(valibot@1.3.1(typescript@6.0.3))
       arktype:
         specifier: 'catalog:'
         version: 2.2.0
@@ -5913,10 +5913,10 @@ packages:
     peerDependencies:
       vue: '>=3.5.18'
 
-  '@valibot/to-json-schema@1.3.0':
-    resolution: {integrity: sha512-82Vv6x7sOYhv5YmTRgSppSqj1nn2pMCk5BqCMGWYp0V/fq+qirrbGncqZAtZ09/lrO40ne/7z8ejwE728aVreg==}
+  '@valibot/to-json-schema@1.6.0':
+    resolution: {integrity: sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==}
     peerDependencies:
-      valibot: ^1.1.0
+      valibot: ^1.3.0
 
   '@vercel/analytics@2.0.1':
     resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
@@ -16526,7 +16526,7 @@ snapshots:
       unhead: 2.1.15
       vue: 3.5.35(typescript@6.0.3)
 
-  '@valibot/to-json-schema@1.3.0(valibot@1.3.1(typescript@6.0.3))':
+  '@valibot/to-json-schema@1.6.0(valibot@1.3.1(typescript@6.0.3))':
     dependencies:
       valibot: 1.3.1(typescript@6.0.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -969,9 +969,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
-      '@valibot/to-json-schema':
-        specifier: 1.6.0
-        version: 1.6.0(valibot@1.3.1(typescript@6.0.3))
       arktype:
         specifier: 'catalog:'
         version: 2.2.0
@@ -987,9 +984,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
-      valibot:
-        specifier: 'catalog:'
-        version: 1.3.1(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -1254,6 +1248,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
+      '@valibot/to-json-schema':
+        specifier: 1.6.0
+        version: 1.6.0(valibot@1.3.1(typescript@6.0.3))
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -1266,6 +1263,15 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      valibot:
+        specifier: 'catalog:'
+        version: 1.3.1(typescript@6.0.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.1
 
   packages/vite-plugin:
     dependencies:
@@ -23187,7 +23193,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
@@ -23218,7 +23224,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
@@ -23249,7 +23255,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the **runtime** half of #1564 on `v1`: optional `toJsonSchema` on `ParseStandardConfig` / `StandardEnvConfig` so Valibot (and similar) can supply JSON Schema for ArkEnv pre-coercion when Standard JSON Schema is not embedded on the schema value.

Companion docs PR (Guides → Validators on Simplify Docs): #1570.

## Changes

- Add `toJsonSchema?: (schema: StandardSchemaV1) => object | undefined` to `ParseStandardConfig`
- Call it **only as a fallback** after built-in Standard JSON Schema probes fail
- `undefined` / falsy → skip that key only; throw / non-plain object → `ArkEnvError` (`INVALID_SCHEMA`) for that key
- Internal plain-object check via `Object.prototype.toString.call === "[object Object]"`
- Tests: Valibot-via-callback, hybrid Zod+Valibot, throw, undefined skip, non-plain object, probe success / `coerce: false` / omitted option
- Update `examples/with-valibot` to use ArkEnv coercion + documented wrapper (`@valibot/to-json-schema@^1.6`); fix HOST regex for JSON Schema; add `.env.example`
- Interim v1 docs updates (Coercion / `@arkenv/standard` / Options)
- Minor changeset for `@arkenv/standard` (+ `@arkenv/core` via fixed group); size-limit 3.6 → 3.7 kB

## Test plan

- [x] `pnpm --filter @repo/utils build && pnpm --filter @arkenv/standard build`
- [x] `pnpm --filter @arkenv/standard size` (3646 / 3700)
- [x] `pnpm --filter @arkenv/core exec vitest run src/standard-mode.test.ts` (29 passed)
- [x] `pnpm run typecheck`
- [x] Local Valibot smoke with `toJsonSchema` + example schema

**Note:** `sync-examples` is already red on `v1` HEAD (unrelated playground/example `package.json` drift); this PR does not touch those synced examples (`with-valibot` is not playground-synced).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79071eb8-d629-42ff-a000-5c9f532d61dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79071eb8-d629-42ff-a000-5c9f532d61dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

