### PR TITLE
refactor(nuxt): deepen boot-gate / capture / flat thin-accessor locality

### DIFF
--- a/.changeset/deepen-nuxt-locality.md
+++ b/.changeset/deepen-nuxt-locality.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/nuxt": patch
+---
+
+#### Deepen Nuxt boot gate and thin accessor locality
+
+Consolidated legacy and flat schema-shape detection into a single cycle-safe helper shared between schema capture and runtime accessors. Schema loading and boot-gate coercion/application are now separable modules, and flat `arkenv()` entries share dispatch locality with strict client/server entries.

--- a/packages/nuxt/src/arkenv-internal.ts
+++ b/packages/nuxt/src/arkenv-internal.ts
@@ -3,20 +3,17 @@ import { getSchemaKeys } from "@repo/utils";
 import { getBootGateResult } from "./boot-gate-state";
 import { createCaptureStub, isCapturing, recordCapture } from "./capture";
 import {
+	ENV_KEYS,
+	EXTENDED_ENV,
 	type FlatSchemaOptions,
 	type LegacyNestedSchema,
 	parseSchemaShape,
 	type SchemaLayoutContext,
+	SERVER_ONLY_KEYS,
 } from "./schema-shape";
 import { isForceServer } from "./validate-context";
 
-/** Symbol key for the raw extended env values object on an env proxy. */
-export const EXTENDED_ENV = Symbol.for("arkenv.extended_env");
-/** Symbol key for the set of declared schema keys on an env proxy. */
-export const ENV_KEYS = Symbol.for("arkenv.keys");
-/** Symbol key for server-only keys that must not be readable on the client. */
-export const SERVER_ONLY_KEYS = Symbol.for("arkenv.server_only_keys");
-
+export { ENV_KEYS, EXTENDED_ENV, SERVER_ONLY_KEYS };
 export type { FlatSchemaOptions, LegacyNestedSchema, SchemaLayoutContext };
 
 /**
@@ -67,7 +64,13 @@ export function arkenvInternal(
 					optionsOrIsServer),
 		);
 
-	const { server, client, shared, extendsList, runtimeEnv } = parsed;
+	const {
+		server,
+		client,
+		shared,
+		extendsList,
+		runtimeEnv,
+	} = parsed;
 
 	if (isServer) {
 		hooks?.ensureBootGate?.();

--- a/packages/nuxt/src/arkenv-internal.ts
+++ b/packages/nuxt/src/arkenv-internal.ts
@@ -1,7 +1,13 @@
-import type { Dict, SchemaShape } from "@repo/types";
+import type { SchemaShape } from "@repo/types";
 import { getSchemaKeys } from "@repo/utils";
 import { getBootGateResult } from "./boot-gate-state";
 import { createCaptureStub, isCapturing, recordCapture } from "./capture";
+import {
+	type FlatSchemaOptions,
+	type LegacyNestedSchema,
+	parseSchemaShape,
+	type SchemaLayoutContext,
+} from "./schema-shape";
 import { isForceServer } from "./validate-context";
 
 /** Symbol key for the raw extended env values object on an env proxy. */
@@ -11,29 +17,7 @@ export const ENV_KEYS = Symbol.for("arkenv.keys");
 /** Symbol key for server-only keys that must not be readable on the client. */
 export const SERVER_ONLY_KEYS = Symbol.for("arkenv.server_only_keys");
 
