### PR TITLE
docs: document DCE trade-offs, SSR execution models, and engine vs adapter boundaries

### DIFF
--- a/apps/www/content/docs/faq.mdx
+++ b/apps/www/content/docs/faq.mdx
@@ -45,6 +45,18 @@ Yes. Point the agent skill at your `.env.example` to set up validation
 and guide your assistant through schema maintenance. See
 [Using AI with ArkEnv](/docs/guides/ai).
 
+## Why does `env.ts` import from `@arkenv/core` in Vite and Bun, but from framework packages in Next.js and Nuxt?
+
+Vite and Bun use build plugins (`@arkenv/vite-plugin` and `@arkenv/bun-plugin`) that perform compile-time AST transforms on your `env.ts` module during bundling. Your application code only needs standard `@arkenv/core` (or `@arkenv/standard`), and the bundler rewrites client-side imports to inline public values and guard secrets.
+
+Next.js and Nuxt rely on host runtime adapters (such as codegen with conditional exports or Nitro runtime configuration hooks), which require dedicated framework entrypoint packages (`@arkenv/nextjs` and `@arkenv/nuxt`). See [Framework integration](/docs/validating-your-environment/framework-integration).
+
+## Why are `@arkenv/core` and `@arkenv/standard` peer dependencies instead of bundled into framework packages?
+
+Separating the validation engine from host adapters keeps runtime overhead minimal and prevents duplicate validation engines in your dependency tree.
+
+Framework packages act as lightweight glue for bundlers and host lifecycles. By declaring `@arkenv/core` and `@arkenv/standard` as peer dependencies, ArkEnv lets you pair any framework adapter with your choice of validator (ArkType DSL or Standard Schema validators like Zod and Valibot) without shipping redundant packages.
+
 ## Next steps
 
 ```package-install

--- a/apps/www/content/docs/faq.mdx
+++ b/apps/www/content/docs/faq.mdx
@@ -47,15 +47,15 @@ and guide your assistant through schema maintenance. See
 
 ## Why does `env.ts` import from `@arkenv/core` in Vite and Bun, but from framework packages in Next.js and Nuxt?
 
-Vite and Bun use build plugins (`@arkenv/vite-plugin` and `@arkenv/bun-plugin`) that perform compile-time AST transforms on your `env.ts` module during bundling. Your application code only needs standard `@arkenv/core` (or `@arkenv/standard`), and the bundler rewrites client-side imports to inline public values and guard secrets.
+Vite and Bun use build plugins (`@arkenv/vite-plugin` and `@arkenv/bun-plugin`) that transform `env.ts` during bundling. Application code imports `@arkenv/core` (or `@arkenv/standard`), and the bundler rewrites client-side imports to inline public values and guard secrets.
 
-Next.js and Nuxt rely on host runtime adapters (such as codegen with conditional exports or Nitro runtime configuration hooks), which require dedicated framework entrypoint packages (`@arkenv/nextjs` and `@arkenv/nuxt`). See [Framework integration](/docs/validating-your-environment/framework-integration).
+Next.js and Nuxt use host runtime adapters (such as codegen with conditional exports or Nitro runtime configuration hooks) that require dedicated framework entrypoints (`@arkenv/nextjs` and `@arkenv/nuxt`). See [Framework integration](/docs/validating-your-environment/framework-integration).
 
 ## Why are `@arkenv/core` and `@arkenv/standard` peer dependencies instead of bundled into framework packages?
 
-Separating the validation engine from host adapters keeps runtime overhead minimal and prevents duplicate validation engines in your dependency tree.
+Separating the validation engine from host adapters keeps runtime overhead minimal and avoids duplicate validation engines in your dependency tree.
 
-Framework packages act as lightweight glue for bundlers and host lifecycles. By declaring `@arkenv/core` and `@arkenv/standard` as peer dependencies, ArkEnv lets you pair any framework adapter with your choice of validator (ArkType DSL or Standard Schema validators like Zod and Valibot) without shipping redundant packages.
+Framework packages handle bundlers and host lifecycles. Declaring `@arkenv/core` and `@arkenv/standard` as peer dependencies lets you pair any framework adapter with your choice of validator (ArkType DSL or Standard Schema validators like Zod and Valibot) without shipping redundant packages.
 
 ## Next steps
 

--- a/apps/www/content/docs/guides/frameworks/bun.mdx
+++ b/apps/www/content/docs/guides/frameworks/bun.mdx
@@ -116,8 +116,8 @@ the typed `env` object so validation runs reliably at process boot. See
 
 Full-stack Bun applications separate server runtime execution from client bundle generation:
 
-- **Server execution:** Server entrypoints and backend APIs execute real `@arkenv/core` validation at startup, ensuring database URLs and backend secrets are validated before serving traffic.
-- **Client bundling:** When `Bun.build` bundles browser entrypoints or `[serve.static]` serves assets, `@arkenv/bun-plugin` transforms `env.ts` imports in client code. It inlines `BUN_PUBLIC_*` values as static literals and replaces server keys with throwing runtime stubs, omitting the validator engine from browser bundles.
+- **Server execution:** Server entrypoints and backend APIs execute real `@arkenv/core` validation at startup, validating database URLs and backend secrets before serving traffic.
+- **Client bundling:** During `Bun.build` runs or `[serve.static]` requests, `@arkenv/bun-plugin` transforms `env.ts` imports in client code. It inlines `BUN_PUBLIC_*` values as static literals and replaces server keys with throwing runtime stubs. Browser bundles omit the validator engine.
 
 ## Next steps
 

--- a/apps/www/content/docs/guides/frameworks/bun.mdx
+++ b/apps/www/content/docs/guides/frameworks/bun.mdx
@@ -112,6 +112,13 @@ so public keys stay typed and coerced. For full-stack applications, prefer expor
 the typed `env` object so validation runs reliably at process boot. See
 [`@arkenv/bun-plugin`](/docs/reference/bun-plugin).
 
+## SSR and bundling execution
+
+Full-stack Bun applications separate server runtime execution from client bundle generation:
+
+- **Server execution:** Server entrypoints and backend APIs run in Bun's runtime environment and execute real `@arkenv/core` validation at startup, ensuring database URLs and backend secrets are validated before serving traffic.
+- **Client bundling:** When `Bun.build` bundles browser entrypoints or `[serve.static]` serves assets, `@arkenv/bun-plugin` transforms `env.ts` imports in client code. It inlines `BUN_PUBLIC_*` values as static literals and replaces server keys with throwing runtime stubs, omitting the validator engine from browser bundles.
+
 ## Next steps
 
 <Cards>

--- a/apps/www/content/docs/guides/frameworks/bun.mdx
+++ b/apps/www/content/docs/guides/frameworks/bun.mdx
@@ -116,7 +116,7 @@ the typed `env` object so validation runs reliably at process boot. See
 
 Full-stack Bun applications separate server runtime execution from client bundle generation:
 
-- **Server execution:** Server entrypoints and backend APIs run in Bun's runtime environment and execute real `@arkenv/core` validation at startup, ensuring database URLs and backend secrets are validated before serving traffic.
+- **Server execution:** Server entrypoints and backend APIs execute real `@arkenv/core` validation at startup, ensuring database URLs and backend secrets are validated before serving traffic.
 - **Client bundling:** When `Bun.build` bundles browser entrypoints or `[serve.static]` serves assets, `@arkenv/bun-plugin` transforms `env.ts` imports in client code. It inlines `BUN_PUBLIC_*` values as static literals and replaces server keys with throwing runtime stubs, omitting the validator engine from browser bundles.
 
 ## Next steps

--- a/apps/www/content/docs/guides/frameworks/nuxt.mdx
+++ b/apps/www/content/docs/guides/frameworks/nuxt.mdx
@@ -116,13 +116,13 @@ export const env = arkenv({
 
 ## Nitro boot gate and runtimeConfig hydration
 
-Containerized deployments (such as Docker or Kubernetes) often follow the "build once, deploy anywhere" pattern. Environment variables are injected when containers start in staging or production rather than during build.
+Containers in staging and production inject environment variables at startup rather than at build time.
 
-While Vite and Bun rely on static compile-time AST transforms that inline literals during build, `@arkenv/nuxt` hooks into Nuxt's Nitro engine:
+Vite and Bun inline literals at build time through compile-time transforms. `@arkenv/nuxt` hooks into Nuxt's Nitro engine instead:
 
-1. **Server boot gate:** At server startup, an internal Nitro plugin runs before any route handler executes. It validates the environment against your schema and throws fail-fast errors on invalid secrets.
-2. **Runtime configuration hydration:** Validated public variables (`NUXT_PUBLIC_*`) are injected dynamically into Nuxt's `useRuntimeConfig().public`.
-3. **Client access:** When pages render and hydrate in the browser, client components access public values via runtime configuration rather than hardcoded build-time literals.
+1. **Server boot gate:** At server startup, an internal Nitro plugin runs before route handlers execute. It validates the environment against your schema and throws fail-fast errors on invalid secrets.
+2. **Runtime configuration hydration:** An internal Nitro plugin passes validated public variables (`NUXT_PUBLIC_*`) into `useRuntimeConfig().public`.
+3. **Client access:** Client components read public values from runtime configuration during browser rendering and hydration, avoiding hardcoded build-time literals.
 
 You can update environment variables across deployment stages without rebuilding client JavaScript bundles.
 

--- a/apps/www/content/docs/guides/frameworks/nuxt.mdx
+++ b/apps/www/content/docs/guides/frameworks/nuxt.mdx
@@ -116,15 +116,15 @@ export const env = arkenv({
 
 ## Nitro boot gate and runtimeConfig hydration
 
-In many modern production environments (such as Docker containers or Kubernetes), applications follow the "build once, deploy anywhere" pattern. Environment variables are not known at build time; instead, they are provided when the container starts in staging or production.
+Containerized deployments (such as Docker or Kubernetes) often follow the "build once, deploy anywhere" pattern. Environment variables are injected when containers start in staging or production rather than during build.
 
-While Vite and Bun rely on static compile-time AST transforms that inline literals during build, `@arkenv/nuxt` integrates directly with Nuxt's Nitro engine:
+While Vite and Bun rely on static compile-time AST transforms that inline literals during build, `@arkenv/nuxt` hooks into Nuxt's Nitro engine:
 
-1. **Server boot gate:** At server startup, an internal Nitro plugin runs before any route handlers execute. It evaluates the process environment against your schema and throws fail-fast errors if required secrets or configurations are invalid.
+1. **Server boot gate:** At server startup, an internal Nitro plugin runs before any route handler executes. It validates the environment against your schema and throws fail-fast errors on invalid secrets.
 2. **Runtime configuration hydration:** Validated public variables (`NUXT_PUBLIC_*`) are injected dynamically into Nuxt's `useRuntimeConfig().public`.
-3. **Client access:** When pages render and hydrate in the browser, client components access the validated public values via runtime configuration rather than hardcoded build-time literals.
+3. **Client access:** When pages render and hydrate in the browser, client components access public values via runtime configuration rather than hardcoded build-time literals.
 
-This architecture ensures you never need to rebuild client JavaScript bundles just to update environment variables across deployment stages.
+You can update environment variables across deployment stages without rebuilding client JavaScript bundles.
 
 ## Next steps
 

--- a/apps/www/content/docs/guides/frameworks/nuxt.mdx
+++ b/apps/www/content/docs/guides/frameworks/nuxt.mdx
@@ -114,6 +114,18 @@ export const env = arkenv({
 });
 ```
 
