### PR TITLE
Remove maintainer rationale from public JSDoc

### DIFF
--- a/packages/build/src/core.ts
+++ b/packages/build/src/core.ts
@@ -19,7 +19,7 @@ let activeWatcher: FSWatcher | undefined;
 
 export type LayoutMode = "simple" | "strict";
 
-/** Public layout values accepted by {@link resolveLayout}. */
+/** Layout values accepted by {@link resolveLayout}. */
 export type LayoutInput = LayoutMode | "flat";
 
 export type ResolvedLayout = {

--- a/packages/build/src/missing-schema-error.ts
+++ b/packages/build/src/missing-schema-error.ts
@@ -29,9 +29,6 @@ export type FormatMissingSchemaErrorOptions = {
 /**
  * Format a missing-schema error shared by host integrations.
  *
- * Owns the no-starter policy: hosts must use this helper instead of inlining
- * example `env.ts` modules in thrown errors.
- *
  * @param options Host-specific labels and optional discovery paths
  * @returns A short, actionable missing-schema error message
  */

--- a/packages/bun-plugin/src/plugin.ts
+++ b/packages/bun-plugin/src/plugin.ts
@@ -23,10 +23,6 @@ const { arkenv: arkenvFn, hybrid: hybridObj } = createBunPlugin(
  *
  * @param options Transform options (`schemaPath`, `clientPrefix`) plus ArkEnv/logging config
  * @returns The Bun plugin instance
- *
- * @remarks
- * ADR 0021: env.ts is the canonical surface. Do not add `env.gen.ts` codegen or
- * client-side re-validation on this host.
  */
 export function arkenv(options?: BunPluginFactoryConfig): BunPlugin;
 /**

--- a/packages/bun-plugin/src/standard.ts
+++ b/packages/bun-plugin/src/standard.ts
@@ -23,10 +23,6 @@ const { arkenv: arkenvFn, hybrid: hybridObj } = createBunPlugin(
  *
  * @param options Transform options (`schemaPath`, `clientPrefix`) plus ArkEnv/logging config
  * @returns The Bun plugin instance
- *
- * @remarks
- * ADR 0021: env.ts is the canonical surface. Do not add `env.gen.ts` codegen or
- * client-side re-validation on this host.
  */
 export function arkenv(options?: BunPluginFactoryConfig): BunPlugin;
 /**

--- a/packages/bun-plugin/src/transform-options.ts
+++ b/packages/bun-plugin/src/transform-options.ts
@@ -14,8 +14,6 @@ const TRANSFORM_OPTION_KEYS = new Set([
 
 /**
  * Options for the Bun plugin's env-module transform mode.
- *
- * @see docs/adr/0021-env-object-canonical-surface.md — transform design
  */
 export type BunTransformOptions = {
 	/**

--- a/packages/core/src/arkenv.ts
+++ b/packages/core/src/arkenv.ts
@@ -12,14 +12,8 @@ import { parse } from "./arktype";
 /**
  * Declarative environment schema definition accepted by ArkEnv.
  *
- * Represents a declarative schema object mapping environment
- * variable names to schema definitions (e.g. ArkType DSL strings
- * or Standard Schema validators).
- *
- * This type is used to validate that a schema object is compatible with
- * ArkEnv’s validator scope before being compiled or parsed.
- *
- * Most users will provide schemas in this form.
+ * Maps environment variable names to schema definitions (e.g. ArkType DSL
+ * strings or Standard Schema validators).
  *
  * @template def - The schema shape object
  */
@@ -59,12 +53,10 @@ export type ArkEnvConfig = {
 	/**
 	 * Control how ArkEnv handles environment variables that are not defined in your schema.
 	 *
-	 * Defaults to `'delete'` to ensure your output object only contains
-	 * keys you've explicitly declared. This differs from ArkType's standard behavior, which
-	 * mirrors TypeScript by defaulting to `'ignore'`.
+	 * Defaults to `'delete'` so the output object only contains keys you've declared.
 	 *
-	 * - `delete` (ArkEnv default): Undeclared keys are allowed on input but stripped from the output.
-	 * - `ignore` (ArkType default): Undeclared keys are allowed and preserved in the output.
+	 * - `delete` (default): Undeclared keys are allowed on input but stripped from the output.
+	 * - `ignore`: Undeclared keys are allowed and preserved in the output.
 	 * - `reject`: Undeclared keys will cause validation to fail.
 	 *
 	 * @default "delete"
@@ -112,18 +104,14 @@ export type ArkEnvConfig = {
 export type { SafeArkEnvResult };
 
 /**
- * Helper type to represent the output of parsing either an EnvSchema or CompiledEnvSchema.
+ * Parsed environment object inferred from an EnvSchema or CompiledEnvSchema.
  */
 export type ArkenvOutput<T extends SchemaShape, D> =
 	| distill.Out<at.infer<T, $>>
 	| InferType<D>;
 
 /**
- * Utility to parse environment variables using ArkType or Standard Schema
- *
- * Naming convention: the main function is lowercase (`arkenv`) following the
- * JavaScript convention for functions (e.g. `zod`, `joi`). Classes and types
- * use PascalCase with the full product name (`ArkEnvError`, `SafeArkEnvResult`).
+ * Parse and validate environment variables using ArkType or Standard Schema.
  *
  * @param def The schema definition
  * @param config The evaluation configuration

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,9 +26,4 @@ export type {
 	SafeArkEnvResult,
 } from "./arkenv";
 
-/**
- * ArkEnv's main export, an alias for {@link arkenv}
- *
- * {@link https://arkenv.js.org | ArkEnv} is a typesafe environment variables validator from editor to runtime.
- */
 export default arkenv;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,4 +26,9 @@ export type {
 	SafeArkEnvResult,
 } from "./arkenv";
 
+/**
+ * ArkEnv's main export, an alias for {@link arkenv}
+ *
+ * {@link https://arkenv.js.org | ArkEnv} is a typesafe environment variables validator from editor to runtime.
+ */
 export default arkenv;

--- a/packages/internal/log/src/types.ts
+++ b/packages/internal/log/src/types.ts
@@ -3,8 +3,6 @@ export type LogLevel = "debug" | "info" | "warn" | "error" | "silent";
 
 /**
  * Shared logger interface for ArkEnv packages.
- *
- * CLI-specific features (spinners, JSON reporters, `flush`) stay outside this type.
  */
 export type Logger = {
 	debug: (message: string, ...optionalParams: unknown[]) => void;

--- a/packages/internal/utils/src/core.ts
+++ b/packages/internal/utils/src/core.ts
@@ -3,7 +3,6 @@ import { styleText } from "./utils/style-text";
 
 /**
  * Machine-readable classification codes for environment validation issues.
- * Serves as the Source of Truth (SoT) for error categorization in ArkEnv.
  */
 export type EnvIssueCode =
 	/** The environment variable is required but was not provided, and has no default value. */

--- a/packages/internal/utils/src/parse-standard.ts
+++ b/packages/internal/utils/src/parse-standard.ts
@@ -45,10 +45,9 @@ export type ParseStandardConfig = {
 	/**
 	 * Control how ArkEnv handles environment variables that are not defined in your schema.
 	 *
-	 * Defaults to `'delete'` to ensure your output object only contains
-	 * keys you've explicitly declared.
+	 * Defaults to `'delete'` so the output object only contains keys you've declared.
 	 *
-	 * - `delete` (ArkEnv default): Undeclared keys are allowed on input but stripped from the output.
+	 * - `delete` (default): Undeclared keys are allowed on input but stripped from the output.
 	 * - `ignore`: Undeclared keys are allowed and preserved in the output.
 	 * - `reject`: Undeclared keys will cause validation to fail.
 	 *

--- a/packages/internal/utils/src/schema.ts
+++ b/packages/internal/utils/src/schema.ts
@@ -1,10 +1,9 @@
 /**
- * Extract the keys from a schema definition dynamically.
+ * Extract the keys from a schema definition.
  * Supports plain objects, ArkType schemas, and Standard Schema validators.
  *
  * @param schema The schema definition to extract keys from
  * @returns An array of extracted key names
- * @internal
  */
 // biome-ignore lint/suspicious/noExplicitAny: Need to handle various schema formats
 export function getSchemaKeys(schema: any): string[] {

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -109,9 +109,4 @@ export { type } from "@arkenv/core";
 export type { ArkEnvScriptProps } from "./script";
 export { ArkEnvScript } from "./script";
 
-/**
- * ArkEnv's Next.js integration export
- *
- * {@link https://arkenv.js.org | ArkEnv} is a typesafe environment variables validator from editor to runtime.
- */
 export default arkenv;

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -109,4 +109,9 @@ export { type } from "@arkenv/core";
 export type { ArkEnvScriptProps } from "./script";
 export { ArkEnvScript } from "./script";
 
+/**
+ * ArkEnv's Next.js integration export
+ *
+ * {@link https://arkenv.js.org | ArkEnv} is a typesafe environment variables validator from editor to runtime.
+ */
 export default arkenv;

--- a/packages/nextjs/src/react-server.ts
+++ b/packages/nextjs/src/react-server.ts
@@ -81,4 +81,9 @@ export { type } from "@arkenv/core";
 export type { ArkEnvScriptProps } from "./script";
 export { ArkEnvScript } from "./script";
 
+/**
+ * ArkEnv's Next.js integration export
+ *
+ * {@link https://arkenv.js.org | ArkEnv} is a typesafe environment variables validator from editor to runtime.
+ */
 export default arkenv;

--- a/packages/nextjs/src/react-server.ts
+++ b/packages/nextjs/src/react-server.ts
@@ -81,9 +81,4 @@ export { type } from "@arkenv/core";
 export type { ArkEnvScriptProps } from "./script";
 export { ArkEnvScript } from "./script";
 
-/**
- * ArkEnv's Next.js integration export
- *
- * {@link https://arkenv.js.org | ArkEnv} is a typesafe environment variables validator from editor to runtime.
- */
 export default arkenv;

--- a/packages/nuxt/src/client.ts
+++ b/packages/nuxt/src/client.ts
@@ -11,9 +11,6 @@ import type { MergeExtends, ResolveExtendsElement } from "./types";
 
 /**
  * Shared schema type auto-merged in Nuxt strict layout when `extends` is omitted.
- *
- * Resolved via the `#arkenv/shared-schema` virtual module alias registered by
- * `@arkenv/nuxt/module`.
  */
 type AutoSharedSchema = typeof import("#arkenv/shared-schema") extends {
 	SharedSchema: infer S;
@@ -24,7 +21,7 @@ type AutoSharedSchema = typeof import("#arkenv/shared-schema") extends {
 /**
  * Create a typesafe environment configuration for Nuxt (client entry).
  *
- * Reads the already-coerced public payload — does not import or run the validator.
+ * Reads already-coerced public values — this entry does not re-validate.
  *
  * With `@arkenv/nuxt/module` in strict layout, omitting `extends` includes the
  * shared schema by default. Any explicit `extends` is used as-is and opts out

--- a/packages/nuxt/src/config.ts
+++ b/packages/nuxt/src/config.ts
@@ -53,11 +53,9 @@ export function normalizeLayout(
 }
 
 /**
- * Configuration options for ArkEnv's build-time integration.
+ * Configuration options for the ArkEnv Nuxt module.
  *
- * This is the single source of truth for the options exposed under the `arkenv`
- * key in framework configs (e.g. `nuxt.config.ts`), which is why the field-level
- * JSDoc and `@default` tags live here.
+ * Provide these under the `arkenv` key in `nuxt.config.ts`.
  */
 export type ArkEnvConfigOptions = {
 	/**

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -5,10 +5,10 @@ import { ensureBootGate } from "#arkenv/server-boot";
 import { arkenvInternal, type FlatSchemaOptions } from "./arkenv-internal";
 
 /**
- * Create a typesafe environment configuration for Nuxt (flat / unified entry).
+ * Create a typesafe environment configuration for Nuxt (nested schema).
  *
- * Values are read from the Nitro boot-gate coerced `runtimeConfig` / `__NUXT__`
- * payload — this entry does not run core validation.
+ * Reads already-coerced values from Nuxt `runtimeConfig` / `__NUXT__`.
+ * This entry does not re-validate.
  *
  * @param options Nested server/client/shared schema options
  * @returns A readonly environment proxy

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -29,9 +29,6 @@ import {
  *
  * Provide these under the `arkenv` key in your `nuxt.config.ts`.
  *
- * Aliased to {@link ArkEnvConfigOptions} so the documented options remain the
- * single source of truth (field-level JSDoc, `@default` tags, and so on).
- *
  * @example
  * ```ts
  * export default defineNuxtConfig({

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -12,9 +12,6 @@ import type { MergeExtends } from "./types";
 
 /**
  * Client env type auto-merged in Nuxt strict layout when `extends` is omitted.
- *
- * Resolved via the `#arkenv/client-env` virtual module alias registered by
- * `@arkenv/nuxt/module`.
  */
 type AutoClientEnv = typeof import("#arkenv/client-env") extends {
 	env: infer E;
@@ -25,8 +22,7 @@ type AutoClientEnv = typeof import("#arkenv/client-env") extends {
 /**
  * Create a typesafe environment configuration for Nuxt (server entry).
  *
- * Calls {@link ensureBootGate} then reads coerced `runtimeConfig` values —
- * does not re-validate with core in this entry.
+ * Reads already-coerced `runtimeConfig` values — this entry does not re-validate.
  *
  * With `@arkenv/nuxt/module` in strict layout, omitting `extends` includes the
  * client and shared env by default. Any explicit `extends` is used as-is and

--- a/packages/nuxt/src/standard/client.ts
+++ b/packages/nuxt/src/standard/client.ts
@@ -8,9 +8,6 @@ import type { MergeExtends, ResolveExtendsElement } from "@/types";
 
 /**
  * Shared schema type auto-merged in Nuxt strict layout when `extends` is omitted.
- *
- * Resolved via the `#arkenv/shared-schema` virtual module alias registered by
- * `@arkenv/nuxt/module`.
  */
 type AutoSharedSchema = typeof import("#arkenv/shared-schema") extends {
 	SharedSchema: infer S;
@@ -21,7 +18,7 @@ type AutoSharedSchema = typeof import("#arkenv/shared-schema") extends {
 /**
  * Create a typesafe environment configuration for Nuxt (client entry, Standard Mode).
  *
- * Reads the already-coerced public payload — does not import or run the validator.
+ * Reads already-coerced public values — this entry does not re-validate.
  *
  * With `@arkenv/nuxt/module` in strict layout, omitting `extends` includes the
  * shared schema by default. Any explicit `extends` is used as-is and opts out

--- a/packages/nuxt/src/standard/index.ts
+++ b/packages/nuxt/src/standard/index.ts
@@ -19,8 +19,8 @@ type ClientVisibleKeys<
 /**
  * Create a typesafe environment configuration for Nuxt (Standard Mode).
  *
- * Values are read from the Nitro boot-gate coerced payload — this entry does
- * not run core validation.
+ * Reads already-coerced values from Nuxt runtime config. This entry does not
+ * re-validate.
  *
  * @param schema A flat schema of environment variable Standard Schema validators
  * @param options Optional configuration including client-side variables and extends

--- a/packages/nuxt/src/standard/server.ts
+++ b/packages/nuxt/src/standard/server.ts
@@ -9,9 +9,6 @@ import type { MergeExtends } from "@/types";
 
 /**
  * Client env type auto-merged in Nuxt strict layout when `extends` is omitted.
- *
- * Resolved via the `#arkenv/client-env` virtual module alias registered by
- * `@arkenv/nuxt/module`.
  */
 type AutoClientEnv = typeof import("#arkenv/client-env") extends {
 	env: infer E;

--- a/packages/standard/src/index.ts
+++ b/packages/standard/src/index.ts
@@ -22,7 +22,7 @@ export {
 };
 
 /**
- * Configuration options for the `arkenv/standard` entry's `arkenv`.
+ * Configuration options for `arkenv` from `@arkenv/standard`.
  */
 export type StandardEnvConfig = ParseStandardConfig;
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -21,10 +21,6 @@ const arkenvCreator = createVitePlugin(coreArkenv, "@arkenv/vite-plugin");
  *
  * @param options Transform options (`schemaPath`, `clientPrefix`) plus ArkEnv/logging config
  * @returns The Vite plugin instance
- *
- * @remarks
- * ADR 0015: env.ts is the canonical surface. Do not add `env.gen.ts` codegen or
- * client-side re-validation on this host.
  */
 export default function arkenv(options?: VitePluginFactoryConfig): Plugin;
 /**

--- a/packages/vite-plugin/src/standard.ts
+++ b/packages/vite-plugin/src/standard.ts
@@ -23,10 +23,6 @@ const arkenvCreator = createVitePlugin(
  *
  * @param options Transform options (`schemaPath`, `clientPrefix`) plus ArkEnv/logging config
  * @returns The Vite plugin instance
- *
- * @remarks
- * ADR 0015: env.ts is the canonical surface. Do not add `env.gen.ts` codegen or
- * client-side re-validation on this host.
  */
 export default function arkenv(options?: VitePluginFactoryConfig): Plugin;
 /**

--- a/packages/vite-plugin/src/transform-options.ts
+++ b/packages/vite-plugin/src/transform-options.ts
@@ -14,8 +14,6 @@ const TRANSFORM_OPTION_KEYS = new Set([
 
 /**
  * Options for the Vite plugin's env-module transform mode.
- *
- * @see docs/adr/0015-env-object-canonical-surface.md (on `dev`) — transform design
  */
 export type ViteTransformOptions = {
 	/**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Public JSDoc on the main package exports now describes behavior, options, and return values—not internal naming or design history.

Hovering `arkenv()` previously included a naming-convention note (`zod`/`joi`, PascalCase types). That is a maintainer decision, not something a consumer needs at the call site. The same pass cleaned the other public exports.

**Removed from consumer-facing docs**
- Naming-convention commentary on `arkenv()`
- Marketing taglines on default exports (`@arkenv/core`, `@arkenv/nextjs`)
- ADR remarks and ADR `@see` links on the Vite/Bun plugin factories
- “Single source of truth” / alias-structure notes on Nuxt module options
- Internal boot-gate / virtual-module implementation details on Nuxt entries
- ArkType-vs-ArkEnv default comparisons on `onUndeclaredKey`

Usage, options, and return-value docs are unchanged. Internal implementation comments (including ADR notes in non-exported files) are unchanged.

No runtime behavior change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a9b49dd-ec6e-4a20-8f03-fedec7452567?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a9b49dd-ec6e-4a20-8f03-fedec7452567&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