-/**
- * Legacy nested schema shape (`server` / `client` / `shared` buckets).
- */
-export type LegacyNestedSchema = {
-	server?: SchemaShape;
-	client?: SchemaShape;
-	shared?: SchemaShape;
-	extends?: readonly unknown[];
-	runtimeEnv?: Dict<string>;
-};
-
-/**
- * Options for the flat (unified) schema form of {@link arkenvInternal}.
- */
-export type FlatSchemaOptions = {
-	extends?: readonly unknown[];
-	runtimeEnv?: Dict<string>;
-	/** @deprecated Use `exposeToClient` instead. */
-	expose?: readonly string[];
-	/** @deprecated Use `exposeToClient` instead. */
-	shared?: readonly string[];
-	exposeToClient?: readonly string[];
-};
+export type { FlatSchemaOptions, LegacyNestedSchema, SchemaLayoutContext };
 
 /**
  * Optional server hooks for the thin Nuxt accessor path.
@@ -64,70 +48,26 @@ export type ArkenvInternalHooks = {
 export function arkenvInternal(
 	schemaOrOptions: SchemaShape | LegacyNestedSchema | null | undefined,
 	optionsOrIsServer: FlatSchemaOptions | boolean | null | undefined,
-	context:
-		| {
-				isServer: boolean;
-				isShared?: boolean;
-				strictLayout?: "client" | "server";
-		  }
-		| undefined,
+	context: SchemaLayoutContext | undefined,
 	hooks?: ArkenvInternalHooks,
 ): unknown {
+	const parsed = parseSchemaShape(schemaOrOptions, optionsOrIsServer, context);
+
 	if (isCapturing()) {
 		recordCapture(schemaOrOptions, optionsOrIsServer, context);
-		const keys = collectDeclaredKeys(
-			schemaOrOptions,
-			optionsOrIsServer,
-			context,
+		return createCaptureStub(parsed.declaredKeys);
+	}
+
+	const isServer =
+		isForceServer() ||
+		Boolean(
+			context?.isServer ||
+				(parsed.isLegacy &&
+					typeof optionsOrIsServer === "boolean" &&
+					optionsOrIsServer),
 		);
-		return createCaptureStub(keys);
-	}
 
-	let server: SchemaShape = {};
-	let client: Record<string, unknown> = {};
-	let shared: SchemaShape = {};
-	let extendsList: readonly unknown[] = [];
-	let runtimeEnv: Dict<string> = {};
-	let isServer = false;
-
-	if (typeof optionsOrIsServer === "boolean") {
-		const legacySchema = schemaOrOptions as
-			| LegacyNestedSchema
-			| null
-			| undefined;
-		server = (legacySchema?.server || {}) as SchemaShape;
-		client = (legacySchema?.client || {}) as Record<string, unknown>;
-		shared = (legacySchema?.shared || {}) as SchemaShape;
-		extendsList = legacySchema?.extends || [];
-		runtimeEnv = (legacySchema?.runtimeEnv || {}) as Dict<string>;
-		isServer = optionsOrIsServer;
-	} else {
-		const flatSchema = (schemaOrOptions || {}) as SchemaShape;
-		const options = optionsOrIsServer || {};
-		extendsList = options.extends || [];
-		runtimeEnv = (options.runtimeEnv || {}) as Dict<string>;
-		isServer = isForceServer() || !!context?.isServer;
-
-		if (context?.isShared) {
-			shared = flatSchema;
-		} else if (context?.strictLayout === "client") {
-			client = flatSchema;
-		} else if (context?.strictLayout === "server") {
-			server = flatSchema;
-		} else {
-			const exposedKeys =
-				options.exposeToClient || options.expose || options.shared || [];
-			for (const key of Object.keys(flatSchema)) {
-				if (exposedKeys.includes(key) || key === "NODE_ENV") {
-					shared[key] = flatSchema[key];
-				} else if (key.startsWith("NUXT_PUBLIC_")) {
-					client[key] = flatSchema[key];
-				} else {
-					server[key] = flatSchema[key];
-				}
-			}
-		}
-	}
+	const { server, client, shared, extendsList, runtimeEnv } = parsed;
 
 	if (isServer) {
 		hooks?.ensureBootGate?.();
@@ -268,54 +208,6 @@ function readThinSourceEnv(isServer: boolean): Record<string, unknown> {
 	}
 
 	return (typeof process !== "undefined" ? process.env : undefined) || {};
-}
-
-/**
- * Collect declared schema key names for capture stubs.
- *
- * @param schemaOrOptions Schema or nested options
- * @param optionsOrIsServer Flat options or legacy boolean
- * @param context Optional layout context
- * @returns Declared key names
- */
-function collectDeclaredKeys(
-	schemaOrOptions: SchemaShape | LegacyNestedSchema | null | undefined,
-	optionsOrIsServer: FlatSchemaOptions | boolean | null | undefined,
-	_context:
-		| {
-				isServer: boolean;
-				isShared?: boolean;
-				strictLayout?: "client" | "server";
-		  }
-		| undefined,
-): string[] {
-	if (typeof optionsOrIsServer === "boolean") {
-		const legacy = schemaOrOptions as LegacyNestedSchema;
-		return [
-			...Object.keys(legacy?.server || {}),
-			...Object.keys(legacy?.client || {}),
-			...Object.keys(legacy?.shared || {}),
-		];
-	}
-
-	const isLegacy =
-		schemaOrOptions &&
-		typeof schemaOrOptions === "object" &&
-		("runtimeEnv" in schemaOrOptions ||
-			"server" in schemaOrOptions ||
-			"client" in schemaOrOptions ||
-			"shared" in schemaOrOptions);
-
-	if (isLegacy) {
-		const legacy = schemaOrOptions as LegacyNestedSchema;
-		return [
-			...Object.keys(legacy.server || {}),
-			...Object.keys(legacy.client || {}),
-			...Object.keys(legacy.shared || {}),
-		];
-	}
-
-	return Object.keys((schemaOrOptions || {}) as SchemaShape);
 }
 
 /**

--- a/packages/nuxt/src/arkenv-internal.ts
+++ b/packages/nuxt/src/arkenv-internal.ts
@@ -13,8 +13,8 @@ import {
 } from "./schema-shape";
 import { isForceServer } from "./validate-context";
 
-export { ENV_KEYS, EXTENDED_ENV, SERVER_ONLY_KEYS };
 export type { FlatSchemaOptions, LegacyNestedSchema, SchemaLayoutContext };
+export { ENV_KEYS, EXTENDED_ENV, SERVER_ONLY_KEYS };
 
 /**
  * Optional server hooks for the thin Nuxt accessor path.
@@ -64,13 +64,7 @@ export function arkenvInternal(
 					optionsOrIsServer),
 		);
 
-	const {
-		server,
-		client,
-		shared,
-		extendsList,
-		runtimeEnv,
-	} = parsed;
+	const { server, client, shared, extendsList, runtimeEnv } = parsed;
 
 	if (isServer) {
 		hooks?.ensureBootGate?.();

--- a/packages/nuxt/src/boot-gate-load.ts
+++ b/packages/nuxt/src/boot-gate-load.ts
@@ -1,0 +1,301 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { SchemaShape } from "@repo/types";
+import { createJiti } from "jiti";
+import {
+	beginCapture,
+	combineCapturedSchemas,
+	endCapture,
+	publicKeysFromCaptures,
+} from "./capture";
+import { withForceServer } from "./validate-context";
+
+export type BootGateEngine = "arktype" | "standard";
+
+export type BootGateConfig = {
+	schemaPath: string;
+	layout: "simple" | "strict";
+	baseDir: string;
+	engine: BootGateEngine;
+};
+
+/**
+ * Build Jiti aliases that point package entry points at this package's source/dist.
+ *
+ * @param packageDir Absolute directory containing this package's entry files
+ * @param resolvedLayout Detected layout mode
+ * @param baseDir Strict-layout env directory, or empty for flat
+ * @param internalOptions Optional alias overrides for tests
+ * @returns Alias map for Jiti
+ */
+export function buildSchemaJitiAliases(
+	packageDir: string,
+	resolvedLayout: "simple" | "strict",
+	baseDir: string,
+	internalOptions?: { _jitiAliases?: Record<string, string> },
+): Record<string, string> {
+	const packageJsonPath = path.resolve(packageDir, "../package.json");
+	let pkgExports: Record<string, unknown> = {};
+	try {
+		const pkgContent = fs.readFileSync(packageJsonPath, "utf-8");
+		pkgExports = JSON.parse(pkgContent).exports || {};
+	} catch {
+		// fallback if package.json isn't adjacent/found
+	}
+
+	const resolveExportPath = (subpath: string, fallbackFile: string): string => {
+		const entry = pkgExports[subpath] as
+			| { import?: string; default?: string }
+			| string
+			| undefined;
+		if (entry) {
+			const target =
+				typeof entry === "string"
+					? entry
+					: entry.import || entry.default || entry;
+			if (typeof target === "string") {
+				const fileBasename = path.basename(target).replace(/\.m?[jt]s$/, "");
+				const tsPath = path.join(packageDir, `${fileBasename}.ts`);
+				if (fs.existsSync(tsPath)) {
+					return tsPath;
+				}
+				const jsPath = path.join(packageDir, `${fileBasename}.js`);
+				if (fs.existsSync(jsPath)) {
+					return jsPath;
+				}
+			}
+		}
+		return fallbackFile;
+	};
+
+	const sharedPath = resolveExportPath(
+		"./shared",
+		fs.existsSync(path.join(packageDir, "shared.ts"))
+			? path.join(packageDir, "shared.ts")
+			: path.join(packageDir, "shared.js"),
+	);
+	const indexPath = resolveExportPath(
+		".",
+		fs.existsSync(path.join(packageDir, "index.ts"))
+			? path.join(packageDir, "index.ts")
+			: path.join(packageDir, "index.js"),
+	);
+	const clientPath = resolveExportPath(
+		"./client",
+		fs.existsSync(path.join(packageDir, "client.ts"))
+			? path.join(packageDir, "client.ts")
+			: path.join(packageDir, "client.js"),
+	);
+	const serverPath = resolveExportPath(
+		"./server",
+		fs.existsSync(path.join(packageDir, "server.ts"))
+			? path.join(packageDir, "server.ts")
+			: path.join(packageDir, "server.js"),
+	);
+	const standardIndexPath = resolveExportPath(
+		"./standard",
+		fs.existsSync(path.join(packageDir, "standard/index.ts"))
+			? path.join(packageDir, "standard/index.ts")
+			: path.join(packageDir, "standard/index.js"),
+	);
+	const standardClientPath = resolveExportPath(
+		"./standard/client",
+		fs.existsSync(path.join(packageDir, "standard/client.ts"))
+			? path.join(packageDir, "standard/client.ts")
+			: path.join(packageDir, "standard/client.js"),
+	);
+	const standardServerPath = resolveExportPath(
+		"./standard/server",
+		fs.existsSync(path.join(packageDir, "standard/server.ts"))
+			? path.join(packageDir, "standard/server.ts")
+			: path.join(packageDir, "standard/server.js"),
+	);
+
+	const mockImportsPath = fs.existsSync(
+		path.join(packageDir, "mock-imports.ts"),
+	)
+		? path.join(packageDir, "mock-imports.ts")
+		: fs.existsSync(path.join(packageDir, "mock-imports.js"))
+			? path.join(packageDir, "mock-imports.js")
+			: path.join(packageDir, "mock-imports.cjs");
+
+	const emptyClientEnvPath = fs.existsSync(
+		path.join(packageDir, "empty-client-env.ts"),
+	)
+		? path.join(packageDir, "empty-client-env.ts")
+		: path.join(packageDir, "empty-client-env.js");
+
+	const emptySharedSchemaPath = fs.existsSync(
+		path.join(packageDir, "empty-shared-schema.ts"),
+	)
+		? path.join(packageDir, "empty-shared-schema.ts")
+		: path.join(packageDir, "empty-shared-schema.js");
+
+	const emptyServerBootPath = fs.existsSync(
+		path.join(packageDir, "empty-server-boot.ts"),
+	)
+		? path.join(packageDir, "empty-server-boot.ts")
+		: path.join(packageDir, "empty-server-boot.js");
+
+	const strictUserClientPath =
+		resolvedLayout === "strict" && baseDir
+			? path.join(baseDir, "client.ts")
+			: undefined;
+
+	const strictUserSharedPath =
+		resolvedLayout === "strict" && baseDir
+			? path.join(baseDir, "internal", "shared.ts")
+			: undefined;
+
+	return {
+		"@arkenv/nuxt/shared": sharedPath,
+		"@arkenv/nuxt": indexPath,
+		"@arkenv/nuxt/client": clientPath,
+		"@arkenv/nuxt/server": serverPath,
+		"@arkenv/nuxt/standard": standardIndexPath,
+		"@arkenv/nuxt/standard/client": standardClientPath,
+		"@arkenv/nuxt/standard/server": standardServerPath,
+		"#imports": mockImportsPath,
+		"#arkenv/server-boot": emptyServerBootPath,
+		"#arkenv/client-env":
+			strictUserClientPath && fs.existsSync(strictUserClientPath)
+				? strictUserClientPath
+				: emptyClientEnvPath,
+		"#arkenv/shared-schema":
+			strictUserSharedPath && fs.existsSync(strictUserSharedPath)
+				? strictUserSharedPath
+				: emptySharedSchemaPath,
+		...internalOptions?._jitiAliases,
+	};
+}
+
+/**
+ * Resolve the directory that contains this package's compiled or source entries.
+ *
+ * @returns Absolute package entry directory
+ */
+function resolvePackageDir(): string {
+	const filenameForJiti =
+		typeof __filename !== "undefined"
+			? __filename
+			: typeof import.meta !== "undefined" && import.meta.url
+				? fileURLToPath(import.meta.url)
+				: "";
+	return path.dirname(filenameForJiti);
+}
+
+/**
+ * Load user schema files under capture mode and return the combined schema.
+ *
+ * @param config Boot-gate schema location options
+ * @param internalOptions Optional Jiti alias overrides for tests
+ * @returns Combined schema and public key set
+ */
+export function loadSchemaViaCapture(
+	config: BootGateConfig,
+	internalOptions?: { _jitiAliases?: Record<string, string> },
+): { schema: SchemaShape; publicKeys: Set<string> } {
+	const packageDir = resolvePackageDir();
+	const fileToEvaluate =
+		config.layout === "strict" && config.baseDir
+			? path.join(config.baseDir, "server.ts")
+			: config.schemaPath;
+
+	const aliases = buildSchemaJitiAliases(
+		packageDir,
+		config.layout,
+		config.baseDir,
+		internalOptions,
+	);
+
+	const jitiOptions = {
+		moduleCache: false,
+		fsCache: false,
+		tsconfigPaths: true,
+		alias: aliases,
+	} as const;
+
+	const g = globalThis as {
+		__ARKENV_STRICT_LAYOUT__?: boolean;
+		__ARKENV_CLIENT_ENV__?: unknown;
+		__ARKENV_SHARED_SCHEMA__?: unknown;
+	};
+
+	return withForceServer(() => {
+		beginCapture();
+		try {
+			const evaluateSchema = (jiti: ReturnType<typeof createJiti>) => {
+				if (config.layout === "strict" && config.baseDir) {
+					const strictUserSharedPath = path.join(
+						config.baseDir,
+						"internal",
+						"shared.ts",
+					);
+					// Absent shared.ts → empty merge (aliases already point at
+					// empty-shared-schema). A present file must export SharedSchema.
+					if (fs.existsSync(strictUserSharedPath)) {
+						const sharedMod = jiti(strictUserSharedPath) as {
+							SharedSchema?: SchemaShape;
+							default?: { SharedSchema?: SchemaShape };
+						};
+						const sharedSchema =
+							sharedMod.SharedSchema ?? sharedMod.default?.SharedSchema;
+						if (sharedSchema === undefined || sharedSchema === null) {
+							throw new Error(
+								`[arkenv] Strict layout requires a usable SharedSchema export from "${strictUserSharedPath}".`,
+							);
+						}
+						g.__ARKENV_SHARED_SCHEMA__ = sharedSchema;
+					}
+
+					const strictUserClientPath = path.join(config.baseDir, "client.ts");
+					if (fs.existsSync(strictUserClientPath)) {
+						g.__ARKENV_STRICT_LAYOUT__ = true;
+						const clientMod = jiti(strictUserClientPath) as {
+							env?: unknown;
+							default?: { env?: unknown };
+						};
+						g.__ARKENV_CLIENT_ENV__ =
+							clientMod.env ?? clientMod.default?.env ?? clientMod;
+					}
+				}
+
+				jiti(fileToEvaluate);
+			};
+
+			try {
+				const jiti = createJiti(fileToEvaluate, jitiOptions);
+				evaluateSchema(jiti);
+			} catch (error: unknown) {
+				const message = error instanceof Error ? error.message : String(error);
+				const isTsconfigNotFound =
+					error instanceof Error &&
+					/tsconfig/i.test(message) &&
+					(/not found/i.test(message) ||
+						(error as NodeJS.ErrnoException).code === "ENOENT");
+
+				if (isTsconfigNotFound) {
+					const fallbackJiti = createJiti(fileToEvaluate, {
+						...jitiOptions,
+						tsconfigPaths: false,
+					});
+					evaluateSchema(fallbackJiti);
+				} else {
+					throw error;
+				}
+			}
+
+			const calls = endCapture();
+			return {
+				schema: combineCapturedSchemas(calls),
+				publicKeys: publicKeysFromCaptures(calls),
+			};
+		} finally {
+			endCapture();
+			delete g.__ARKENV_STRICT_LAYOUT__;
+			delete g.__ARKENV_CLIENT_ENV__;
+			delete g.__ARKENV_SHARED_SCHEMA__;
+		}
+	});
+}