+## Nitro boot gate and runtimeConfig hydration
+
+In many modern production environments (such as Docker containers or Kubernetes), applications follow the "build once, deploy anywhere" pattern. Environment variables are not known at build time; instead, they are provided when the container starts in staging or production.
+
+While Vite and Bun rely on static compile-time AST transforms that inline literals during build, `@arkenv/nuxt` integrates directly with Nuxt's Nitro engine:
+
+1. **Server boot gate:** At server startup, an internal Nitro plugin runs before any route handlers execute. It evaluates the process environment against your schema and throws fail-fast errors if required secrets or configurations are invalid.
+2. **Runtime configuration hydration:** Validated public variables (`NUXT_PUBLIC_*`) are injected dynamically into Nuxt's `useRuntimeConfig().public`.
+3. **Client access:** When pages render and hydrate in the browser, client components access the validated public values via runtime configuration rather than hardcoded build-time literals.
+
+This architecture ensures you never need to rebuild client JavaScript bundles just to update environment variables across deployment stages.
+
 ## Next steps
 
 <Cards>

--- a/apps/www/content/docs/guides/frameworks/vite.mdx
+++ b/apps/www/content/docs/guides/frameworks/vite.mdx
@@ -119,6 +119,13 @@ Import the validated `env` object from your schema module. Prefer that over read
 `import.meta.env` for schema keys so server secrets still validate at boot. Types
 and options: [`@arkenv/vite-plugin`](/docs/reference/vite-plugin).
 
