### PR TITLE
fix: (v1) Harden CLI runtime import guard for native ESM and CJS (arkenv)

### DIFF
--- a/.changeset/harden-cli-runtime-import-guard.md
+++ b/.changeset/harden-cli-runtime-import-guard.md
@@ -4,9 +4,9 @@
 
 #### Harden runtime import guard for native ESM and CommonJS
 
-Separated the CLI binary executable (`src/bin.ts`) from the package root export (`src/index.ts`) so that importing or requiring `arkenv` as a library unconditionally throws a descriptive migration error guiding users to `@arkenv/core` in both ESM and CommonJS module systems.
+Separated the CLI binary executable (`src/bin.ts`) from the package root export (`src/index.ts`) so that importing or requiring `arkenv` as a library unconditionally throws a descriptive migration error guiding users to `@arkenv/core` (or `@arkenv/standard`) in both ESM and CommonJS module systems.
 
 ```ts
 // Importing arkenv in ESM or requiring it in CJS throws immediately:
-import "arkenv"; // 🚨 [ArkEnv] You imported the 'arkenv' package as a library. Starting with v1.0.0, the 'arkenv' package is exclusively the interactive CLI. If you want to validate environment variables in your code, please install and import '@arkenv/core' instead.
+import "arkenv"; // 🚨 [ArkEnv] You imported the 'arkenv' package as a library. Starting with v1.0.0, the 'arkenv' package is exclusively the interactive CLI. If you want to validate environment variables in your code, please install and import '@arkenv/core' (or '@arkenv/standard') instead, or run `npx arkenv@latest init` to guide you through setup.
 ```

--- a/.changeset/harden-cli-runtime-import-guard.md
+++ b/.changeset/harden-cli-runtime-import-guard.md
@@ -4,4 +4,9 @@
 
 #### Harden runtime import guard for native ESM and CommonJS
 
-Separate the CLI binary executable (`src/bin.ts`) from the package root export (`src/index.ts`) so that importing or requiring `arkenv` as a library unconditionally throws a descriptive migration error guiding users to `@arkenv/core` in both ESM and CommonJS module systems.
+Separated the CLI binary executable (`src/bin.ts`) from the package root export (`src/index.ts`) so that importing or requiring `arkenv` as a library unconditionally throws a descriptive migration error guiding users to `@arkenv/core` in both ESM and CommonJS module systems.
+
+```ts
+// Importing arkenv in ESM or requiring it in CJS throws immediately:
+import "arkenv"; // 🚨 [ArkEnv] You imported the 'arkenv' package as a library. Starting with v1.0.0, the 'arkenv' package is exclusively the interactive CLI. If you want to validate environment variables in your code, please install and import '@arkenv/core' instead.
+```

--- a/.changeset/harden-cli-runtime-import-guard.md
+++ b/.changeset/harden-cli-runtime-import-guard.md
@@ -1,0 +1,7 @@
+---
+"arkenv": patch
+---
+
+#### Harden runtime import guard for native ESM and CommonJS
+
+Separate the CLI binary executable (`src/bin.ts`) from the package root export (`src/index.ts`) so that importing or requiring `arkenv` as a library unconditionally throws a descriptive migration error guiding users to `@arkenv/core` in both ESM and CommonJS module systems.

--- a/packages/arkenv/package.json
+++ b/packages/arkenv/package.json
@@ -4,9 +4,10 @@
 	"version": "1.0.0-alpha.11",
 	"description": "Interactive CLI for scaffolding ArkEnv projects",
 	"bin": {
-		"arkenv": "./dist/index.cjs"
+		"arkenv": "./dist/bin.cjs"
 	},
 	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
