### PR TITLE
fix: (v1) Fix bad search UX on mobile for simplify-docs

### DIFF
--- a/.changeset/search-dialog-expanded-radius.md
+++ b/.changeset/search-dialog-expanded-radius.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/fumadocs-ui": patch
+---
+
+#### Keep search results readable when the mobile dialog expands
+
+Use a modest radius on the expanded search panel so `overflow-hidden` no longer clips result titles and excerpts into a pill mask. The input-only overlay still matches the Site Nav capsule.

--- a/.changeset/search-dialog-expanded-radius.md
+++ b/.changeset/search-dialog-expanded-radius.md
@@ -2,6 +2,6 @@
 "@arkenv/fumadocs-ui": patch
 ---
 
-#### Keep search results readable when the mobile dialog expands
+#### Keep search results readable when the dialog expands
 
 Use a modest radius on the expanded search panel so `overflow-hidden` no longer clips result titles and excerpts into a pill mask. The input-only overlay still matches the Site Nav capsule.

--- a/apps/playwright-www/tests/search-dialog.test.ts
+++ b/apps/playwright-www/tests/search-dialog.test.ts
@@ -38,12 +38,18 @@ test.describe("Docs search dialog", () => {
 
 		const titleHit = await result.evaluate((el) => {
 			const box = el.getBoundingClientRect();
-			const top = document.elementFromPoint(box.left + 12, box.top + box.height / 2);
-			return Boolean(top && (el === top || el.contains(top) || top.contains(el)));
+			const top = document.elementFromPoint(
+				box.left + 12,
+				box.top + box.height / 2,
+			);
+			return Boolean(
+				top && (el === top || el.contains(top) || top.contains(el)),
+			);
 		});
-		expect(titleHit, "result title should not be clipped by the dialog mask").toBe(
-			true,
-		);
+		expect(
+			titleHit,
+			"result title should not be clipped by the dialog mask",
+		).toBe(true);
 
 		await page.keyboard.press("Escape");
 		await expect(dialog).toBeHidden();

--- a/apps/playwright-www/tests/search-dialog.test.ts
+++ b/apps/playwright-www/tests/search-dialog.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Parse the first border-radius length from computed style (e.g. "20px").
+ *
+ * @param value Computed `border-radius` (possibly 1–4 lengths)
+ * @returns Pixel size of the first radius, or Infinity when unparseable
+ */
+function firstRadiusPx(value: string): number {
+	const token = value.trim().split(/\s+/)[0] ?? "";
+	const px = Number.parseFloat(token);
+	return Number.isFinite(px) ? px : Number.POSITIVE_INFINITY;
+}
+
+test.describe("Docs search dialog", () => {
+	test("mobile results are not pill-clipped", async ({ page }) => {
+		await page.setViewportSize({ width: 375, height: 667 });
+		await page.goto("/docs");
+
+		await page.getByRole("button", { name: "Open Search" }).click();
+		const dialog = page.getByRole("dialog");
+		await expect(dialog).toBeVisible();
+
+		const input = dialog.locator("input").first();
+		await expect(input).toBeFocused();
+		await input.fill("getting");
+
+		const result = dialog.getByText(/getting started/i).first();
+		await expect(result).toBeVisible();
+
+		const radius = await dialog.evaluate(
+			(el) => getComputedStyle(el).borderRadius,
+		);
+		expect(
+			firstRadiusPx(radius),
+			`expanded dialog should not use pill radius (got ${radius})`,
+		).toBeLessThan(40);
+
+		const titleHit = await result.evaluate((el) => {
+			const box = el.getBoundingClientRect();
+			const top = document.elementFromPoint(box.left + 12, box.top + box.height / 2);
+			return Boolean(top && (el === top || el.contains(top) || top.contains(el)));
+		});
+		expect(titleHit, "result title should not be clipped by the dialog mask").toBe(
+			true,
+		);
+
+		await page.keyboard.press("Escape");
+		await expect(dialog).toBeHidden();
+	});
+
+	test("desktop search still opens, lists results, and closes", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/docs");
+
+		await page.getByRole("button", { name: "Open Search" }).click();
+		const dialog = page.getByRole("dialog");
+		await expect(dialog).toBeVisible();
+
+		const input = dialog.locator("input").first();
+		await input.fill("getting");
+		await expect(dialog.getByText(/getting started/i).first()).toBeVisible();
+
+		await page.keyboard.press("Escape");
+		await expect(dialog).toBeHidden();
+	});
+});

--- a/apps/playwright-www/tests/search-dialog.test.ts
+++ b/apps/playwright-www/tests/search-dialog.test.ts
@@ -55,7 +55,7 @@ test.describe("Docs search dialog", () => {
 		await expect(dialog).toBeHidden();
 	});
 
-	test("desktop search still opens, lists results, and closes", async ({
+	test("desktop search lists results without pill-clipping and closes", async ({
 		page,
 	}) => {
 		await page.setViewportSize({ width: 1280, height: 800 });
@@ -68,6 +68,14 @@ test.describe("Docs search dialog", () => {
 		const input = dialog.locator("input").first();
 		await input.fill("getting");
 		await expect(dialog.getByText(/getting started/i).first()).toBeVisible();
+
+		const radius = await dialog.evaluate(
+			(el) => getComputedStyle(el).borderRadius,
+		);
+		expect(
+			firstRadiusPx(radius),
+			`expanded desktop dialog should not use pill radius (got ${radius})`,
+		).toBeLessThan(40);
 
 		await page.keyboard.press("Escape");
 		await expect(dialog).toBeHidden();

--- a/apps/www/components/search/arkenv-search-dialog.test.tsx
+++ b/apps/www/components/search/arkenv-search-dialog.test.tsx
@@ -74,17 +74,16 @@ describe("ArkenvSearchDialog", () => {
 		searchState.query = { isLoading: false, data: "empty" };
 	});
 
-	it("uses a capsule radius while the results list is collapsed", () => {
+	it("keeps the capsule class and collapsed list while the query is empty", () => {
 		render(<ArkenvSearchDialog open onOpenChange={vi.fn()} />);
 
 		const dialog = screen.getByRole("dialog");
 		expect(dialog).toHaveClass("arkenv-search-dialog");
 		expect(dialog).toHaveClass("rounded-full");
-		expect(dialog).not.toHaveClass("rounded-2xl");
 		expect(dialog.querySelector("[data-empty='true']")).toBeTruthy();
 	});
 
-	it("drops pill radius and shows result titles when matches are present", () => {
+	it("marks the list non-empty and shows result titles when matches are present", () => {
 		searchState.search = "getting";
 		searchState.query = {
 			isLoading: false,
@@ -101,21 +100,19 @@ describe("ArkenvSearchDialog", () => {
 
 		const dialog = screen.getByRole("dialog");
 		expect(dialog).toHaveClass("arkenv-search-dialog");
-		expect(dialog).toHaveClass("rounded-2xl");
-		expect(dialog).not.toHaveClass("rounded-full");
+		expect(dialog).toHaveClass("rounded-full");
 		expect(dialog.querySelector("[data-empty='false']")).toBeTruthy();
 		expect(screen.getByText("Getting started")).toBeInTheDocument();
 	});
 
-	it("keeps modest radius for an expanded empty-results panel", () => {
+	it("marks the list non-empty for an expanded no-match panel", () => {
 		searchState.search = "zzzz-no-match";
 		searchState.query = { isLoading: false, data: [] };
 
 		render(<ArkenvSearchDialog open onOpenChange={vi.fn()} />);
 
 		const dialog = screen.getByRole("dialog");
-		expect(dialog).toHaveClass("rounded-2xl");
-		expect(dialog).not.toHaveClass("rounded-full");
+		expect(dialog).toHaveClass("rounded-full");
 		expect(dialog.querySelector("[data-empty='false']")).toBeTruthy();
 	});
 });

--- a/apps/www/components/search/arkenv-search-dialog.test.tsx
+++ b/apps/www/components/search/arkenv-search-dialog.test.tsx
@@ -26,7 +26,9 @@ vi.mock("fumadocs-ui/contexts/i18n", () => ({
 }));
 
 vi.mock("fumadocs-ui/components/dialog/search", () => ({
-	SearchDialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	SearchDialog: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
 	SearchDialogOverlay: () => <div data-testid="search-overlay" />,
 	SearchDialogContent: ({
 		children,

--- a/apps/www/components/search/arkenv-search-dialog.test.tsx
+++ b/apps/www/components/search/arkenv-search-dialog.test.tsx
@@ -1,0 +1,119 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ArkenvSearchDialog from "./arkenv-search-dialog";
+
+type SearchHit = { id: string; type: string; content: string };
+
+const searchState = vi.hoisted(() => ({
+	search: "",
+	query: {
+		isLoading: false,
+		data: "empty" as "empty" | SearchHit[],
+	},
+}));
+
+vi.mock("fumadocs-core/search/client", () => ({
+	useDocsSearch: () => ({
+		search: searchState.search,
+		setSearch: vi.fn(),
+		query: searchState.query,
+	}),
+}));
+
+vi.mock("fumadocs-ui/contexts/i18n", () => ({
+	useI18n: () => ({ locale: "en" }),
+}));
+
+vi.mock("fumadocs-ui/components/dialog/search", () => ({
+	SearchDialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	SearchDialogOverlay: () => <div data-testid="search-overlay" />,
+	SearchDialogContent: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => (
+		<div role="dialog" data-state="open" className={className}>
+			{children}
+		</div>
+	),
+	SearchDialogHeader: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	SearchDialogIcon: () => <span>icon</span>,
+	SearchDialogInput: () => <input aria-label="Search" />,
+	SearchDialogClose: () => (
+		<button type="button" className="font-mono">
+			ESC
+		</button>
+	),
+	SearchDialogList: ({ items }: { items: SearchHit[] | null }) => (
+		<div data-empty={items === null}>
+			{items?.map((item) => (
+				<div key={item.id}>{item.content}</div>
+			))}
+		</div>
+	),
+}));
+
+describe("ArkenvSearchDialog", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	beforeEach(() => {
+		searchState.search = "";
+		searchState.query = { isLoading: false, data: "empty" };
+	});
+
+	it("uses a capsule radius while the results list is collapsed", () => {
+		render(<ArkenvSearchDialog open onOpenChange={vi.fn()} />);
+
+		const dialog = screen.getByRole("dialog");
+		expect(dialog).toHaveClass("arkenv-search-dialog");
+		expect(dialog).toHaveClass("rounded-full");
+		expect(dialog).not.toHaveClass("rounded-2xl");
+		expect(dialog.querySelector("[data-empty='true']")).toBeTruthy();
+	});
+
+	it("drops pill radius and shows result titles when matches are present", () => {
+		searchState.search = "getting";
+		searchState.query = {
+			isLoading: false,
+			data: [
+				{
+					id: "getting-started",
+					type: "page",
+					content: "Getting started",
+				},
+			],
+		};
+
+		render(<ArkenvSearchDialog open onOpenChange={vi.fn()} />);
+
+		const dialog = screen.getByRole("dialog");
+		expect(dialog).toHaveClass("arkenv-search-dialog");
+		expect(dialog).toHaveClass("rounded-2xl");
+		expect(dialog).not.toHaveClass("rounded-full");
+		expect(dialog.querySelector("[data-empty='false']")).toBeTruthy();
+		expect(screen.getByText("Getting started")).toBeInTheDocument();
+	});
+
+	it("keeps modest radius for an expanded empty-results panel", () => {
+		searchState.search = "zzzz-no-match";
+		searchState.query = { isLoading: false, data: [] };
+
+		render(<ArkenvSearchDialog open onOpenChange={vi.fn()} />);
+
+		const dialog = screen.getByRole("dialog");
+		expect(dialog).toHaveClass("rounded-2xl");
+		expect(dialog).not.toHaveClass("rounded-full");
+		expect(dialog.querySelector("[data-empty='false']")).toBeTruthy();
+	});
+});

--- a/apps/www/components/search/arkenv-search-dialog.tsx
+++ b/apps/www/components/search/arkenv-search-dialog.tsx
@@ -13,6 +13,7 @@ import {
 } from "fumadocs-ui/components/dialog/search";
 import { useI18n } from "fumadocs-ui/contexts/i18n";
 import type { SharedProps } from "fumadocs-ui/contexts/search";
+import { cn } from "~/lib/utils";
 
 type Props = SharedProps & {
 	api?: string;
@@ -23,6 +24,10 @@ type Props = SharedProps & {
 /**
  * Fumadocs fetch search dialog — capsule overlays Site Nav on mobile
  * (same inset / gutter / bar height; see theme.css).
+ *
+ * Keep full-pill radius only while the results list is collapsed. Fumadocs
+ * `SearchDialogContent` uses `overflow-hidden`; `rounded-full` on a tall
+ * panel clips titles and excerpts into a circular mask.
  */
 export default function ArkenvSearchDialog({
 	api,
@@ -36,6 +41,7 @@ export default function ArkenvSearchDialog({
 			? { type: "fetch", api, locale, delayMs }
 			: { type: "static", from: api, locale, delayMs },
 	);
+	const resultsOpen = query.data !== "empty";
 
 	return (
 		<SearchDialog
@@ -46,13 +52,18 @@ export default function ArkenvSearchDialog({
 		>
 			<SearchDialogOverlay />
 			{/* Capsule overlays Site Nav on mobile — see theme.css search dialog rules */}
-			<SearchDialogContent className="rounded-full">
+			<SearchDialogContent
+				className={cn(
+					"arkenv-search-dialog",
+					resultsOpen ? "rounded-2xl" : "rounded-full",
+				)}
+			>
 				<SearchDialogHeader className="arkenv-search-dialog__bar">
 					<SearchDialogIcon />
 					<SearchDialogInput />
 					<SearchDialogClose />
 				</SearchDialogHeader>
-				<SearchDialogList items={query.data !== "empty" ? query.data : null} />
+				<SearchDialogList items={resultsOpen ? query.data : null} />
 			</SearchDialogContent>
 		</SearchDialog>
 	);

--- a/apps/www/components/search/arkenv-search-dialog.tsx
+++ b/apps/www/components/search/arkenv-search-dialog.tsx
@@ -41,7 +41,8 @@ export default function ArkenvSearchDialog({
 			? { type: "fetch", api, locale, delayMs }
 			: { type: "static", from: api, locale, delayMs },
 	);
-	const resultsOpen = query.data !== "empty";
+	const items = query.data !== "empty" ? query.data : null;
+	const resultsOpen = Array.isArray(items);
 
 	return (
 		<SearchDialog
@@ -63,7 +64,7 @@ export default function ArkenvSearchDialog({
 					<SearchDialogInput />
 					<SearchDialogClose />
 				</SearchDialogHeader>
-				<SearchDialogList items={resultsOpen ? query.data : null} />
+				<SearchDialogList items={items} />
 			</SearchDialogContent>
 		</SearchDialog>
 	);

--- a/apps/www/components/search/arkenv-search-dialog.tsx
+++ b/apps/www/components/search/arkenv-search-dialog.tsx
@@ -13,7 +13,6 @@ import {
 } from "fumadocs-ui/components/dialog/search";
 import { useI18n } from "fumadocs-ui/contexts/i18n";
 import type { SharedProps } from "fumadocs-ui/contexts/search";
-import { cn } from "~/lib/utils";
 
 type Props = SharedProps & {
 	api?: string;
@@ -25,9 +24,9 @@ type Props = SharedProps & {
  * Fumadocs fetch search dialog — capsule overlays Site Nav on mobile
  * (same inset / gutter / bar height; see theme.css).
  *
- * Keep full-pill radius only while the results list is collapsed. Fumadocs
- * `SearchDialogContent` uses `overflow-hidden`; `rounded-full` on a tall
- * panel clips titles and excerpts into a circular mask.
+ * `rounded-full` is the collapsed (input-only) overlay. Expanded radius is
+ * owned by `.arkenv-search-dialog:has([data-empty="false"])` in theme.css so
+ * Fumadocs `overflow-hidden` does not clip the list into a pill mask.
  */
 export default function ArkenvSearchDialog({
 	api,
@@ -42,7 +41,6 @@ export default function ArkenvSearchDialog({
 			: { type: "static", from: api, locale, delayMs },
 	);
 	const items = query.data !== "empty" ? query.data : null;
-	const resultsOpen = Array.isArray(items);
 
 	return (
 		<SearchDialog
@@ -52,13 +50,8 @@ export default function ArkenvSearchDialog({
 			{...props}
 		>
 			<SearchDialogOverlay />
-			{/* Capsule overlays Site Nav on mobile — see theme.css search dialog rules */}
-			<SearchDialogContent
-				className={cn(
-					"arkenv-search-dialog",
-					resultsOpen ? "rounded-2xl" : "rounded-full",
-				)}
-			>
+			{/* Capsule overlays Site Nav on mobile — expanded radius is theme.css */}
+			<SearchDialogContent className="arkenv-search-dialog rounded-full">
 				<SearchDialogHeader className="arkenv-search-dialog__bar">
 					<SearchDialogIcon />
 					<SearchDialogInput />

--- a/packages/fumadocs-ui/css/theme.css
+++ b/packages/fumadocs-ui/css/theme.css
@@ -407,10 +407,11 @@ div:has(+ #nd-sidebar-mobile) {
 }
 
 /*
- * Expanded results: modest radius so fumadocs’ overflow-hidden does not
- * clip the list into a pill/circle. Fumadocs SearchDialogList sets
- * data-empty=false once a query has result data (including “no matches”).
- * Input-only overlay keeps the Site Nav capsule (rounded-full).
+ * Expanded results (all viewports): modest radius so fumadocs’
+ * overflow-hidden does not clip the list into a pill/circle. Applies
+ * wherever the panel is tall — desktop had the same clip. Fumadocs
+ * SearchDialogList sets data-empty=false once a query has result data
+ * (including “no matches”). Input-only overlay keeps rounded-full.
  */
 .arkenv-search-dialog:has([data-empty="false"]) {
 	border-radius: 1.25rem !important;

--- a/packages/fumadocs-ui/css/theme.css
+++ b/packages/fumadocs-ui/css/theme.css
@@ -405,3 +405,13 @@ div:has(+ #nd-sidebar-mobile) {
 		display: none;
 	}
 }
+
+/*
+ * Expanded results: modest radius so fumadocs’ overflow-hidden does not
+ * clip the list into a pill/circle. Fumadocs SearchDialogList sets
+ * data-empty=false once a query has result data (including “no matches”).
+ * Input-only overlay keeps the Site Nav capsule (rounded-full).
+ */
+.arkenv-search-dialog:has([data-empty="false"]) {
+	border-radius: 1.25rem !important;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1546

Stop the docs search dialog from pill-clipping results.

`SearchDialogContent` already uses `overflow-hidden`. Applying `rounded-full` to that wrapper is correct for the empty input capsule that overlays Site Nav, but once the results list expands the same full-pill radius masks titles, breadcrumbs, and excerpts.

This change:
- Keeps `rounded-full` on the input-only overlay (Site Nav capsule on mobile)
- Lets theme.css own the expanded radius via `.arkenv-search-dialog:has([data-empty="false"])` — a modest `1.25rem`, no duplicate React class toggle
- Applies that expanded radius on every viewport. Desktop had the same clip; open/center/close behavior is unchanged
- Adds unit coverage for the `data-empty` trigger, plus Playwright checks that result titles stay hit-testable and the computed radius is not a pill

Validation: `pnpm run typecheck`, `pnpm run test` (1100 tests), and `pnpm run fix` all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdc96fb2-6e81-400c-9aa0-3307a62385df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdc96fb2-6e81-400c-9aa0-3307a62385df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