+## SSR and dual-graph execution
+
+Vite maintains two distinct module graphs when building and serving full-stack or SSR applications:
+
+- **Server Graph (SSR rendering and dev server):** During SSR execution, Vite loads modules in the Node.js/runtime environment. `env.ts` executes real `@arkenv/core` runtime validation at server boot, ensuring private secrets (such as `DATABASE_URL`) and public keys are strictly validated before handling requests.
+- **Client Graph (Browser bundles):** When Vite compiles client assets for browser delivery, `@arkenv/vite-plugin` intercepts and transforms `env.ts`. It inlines public `VITE_*` values as static literals and replaces private server keys with throwing runtime stubs. The validator engine is completely omitted from the client bundle.
+
 ## Next steps
 
 <Cards>

--- a/apps/www/content/docs/guides/frameworks/vite.mdx
+++ b/apps/www/content/docs/guides/frameworks/vite.mdx
@@ -123,8 +123,8 @@ and options: [`@arkenv/vite-plugin`](/docs/reference/vite-plugin).
 
 Vite maintains two distinct module graphs when building and serving full-stack or SSR applications:
 
-- **Server Graph (SSR rendering and dev server):** During SSR execution, Vite loads modules in the Node.js/runtime environment. `env.ts` executes real `@arkenv/core` runtime validation at server boot, ensuring private secrets (such as `DATABASE_URL`) and public keys are strictly validated before handling requests.
-- **Client Graph (Browser bundles):** When Vite compiles client assets for browser delivery, `@arkenv/vite-plugin` intercepts and transforms `env.ts`. It inlines public `VITE_*` values as static literals and replaces private server keys with throwing runtime stubs. The validator engine is completely omitted from the client bundle.
+- **Server graph:** During SSR execution and dev server requests, `env.ts` executes real `@arkenv/core` runtime validation at boot. It ensures private secrets (such as `DATABASE_URL`) and public configuration validate before handling requests.
+- **Client graph:** When Vite compiles client assets for browser delivery, `@arkenv/vite-plugin` intercepts and transforms `env.ts`. It inlines public `VITE_*` values as static literals and replaces private server keys with throwing runtime stubs. The validator engine is omitted from the client bundle.
 
 ## Next steps
 