--- a/packages/nuxt/src/boot-gate.test.ts
+++ b/packages/nuxt/src/boot-gate.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { resetBootGateForTests, runBootGate } from "./boot-gate";
+import { applyBootGate, resetBootGateForTests, runBootGate } from "./boot-gate";
 import {
 	getBootGateResult,
 	resetBootGateResultForTests,
@@ -12,7 +12,106 @@ afterEach(() => {
 	resetBootGateResultForTests();
 });
 
-describe("Nuxt boot gate", () => {
+describe("Nuxt boot gate - applyBootGate (pure transformation)", () => {
+	it("coerces values and populates public and server runtimeConfig keys", () => {
+		const schema = {
+			PORT: "number",
+			NUXT_PUBLIC_HOST: "string",
+			NUXT_PUBLIC_ENABLED: "boolean",
+		};
+		const publicKeys = new Set(["NUXT_PUBLIC_HOST", "NUXT_PUBLIC_ENABLED"]);
+
+		const runtimeConfig = {
+			public: {
+				NUXT_PUBLIC_HOST: "localhost",
+				NUXT_PUBLIC_ENABLED: "true",
+			},
+			PORT: "3000",
+		};
+
+		const result = applyBootGate(
+			schema as any,
+			publicKeys,
+			"arktype",
+			runtimeConfig,
+		);
+
+		expect(runtimeConfig.PORT).toBe(3000);
+		expect(typeof runtimeConfig.PORT).toBe("number");
+		expect(runtimeConfig.public.NUXT_PUBLIC_HOST).toBe("localhost");
+		expect(runtimeConfig.public.NUXT_PUBLIC_ENABLED).toBe(true);
+		expect(typeof runtimeConfig.public.NUXT_PUBLIC_ENABLED).toBe("boolean");
+
+		expect(result.PORT).toBe(3000);
+		expect(result.NUXT_PUBLIC_ENABLED).toBe(true);
+		expect(getBootGateResult()?.PORT).toBe(3000);
+	});
+
+	it("returns flattened runtimeConfig when schema is empty", () => {
+		const runtimeConfig = {
+			public: { FOO: "bar" },
+			SECRET: "123",
+		};
+
+		const result = applyBootGate({}, new Set(), "arktype", runtimeConfig);
+		expect(result).toEqual({ FOO: "bar", SECRET: "123" });
+		expect(getBootGateResult()).toEqual({ FOO: "bar", SECRET: "123" });
+	});
+
+	it("fails fast when validation fails on invalid string value", () => {
+		const schema = {
+			PORT: "number",
+		};
+
+		const runtimeConfig = {
+			PORT: "not-a-number",
+		};
+
+		expect(() =>
+			applyBootGate(schema as any, new Set(), "arktype", runtimeConfig),
+		).toThrow();
+	});
+
+	it("coerces values using standard engine", () => {
+		const numberSchema = {
+			"~standard": {
+				version: 1,
+				vendor: "mock",
+				validate: (value: unknown) => {
+					const n = Number(value);
+					if (value === undefined || value === "" || Number.isNaN(n)) {
+						return { issues: [{ message: "expected number" }] };
+					}
+					return { value: n };
+				},
+			},
+		};
+
+		const schema = {
+			NUXT_PUBLIC_PORT: numberSchema,
+		};
+		const publicKeys = new Set(["NUXT_PUBLIC_PORT"]);
+
+		const runtimeConfig = {
+			public: {
+				NUXT_PUBLIC_PORT: "9000",
+			},
+		};
+
+		const result = applyBootGate(
+			schema as any,
+			publicKeys,
+			"standard",
+			runtimeConfig,
+		);
+
+		expect(runtimeConfig.public.NUXT_PUBLIC_PORT).toBe(9000);
+		expect(typeof runtimeConfig.public.NUXT_PUBLIC_PORT).toBe("number");
+		expect(result.NUXT_PUBLIC_PORT).toBe(9000);
+	});
+});
+
+describe("Nuxt boot gate - runBootGate (capture + apply integration)", () => {
 	it("coerces NUXT_PUBLIC_* string overrides into runtimeConfig.public", () => {
 		const tempDir = path.resolve(__dirname, "temp-boot-gate-coerce");
 		fs.mkdirSync(tempDir, { recursive: true });
@@ -161,7 +260,7 @@ describe("Nuxt boot gate", () => {
 				"~standard": {
 					version: 1,
 					vendor: "mock",
-					validate: (value) => {
+					validate: (value: unknown) => {
 						const n = Number(value);
 						if (value === undefined || value === "" || Number.isNaN(n)) {
 							return { issues: [{ message: "expected number" }] };

--- a/packages/nuxt/src/boot-gate.ts
+++ b/packages/nuxt/src/boot-gate.ts
@@ -1,31 +1,20 @@
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { Dict, SchemaShape } from "@repo/types";
-import { createJiti } from "jiti";
+import {
+	type BootGateConfig,
+	type BootGateEngine,
+	buildSchemaJitiAliases,
+	loadSchemaViaCapture,
+} from "./boot-gate-load";
 import {
 	getBootGateResult,
 	isBootGateDone,
 	resetBootGateResultForTests,
 	setBootGateResult,
 } from "./boot-gate-state";
-import {
-	beginCapture,
-	combineCapturedSchemas,
-	endCapture,
-	publicKeysFromCaptures,
-} from "./capture";
 import { resolveCoreArkenv } from "./resolve-core-arkenv";
-import { withForceServer } from "./validate-context";
 
-export type BootGateEngine = "arktype" | "standard";
-
-export type BootGateConfig = {
-	schemaPath: string;
-	layout: "simple" | "strict";
-	baseDir: string;
-	engine: BootGateEngine;
-};
+export type { BootGateConfig, BootGateEngine };
+export { buildSchemaJitiAliases, loadSchemaViaCapture };
 
 export type BootGateRuntimeConfig = {
 	public?: Record<string, unknown>;
@@ -64,286 +53,6 @@ export function getBootGateConfig(): BootGateConfig | null {
 export function resetBootGateForTests(): void {
 	gateConfig = null;
 	resetBootGateResultForTests();
-}
-
-/**
- * Build Jiti aliases that point package entry points at this package's source/dist.
- *
- * @param packageDir Absolute directory containing this package's entry files
- * @param resolvedLayout Detected layout mode
- * @param baseDir Strict-layout env directory, or empty for flat
- * @param internalOptions Optional alias overrides for tests
- * @returns Alias map for Jiti
- */
-export function buildSchemaJitiAliases(
-	packageDir: string,
-	resolvedLayout: "simple" | "strict",
-	baseDir: string,
-	internalOptions?: { _jitiAliases?: Record<string, string> },
-): Record<string, string> {
-	const packageJsonPath = path.resolve(packageDir, "../package.json");
-	let pkgExports: Record<string, unknown> = {};
-	try {
-		const pkgContent = fs.readFileSync(packageJsonPath, "utf-8");
-		pkgExports = JSON.parse(pkgContent).exports || {};
-	} catch {
-		// fallback if package.json isn't adjacent/found
-	}
-
-	const resolveExportPath = (subpath: string, fallbackFile: string): string => {
-		const entry = pkgExports[subpath] as
-			| { import?: string; default?: string }
-			| string
-			| undefined;
-		if (entry) {
-			const target =
-				typeof entry === "string"
-					? entry
-					: entry.import || entry.default || entry;
-			if (typeof target === "string") {
-				const fileBasename = path.basename(target).replace(/\.m?[jt]s$/, "");
-				const tsPath = path.join(packageDir, `${fileBasename}.ts`);
-				if (fs.existsSync(tsPath)) {
-					return tsPath;
-				}
-				const jsPath = path.join(packageDir, `${fileBasename}.js`);
-				if (fs.existsSync(jsPath)) {
-					return jsPath;
-				}
-			}
-		}
-		return fallbackFile;
-	};
-
-	const sharedPath = resolveExportPath(
-		"./shared",
-		fs.existsSync(path.join(packageDir, "shared.ts"))
-			? path.join(packageDir, "shared.ts")
-			: path.join(packageDir, "shared.js"),
-	);
-	const indexPath = resolveExportPath(
-		".",
-		fs.existsSync(path.join(packageDir, "index.ts"))
-			? path.join(packageDir, "index.ts")
-			: path.join(packageDir, "index.js"),
-	);
-	const clientPath = resolveExportPath(
-		"./client",
-		fs.existsSync(path.join(packageDir, "client.ts"))
-			? path.join(packageDir, "client.ts")
-			: path.join(packageDir, "client.js"),
-	);
-	const serverPath = resolveExportPath(
-		"./server",
-		fs.existsSync(path.join(packageDir, "server.ts"))
-			? path.join(packageDir, "server.ts")
-			: path.join(packageDir, "server.js"),
-	);
-	const standardIndexPath = resolveExportPath(
-		"./standard",
-		fs.existsSync(path.join(packageDir, "standard/index.ts"))
-			? path.join(packageDir, "standard/index.ts")
-			: path.join(packageDir, "standard/index.js"),
-	);
-	const standardClientPath = resolveExportPath(
-		"./standard/client",
-		fs.existsSync(path.join(packageDir, "standard/client.ts"))
-			? path.join(packageDir, "standard/client.ts")
-			: path.join(packageDir, "standard/client.js"),
-	);
-	const standardServerPath = resolveExportPath(
-		"./standard/server",
-		fs.existsSync(path.join(packageDir, "standard/server.ts"))
-			? path.join(packageDir, "standard/server.ts")
-			: path.join(packageDir, "standard/server.js"),
-	);
-
-	const mockImportsPath = fs.existsSync(
-		path.join(packageDir, "mock-imports.ts"),
-	)
-		? path.join(packageDir, "mock-imports.ts")
-		: fs.existsSync(path.join(packageDir, "mock-imports.js"))
-			? path.join(packageDir, "mock-imports.js")
-			: path.join(packageDir, "mock-imports.cjs");
-
-	const emptyClientEnvPath = fs.existsSync(
-		path.join(packageDir, "empty-client-env.ts"),
-	)
-		? path.join(packageDir, "empty-client-env.ts")
-		: path.join(packageDir, "empty-client-env.js");
-
-	const emptySharedSchemaPath = fs.existsSync(
-		path.join(packageDir, "empty-shared-schema.ts"),
-	)
-		? path.join(packageDir, "empty-shared-schema.ts")
-		: path.join(packageDir, "empty-shared-schema.js");
-
-	const emptyServerBootPath = fs.existsSync(
-		path.join(packageDir, "empty-server-boot.ts"),
-	)
-		? path.join(packageDir, "empty-server-boot.ts")
-		: path.join(packageDir, "empty-server-boot.js");
-
-	const strictUserClientPath =
-		resolvedLayout === "strict" && baseDir
-			? path.join(baseDir, "client.ts")
-			: undefined;
-
-	const strictUserSharedPath =
-		resolvedLayout === "strict" && baseDir
-			? path.join(baseDir, "internal", "shared.ts")
-			: undefined;
-
-	return {
-		"@arkenv/nuxt/shared": sharedPath,
-		"@arkenv/nuxt": indexPath,
-		"@arkenv/nuxt/client": clientPath,
-		"@arkenv/nuxt/server": serverPath,
-		"@arkenv/nuxt/standard": standardIndexPath,
-		"@arkenv/nuxt/standard/client": standardClientPath,
-		"@arkenv/nuxt/standard/server": standardServerPath,
-		"#imports": mockImportsPath,
-		"#arkenv/server-boot": emptyServerBootPath,
-		"#arkenv/client-env":
-			strictUserClientPath && fs.existsSync(strictUserClientPath)
-				? strictUserClientPath
-				: emptyClientEnvPath,
-		"#arkenv/shared-schema":
-			strictUserSharedPath && fs.existsSync(strictUserSharedPath)
-				? strictUserSharedPath
-				: emptySharedSchemaPath,
-		...internalOptions?._jitiAliases,
-	};
-}
-
-/**
- * Resolve the directory that contains this package's compiled or source entries.
- *
- * @returns Absolute package entry directory
- */
-function resolvePackageDir(): string {
-	const filenameForJiti =
-		typeof __filename !== "undefined"
-			? __filename
-			: typeof import.meta !== "undefined" && import.meta.url
-				? fileURLToPath(import.meta.url)
-				: "";
-	return path.dirname(filenameForJiti);
-}
-
-/**
- * Load user schema files under capture mode and return the combined schema.
- *
- * @param config Boot-gate schema location options
- * @param internalOptions Optional Jiti alias overrides for tests
- * @returns Combined schema and public key set
- */
-export function loadSchemaViaCapture(
-	config: BootGateConfig,
-	internalOptions?: { _jitiAliases?: Record<string, string> },
-): { schema: SchemaShape; publicKeys: Set<string> } {
-	const packageDir = resolvePackageDir();
-	const fileToEvaluate =
-		config.layout === "strict" && config.baseDir
-			? path.join(config.baseDir, "server.ts")
-			: config.schemaPath;
-
-	const aliases = buildSchemaJitiAliases(
-		packageDir,
-		config.layout,
-		config.baseDir,
-		internalOptions,
-	);
-
-	const jitiOptions = {
-		moduleCache: false,
-		fsCache: false,
-		tsconfigPaths: true,
-		alias: aliases,
-	} as const;
-
-	const g = globalThis as {
-		__ARKENV_STRICT_LAYOUT__?: boolean;
-		__ARKENV_CLIENT_ENV__?: unknown;
-		__ARKENV_SHARED_SCHEMA__?: unknown;
-	};
-
-	return withForceServer(() => {
-		beginCapture();
-		try {
-			const evaluateSchema = (jiti: ReturnType<typeof createJiti>) => {
-				if (config.layout === "strict" && config.baseDir) {
-					const strictUserSharedPath = path.join(
-						config.baseDir,
-						"internal",
-						"shared.ts",
-					);
-					// Absent shared.ts → empty merge (aliases already point at
-					// empty-shared-schema). A present file must export SharedSchema.
-					if (fs.existsSync(strictUserSharedPath)) {
-						const sharedMod = jiti(strictUserSharedPath) as {
-							SharedSchema?: SchemaShape;
-							default?: { SharedSchema?: SchemaShape };
-						};
-						const sharedSchema =
-							sharedMod.SharedSchema ?? sharedMod.default?.SharedSchema;
-						if (sharedSchema === undefined || sharedSchema === null) {
-							throw new Error(
-								`[arkenv] Strict layout requires a usable SharedSchema export from "${strictUserSharedPath}".`,
-							);
-						}
-						g.__ARKENV_SHARED_SCHEMA__ = sharedSchema;
-					}
-
-					const strictUserClientPath = path.join(config.baseDir, "client.ts");
-					if (fs.existsSync(strictUserClientPath)) {
-						g.__ARKENV_STRICT_LAYOUT__ = true;
-						const clientMod = jiti(strictUserClientPath) as {
-							env?: unknown;
-							default?: { env?: unknown };
-						};
-						g.__ARKENV_CLIENT_ENV__ =
-							clientMod.env ?? clientMod.default?.env ?? clientMod;
-					}
-				}
-
-				jiti(fileToEvaluate);
-			};
-
-			try {
-				const jiti = createJiti(fileToEvaluate, jitiOptions);
-				evaluateSchema(jiti);
-			} catch (error: unknown) {
-				const message = error instanceof Error ? error.message : String(error);
-				const isTsconfigNotFound =
-					error instanceof Error &&
-					/tsconfig/i.test(message) &&
-					(/not found/i.test(message) ||
-						(error as NodeJS.ErrnoException).code === "ENOENT");
-
-				if (isTsconfigNotFound) {
-					const fallbackJiti = createJiti(fileToEvaluate, {
-						...jitiOptions,
-						tsconfigPaths: false,
-					});
-					evaluateSchema(fallbackJiti);
-				} else {
-					throw error;
-				}
-			}
-
-			const calls = endCapture();
-			return {
-				schema: combineCapturedSchemas(calls),
-				publicKeys: publicKeysFromCaptures(calls),
-			};
-		} finally {
-			endCapture();
-			delete g.__ARKENV_STRICT_LAYOUT__;
-			delete g.__ARKENV_CLIENT_ENV__;
-			delete g.__ARKENV_SHARED_SCHEMA__;
-		}
-	});
 }
 
 /**
@@ -387,21 +96,24 @@ export function applyCoercedToRuntimeConfig(
 }
 
 /**
- * Run the Nuxt boot gate: capture schema, validate/coerce against live config, write back.
+ * Apply validation and coercion on live runtimeConfig for a given schema and public key set.
  *
- * @param config Schema path and engine
+ * Separable from file-system and Jiti schema capture, enabling isolated testing
+ * and direct runtime application.
+ *
+ * @param schema Flat schema object for core validation
+ * @param publicKeys Set of public keys to route to runtimeConfig.public
+ * @param engine Validation engine ("arktype" | "standard")
  * @param runtimeConfig Live Nitro runtime config (mutated in place)
- * @param internalOptions Optional Jiti overrides for tests
- * @returns Flattened coerced values
+ * @returns Coerced values recorded in the boot-gate result
  * @throws When validation fails (fail-fast)
  */
-export function runBootGate(
-	config: BootGateConfig,
+export function applyBootGate(
+	schema: SchemaShape,
+	publicKeys: Set<string>,
+	engine: BootGateEngine,
 	runtimeConfig: BootGateRuntimeConfig,
-	internalOptions?: { _jitiAliases?: Record<string, string> },
 ): Record<string, unknown> {
-	const { schema, publicKeys } = loadSchemaViaCapture(config, internalOptions);
-
 	if (Object.keys(schema).length === 0) {
 		const flat = flattenRuntimeConfig(runtimeConfig);
 		setBootGateResult(flat);
@@ -422,7 +134,7 @@ export function runBootGate(
 		}
 	}
 
-	const coreArkenv = resolveCoreArkenv(config.engine);
+	const coreArkenv = resolveCoreArkenv(engine);
 	const coerced = coreArkenv(schema, {
 		env: combinedEnv as Dict<string>,
 		safe: false,
@@ -431,6 +143,24 @@ export function runBootGate(
 	applyCoercedToRuntimeConfig(runtimeConfig, coerced, publicKeys);
 	setBootGateResult({ ...coerced });
 	return getBootGateResult() as Record<string, unknown>;
+}
+
+/**
+ * Run the Nuxt boot gate: capture schema, validate/coerce against live config, write back.
+ *
+ * @param config Schema path and engine
+ * @param runtimeConfig Live Nitro runtime config (mutated in place)
+ * @param internalOptions Optional Jiti overrides for tests
+ * @returns Flattened coerced values
+ * @throws When validation fails (fail-fast)
+ */
+export function runBootGate(
+	config: BootGateConfig,
+	runtimeConfig: BootGateRuntimeConfig,
+	internalOptions?: { _jitiAliases?: Record<string, string> },
+): Record<string, unknown> {
+	const { schema, publicKeys } = loadSchemaViaCapture(config, internalOptions);
+	return applyBootGate(schema, publicKeys, config.engine, runtimeConfig);
 }
 
 /**

--- a/packages/nuxt/src/capture.ts
+++ b/packages/nuxt/src/capture.ts
@@ -1,4 +1,10 @@
 import type { Dict, SchemaShape } from "@repo/types";
+import {
+	type FlatSchemaOptions,
+	type LegacyNestedSchema,
+	parseSchemaShape,
+	type SchemaLayoutContext,
+} from "./schema-shape";
 
 /** Matches {@link EXTENDED_ENV} in arkenv-internal without importing it (avoid cycles). */
 const EXTENDED_ENV = Symbol.for("arkenv.extended_env");
@@ -14,32 +20,14 @@ type CaptureState = {
 	captures: CapturedSchemaCall[];
 };
 
-export type CaptureLegacyNested = {
-	server?: SchemaShape;
-	client?: SchemaShape;
-	shared?: SchemaShape;
-	extends?: readonly unknown[];
-	runtimeEnv?: Dict<string>;
-};
+export type CaptureLegacyNested = LegacyNestedSchema;
 
-export type CaptureFlatOptions = {
-	extends?: readonly unknown[];
-	runtimeEnv?: Dict<string>;
-	expose?: readonly string[];
-	shared?: readonly string[];
-	exposeToClient?: readonly string[];
-};
+export type CaptureFlatOptions = FlatSchemaOptions;
 
 export type CapturedSchemaCall = {
-	schemaOrOptions: SchemaShape | CaptureLegacyNested;
-	optionsOrIsServer: CaptureFlatOptions | boolean | null | undefined;
-	context:
-		| {
-				isServer: boolean;
-				isShared?: boolean;
-				strictLayout?: "client" | "server";
-		  }
-		| undefined;
+	schemaOrOptions: SchemaShape | LegacyNestedSchema;
+	optionsOrIsServer: FlatSchemaOptions | boolean | null | undefined;
+	context: SchemaLayoutContext | undefined;
 };
 
 /**
@@ -92,20 +80,14 @@ export function isCapturing(): boolean {
  * @param context Optional server/client/strict-layout context
  */
 export function recordCapture(
-	schemaOrOptions: SchemaShape | CaptureLegacyNested | null | undefined,
-	optionsOrIsServer: CaptureFlatOptions | boolean | null | undefined,
-	context:
-		| {
-				isServer: boolean;
-				isShared?: boolean;
-				strictLayout?: "client" | "server";
-		  }
-		| undefined,
+	schemaOrOptions: SchemaShape | LegacyNestedSchema | null | undefined,
+	optionsOrIsServer: FlatSchemaOptions | boolean | null | undefined,
+	context: SchemaLayoutContext | undefined,
 ): void {
 	getCaptureState().captures.push({
 		schemaOrOptions: (schemaOrOptions || {}) as
 			| SchemaShape
-			| CaptureLegacyNested,
+			| LegacyNestedSchema,
 		optionsOrIsServer,
 		context,
 	});
@@ -123,48 +105,15 @@ export function combineCapturedSchemas(
 	const combined: SchemaShape = {};
 
 	for (const call of calls) {
-		Object.assign(combined, schemaFromCapture(call));
+		const parsed = parseSchemaShape(
+			call.schemaOrOptions,
+			call.optionsOrIsServer,
+			call.context,
+		);
+		Object.assign(combined, parsed.server, parsed.client, parsed.shared);
 	}
 
 	return combined;
-}
-
-/**
- * Derive a flat schema shape from a single captured call.
- *
- * @param call The captured `arkenv()` invocation
- * @returns Schema keys contributed by that call
- */
-function schemaFromCapture(call: CapturedSchemaCall): SchemaShape {
-	const { schemaOrOptions, optionsOrIsServer } = call;
-
-	if (typeof optionsOrIsServer === "boolean") {
-		const legacy = schemaOrOptions as CaptureLegacyNested;
-		return {
-			...(legacy.server || {}),
-			...(legacy.client || {}),
-			...(legacy.shared || {}),
-		} as SchemaShape;
-	}
-
-	const isLegacy =
-		schemaOrOptions &&
-		typeof schemaOrOptions === "object" &&
-		("runtimeEnv" in schemaOrOptions ||
-			"server" in schemaOrOptions ||
-			"client" in schemaOrOptions ||
-			"shared" in schemaOrOptions);
-
-	if (isLegacy) {
-		const legacy = schemaOrOptions as CaptureLegacyNested;
-		return {
-			...(legacy.server || {}),
-			...(legacy.client || {}),
-			...(legacy.shared || {}),
-		} as SchemaShape;
-	}
-
-	return (schemaOrOptions || {}) as SchemaShape;
 }
 
 /**
@@ -179,51 +128,13 @@ export function publicKeysFromCaptures(
 	const publicKeys = new Set<string>();
 
 	for (const call of calls) {
-		const { schemaOrOptions, optionsOrIsServer, context } = call;
-
-		if (typeof optionsOrIsServer === "boolean") {
-			const legacy = schemaOrOptions as CaptureLegacyNested;
-			for (const key of Object.keys(legacy.client || {})) publicKeys.add(key);
-			for (const key of Object.keys(legacy.shared || {})) publicKeys.add(key);
-			continue;
-		}
-
-		const isLegacy =
-			schemaOrOptions &&
-			typeof schemaOrOptions === "object" &&
-			("server" in schemaOrOptions ||
-				"client" in schemaOrOptions ||
-				"shared" in schemaOrOptions);
-
-		if (isLegacy) {
-			const legacy = schemaOrOptions as CaptureLegacyNested;
-			for (const key of Object.keys(legacy.client || {})) publicKeys.add(key);
-			for (const key of Object.keys(legacy.shared || {})) publicKeys.add(key);
-			continue;
-		}
-
-		const flat = (schemaOrOptions || {}) as SchemaShape;
-		const options = (optionsOrIsServer || {}) as CaptureFlatOptions;
-
-		if (context?.isShared || context?.strictLayout === "client") {
-			for (const key of Object.keys(flat)) publicKeys.add(key);
-			continue;
-		}
-
-		if (context?.strictLayout === "server") {
-			continue;
-		}
-
-		const exposed =
-			options.exposeToClient || options.expose || options.shared || [];
-		for (const key of Object.keys(flat)) {
-			if (
-				exposed.includes(key) ||
-				key === "NODE_ENV" ||
-				key.startsWith("NUXT_PUBLIC_")
-			) {
-				publicKeys.add(key);
-			}
+		const parsed = parseSchemaShape(
+			call.schemaOrOptions,
+			call.optionsOrIsServer,
+			call.context,
+		);
+		for (const key of parsed.publicKeys) {
+			publicKeys.add(key);
 		}
 	}
 

--- a/packages/nuxt/src/capture.ts
+++ b/packages/nuxt/src/capture.ts
@@ -1,17 +1,13 @@
 import type { Dict, SchemaShape } from "@repo/types";
 import {
+	ENV_KEYS,
+	EXTENDED_ENV,
 	type FlatSchemaOptions,
 	type LegacyNestedSchema,
 	parseSchemaShape,
 	type SchemaLayoutContext,
+	SERVER_ONLY_KEYS,
 } from "./schema-shape";
-
-/** Matches {@link EXTENDED_ENV} in arkenv-internal without importing it (avoid cycles). */
-const EXTENDED_ENV = Symbol.for("arkenv.extended_env");
-/** Matches {@link ENV_KEYS} in arkenv-internal without importing it (avoid cycles). */
-const ENV_KEYS = Symbol.for("arkenv.keys");
-/** Matches {@link SERVER_ONLY_KEYS} in arkenv-internal without importing it (avoid cycles). */
-const SERVER_ONLY_KEYS = Symbol.for("arkenv.server_only_keys");
 
 const CAPTURE_STATE_KEY = "__ARKENV_SCHEMA_CAPTURE__";
 

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -2,7 +2,8 @@ import type { EnvSchema, Infer } from "@arkenv/core";
 import type { SchemaShape } from "@repo/types";
 // Virtual: empty on client, real ensureBootGate on server (see module aliases).
 import { ensureBootGate } from "#arkenv/server-boot";
-import { arkenvInternal, type FlatSchemaOptions } from "./arkenv-internal";
+import type { FlatSchemaOptions } from "./schema-shape";
+import { dispatchFlatThinArkenv } from "./thin-accessor";
 
 /**
  * Create a typesafe environment configuration for Nuxt (flat / unified entry).
@@ -42,28 +43,9 @@ export function arkenv(
 	schemaOrOptions: SchemaShape | Record<string, unknown>,
 	optionsOrIsServer?: FlatSchemaOptions | boolean,
 ): unknown {
-	const isLegacy =
-		schemaOrOptions &&
-		typeof schemaOrOptions === "object" &&
-		("runtimeEnv" in schemaOrOptions ||
-			"server" in schemaOrOptions ||
-			"client" in schemaOrOptions ||
-			"shared" in schemaOrOptions);
-
-	const isServer = typeof window === "undefined";
-
-	const hooks = isServer ? { ensureBootGate } : undefined;
-
-	if (isLegacy) {
-		return arkenvInternal(schemaOrOptions, isServer, undefined, hooks);
-	}
-
-	return arkenvInternal(
-		schemaOrOptions,
-		optionsOrIsServer as FlatSchemaOptions | undefined,
-		{ isServer },
-		hooks,
-	);
+	return dispatchFlatThinArkenv(schemaOrOptions, optionsOrIsServer, {
+		ensureBootGate,
+	});
 }
 
 export type { EnvSchema, Infer } from "@arkenv/core";

--- a/packages/nuxt/src/schema-shape.test.ts
+++ b/packages/nuxt/src/schema-shape.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { isLegacyNestedSchema, parseSchemaShape } from "./schema-shape";
+
+describe("schema-shape helper", () => {
+	describe("isLegacyNestedSchema", () => {
+		it("detects boolean optionsOrIsServer as legacy", () => {
+			expect(isLegacyNestedSchema({}, true)).toBe(true);
+			expect(isLegacyNestedSchema({}, false)).toBe(true);
+		});
+
+		it("detects nested schema buckets as legacy", () => {
+			expect(isLegacyNestedSchema({ server: { A: "string" } })).toBe(true);
+			expect(
+				isLegacyNestedSchema({ client: { NUXT_PUBLIC_B: "string" } }),
+			).toBe(true);
+			expect(isLegacyNestedSchema({ shared: { C: "string" } })).toBe(true);
+			expect(isLegacyNestedSchema({ runtimeEnv: {} })).toBe(true);
+		});
+
+		it("detects flat schema as non-legacy", () => {
+			expect(
+				isLegacyNestedSchema({ PORT: "number", NUXT_PUBLIC_HOST: "string" }),
+			).toBe(false);
+			expect(
+				isLegacyNestedSchema({ PORT: "number" }, { exposeToClient: ["PORT"] }),
+			).toBe(false);
+			expect(isLegacyNestedSchema(null)).toBe(false);
+			expect(isLegacyNestedSchema(undefined)).toBe(false);
+		});
+	});
+
+	describe("parseSchemaShape", () => {
+		it("parses flat schema with default NUXT_PUBLIC_ and NODE_ENV partitioning", () => {
+			const schema = {
+				DATABASE_URL: "string",
+				NUXT_PUBLIC_API_URL: "string",
+				NODE_ENV: "string",
+			};
+
+			const parsed = parseSchemaShape(schema, undefined, { isServer: true });
+			expect(parsed.isLegacy).toBe(false);
+			expect(Object.keys(parsed.server)).toEqual(["DATABASE_URL"]);
+			expect(Object.keys(parsed.client)).toEqual(["NUXT_PUBLIC_API_URL"]);
+			expect(Object.keys(parsed.shared)).toEqual(["NODE_ENV"]);
+			expect(parsed.declaredKeys).toEqual([
+				"DATABASE_URL",
+				"NUXT_PUBLIC_API_URL",
+				"NODE_ENV",
+			]);
+			expect(parsed.publicKeys).toEqual(["NUXT_PUBLIC_API_URL", "NODE_ENV"]);
+		});
+
+		it("parses flat schema with exposeToClient option", () => {
+			const schema = {
+				API_KEY: "string",
+				PUBLIC_NAME: "string",
+			};
+
+			const parsed = parseSchemaShape(
+				schema,
+				{ exposeToClient: ["PUBLIC_NAME"] },
+				{ isServer: true },
+			);
+
+			expect(Object.keys(parsed.server)).toEqual(["API_KEY"]);
+			expect(Object.keys(parsed.shared)).toEqual(["PUBLIC_NAME"]);
+			expect(parsed.publicKeys).toEqual(["PUBLIC_NAME"]);
+		});
+
+		it("parses strict client layout as all public", () => {
+			const schema = {
+				NUXT_PUBLIC_SITE_NAME: "string",
+			};
+
+			const parsed = parseSchemaShape(schema, undefined, {
+				isServer: false,
+				strictLayout: "client",
+			});
+
+			expect(Object.keys(parsed.client)).toEqual(["NUXT_PUBLIC_SITE_NAME"]);
+			expect(parsed.publicKeys).toEqual(["NUXT_PUBLIC_SITE_NAME"]);
+		});
+
+		it("parses strict server layout with no public keys", () => {
+			const schema = {
+				SECRET_KEY: "string",
+			};
+
+			const parsed = parseSchemaShape(schema, undefined, {
+				isServer: true,
+				strictLayout: "server",
+			});
+
+			expect(Object.keys(parsed.server)).toEqual(["SECRET_KEY"]);
+			expect(parsed.publicKeys).toEqual([]);
+		});
+
+		it("parses isShared context as all shared/public", () => {
+			const schema = {
+				SHARED_VAR: "string",
+			};
+
+			const parsed = parseSchemaShape(schema, undefined, {
+				isServer: true,
+				isShared: true,
+			});
+
+			expect(Object.keys(parsed.shared)).toEqual(["SHARED_VAR"]);
+			expect(parsed.publicKeys).toEqual(["SHARED_VAR"]);
+		});
+
+		it("parses legacy nested structure correctly", () => {
+			const legacy = {
+				server: { DB: "string" },
+				client: { NUXT_PUBLIC_CLIENT: "string" },
+				shared: { SHARED: "string" },
+				runtimeEnv: { DB: "val" },
+			};
+
+			const parsed = parseSchemaShape(legacy, true);
+			expect(parsed.isLegacy).toBe(true);
+			expect(Object.keys(parsed.server)).toEqual(["DB"]);
+			expect(Object.keys(parsed.client)).toEqual(["NUXT_PUBLIC_CLIENT"]);
+			expect(Object.keys(parsed.shared)).toEqual(["SHARED"]);
+			expect(parsed.declaredKeys).toEqual([
+				"DB",
+				"NUXT_PUBLIC_CLIENT",
+				"SHARED",
+			]);
+			expect(parsed.publicKeys).toEqual(["NUXT_PUBLIC_CLIENT", "SHARED"]);
+			expect(parsed.runtimeEnv).toEqual({ DB: "val" });
+		});
+	});
+});

--- a/packages/nuxt/src/schema-shape.ts
+++ b/packages/nuxt/src/schema-shape.ts
@@ -1,5 +1,12 @@
 import type { Dict, SchemaShape } from "@repo/types";
 
+/** Symbol key for the raw extended env values object on an env proxy. */
+export const EXTENDED_ENV = Symbol.for("arkenv.extended_env");
+/** Symbol key for the set of declared schema keys on an env proxy. */
+export const ENV_KEYS = Symbol.for("arkenv.keys");
+/** Symbol key for server-only keys that must not be readable on the client. */
+export const SERVER_ONLY_KEYS = Symbol.for("arkenv.server_only_keys");
+
 /**
  * Legacy nested schema shape (`server` / `client` / `shared` buckets).
  */
@@ -130,7 +137,11 @@ export function parseSchemaShape(
 	}
 
 	const declaredKeys = isLegacy
-		? [...Object.keys(server), ...Object.keys(client), ...Object.keys(shared)]
+		? [
+				...Object.keys(server),
+				...Object.keys(client),
+				...Object.keys(shared),
+			]
 		: Object.keys((schemaOrOptions || {}) as SchemaShape);
 
 	const publicKeys = isLegacy

--- a/packages/nuxt/src/schema-shape.ts
+++ b/packages/nuxt/src/schema-shape.ts
@@ -1,0 +1,154 @@
+import type { Dict, SchemaShape } from "@repo/types";
+
+/**
+ * Legacy nested schema shape (`server` / `client` / `shared` buckets).
+ */
+export type LegacyNestedSchema = {
+	server?: SchemaShape;
+	client?: SchemaShape;
+	shared?: SchemaShape;
+	extends?: readonly unknown[];
+	runtimeEnv?: Dict<string>;
+};
+
+/**
+ * Options for the flat (unified) schema form of `arkenv()`.
+ */
+export type FlatSchemaOptions = {
+	extends?: readonly unknown[];
+	runtimeEnv?: Dict<string>;
+	exposeToClient?: readonly string[];
+	/** @deprecated Use `exposeToClient` instead. */
+	expose?: readonly string[];
+	/** @deprecated Use `exposeToClient` instead. */
+	shared?: readonly string[];
+};
+
+/**
+ * Context flags describing the execution environment and strict layout entrypoint.
+ */
+export type SchemaLayoutContext = {
+	isServer: boolean;
+	isShared?: boolean;
+	strictLayout?: "client" | "server";
+};
+
+/**
+ * Result of parsing and partitioning a schema definition.
+ */
+export type ParsedSchemaShape = {
+	isLegacy: boolean;
+	server: SchemaShape;
+	client: Record<string, unknown>;
+	shared: SchemaShape;
+	extendsList: readonly unknown[];
+	runtimeEnv: Dict<string>;
+	declaredKeys: string[];
+	publicKeys: string[];
+};
+
+/**
+ * Determine whether a schema invocation uses the legacy nested bucket structure.
+ *
+ * @param schemaOrOptions The schema definition or nested options object
+ * @param optionsOrIsServer Flat options, legacy boolean, or undefined
+ * @returns `true` if the invocation uses legacy nested options or a boolean isServer flag
+ */
+export function isLegacyNestedSchema(
+	schemaOrOptions: unknown,
+	optionsOrIsServer?: unknown,
+): boolean {
+	if (typeof optionsOrIsServer === "boolean") {
+		return true;
+	}
+	return Boolean(
+		schemaOrOptions &&
+			typeof schemaOrOptions === "object" &&
+			("runtimeEnv" in schemaOrOptions ||
+				"server" in schemaOrOptions ||
+				"client" in schemaOrOptions ||
+				"shared" in schemaOrOptions),
+	);
+}
+
+/**
+ * Parse and partition a schema definition into server, client, and shared buckets.
+ *
+ * Provides a single, cycle-safe source of truth for nested-vs-flat decisions,
+ * declared key collection, and public key extraction across schema capture and
+ * thin accessors.
+ *
+ * @param schemaOrOptions Schema definition or legacy options object
+ * @param optionsOrIsServer Flat options or legacy boolean flag
+ * @param context Optional layout and environment context
+ * @returns Structured partition of schema buckets and key collections
+ */
+export function parseSchemaShape(
+	schemaOrOptions: SchemaShape | LegacyNestedSchema | null | undefined,
+	optionsOrIsServer?: FlatSchemaOptions | boolean | null | undefined,
+	context?: SchemaLayoutContext,
+): ParsedSchemaShape {
+	const isLegacy = isLegacyNestedSchema(schemaOrOptions, optionsOrIsServer);
+	let server: SchemaShape = {};
+	let client: Record<string, unknown> = {};
+	let shared: SchemaShape = {};
+	let extendsList: readonly unknown[] = [];
+	let runtimeEnv: Dict<string> = {};
+
+	if (isLegacy) {
+		const legacy = (schemaOrOptions || {}) as LegacyNestedSchema;
+		server = (legacy.server || {}) as SchemaShape;
+		client = (legacy.client || {}) as Record<string, unknown>;
+		shared = (legacy.shared || {}) as SchemaShape;
+		extendsList = legacy.extends || [];
+		runtimeEnv = (legacy.runtimeEnv || {}) as Dict<string>;
+	} else {
+		const flatSchema = (schemaOrOptions || {}) as SchemaShape;
+		const options = (optionsOrIsServer || {}) as FlatSchemaOptions;
+		extendsList = options.extends || [];
+		runtimeEnv = (options.runtimeEnv || {}) as Dict<string>;
+
+		if (context?.isShared) {
+			shared = flatSchema;
+		} else if (context?.strictLayout === "client") {
+			client = flatSchema;
+		} else if (context?.strictLayout === "server") {
+			server = flatSchema;
+		} else {
+			const exposedKeys =
+				options.exposeToClient || options.expose || options.shared || [];
+			for (const key of Object.keys(flatSchema)) {
+				if (exposedKeys.includes(key) || key === "NODE_ENV") {
+					shared[key] = flatSchema[key];
+				} else if (key.startsWith("NUXT_PUBLIC_")) {
+					client[key] = flatSchema[key];
+				} else {
+					server[key] = flatSchema[key];
+				}
+			}
+		}
+	}
+
+	const declaredKeys = isLegacy
+		? [...Object.keys(server), ...Object.keys(client), ...Object.keys(shared)]
+		: Object.keys((schemaOrOptions || {}) as SchemaShape);
+
+	const publicKeys = isLegacy
+		? [...Object.keys(client), ...Object.keys(shared)]
+		: context?.strictLayout === "server"
+			? []
+			: context?.isShared || context?.strictLayout === "client"
+				? Object.keys((schemaOrOptions || {}) as SchemaShape)
+				: [...Object.keys(client), ...Object.keys(shared)];
+
+	return {
+		isLegacy,
+		server,
+		client,
+		shared,
+		extendsList,
+		runtimeEnv,
+		declaredKeys,
+		publicKeys,
+	};
+}

--- a/packages/nuxt/src/schema-shape.ts
+++ b/packages/nuxt/src/schema-shape.ts
@@ -137,11 +137,7 @@ export function parseSchemaShape(
 	}
 
 	const declaredKeys = isLegacy
-		? [
-				...Object.keys(server),
-				...Object.keys(client),
-				...Object.keys(shared),
-			]
+		? [...Object.keys(server), ...Object.keys(client), ...Object.keys(shared)]
 		: Object.keys((schemaOrOptions || {}) as SchemaShape);
 
 	const publicKeys = isLegacy

--- a/packages/nuxt/src/standard/index.ts
+++ b/packages/nuxt/src/standard/index.ts
@@ -1,6 +1,6 @@
 import type { StandardSchemaV1 } from "@repo/types";
 import { ensureBootGate } from "#arkenv/server-boot";
-import { arkenvInternal } from "@/arkenv-internal";
+import { dispatchFlatThinArkenv } from "@/thin-accessor";
 import type { MergeExtends } from "../types";
 
 type ClientVisibleKeys<
@@ -73,27 +73,9 @@ export function arkenv<
 }>;
 
 export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
-	const isLegacy =
-		schemaOrOptions &&
-		typeof schemaOrOptions === "object" &&
-		("runtimeEnv" in schemaOrOptions ||
-			"server" in schemaOrOptions ||
-			"client" in schemaOrOptions ||
-			"shared" in schemaOrOptions);
-
-	const isServer = typeof window === "undefined";
-	const hooks = isServer ? { ensureBootGate } : undefined;
-
-	if (isLegacy) {
-		return arkenvInternal(schemaOrOptions, isServer, undefined, hooks);
-	}
-
-	return arkenvInternal(
-		schemaOrOptions,
-		optionsOrIsServer,
-		{ isServer },
-		hooks,
-	);
+	return dispatchFlatThinArkenv(schemaOrOptions, optionsOrIsServer, {
+		ensureBootGate,
+	});
 }
 
 export default arkenv;

--- a/packages/nuxt/src/thin-accessor.ts
+++ b/packages/nuxt/src/thin-accessor.ts
@@ -1,7 +1,45 @@
 import { type ArkenvInternalHooks, arkenvInternal } from "./arkenv-internal";
 import { withAutoExtend } from "./auto-extend";
+import { isLegacyNestedSchema } from "./schema-shape";
 
 export type ThinStrictLayout = "client" | "server";
+
+/**
+ * Dispatch a flat-layout thin `arkenv()` call into {@link arkenvInternal}.
+ *
+ * Shared by ArkType and Standard flat entries so legacy detection, server hooks,
+ * and context construction stay unified.
+ *
+ * @param schemaOrOptions Schema or nested options object
+ * @param optionsOrIsServer Flat options, legacy boolean, or undefined
+ * @param options Optional server hooks (e.g. ensureBootGate)
+ * @returns The thin env proxy from {@link arkenvInternal}
+ */
+export function dispatchFlatThinArkenv(
+	schemaOrOptions: unknown,
+	optionsOrIsServer: unknown,
+	options?: {
+		ensureBootGate?: () => void;
+	},
+): unknown {
+	const isServer = typeof window === "undefined";
+	const hooks: ArkenvInternalHooks | undefined =
+		isServer && options?.ensureBootGate
+			? { ensureBootGate: options.ensureBootGate }
+			: undefined;
+
+	const isLegacy = isLegacyNestedSchema(schemaOrOptions, optionsOrIsServer);
+	if (isLegacy) {
+		return arkenvInternal(schemaOrOptions as never, isServer, undefined, hooks);
+	}
+
+	return arkenvInternal(
+		schemaOrOptions as never,
+		optionsOrIsServer as never,
+		{ isServer },
+		hooks,
+	);
+}
 
 /**
  * Dispatch a strict-layout thin `arkenv()` call into {@link arkenvInternal}.
@@ -30,27 +68,30 @@ export function dispatchStrictThinArkenv(
 		? { ensureBootGate: options.ensureBootGate }
 		: undefined;
 
-	const isLegacy =
-		schemaOrOptions &&
-		typeof schemaOrOptions === "object" &&
-		(isServer
-			? "runtimeEnv" in schemaOrOptions ||
-				"server" in schemaOrOptions ||
-				"shared" in schemaOrOptions
-			: "client" in schemaOrOptions || "shared" in schemaOrOptions);
+	const isLegacy = isLegacyNestedSchema(schemaOrOptions, optionsOrIsServer);
 
 	if (isLegacy) {
-		if (isServer && "client" in schemaOrOptions) {
+		if (
+			isServer &&
+			typeof schemaOrOptions === "object" &&
+			schemaOrOptions !== null &&
+			"client" in schemaOrOptions
+		) {
 			throw new Error(
 				"server entry point only accepts 'server' and 'shared' schemas.",
 			);
 		}
-		if (!isServer && "server" in schemaOrOptions) {
+		if (
+			!isServer &&
+			typeof schemaOrOptions === "object" &&
+			schemaOrOptions !== null &&
+			"server" in schemaOrOptions
+		) {
 			throw new Error(
 				"client entry point only accepts 'client' and 'shared' schemas.",
 			);
 		}
-		return arkenvInternal(schemaOrOptions, isServer, undefined, hooks);
+		return arkenvInternal(schemaOrOptions as never, isServer, undefined, hooks);
 	}
 
 	return arkenvInternal(

--- a/packages/nuxt/src/validate-schema.ts
+++ b/packages/nuxt/src/validate-schema.ts
@@ -1,6 +1,5 @@
 import type { Dict } from "@repo/types";
-import type { BootGateEngine } from "./boot-gate";
-import { loadSchemaViaCapture } from "./boot-gate";
+import { type BootGateEngine, loadSchemaViaCapture } from "./boot-gate-load";
 import { resolveCoreArkenv } from "./resolve-core-arkenv";
 
 /**


### PR DESCRIPTION
Fixes #1463

## Summary
- Consolidates legacy and flat schema-shape detection and key extraction into a single cycle-safe parser (`src/schema-shape.ts`) shared between schema capture and thin accessors.
- Decouples Jiti schema capture loading (`src/boot-gate-load.ts`) from boot-gate coercion and application (`applyBootGate` in `src/boot-gate.ts`), enabling isolated testing of the apply path without Jiti/filesystem setup.
- Unifies thin-accessor dispatch locality (`dispatchFlatThinArkenv` and `dispatchStrictThinArkenv` in `src/thin-accessor.ts`), making flat ArkType and Standard entries thin type shells over the shared dispatcher.
- Preserves validator-free client bundle isolation (no `@arkenv/core` or `arktype` in browser bundles).

## Verification
- `pnpm --filter @arkenv/nuxt test -- --run` (all 11 test files, 72 tests passed)
- `pnpm typecheck` (clean)
- `pnpm test -- --run` (102 test files, 1,071 tests passed)
- `pnpm check` (clean)