@@ -21,7 +22,7 @@
 	],
 	"scripts": {
 		"build": "tsdown",
-		"start": "node ./dist/index.cjs init",
+		"start": "node ./dist/bin.cjs init",
 		"dev": "tsdown --watch",
 		"test": "vitest",
 		"test:run": "vitest run",

--- a/packages/arkenv/src/bin.ts
+++ b/packages/arkenv/src/bin.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+import { shake } from "radashi";
+import { Logger } from "./adapters/logger.adapter";
+import { compose } from "./cli/composition";
+
+const fallbackLogger = new Logger({ isQuiet: false, isJson: false });
+
+let globalLogger: Logger | undefined;
+let isShuttingDown = false;
+
+/**
+ * Compose the CLI, dispatch the requested command, and handle fatal failures.
+ */
+async function main() {
+	if (process.env.INIT_CWD) {
+		try {
+			process.chdir(process.env.INIT_CWD);
+		} catch {
+			// Fallback to process.cwd() if directory change fails
+		}
+	}
+
+	const { cli, logger, initUseCase, addUseCase, helpUseCase } = compose(
+		process.argv,
+	);
+	globalLogger = logger;
+
+	setupGracefulShutdown(logger);
+
+	if (cli.validationError) {
+		logger.error(cli.validationError);
+		await helpUseCase.execute();
+		await logger.flush();
+		process.exit(1);
+	}
+
+	if (cli.helpRequested) {
+		await helpUseCase.execute();
+		await logger.flush();
+		process.exit(0);
+	}
+
+	const commands = {
+		init: () => initUseCase.execute(shake(cli.initInput)),
+		add: () => addUseCase.execute(cli.addInput),
+	} as const;
+
+	const handler = cli.command
+		? commands[cli.command as keyof typeof commands]
+		: undefined;
+
+	if (!handler) {
+		if (cli.command) {
+			logger.error(`Unknown command: ${cli.command}`);
+		} else {
+			logger.error("Missing command.");
+		}
+		await helpUseCase.execute();
+		await logger.flush();
+		process.exit(1);
+	}
+
+	try {
+		const success = await handler();
+		if (!success) {
+			await logger.flush();
+			process.exit(1);
+		}
+	} catch (error) {
+		try {
+			logger.fatal("An unexpected error occurred", error);
+		} catch {
+			// Ignore throw from fatal as we are already handling the error
+		}
+		await logger.flush();
+		process.exit(1);
+	}
+}
+
+/**
+ * Install signal handlers that cancel prompts and flush logs before exiting.
+ *
+ * @param logger The active logger instance to flush on shutdown
+ */
+function setupGracefulShutdown(logger: any) {
+	/**
+	 * Flush the current prompt and logger state before exiting with a signal code.
+	 *
+	 * @param code The process exit code
+	 */
+	const shutdown = async (code: number) => {
+		if (isShuttingDown) {
+			process.exit(code);
+		}
+		isShuttingDown = true;
+
+		// Force exit after 2 seconds if graceful shutdown hangs
+		const timeout = setTimeout(() => {
+			process.exit(code);
+		}, 2000);
+		timeout.unref();
+
+		if (logger.interactiveStdout) {
+			logger.interactiveStdout(false);
+		}
+
+		try {
+			logger.cancel("Operation cancelled.");
+			await logger.flush();
+		} catch (err) {
+			// Best-effort logging on shutdown failure
+			if (logger.error) {
+				logger.error("Logger failed during shutdown", err);
+			}
+		} finally {
+			process.exit(code);
+		}
+	};
+
+	process.on("SIGINT", () => shutdown(130));
+	process.on("SIGTERM", () => shutdown(143));
+}
+
+main();
+
+// Defense-in-depth for unforeseen async rejections
+process.on("unhandledRejection", async (err) => {
+	const logger = globalLogger ?? fallbackLogger;
+	try {
+		logger.fatal("Unhandled rejection", err);
+	} catch {
+		// Already logged
+	}
+	await logger.flush();
+	process.exit(1);
+});
+
+process.on("uncaughtException", async (err) => {
+	const logger = globalLogger ?? fallbackLogger;
+	try {
+		logger.fatal("Uncaught exception", err);
+	} catch {
+		// Already logged
+	}
+	await logger.flush();
+	process.exit(1);
+});

--- a/packages/arkenv/src/index.ts
+++ b/packages/arkenv/src/index.ts
@@ -4,19 +4,19 @@ throw new Error(
 	`🚨 ${formatBuildError(
 		"You imported the 'arkenv' package as a library. " +
 			"Starting with v1.0.0, the 'arkenv' package is exclusively the interactive CLI. " +
-			"If you want to validate environment variables in your code, please install and import '@arkenv/core' instead.",
+			"If you want to validate environment variables in your code, please install and import '@arkenv/core' (or '@arkenv/standard') instead, or run `npx arkenv@latest init` to guide you through setup.",
 	)}`,
 );
 
 /**
  * @deprecated The 'arkenv' package is exclusively an interactive CLI in v1.0.0+.
- * If you want to validate environment variables in your code, please install and import '@arkenv/core' instead.
+ * If you want to validate environment variables in your code, please install and import '@arkenv/core' (or '@arkenv/standard') instead, or run `npx arkenv@latest init`.
  */
 declare const arkenv: never;
 
 /**
  * @deprecated The 'arkenv' package is exclusively an interactive CLI in v1.0.0+.
- * If you want to validate environment variables in your code, please install and import '@arkenv/core' instead.
+ * If you want to validate environment variables in your code, please install and import '@arkenv/core' (or '@arkenv/standard') instead, or run `npx arkenv@latest init`.
  */
 export type Arkenv = never;
 

--- a/packages/arkenv/src/index.ts
+++ b/packages/arkenv/src/index.ts
@@ -1,155 +1,24 @@
-#!/usr/bin/env node
 import { formatBuildError } from "@repo/utils";
-import { shake } from "radashi";
-import { Logger } from "./adapters/logger.adapter";
-import { compose } from "./cli/composition";
 
-// Detect if this file is being imported/required as a library rather than run directly as a CLI.
-if (typeof require !== "undefined" && require.main !== module) {
-	throw new Error(
-		`🚨 ${formatBuildError(
-			"You imported the 'arkenv' package as a library. " +
-				"Starting with v1.0.0, the 'arkenv' package is exclusively the interactive CLI. " +
-				"If you want to validate environment variables in your code, please install and import '@arkenv/core' instead.",
-		)}`,
-	);
-}
-
-const fallbackLogger = new Logger({ isQuiet: false, isJson: false });
-
-let globalLogger: Logger | undefined;
-let isShuttingDown = false;
+throw new Error(
+	`🚨 ${formatBuildError(
+		"You imported the 'arkenv' package as a library. " +
+			"Starting with v1.0.0, the 'arkenv' package is exclusively the interactive CLI. " +
+			"If you want to validate environment variables in your code, please install and import '@arkenv/core' instead.",
+	)}`,
+);
 
 /**
- * Composes the CLI, dispatches the requested command, and handles fatal failures.
+ * @deprecated The 'arkenv' package is exclusively an interactive CLI in v1.0.0+.
+ * If you want to validate environment variables in your code, please install and import '@arkenv/core' instead.
  */
-async function main() {
-	if (process.env.INIT_CWD) {
-		try {
-			process.chdir(process.env.INIT_CWD);
-		} catch {
-			// Fallback to process.cwd() if directory change fails
-		}
-	}
-
-	const { cli, logger, initUseCase, addUseCase, helpUseCase } = compose(
-		process.argv,
-	);
-	globalLogger = logger;
-
-	setupGracefulShutdown(logger);
-
-	if (cli.validationError) {
-		logger.error(cli.validationError);
-		await helpUseCase.execute();
-		await logger.flush();
-		process.exit(1);
-	}
-
-	if (cli.helpRequested) {
-		await helpUseCase.execute();
-		await logger.flush();
-		process.exit(0);
-	}
-
-	const commands = {
-		init: () => initUseCase.execute(shake(cli.initInput)),
-		add: () => addUseCase.execute(cli.addInput),
-	} as const;
-
-	const handler = cli.command
-		? commands[cli.command as keyof typeof commands]
-		: undefined;
-
-	if (!handler) {
-		if (cli.command) {
-			logger.error(`Unknown command: ${cli.command}`);
-		} else {
-			logger.error("Missing command.");
-		}
-		await helpUseCase.execute();
-		await logger.flush();
-		process.exit(1);
-	}
-
-	try {
-		const success = await handler();
-		if (!success) {
-			await logger.flush();
-			process.exit(1);
-		}
-	} catch (error) {
-		try {
-			logger.fatal("An unexpected error occurred", error);
-		} catch {
-			// Ignore throw from fatal as we are already handling the error
-		}
-		await logger.flush();
-		process.exit(1);
-	}
-}
+declare const arkenv: never;
 
 /**
- * Installs signal handlers that cancel prompts and flush logs before exiting.
+ * @deprecated The 'arkenv' package is exclusively an interactive CLI in v1.0.0+.
+ * If you want to validate environment variables in your code, please install and import '@arkenv/core' instead.
  */
-function setupGracefulShutdown(logger: any) {
-	/**
-	 * Flushes the current prompt and logger state before exiting with a signal code.
-	 */
-	const shutdown = async (code: number) => {
-		if (isShuttingDown) {
-			process.exit(code);
-		}
-		isShuttingDown = true;
+export type Arkenv = never;
 
-		// Force exit after 2 seconds if graceful shutdown hangs
-		const timeout = setTimeout(() => {
-			process.exit(code);
-		}, 2000);
-		timeout.unref();
-
-		if (logger.interactiveStdout) {
-			logger.interactiveStdout(false);
-		}
-
-		try {
-			logger.cancel("Operation cancelled.");
-			await logger.flush();
-		} catch (err) {
-			// Best-effort logging on shutdown failure
-			if (logger.error) {
-				logger.error("Logger failed during shutdown", err);
-			}
-		} finally {
-			process.exit(code);
-		}
-	};
-
-	process.on("SIGINT", () => shutdown(130));
-	process.on("SIGTERM", () => shutdown(143));
-}
-
-main();
-
-// Defense-in-depth for unforeseen async rejections
-process.on("unhandledRejection", async (err) => {
-	const logger = globalLogger ?? fallbackLogger;
-	try {
-		logger.fatal("Unhandled rejection", err);
-	} catch {
-		// Already logged
-	}
-	await logger.flush();
-	process.exit(1);
-});
-
-process.on("uncaughtException", async (err) => {
-	const logger = globalLogger ?? fallbackLogger;
-	try {
-		logger.fatal("Uncaught exception", err);
-	} catch {
-		// Already logged
-	}
-	await logger.flush();
-	process.exit(1);
-});
+export default arkenv;
+export { arkenv };

--- a/packages/arkenv/src/smoke.test.ts
+++ b/packages/arkenv/src/smoke.test.ts
@@ -1,11 +1,53 @@
 import { exec as execCallback } from "node:child_process";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
 const exec = promisify(execCallback);
-const cliPath = path.resolve(__dirname, "../dist/index.cjs");
+const require = createRequire(import.meta.url);
+
+const cliPath = path.resolve(__dirname, "../dist/bin.cjs");
+const esmIndexPath = path.resolve(__dirname, "../dist/index.js");
+const cjsIndexPath = path.resolve(__dirname, "../dist/index.cjs");
+
+describe("library import guard", () => {
+	it("importing ESM entry throws migration error", async () => {
+		await expect(import(pathToFileURL(esmIndexPath).href)).rejects.toThrow(
+			"You imported the 'arkenv' package as a library",
+		);
+	});
+
+	it("requiring CJS entry throws migration error", () => {
+		expect(() => require(cjsIndexPath)).toThrow(
+			"You imported the 'arkenv' package as a library",
+		);
+	});
+
+	it("running node with ESM import throws migration error", async () => {
+		await expect(
+			exec(
+				`node --input-type=module -e "import '${pathToFileURL(esmIndexPath).href}'"`,
+			),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining(
+				"You imported the 'arkenv' package as a library",
+			),
+		});
+	});
+
+	it("running node with CJS require throws migration error", async () => {
+		await expect(
+			exec(`node -e "require('${cjsIndexPath.replace(/\\/g, "\\\\")}')"`),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining(
+				"You imported the 'arkenv' package as a library",
+			),
+		});
+	});
+});
 
 describe("cli smoke tests", () => {
 	it("--help prints usage and exits 0", async () => {

--- a/packages/arkenv/tsdown.config.ts
+++ b/packages/arkenv/tsdown.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	entry: "src/index.ts",
-	format: "cjs",
+	entry: ["src/index.ts", "src/bin.ts"],
+	format: ["esm", "cjs"],
 	platform: "node",
 	minify: true,
-	fixedExtension: true,
+	fixedExtension: false,
 	shims: true,
 	deps: {
 		alwaysBundle: ["@repo/log", "@clack/prompts", "@repo/utils", "picocolors"],

--- a/scripts/test-cli.js
+++ b/scripts/test-cli.js
@@ -135,7 +135,7 @@ const extraArgs = process.argv.slice(process.argv[2] === mode ? 3 : 2);
 console.log(`Running arkenv init inside ${tempDir}...\n`);
 try {
 	execSync(
-		`node ${path.resolve(rootDir, "packages/arkenv/dist/index.cjs")} init ${extraArgs.join(" ")}`,
+		`node ${path.resolve(rootDir, "packages/arkenv/dist/bin.cjs")} init ${extraArgs.join(" ")}`,
 		{
 			cwd: tempDir,
 			stdio: "inherit",


### PR DESCRIPTION
Fixes #1589

### Summary of Changes
- Separated the CLI binary executable into a dedicated entry point (`packages/arkenv/src/bin.ts`) and mapped `"bin"` in `package.json` directly to `./dist/bin.cjs`.
- Updated `packages/arkenv/src/index.ts` to unconditionally throw a helpful migration error guiding developers to `@arkenv/core` when imported as a library, in both ESM and CJS module formats.
- Exported compile-time `@deprecated` typings (`arkenv`, `Arkenv`) typed as `never` from `src/index.ts`.
- Updated `packages/arkenv/tsdown.config.ts` to build both `src/index.ts` and `src/bin.ts` in ESM and CJS formats.
- Added comprehensive smoke tests covering dynamic ESM imports, CJS requires, and CLI binary invocations.
- Added a patch changeset for `arkenv`.