--- a/apps/www/content/docs/guides/frameworks/vite.mdx
+++ b/apps/www/content/docs/guides/frameworks/vite.mdx
@@ -124,7 +124,7 @@ and options: [`@arkenv/vite-plugin`](/docs/reference/vite-plugin).
 Vite maintains two distinct module graphs when building and serving full-stack or SSR applications:
 
 - **Server graph:** During SSR execution and dev server requests, `env.ts` executes real `@arkenv/core` runtime validation at boot. It ensures private secrets (such as `DATABASE_URL`) and public configuration validate before handling requests.
-- **Client graph:** When Vite compiles client assets for browser delivery, `@arkenv/vite-plugin` intercepts and transforms `env.ts`. It inlines public `VITE_*` values as static literals and replaces private server keys with throwing runtime stubs. The validator engine is omitted from the client bundle.
+- **Client graph:** During client compilation, `@arkenv/vite-plugin` intercepts and transforms `env.ts`. It inlines public `VITE_*` values as static literals and replaces private server keys with throwing runtime stubs. Client bundles omit the validator engine.
 
 ## Next steps
 

--- a/apps/www/content/docs/validating-your-environment/client-vs-server.mdx
+++ b/apps/www/content/docs/validating-your-environment/client-vs-server.mdx
@@ -135,6 +135,27 @@ npx arkenv@latest init --strict
 
 Nuxt strict layout uses `@arkenv/nuxt/client` and `@arkenv/nuxt/server`. Omitting `extends` can auto-merge shared and client schemas via Nuxt virtual aliases. Details live in the [Next.js](/docs/guides/frameworks/nextjs) and [Nuxt](/docs/guides/frameworks/nuxt) guides.
 
+## Dead-code elimination and constant folding
+
+When bundlers (such as Next.js with Turbopack or webpack, Vite with Rollup or esbuild, and Bun) compile client bundles, they perform lexical search-and-replace on direct identifier expressions like `process.env.NEXT_PUBLIC_FEATURE_FLAG` or `import.meta.env.VITE_FEATURE_FLAG`. When an expression becomes a static literal like `if (false)` or `if ("")`, the minifier's dead-code elimination (DCE) pass can completely drop unreachable branches and omit modules imported exclusively within those blocks.
+
+Accessing properties on an imported `env` object (`if (env.NEXT_PUBLIC_FEATURE_FLAG)`) behaves as normal JavaScript object property access at runtime:
+
+```ts title="./src/feature.ts"
+import { env } from "./env";
+
+// Evaluated as runtime object property access
+if (env.NEXT_PUBLIC_ADMIN_PREVIEW) {
+  mountAdminPreview();
+}
+```
+
+Because `env` is an exported object reference across module boundaries, bundlers and minifiers cannot always guarantee that object properties are constant or side-effect-free without inter-module whole-program analysis. As a result, code inside the `if` branch might not be aggressively eliminated from the client bundle when the flag is disabled.
+
+<Callout type="warn">
+  If you have large, sensitive client chunks or internal admin tooling that **must** be guaranteed absent from production bundles when a flag is disabled, use direct bundler identifiers (such as `process.env.NEXT_PUBLIC_FEATURE_FLAG` or `import.meta.env.VITE_FEATURE_FLAG`) in the branching condition, or load heavy modules dynamically with `import()`. Use `env` for typesafe runtime validation and secure secret guarding.
+</Callout>
+
 ## Next steps
 
 <Cards>

--- a/apps/www/content/docs/validating-your-environment/client-vs-server.mdx
+++ b/apps/www/content/docs/validating-your-environment/client-vs-server.mdx
@@ -137,23 +137,22 @@ Nuxt strict layout uses `@arkenv/nuxt/client` and `@arkenv/nuxt/server`. Omittin
 
 ## Dead-code elimination and constant folding
 
-When bundlers (such as Next.js with Turbopack or webpack, Vite with Rollup or esbuild, and Bun) compile client bundles, they perform lexical search-and-replace on direct identifier expressions like `process.env.NEXT_PUBLIC_FEATURE_FLAG` or `import.meta.env.VITE_FEATURE_FLAG`. When an expression becomes a static literal like `if (false)` or `if ("")`, the minifier's dead-code elimination (DCE) pass can completely drop unreachable branches and omit modules imported exclusively within those blocks.
+Bundlers (like Next.js, Vite, and Bun) replace direct identifier expressions such as `process.env.NEXT_PUBLIC_FEATURE_FLAG` or `import.meta.env.VITE_FEATURE_FLAG` with literal strings during compilation. When a condition evaluates to `if (false)` or `if ("")`, minifiers drop the dead branch and omit any modules imported inside it.
 
 Accessing properties on an imported `env` object (`if (env.NEXT_PUBLIC_FEATURE_FLAG)`) behaves as normal JavaScript object property access at runtime:
 
 ```ts title="./src/feature.ts"
 import { env } from "./env";
 
-// Evaluated as runtime object property access
 if (env.NEXT_PUBLIC_ADMIN_PREVIEW) {
   mountAdminPreview();
 }
 ```
 
-Because `env` is an exported object reference across module boundaries, bundlers and minifiers cannot always guarantee that object properties are constant or side-effect-free without inter-module whole-program analysis. As a result, code inside the `if` branch might not be aggressively eliminated from the client bundle when the flag is disabled.
+Because `env` is an exported object reference, minifiers cannot guarantee that properties remain immutable across module boundaries without whole-program analysis. Code inside the `if` block may remain in the client bundle even when the flag is disabled.
 
 <Callout type="warn">
-  If you have large, sensitive client chunks or internal admin tooling that **must** be guaranteed absent from production bundles when a flag is disabled, use direct bundler identifiers (such as `process.env.NEXT_PUBLIC_FEATURE_FLAG` or `import.meta.env.VITE_FEATURE_FLAG`) in the branching condition, or load heavy modules dynamically with `import()`. Use `env` for typesafe runtime validation and secure secret guarding.
+  If you have large client-only chunks or internal admin tooling that **must** be removed from production bundles when a flag is disabled, use direct bundler identifiers (such as `process.env.NEXT_PUBLIC_FEATURE_FLAG` or `import.meta.env.VITE_FEATURE_FLAG`) in the branching condition, or load heavy modules dynamically with `import()`. Use `env` for Typesafe runtime validation across your application.
 </Callout>
 
 ## Next steps

--- a/apps/www/content/docs/validating-your-environment/client-vs-server.mdx
+++ b/apps/www/content/docs/validating-your-environment/client-vs-server.mdx
@@ -137,7 +137,7 @@ Nuxt strict layout uses `@arkenv/nuxt/client` and `@arkenv/nuxt/server`. Omittin
 
 ## Dead-code elimination and constant folding
 
-Bundlers (like Next.js, Vite, and Bun) replace direct identifier expressions such as `process.env.NEXT_PUBLIC_FEATURE_FLAG` or `import.meta.env.VITE_FEATURE_FLAG` with literal strings during compilation. When a condition evaluates to `if (false)` or `if ("")`, minifiers drop the dead branch and omit any modules imported inside it.
+Bundlers (like Next.js, Vite, and Bun) replace direct identifier expressions such as `process.env.NEXT_PUBLIC_FEATURE_FLAG` or `import.meta.env.VITE_FEATURE_FLAG` with literal strings during compilation. If a condition evaluates to `if (false)` or `if ("")`, minifiers drop the dead branch and omit modules imported inside it.
 
 Accessing properties on an imported `env` object (`if (env.NEXT_PUBLIC_FEATURE_FLAG)`) behaves as normal JavaScript object property access at runtime:
 
@@ -149,10 +149,10 @@ if (env.NEXT_PUBLIC_ADMIN_PREVIEW) {
 }
 ```
 
-Because `env` is an exported object reference, minifiers cannot guarantee that properties remain immutable across module boundaries without whole-program analysis. Code inside the `if` block may remain in the client bundle even when the flag is disabled.
+Because `env` is an exported object reference, minifiers cannot guarantee that properties remain immutable across module boundaries without whole-program analysis. Code inside the `if` block may remain in the client bundle even when the flag is off.
 
 <Callout type="warn">
-  If you have large client-only chunks or internal admin tooling that **must** be removed from production bundles when a flag is disabled, use direct bundler identifiers (such as `process.env.NEXT_PUBLIC_FEATURE_FLAG` or `import.meta.env.VITE_FEATURE_FLAG`) in the branching condition, or load heavy modules dynamically with `import()`. Use `env` for Typesafe runtime validation across your application.
+  If you have client-only chunks or admin tools that must stay out of production bundles when a flag is off, use direct bundler identifiers (such as `process.env.NEXT_PUBLIC_FEATURE_FLAG` or `import.meta.env.VITE_FEATURE_FLAG`) in the condition, or load modules with dynamic `import()`. Use `env` for Typesafe runtime validation across your application.
 </Callout>
 
 ## Next steps

--- a/apps/www/content/docs/validating-your-environment/framework-integration.mdx
+++ b/apps/www/content/docs/validating-your-environment/framework-integration.mdx
@@ -65,22 +65,22 @@ Frameworks enforce client/server boundaries using two distinct strategies: **com
 
 Vite and Bun evaluate two separate module graphs in full-stack and SSR applications:
 
-1. **Server Graph:** Executes the real `@arkenv/core` runtime validator at server boot. It evaluates the entire schema against the real server environment, enforcing types, coercing values, and throwing fail-fast errors if secrets or required keys are invalid.
-2. **Client Graph:** Transformed at compile time by `@arkenv/vite-plugin` or `@arkenv/bun-plugin`. The plugin intercepts `env.ts` imports in browser bundles, replacing server secrets with throwing stubs and inlining public keys (`VITE_*` or `BUN_PUBLIC_*`) as static literals. The validator engine is omitted entirely from browser bundles.
+1. **Server graph:** Executes `@arkenv/core` runtime validation at server boot. It evaluates the entire schema against the environment, coercing values and throwing fail-fast errors on missing or invalid keys.
+2. **Client graph:** Transformed at compile time by `@arkenv/vite-plugin` or `@arkenv/bun-plugin`. The plugin intercepts `env.ts` imports in client bundles, replacing server secrets with throwing stubs and inlining public keys (`VITE_*` or `BUN_PUBLIC_*`) as static literals. The validator engine is omitted from client output.
 
 Because of this transform, `env.ts` in Vite and Bun projects imports directly from `@arkenv/core` (or `@arkenv/standard`).
 
 ### Dynamic hydration in Nuxt
 
-Nuxt takes a different approach designed for containerized deployments. Instead of inlining environment variables into client JavaScript chunks at build time, `@arkenv/nuxt` validates the environment during Nitro server boot and hydrates public variables dynamically into Nuxt's `runtimeConfig.public`. This preserves Docker "build once, deploy anywhere" workflows where environment variables change between environments without requiring a new client build.
+Nuxt takes an approach designed for containerized deployments. Instead of inlining environment variables into client JavaScript chunks at build time, `@arkenv/nuxt` validates the environment during Nitro server boot and hydrates public variables dynamically into Nuxt's `runtimeConfig.public`. This preserves Docker "build once, deploy anywhere" workflows where environment variables change between environments without requiring a new client build.
 
 ## Engine vs. host adapter architecture
 
-ArkEnv deliberately separates the **validation engine** (`@arkenv/core` and `@arkenv/standard`) from **framework adapters** (`@arkenv/nextjs`, `@arkenv/nuxt`, `@arkenv/vite-plugin`, `@arkenv/bun-plugin`).
+ArkEnv separates the **validation engine** (`@arkenv/core` and `@arkenv/standard`) from **framework adapters** (`@arkenv/nextjs`, `@arkenv/nuxt`, `@arkenv/vite-plugin`, `@arkenv/bun-plugin`).
 
 Framework adapters act as lightweight glue: they manage build plugins, virtual aliases, codegen, and security fences. Installing the validation engine as a peer dependency offers two major benefits:
 
-- **Zero redundant dependencies:** Framework packages do not bundle duplicate copies of validation libraries.
+- **Zero redundant dependencies:** Framework packages stay lean and avoid bundling redundant validation runtimes.
 - **Validator flexibility:** You can pair any framework adapter with either `@arkenv/core` (ArkType DSL) or `@arkenv/standard` (Zod, Valibot, Typia, or any Standard Schema library) using the exact same boundary guarantees.
 
 ## Loading `.env` files

--- a/apps/www/content/docs/validating-your-environment/framework-integration.mdx
+++ b/apps/www/content/docs/validating-your-environment/framework-integration.mdx
@@ -54,12 +54,12 @@ Plain Node or Bun **as a runtime** (no browser bundle) can stay on `@arkenv/core
 
 Frameworks enforce client/server boundaries using two distinct strategies: **compile-time AST transforms** and **host runtime adapters**.
 
-| Framework | Integration strategy                         | Client bundle output                     | SSR and server validation          | Docker "build once, deploy anywhere" |
+| Framework | Integration strategy                         | Client bundle output                     | SSR and server validation          | Public env without rebuild (Docker)  |
 | --------- | -------------------------------------------- | ---------------------------------------- | ---------------------------------- | ------------------------------------ |
-| Next.js   | Host adapter + codegen (`@arkenv/nextjs`)    | Generated runtime proxy                  | Process boot (`process.env`)       | Yes                                  |
-| Nuxt      | Nitro plugin (`@arkenv/nuxt`)                | Dynamic `runtimeConfig` hydration        | Nitro server boot gate             | Yes (no build-time inlining)         |
-| Vite      | AST build transform (`@arkenv/vite-plugin`)  | Inlined public literals + throwing stubs | Full `@arkenv/core` at server boot | Requires rebuild or SSR runtime      |
-| Bun       | Bundler AST transform (`@arkenv/bun-plugin`) | Inlined public literals + throwing stubs | Full `@arkenv/core` at server boot | Requires rebuild or SSR runtime      |
+| Next.js   | Host adapter + codegen (`@arkenv/nextjs`)    | Generated runtime proxy                  | Process boot (`process.env`)       | Requires rebuild for `NEXT_PUBLIC_*` |
+| Nuxt      | Nitro plugin (`@arkenv/nuxt`)                | Dynamic `runtimeConfig` hydration        | Nitro server boot gate             | Yes (via Nitro `runtimeConfig`)      |
+| Vite      | AST build transform (`@arkenv/vite-plugin`)  | Inlined public literals + throwing stubs | Full `@arkenv/core` at server boot | Requires rebuild for `VITE_*`        |
+| Bun       | Bundler AST transform (`@arkenv/bun-plugin`) | Inlined public literals + throwing stubs | Full `@arkenv/core` at server boot | Requires rebuild for `BUN_PUBLIC_*`  |
 
 ### Dual-graph execution in Vite and Bun
 

--- a/apps/www/content/docs/validating-your-environment/framework-integration.mdx
+++ b/apps/www/content/docs/validating-your-environment/framework-integration.mdx
@@ -54,12 +54,12 @@ Plain Node or Bun **as a runtime** (no browser bundle) can stay on `@arkenv/core
 
 Frameworks enforce client/server boundaries using two distinct strategies: **compile-time AST transforms** and **host runtime adapters**.
 
-| Framework | Integration strategy | Client bundle output | SSR and server validation | Docker "build once, deploy anywhere" |
-| --------- | -------------------- | -------------------- | ------------------------- | ------------------------------------ |
-| Next.js   | Host adapter + codegen (`@arkenv/nextjs`) | Generated runtime proxy | Process boot (`process.env`) | Yes |
-| Nuxt      | Nitro plugin (`@arkenv/nuxt`) | Dynamic `runtimeConfig` hydration | Nitro server boot gate | Yes (no build-time inlining) |
-| Vite      | AST build transform (`@arkenv/vite-plugin`) | Inlined public literals + throwing stubs | Full `@arkenv/core` at server boot | Requires rebuild or SSR runtime |
-| Bun       | Bundler AST transform (`@arkenv/bun-plugin`) | Inlined public literals + throwing stubs | Full `@arkenv/core` at server boot | Requires rebuild or SSR runtime |
+| Framework | Integration strategy                         | Client bundle output                     | SSR and server validation          | Docker "build once, deploy anywhere" |
+| --------- | -------------------------------------------- | ---------------------------------------- | ---------------------------------- | ------------------------------------ |
+| Next.js   | Host adapter + codegen (`@arkenv/nextjs`)    | Generated runtime proxy                  | Process boot (`process.env`)       | Yes                                  |
+| Nuxt      | Nitro plugin (`@arkenv/nuxt`)                | Dynamic `runtimeConfig` hydration        | Nitro server boot gate             | Yes (no build-time inlining)         |
+| Vite      | AST build transform (`@arkenv/vite-plugin`)  | Inlined public literals + throwing stubs | Full `@arkenv/core` at server boot | Requires rebuild or SSR runtime      |
+| Bun       | Bundler AST transform (`@arkenv/bun-plugin`) | Inlined public literals + throwing stubs | Full `@arkenv/core` at server boot | Requires rebuild or SSR runtime      |
 
 ### Dual-graph execution in Vite and Bun
 

--- a/apps/www/content/docs/validating-your-environment/framework-integration.mdx
+++ b/apps/www/content/docs/validating-your-environment/framework-integration.mdx
@@ -50,6 +50,39 @@ npx arkenv@latest init
 
 Plain Node or Bun **as a runtime** (no browser bundle) can stay on `@arkenv/core` alone. The Bun plugin targets apps that ship client code through Bun's bundler or fullstack server, not Bun-as-Node replacements or Bun-as-package-manager.
 
+## Compilation vs. runtime execution
+
+Frameworks enforce client/server boundaries using two distinct strategies: **compile-time AST transforms** and **host runtime adapters**.
+
+| Framework | Integration strategy | Client bundle output | SSR and server validation | Docker "build once, deploy anywhere" |
+| --------- | -------------------- | -------------------- | ------------------------- | ------------------------------------ |
+| Next.js   | Host adapter + codegen (`@arkenv/nextjs`) | Generated runtime proxy | Process boot (`process.env`) | Yes |
+| Nuxt      | Nitro plugin (`@arkenv/nuxt`) | Dynamic `runtimeConfig` hydration | Nitro server boot gate | Yes (no build-time inlining) |
+| Vite      | AST build transform (`@arkenv/vite-plugin`) | Inlined public literals + throwing stubs | Full `@arkenv/core` at server boot | Requires rebuild or SSR runtime |
+| Bun       | Bundler AST transform (`@arkenv/bun-plugin`) | Inlined public literals + throwing stubs | Full `@arkenv/core` at server boot | Requires rebuild or SSR runtime |
+
+### Dual-graph execution in Vite and Bun
+
+Vite and Bun evaluate two separate module graphs in full-stack and SSR applications:
+
+1. **Server Graph:** Executes the real `@arkenv/core` runtime validator at server boot. It evaluates the entire schema against the real server environment, enforcing types, coercing values, and throwing fail-fast errors if secrets or required keys are invalid.
+2. **Client Graph:** Transformed at compile time by `@arkenv/vite-plugin` or `@arkenv/bun-plugin`. The plugin intercepts `env.ts` imports in browser bundles, replacing server secrets with throwing stubs and inlining public keys (`VITE_*` or `BUN_PUBLIC_*`) as static literals. The validator engine is omitted entirely from browser bundles.
+
+Because of this transform, `env.ts` in Vite and Bun projects imports directly from `@arkenv/core` (or `@arkenv/standard`).
+
+### Dynamic hydration in Nuxt
+
+Nuxt takes a different approach designed for containerized deployments. Instead of inlining environment variables into client JavaScript chunks at build time, `@arkenv/nuxt` validates the environment during Nitro server boot and hydrates public variables dynamically into Nuxt's `runtimeConfig.public`. This preserves Docker "build once, deploy anywhere" workflows where environment variables change between environments without requiring a new client build.
+
+## Engine vs. host adapter architecture
+
+ArkEnv deliberately separates the **validation engine** (`@arkenv/core` and `@arkenv/standard`) from **framework adapters** (`@arkenv/nextjs`, `@arkenv/nuxt`, `@arkenv/vite-plugin`, `@arkenv/bun-plugin`).
+
+Framework adapters act as lightweight glue: they manage build plugins, virtual aliases, codegen, and security fences. Installing the validation engine as a peer dependency offers two major benefits:
+
+- **Zero redundant dependencies:** Framework packages do not bundle duplicate copies of validation libraries.
+- **Validator flexibility:** You can pair any framework adapter with either `@arkenv/core` (ArkType DSL) or `@arkenv/standard` (Zod, Valibot, Typia, or any Standard Schema library) using the exact same boundary guarantees.
+
 ## Loading `.env` files
 
 ArkEnv does not read `.env` files. Something else must load them before

--- a/apps/www/content/docs/validating-your-environment/framework-integration.mdx
+++ b/apps/www/content/docs/validating-your-environment/framework-integration.mdx
@@ -66,19 +66,19 @@ Frameworks enforce client/server boundaries using two distinct strategies: **com
 Vite and Bun evaluate two separate module graphs in full-stack and SSR applications:
 
 1. **Server graph:** Executes `@arkenv/core` runtime validation at server boot. It evaluates the entire schema against the environment, coercing values and throwing fail-fast errors on missing or invalid keys.
-2. **Client graph:** Transformed at compile time by `@arkenv/vite-plugin` or `@arkenv/bun-plugin`. The plugin intercepts `env.ts` imports in client bundles, replacing server secrets with throwing stubs and inlining public keys (`VITE_*` or `BUN_PUBLIC_*`) as static literals. The validator engine is omitted from client output.
+2. **Client graph:** `@arkenv/vite-plugin` and `@arkenv/bun-plugin` transform the client graph during bundling. The plugin intercepts `env.ts` imports in client bundles, replaces server secrets with throwing stubs, and inlines public keys (`VITE_*` or `BUN_PUBLIC_*`) as static literals. The bundle excludes the validation engine.
 
-Because of this transform, `env.ts` in Vite and Bun projects imports directly from `@arkenv/core` (or `@arkenv/standard`).
+Because of this transform, `env.ts` in Vite and Bun projects imports from `@arkenv/core` (or `@arkenv/standard`).
 
 ### Dynamic hydration in Nuxt
 
-Nuxt takes an approach designed for containerized deployments. Instead of inlining environment variables into client JavaScript chunks at build time, `@arkenv/nuxt` validates the environment during Nitro server boot and hydrates public variables dynamically into Nuxt's `runtimeConfig.public`. This preserves Docker "build once, deploy anywhere" workflows where environment variables change between environments without requiring a new client build.
+Nuxt targets containerized deployments. Instead of inlining environment variables into client JavaScript chunks at build time, `@arkenv/nuxt` validates the environment during Nitro server boot and passes public variables to Nuxt's `runtimeConfig.public`. You can update environment variables between staging and production without rebuilding client code.
 
 ## Engine vs. host adapter architecture
 
 ArkEnv separates the **validation engine** (`@arkenv/core` and `@arkenv/standard`) from **framework adapters** (`@arkenv/nextjs`, `@arkenv/nuxt`, `@arkenv/vite-plugin`, `@arkenv/bun-plugin`).
 
-Framework adapters act as lightweight glue: they manage build plugins, virtual aliases, codegen, and security fences. Installing the validation engine as a peer dependency offers two major benefits:
+Framework adapters manage build plugins, virtual aliases, codegen, and security fences. Declaring the validation engine as a peer dependency provides two advantages:
 
 - **Zero redundant dependencies:** Framework packages stay lean and avoid bundling redundant validation runtimes.
 - **Validator flexibility:** You can pair any framework adapter with either `@arkenv/core` (ArkType DSL) or `@arkenv/standard` (Zod, Valibot, Typia, or any Standard Schema library) using the exact same boundary guarantees.


### PR DESCRIPTION
Fixes #1597

## Summary
Expands and clarifies the documentation across key architectural vectors:
- **Dead-Code Elimination (DCE) & Constant Folding Caveats:** Added callout and explanation in `client-vs-server.mdx` regarding runtime object property access vs direct compiler macro replacement (`process.env` / `import.meta.env`).
- **Compilation vs. Runtime & SSR Execution:** Added execution matrix and detailed explanation of Vite & Bun SSR server graph validation vs client graph AST transformation in `framework-integration.mdx`, `vite.mdx`, and `bun.mdx`.
- **Framework Host Mechanics:** Documented Nuxt's Nitro boot gate validation and `runtimeConfig` hydration model for Docker "build once, deploy anywhere" workflows in `framework-integration.mdx` and `nuxt.mdx`.
- **Engine vs. Host Adapter Architecture:** Documented why `@arkenv/core` and `@arkenv/standard` are standalone peer dependencies in `framework-integration.mdx` and `faq.mdx`.