### PR TITLE
feat(vite,bun): (v1) strict layout for Vite/Bun via ADR 0013 import blocking

### DIFF
--- a/.changeset/strict-layout-vite-bun.md
+++ b/.changeset/strict-layout-vite-bun.md
@@ -6,9 +6,9 @@
 
 #### Add strict layout support and compile-time import blocking to Vite and Bun plugins
 
-Added strict layout (`env/client.ts`, `env/server.ts`) support to `@arkenv/vite-plugin` and `@arkenv/bun-plugin` with compile-time import blocking in accordance with ADR 0013 and ADR 0016:
+Added strict layout (`env/client.ts`, `env/server.ts`) support to `@arkenv/vite-plugin` and `@arkenv/bun-plugin` with compile-time import blocking:
 
-- Generalized the client-import blocker in `@arkenv/vite-plugin` so any client-graph import of `/server` schema files fails the Vite build with a descriptive security error.
-- Enforced compile-time client-import blocking in `@arkenv/bun-plugin` via `onResolve` and `onLoad` hooks for `target: "browser"` builds.
-- Added `CLIENT_SECURITY_ERROR` and `isServerSchemaImport` to `@arkenv/build` to share strict layout resolution and import blocking logic across bundler integrations.
+- Configured `@arkenv/vite-plugin` to reject client-graph imports of server-only environment schemas during build with a descriptive error.
+- Enforced compile-time server schema import blocking in `@arkenv/bun-plugin` for `target: "browser"` builds.
+- Added strict layout resolution and server schema detection utilities to `@arkenv/build` to share security mechanisms across bundler integrations.
 - Preserved existing flat layout transform behavior and zero-validator client bundle inlining.

--- a/.changeset/strict-layout-vite-bun.md
+++ b/.changeset/strict-layout-vite-bun.md
@@ -1,0 +1,14 @@
+---
+"@arkenv/build": minor
+"@arkenv/vite-plugin": minor
+"@arkenv/bun-plugin": minor
+---
+
+#### Add strict layout support and compile-time import blocking to Vite and Bun plugins
+
+Added strict layout (`env/client.ts`, `env/server.ts`) support to `@arkenv/vite-plugin` and `@arkenv/bun-plugin` with compile-time import blocking in accordance with ADR 0013 and ADR 0016:
+
+- Generalized the client-import blocker in `@arkenv/vite-plugin` so any client-graph import of `/server` schema files fails the Vite build with a descriptive security error.
+- Enforced compile-time client-import blocking in `@arkenv/bun-plugin` via `onResolve` and `onLoad` hooks for `target: "browser"` builds.
+- Added `CLIENT_SECURITY_ERROR` and `isServerSchemaImport` to `@arkenv/build` to share strict layout resolution and import blocking logic across bundler integrations.
+- Preserved existing flat layout transform behavior and zero-validator client bundle inlining.

--- a/packages/build/src/core.test.ts
+++ b/packages/build/src/core.test.ts
@@ -179,7 +179,14 @@ describe("@arkenv/build layout resolution", () => {
 				isServerSchemaImport("env/server", undefined, baseDir, "/app"),
 			).toBe(true);
 
-			// Allowed imports
+			expect(
+				isServerSchemaImport("/app/src/env/server.mts", undefined, baseDir),
+			).toBe(true);
+			expect(
+				isServerSchemaImport("/app/src/env/server.tsx", undefined, baseDir),
+			).toBe(true);
+
+			// Allowed imports (including sibling packages and unrelated packages ending with /env/server)
 			expect(
 				isServerSchemaImport(
 					"./env/client",
@@ -194,6 +201,19 @@ describe("@arkenv/build layout resolution", () => {
 			expect(
 				isServerSchemaImport("other-pkg/server", undefined, baseDir, "/app"),
 			).toBe(false);
+			expect(
+				isServerSchemaImport(
+					"/other/pkgs/tool/env/server.ts",
+					undefined,
+					baseDir,
+				),
+			).toBe(false);
+			expect(
+				isServerSchemaImport("some-pkg/env/server", undefined, baseDir, "/app"),
+			).toBe(false);
+			expect(isServerSchemaImport("lodash", undefined, baseDir, "/app")).toBe(
+				false,
+			);
 		});
 	});
 

--- a/packages/build/src/core.test.ts
+++ b/packages/build/src/core.test.ts
@@ -7,6 +7,7 @@ import {
 	extractKeys,
 	findSchemaPath,
 	formatMissingSchemaError,
+	isServerSchemaImport,
 	isStrictLayoutDir,
 	resolveLayout,
 } from "./core";
@@ -136,6 +137,63 @@ describe("@arkenv/build layout resolution", () => {
 			} finally {
 				fs.rmSync(tempDir, { recursive: true, force: true });
 			}
+		});
+
+		it("isServerSchemaImport correctly flags server schema imports", () => {
+			const baseDir = "/app/src/env";
+			expect(isServerSchemaImport("@arkenv/nuxt/server")).toBe(true);
+			expect(isServerSchemaImport("@arkenv/nuxt/standard/server")).toBe(true);
+			expect(isServerSchemaImport("@arkenv/nextjs/server")).toBe(true);
+			expect(
+				isServerSchemaImport(
+					"./env/server",
+					"/app/src/main.ts",
+					baseDir,
+					"/app",
+				),
+			).toBe(true);
+			expect(
+				isServerSchemaImport(
+					"./server.ts",
+					"/app/src/env/client.ts",
+					baseDir,
+					"/app",
+				),
+			).toBe(true);
+			expect(
+				isServerSchemaImport("/app/src/env/server.ts", undefined, baseDir),
+			).toBe(true);
+			expect(
+				isServerSchemaImport("@/env/server", undefined, baseDir, "/app"),
+			).toBe(true);
+			expect(
+				isServerSchemaImport(
+					"~/env/server",
+					undefined,
+					baseDir,
+					"/app",
+					"/app/src",
+				),
+			).toBe(true);
+			expect(
+				isServerSchemaImport("env/server", undefined, baseDir, "/app"),
+			).toBe(true);
+
+			// Allowed imports
+			expect(
+				isServerSchemaImport(
+					"./env/client",
+					"/app/src/main.ts",
+					baseDir,
+					"/app",
+				),
+			).toBe(false);
+			expect(
+				isServerSchemaImport("/app/src/env/client.ts", undefined, baseDir),
+			).toBe(false);
+			expect(
+				isServerSchemaImport("other-pkg/server", undefined, baseDir, "/app"),
+			).toBe(false);
 		});
 	});
 

--- a/packages/build/src/core.ts
+++ b/packages/build/src/core.ts
@@ -14,6 +14,138 @@ export {
 	formatMissingSchemaError,
 } from "./missing-schema-error";
 
+/**
+ * Standard build-time error thrown when client-graph code imports a server-only schema.
+ */
+export const CLIENT_SECURITY_ERROR = formatBuildError(
+	"Importing server-only environment schema on the client is not allowed!",
+);
+
+/**
+ * Check whether an imported module ID / path refers to a server schema file
+ * that must be blocked from client-graph bundles (ADR 0013 / ADR 0016).
+ *
+ * @param id The module identifier or file path being imported
+ * @param importer The module path that initiated the import (if available)
+ * @param baseDir The strict-layout base directory (e.g. `/project/env` or `/project/src/env`)
+ * @param rootDir Optional project root directory for resolving aliases
+ * @param srcDir Optional source directory for resolving aliases
+ * @returns `true` if the import targets a server-only schema file
+ */
+export function isServerSchemaImport(
+	id: string,
+	importer?: string,
+	baseDir?: string,
+	rootDir?: string,
+	srcDir?: string,
+): boolean {
+	if (!id) return false;
+
+	const isKnownServerModule =
+		id === "@arkenv/nuxt/server" ||
+		id === "@arkenv/nuxt/standard/server" ||
+		id === "@arkenv/nextjs/server" ||
+		id === "@arkenv/nextjs/standard/server" ||
+		/[/\\]@arkenv[/\\](?:nuxt|nextjs)[/\\](?:src|dist)[/\\](?:standard[/\\])?server(?:\.(?:js|mjs|cjs|ts))?$/.test(
+			id,
+		);
+
+	if (isKnownServerModule) {
+		return true;
+	}
+
+	if (!baseDir) {
+		return false;
+	}
+
+	const normalizedBaseDir = path.resolve(baseDir);
+
+	let cleanId = id;
+	if (cleanId.startsWith("\0")) {
+		cleanId = cleanId.slice(1);
+	}
+	const queryIndex = cleanId.indexOf("?");
+	if (queryIndex !== -1) {
+		cleanId = cleanId.slice(0, queryIndex);
+	}
+
+	let targetId = cleanId;
+	if ((cleanId.startsWith(".") || !path.isAbsolute(cleanId)) && importer) {
+		targetId = path.resolve(path.dirname(importer), cleanId);
+	} else if (rootDir) {
+		if (cleanId.startsWith("~~/")) {
+			targetId = path.resolve(rootDir, cleanId.slice(3));
+		} else if (cleanId.startsWith("~/") || cleanId.startsWith("@/")) {
+			const subPath = cleanId.slice(2);
+			targetId = srcDir
+				? path.resolve(srcDir, subPath)
+				: path.resolve(rootDir, subPath);
+		} else if (cleanId.startsWith("/")) {
+			targetId = path.resolve(rootDir, cleanId.slice(1));
+		}
+	}
+
+	if (path.isAbsolute(targetId)) {
+		let realTarget = targetId;
+		let realBase = normalizedBaseDir;
+		try {
+			if (fs.existsSync(targetId)) realTarget = fs.realpathSync(targetId);
+			if (fs.existsSync(normalizedBaseDir))
+				realBase = fs.realpathSync(normalizedBaseDir);
+		} catch {
+			// ignore
+		}
+
+		for (const [base, target] of [
+			[normalizedBaseDir, targetId],
+			[realBase, realTarget],
+		]) {
+			const relativePath = path.relative(base, target);
+			const isUnderBaseDir =
+				!relativePath.startsWith("..") && !path.isAbsolute(relativePath);
+			const isServerFile = /(^|[/\\])server(?:[/\\]|\.[^./\\]*|$)/.test(
+				relativePath,
+			);
+
+			if (isUnderBaseDir && isServerFile) {
+				return true;
+			}
+		}
+	}
+
+	const baseName = path.basename(normalizedBaseDir);
+	const normalizedTarget = path.normalize(cleanId);
+	if (
+		normalizedTarget === `${baseName}/server` ||
+		normalizedTarget.startsWith(`${baseName}/server.`) ||
+		normalizedTarget.endsWith(`/${baseName}/server`) ||
+		normalizedTarget.endsWith(`/${baseName}/server.ts`) ||
+		normalizedTarget.endsWith(`/${baseName}/server.js`) ||
+		normalizedTarget.endsWith(`/${baseName}/server.mjs`) ||
+		normalizedTarget.endsWith(`/${baseName}/server.cjs`)
+	) {
+		return true;
+	}
+
+	// Also check if resolving under rootDir or srcDir targets baseDir server
+	if (rootDir) {
+		const candidates = [
+			path.resolve(rootDir, normalizedTarget),
+			path.resolve(rootDir, "src", normalizedTarget),
+		];
+		for (const cand of candidates) {
+			const rel = path.relative(normalizedBaseDir, cand);
+			const isUnder = !rel.startsWith("..") && !path.isAbsolute(rel);
+			const isServer = /(^|[/\\])server(?:[/\\]|\.[^./\\]*|$)/.test(rel);
+			if (isUnder && isServer) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 // Global watcher reference isolated to this bundle's scope
 let activeWatcher: FSWatcher | undefined;
 

--- a/packages/build/src/core.ts
+++ b/packages/build/src/core.ts
@@ -39,14 +39,14 @@ export function isServerSchemaImport(
 	rootDir?: string,
 	srcDir?: string,
 ): boolean {
-	if (!id) return false;
+	if (!id || !id.includes("server")) return false;
 
 	const isKnownServerModule =
 		id === "@arkenv/nuxt/server" ||
 		id === "@arkenv/nuxt/standard/server" ||
 		id === "@arkenv/nextjs/server" ||
 		id === "@arkenv/nextjs/standard/server" ||
-		/[/\\]@arkenv[/\\](?:nuxt|nextjs)[/\\](?:src|dist)[/\\](?:standard[/\\])?server(?:\.(?:js|mjs|cjs|ts))?$/.test(
+		/[/\\]@arkenv[/\\](?:nuxt|nextjs)[/\\](?:src|dist)[/\\](?:standard[/\\])?server(?:\.[mc]?[jt]sx?)?$/.test(
 			id,
 		);
 
@@ -69,6 +69,38 @@ export function isServerSchemaImport(
 		cleanId = cleanId.slice(0, queryIndex);
 	}
 
+	const isTargetUnderBase = (target: string): boolean => {
+		if (!path.isAbsolute(target)) return false;
+
+		let realTarget = target;
+		let realBase = normalizedBaseDir;
+		try {
+			if (fs.existsSync(target)) realTarget = fs.realpathSync(target);
+			if (fs.existsSync(normalizedBaseDir))
+				realBase = fs.realpathSync(normalizedBaseDir);
+		} catch {
+			// ignore
+		}
+
+		for (const [base, candidate] of [
+			[normalizedBaseDir, target],
+			[realBase, realTarget],
+		]) {
+			const relativePath = path.relative(base, candidate);
+			const isUnderBaseDir =
+				!relativePath.startsWith("..") && !path.isAbsolute(relativePath);
+			const isServerFile = /(^|[/\\])server(?:\.[mc]?[jt]sx?|[/\\]|$)/.test(
+				relativePath,
+			);
+
+			if (isUnderBaseDir && isServerFile) {
+				return true;
+			}
+		}
+
+		return false;
+	};
+
 	let targetId = cleanId;
 	if ((cleanId.startsWith(".") || !path.isAbsolute(cleanId)) && importer) {
 		targetId = path.resolve(path.dirname(importer), cleanId);
@@ -77,69 +109,32 @@ export function isServerSchemaImport(
 			targetId = path.resolve(rootDir, cleanId.slice(3));
 		} else if (cleanId.startsWith("~/") || cleanId.startsWith("@/")) {
 			const subPath = cleanId.slice(2);
-			targetId = srcDir
-				? path.resolve(srcDir, subPath)
-				: path.resolve(rootDir, subPath);
+			if (isTargetUnderBase(path.resolve(rootDir, subPath))) return true;
+			if (isTargetUnderBase(path.resolve(rootDir, "src", subPath))) return true;
+			if (srcDir && isTargetUnderBase(path.resolve(srcDir, subPath)))
+				return true;
 		} else if (cleanId.startsWith("/")) {
 			targetId = path.resolve(rootDir, cleanId.slice(1));
 		}
 	}
 
-	if (path.isAbsolute(targetId)) {
-		let realTarget = targetId;
-		let realBase = normalizedBaseDir;
-		try {
-			if (fs.existsSync(targetId)) realTarget = fs.realpathSync(targetId);
-			if (fs.existsSync(normalizedBaseDir))
-				realBase = fs.realpathSync(normalizedBaseDir);
-		} catch {
-			// ignore
-		}
-
-		for (const [base, target] of [
-			[normalizedBaseDir, targetId],
-			[realBase, realTarget],
-		]) {
-			const relativePath = path.relative(base, target);
-			const isUnderBaseDir =
-				!relativePath.startsWith("..") && !path.isAbsolute(relativePath);
-			const isServerFile = /(^|[/\\])server(?:[/\\]|\.[^./\\]*|$)/.test(
-				relativePath,
-			);
-
-			if (isUnderBaseDir && isServerFile) {
-				return true;
-			}
-		}
-	}
-
-	const baseName = path.basename(normalizedBaseDir);
-	const normalizedTarget = path.normalize(cleanId);
-	if (
-		normalizedTarget === `${baseName}/server` ||
-		normalizedTarget.startsWith(`${baseName}/server.`) ||
-		normalizedTarget.endsWith(`/${baseName}/server`) ||
-		normalizedTarget.endsWith(`/${baseName}/server.ts`) ||
-		normalizedTarget.endsWith(`/${baseName}/server.js`) ||
-		normalizedTarget.endsWith(`/${baseName}/server.mjs`) ||
-		normalizedTarget.endsWith(`/${baseName}/server.cjs`)
-	) {
+	if (isTargetUnderBase(targetId)) {
 		return true;
 	}
 
-	// Also check if resolving under rootDir or srcDir targets baseDir server
+	// Also check bare specifiers resolved against candidate roots (e.g. rootDir, srcDir, parent of baseDir)
+	const candidateRoots: string[] = [];
 	if (rootDir) {
-		const candidates = [
-			path.resolve(rootDir, normalizedTarget),
-			path.resolve(rootDir, "src", normalizedTarget),
-		];
-		for (const cand of candidates) {
-			const rel = path.relative(normalizedBaseDir, cand);
-			const isUnder = !rel.startsWith("..") && !path.isAbsolute(rel);
-			const isServer = /(^|[/\\])server(?:[/\\]|\.[^./\\]*|$)/.test(rel);
-			if (isUnder && isServer) {
-				return true;
-			}
+		candidateRoots.push(rootDir, path.resolve(rootDir, "src"));
+		if (srcDir) candidateRoots.push(srcDir);
+	}
+	candidateRoots.push(path.dirname(normalizedBaseDir));
+
+	const normalizedTarget = path.normalize(cleanId);
+	for (const candRoot of candidateRoots) {
+		const candPath = path.resolve(candRoot, normalizedTarget);
+		if (isTargetUnderBase(candPath)) {
+			return true;
 		}
 	}
 

--- a/packages/build/src/env-module-path.test.ts
+++ b/packages/build/src/env-module-path.test.ts
@@ -74,4 +74,19 @@ describe("env-module-path utilities", () => {
 			/does not exist/,
 		);
 	});
+
+	it("resolveEnvModulePath discovers and resolves strict layout directories", () => {
+		const tmp = fs.mkdtempSync(
+			path.join(os.tmpdir(), "arkenv-resolve-strict-"),
+		);
+		tempDirs.push(tmp);
+
+		const envDir = path.join(tmp, "env");
+		fs.mkdirSync(envDir, { recursive: true });
+		fs.writeFileSync(path.join(envDir, "client.ts"), "export const env = {};");
+		fs.writeFileSync(path.join(envDir, "server.ts"), "export const env = {};");
+
+		expect(resolveEnvModulePath(tmp)).toBe(envDir);
+		expect(resolveEnvModulePath(tmp, "env")).toBe(envDir);
+	});
 });

--- a/packages/build/src/env-module-path.ts
+++ b/packages/build/src/env-module-path.ts
@@ -34,23 +34,38 @@ export function normalizeModuleId(id: string): string {
  * @returns Whether `id` identifies the same module as `schemaPath`
  */
 export function isEnvModuleId(id: string, schemaPath: string): boolean {
+	const stripExt = (filePath: string) =>
+		filePath.replace(/\.(m|c)?[jt]sx?$/, "");
+
 	const normalizedId = path.resolve(normalizeModuleId(id));
 	const normalizedSchema = path.resolve(schemaPath);
 	if (normalizedId === normalizedSchema) return true;
+	if (stripExt(normalizedId) === stripExt(normalizedSchema)) return true;
 
-	const stripExt = (filePath: string) =>
-		filePath.replace(/\.(m|c)?[jt]sx?$/, "");
-	return stripExt(normalizedId) === stripExt(normalizedSchema);
+	try {
+		const realId = fs.existsSync(normalizedId)
+			? fs.realpathSync(normalizedId)
+			: normalizedId;
+		const realSchema = fs.existsSync(normalizedSchema)
+			? fs.realpathSync(normalizedSchema)
+			: normalizedSchema;
+		if (realId === realSchema) return true;
+		if (stripExt(realId) === stripExt(realSchema)) return true;
+	} catch {
+		// Ignore filesystem errors for virtual or missing files
+	}
+
+	return false;
 }
 
 /**
- * Resolve the absolute env-module path from options and a project root.
+ * Resolve the absolute env-module or layout path from options and a project root.
  *
  * @param root The project root directory
  * @param schemaPath An optional relative or absolute schema path from config
  * @param prefix Brand prefix for diagnostics (e.g. `"[ArkEnv]"`, `"ArkEnv Vite plugin:"`, `"ArkEnv Bun plugin:"`)
- * @returns The absolute path to the env module
- * @throws If no env module can be found or if it points to a directory
+ * @returns The absolute path to the env module or strict schema directory
+ * @throws If no env module can be found or if schemaPath does not exist
  */
 export function resolveEnvModulePath(
 	root: string,
@@ -69,7 +84,7 @@ export function resolveEnvModulePath(
 				`${cleanPrefix} schemaPath "${schemaPath}" does not exist (resolved to "${resolved}").`,
 			);
 		}
-		return assertFlatSchemaFile(resolved, cleanPrefix);
+		return resolved;
 	}
 
 	const discovered = findSchemaPath(root);
@@ -82,7 +97,7 @@ export function resolveEnvModulePath(
 			}),
 		);
 	}
-	return assertFlatSchemaFile(discovered, cleanPrefix);
+	return discovered;
 }
 
 /**

--- a/packages/build/src/transform-options.ts
+++ b/packages/build/src/transform-options.ts
@@ -3,6 +3,7 @@
  */
 export const TRANSFORM_OPTION_KEYS = new Set([
 	"schemaPath",
+	"layout",
 	"clientPrefix",
 	"logger",
 	"logLevel",
@@ -21,11 +22,17 @@ export const TRANSFORM_OPTION_KEYS = new Set([
  */
 export type TransformOptions = {
 	/**
-	 * Path to the env module (`env.ts`), relative to the project root.
+	 * Path to the env module (`env.ts`) or strict schema directory, relative to the project root.
 	 *
-	 * When omitted, ArkEnv auto-discovers `src/env.ts` or `env.ts`.
+	 * When omitted, ArkEnv auto-discovers `src/env.ts`, `env.ts`, `src/env`, or `env`.
 	 */
 	schemaPath?: string;
+	/**
+	 * Explicit layout structure mode ("flat", "simple", or "strict").
+	 *
+	 * When omitted, ArkEnv auto-detects from the schema file/directory.
+	 */
+	layout?: "simple" | "strict" | "flat";
 	/**
 	 * Prefix(es) that mark client-exposed environment variables.
 	 *

--- a/packages/bun-plugin/src/env-module.test.ts
+++ b/packages/bun-plugin/src/env-module.test.ts
@@ -337,7 +337,7 @@ describe("missing-schema errors", () => {
 		expect(message).not.toMatch(/from "zod"/);
 	});
 
-	it("rejects a discovered strict layout directory", async () => {
+	it("discovers a strict layout directory without error", async () => {
 		const { resolveEnvModulePath } = await import("./env-module.js");
 		const root = mkdtempSync(join(tmpdir(), "arkenv-bun-strict-dir-"));
 		temps.push(root);
@@ -346,8 +346,153 @@ describe("missing-schema errors", () => {
 		writeFileSync(join(envDir, "client.ts"), "export const env = {}");
 		writeFileSync(join(envDir, "server.ts"), "export const env = {}");
 
-		expect(() => resolveEnvModulePath(root)).toThrow(
-			/only supports a flat env module file/,
+		expect(resolveEnvModulePath(root)).toBe(envDir);
+	});
+});
+
+describe("strict layout plugin behavior", () => {
+	const temps: string[] = [];
+
+	afterEach(() => {
+		for (const dir of temps.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("blocks imports of env/server in browser bundles via onResolve", async () => {
+		const root = mkdtempSync(join(tmpdir(), "arkenv-bun-strict-fail-"));
+		temps.push(root);
+		const envDir = join(root, "env");
+		mkdirSync(envDir, { recursive: true });
+
+		writeFileSync(
+			join(envDir, "client.ts"),
+			`import arkenv from "@arkenv/core";
+export const env = arkenv({ BUN_PUBLIC_API_URL: "string" });
+`,
 		);
+		writeFileSync(
+			join(envDir, "server.ts"),
+			`import arkenv from "@arkenv/core";
+export const env = arkenv({ DATABASE_URL: "string" });
+`,
+		);
+
+		const previous = { ...process.env };
+		process.env.BUN_PUBLIC_API_URL = "https://api.example.com";
+
+		try {
+			const plugin = arkenv({ schemaPath: envDir });
+
+			let onStart: (() => void | Promise<void>) | undefined;
+			let onResolve:
+				| ((args: { path: string; importer?: string }) => unknown)
+				| undefined;
+
+			plugin.setup({
+				onStart(cb: () => void | Promise<void>) {
+					onStart = cb;
+				},
+				onResolve(
+					_opts: { filter: RegExp },
+					cb: typeof onResolve extends infer T ? T : never,
+				) {
+					onResolve = cb;
+				},
+				onLoad() {},
+			} as any);
+
+			await onStart?.();
+
+			expect(() =>
+				onResolve?.({
+					path: "./env/server",
+					importer: join(root, "index.ts"),
+				}),
+			).toThrow(
+				/Importing server-only environment schema on the client is not allowed/,
+			);
+		} finally {
+			process.env = previous;
+		}
+	});
+
+	it("transforms env/client in browser bundles via onLoad", async () => {
+		const root = mkdtempSync(join(tmpdir(), "arkenv-bun-strict-pass-"));
+		temps.push(root);
+		const envDir = join(root, "env");
+		mkdirSync(envDir, { recursive: true });
+
+		const clientPath = join(envDir, "client.ts");
+		writeFileSync(
+			clientPath,
+			`import arkenv from "@arkenv/core";
+export const env = arkenv({ BUN_PUBLIC_API_URL: "string" });
+`,
+		);
+		writeFileSync(
+			join(envDir, "server.ts"),
+			`import arkenv from "@arkenv/core";
+export const env = arkenv({ DATABASE_URL: "string" });
+`,
+		);
+
+		const previous = { ...process.env };
+		process.env.BUN_PUBLIC_API_URL = "https://api.example.com";
+
+		try {
+			const plugin = arkenv({ schemaPath: envDir });
+
+			let onStart: (() => void | Promise<void>) | undefined;
+			let onResolve:
+				| ((args: {
+						path: string;
+						importer?: string;
+				  }) => { errors?: { text: string }[] } | undefined)
+				| undefined;
+			let onLoad:
+				| ((args: {
+						path: string;
+				  }) =>
+						| { contents?: string; loader?: string }
+						| undefined
+						| Promise<{ contents?: string; loader?: string } | undefined>)
+				| undefined;
+
+			plugin.setup({
+				onStart(cb: () => void | Promise<void>) {
+					onStart = cb;
+				},
+				onResolve(
+					_opts: { filter: RegExp },
+					cb: typeof onResolve extends infer T ? T : never,
+				) {
+					onResolve = cb;
+				},
+				onLoad(
+					_opts: { filter: RegExp },
+					cb: typeof onLoad extends infer T ? T : never,
+				) {
+					onLoad = cb;
+				},
+			} as any);
+
+			await onStart?.();
+
+			const resolveResult = onResolve?.({
+				path: "./env/client",
+				importer: join(root, "index.ts"),
+			});
+			expect(resolveResult).toBeUndefined();
+
+			const loadResult = await onLoad?.({
+				path: clientPath,
+			});
+			expect(loadResult?.contents).toBeDefined();
+			expect(loadResult?.contents).toContain("https://api.example.com");
+			expect(loadResult?.contents).not.toContain("@arkenv/core");
+		} finally {
+			process.env = previous;
+		}
 	});
 });

--- a/packages/bun-plugin/src/env-module.ts
+++ b/packages/bun-plugin/src/env-module.ts
@@ -1,14 +1,17 @@
 export {
 	assertTransformModeCall,
+	CLIENT_SECURITY_ERROR,
 	classifyEnvKeys,
 	filterEnvByPrefix,
 	generateClientEnvModule,
 	isEnvModuleId,
+	isServerSchemaImport,
 	isTransformModeCall,
 	loadValidatedEnv,
 	normalizeModuleId,
 	normalizePrefixes,
 	resolveEnvModulePath,
+	resolveLayout,
 	SCHEMA_DEFINE_REMOVED,
 	type TransformOptions as BunTransformOptions,
 } from "@arkenv/build";

--- a/packages/bun-plugin/src/transform-plugin.ts
+++ b/packages/bun-plugin/src/transform-plugin.ts
@@ -154,7 +154,7 @@ export function createTransformPlugin(
 			});
 
 			if (typeof build.onResolve === "function") {
-				build.onResolve({ filter: /.*/ }, (args) => {
+				build.onResolve({ filter: /server/ }, (args) => {
 					if (state.resolvedLayout === "strict" && state.baseDir) {
 						if (
 							isServerSchemaImport(

--- a/packages/bun-plugin/src/transform-plugin.ts
+++ b/packages/bun-plugin/src/transform-plugin.ts
@@ -1,11 +1,15 @@
 import fs from "node:fs";
+import path from "node:path";
 import {
+	CLIENT_SECURITY_ERROR,
 	classifyEnvKeys,
 	generateClientEnvModule,
 	isEnvModuleId,
+	isServerSchemaImport,
 	loadValidatedEnv,
 	normalizePrefixes,
 	resolveEnvModulePath,
+	resolveLayout,
 } from "@arkenv/build";
 import {
 	type ArkEnvLogOptions,
@@ -24,7 +28,7 @@ import type { BunPluginFactoryConfig } from "./plugin-config";
  * @param pluginName The Bun plugin name
  * @param transformOptions Plugin options including `schemaPath` / `clientPrefix`
  * @param factoryLogOptions Default logging options from the factory
- * @returns A Bun plugin that rewrites `env.ts` in browser bundles
+ * @returns A Bun plugin that rewrites `env.ts` in browser bundles and blocks server schema imports
  */
 export function createTransformPlugin(
 	pluginName: string,
@@ -33,6 +37,7 @@ export function createTransformPlugin(
 ): BunPlugin {
 	const {
 		schemaPath: schemaPathOption,
+		layout: layoutOption,
 		clientPrefix: clientPrefixOption,
 		...configWithoutTransformKeys
 	} = transformOptions;
@@ -42,7 +47,11 @@ export function createTransformPlugin(
 	const buildLog = resolveBuildLog({ ...factoryLogOptions, ...logOptions });
 
 	const state: {
+		resolvedLayout?: "simple" | "strict";
+		baseDir?: string;
 		schemaPath?: string;
+		clientPath?: string;
+		serverPath?: string;
 		prefixes: string[];
 		clientValues: Record<string, unknown>;
 		serverKeys: string[];
@@ -57,17 +66,19 @@ export function createTransformPlugin(
 	 * Reload validated env values and key classification from the env module.
 	 */
 	const refreshTransformState = () => {
-		if (!state.schemaPath) return;
+		const targetPath =
+			state.resolvedLayout === "strict" ? state.clientPath : state.schemaPath;
+		if (!targetPath || !fs.existsSync(targetPath)) return;
 
 		const loaded = {
 			...process.env,
 			...(pluginConfig.env as Record<string, string | undefined> | undefined),
 		};
 
-		const validated = loadValidatedEnv(state.schemaPath, loaded, {
+		const validated = loadValidatedEnv(targetPath, loaded, {
 			prefix: "ArkEnv Bun plugin:",
 		});
-		const content = fs.readFileSync(state.schemaPath, "utf8");
+		const content = fs.readFileSync(targetPath, "utf8");
 		const { clientKeys, sharedKeys, serverKeys } = classifyEnvKeys(
 			content,
 			state.prefixes,
@@ -82,8 +93,11 @@ export function createTransformPlugin(
 		}
 
 		state.clientValues = clientValues;
-		state.serverKeys = serverKeys;
-		state.transformedSource = generateClientEnvModule(clientValues, serverKeys);
+		state.serverKeys = state.resolvedLayout === "strict" ? [] : serverKeys;
+		state.transformedSource = generateClientEnvModule(
+			clientValues,
+			state.serverKeys,
+		);
 	};
 
 	return {
@@ -109,11 +123,23 @@ export function createTransformPlugin(
 			 */
 			build.onStart(() => {
 				try {
-					state.schemaPath = resolveEnvModulePath(
+					const discovered = resolveEnvModulePath(
 						process.cwd(),
 						schemaPathOption,
 						"ArkEnv Bun plugin:",
 					);
+					const layoutResult = resolveLayout(discovered, layoutOption);
+					state.resolvedLayout = layoutResult.layout;
+					state.baseDir = layoutResult.baseDir;
+
+					if (state.resolvedLayout === "strict") {
+						state.clientPath = path.join(state.baseDir, "client.ts");
+						state.serverPath = path.join(state.baseDir, "server.ts");
+						state.schemaPath = state.clientPath;
+					} else {
+						state.schemaPath = discovered;
+					}
+
 					state.prefixes = normalizePrefixes(clientPrefixOption, [
 						"BUN_PUBLIC_",
 					]);
@@ -127,7 +153,50 @@ export function createTransformPlugin(
 				}
 			});
 
+			if (typeof build.onResolve === "function") {
+				build.onResolve({ filter: /.*/ }, (args) => {
+					if (state.resolvedLayout === "strict" && state.baseDir) {
+						if (
+							isServerSchemaImport(
+								args.path,
+								args.importer,
+								state.baseDir,
+								process.cwd(),
+							)
+						) {
+							buildLog.logBuildErrorWithCause(
+								"Client security error",
+								new Error(CLIENT_SECURITY_ERROR),
+							);
+							throw new Error(CLIENT_SECURITY_ERROR);
+						}
+					}
+					return undefined;
+				});
+			}
+
 			build.onLoad({ filter: /\.(m|c)?[jt]sx?$/ }, (args) => {
+				if (state.resolvedLayout === "strict" && state.baseDir) {
+					if (
+						isServerSchemaImport(
+							args.path,
+							undefined,
+							state.baseDir,
+							process.cwd(),
+						)
+					) {
+						throw new Error(CLIENT_SECURITY_ERROR);
+					}
+					if (state.clientPath && isEnvModuleId(args.path, state.clientPath)) {
+						if (!state.transformedSource) return undefined;
+						return {
+							contents: state.transformedSource,
+							loader: "js",
+						};
+					}
+					return undefined;
+				}
+
 				if (!state.schemaPath) return undefined;
 				if (!isEnvModuleId(args.path, state.schemaPath)) return undefined;
 				if (!state.transformedSource) return undefined;

--- a/packages/vite-plugin/src/env-module.test.ts
+++ b/packages/vite-plugin/src/env-module.test.ts
@@ -299,7 +299,7 @@ describe("missing-schema errors", () => {
 		expect(message).not.toMatch(/from "zod"/);
 	});
 
-	it("rejects a discovered strict layout directory", async () => {
+	it("discovers a strict layout directory without error", async () => {
 		const { resolveEnvModulePath } = await import("./env-module.js");
 		const root = mkdtempSync(join(tmpdir(), "arkenv-vite-strict-dir-"));
 		temps.push(root);
@@ -308,8 +308,181 @@ describe("missing-schema errors", () => {
 		writeFileSync(join(envDir, "client.ts"), "export const env = {}");
 		writeFileSync(join(envDir, "server.ts"), "export const env = {}");
 
-		expect(() => resolveEnvModulePath(root)).toThrow(
-			/only supports a flat env module file/,
+		expect(resolveEnvModulePath(root)).toBe(envDir);
+	});
+});
+
+describe("strict layout plugin behavior", () => {
+	const temps: string[] = [];
+
+	afterEach(() => {
+		for (const dir of temps.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("fails the client build when client-graph code imports env/server", async () => {
+		const root = mkdtempSync(join(tmpdir(), "arkenv-vite-strict-fail-"));
+		temps.push(root);
+		const envDir = join(root, "env");
+		mkdirSync(envDir, { recursive: true });
+
+		writeFileSync(
+			join(envDir, "client.ts"),
+			`import arkenv from "@arkenv/core";
+export const env = arkenv({ VITE_API_URL: "string" });
+`,
 		);
+		writeFileSync(
+			join(envDir, "server.ts"),
+			`import arkenv from "@arkenv/core";
+export const env = arkenv({ DATABASE_URL: "string" });
+`,
+		);
+		writeFileSync(
+			join(root, "index.ts"),
+			`import { env } from "./env/server";
+export const secret = env.DATABASE_URL;
+`,
+		);
+		writeFileSync(join(root, ".env"), "VITE_API_URL=https://api.example.com\n");
+
+		const outDir = mkdtempSync(join(tmpdir(), "arkenv-vite-strict-out-"));
+		temps.push(outDir);
+
+		await expect(
+			vite.build({
+				mode: "test",
+				configFile: false,
+				root,
+				plugins: [arkenvPlugin()],
+				logLevel: "silent",
+				build: {
+					outDir,
+					write: false,
+					lib: {
+						entry: "index.ts",
+						formats: ["es"],
+						fileName: () => "bundle.js",
+					},
+				},
+			}),
+		).rejects.toThrow(
+			/Importing server-only environment schema on the client is not allowed/,
+		);
+	});
+
+	it("builds successfully when client-graph code imports env/client", async () => {
+		const root = mkdtempSync(join(tmpdir(), "arkenv-vite-strict-pass-"));
+		temps.push(root);
+		const envDir = join(root, "env");
+		mkdirSync(envDir, { recursive: true });
+
+		writeFileSync(
+			join(envDir, "client.ts"),
+			`import arkenv from "@arkenv/core";
+export const env = arkenv({ VITE_API_URL: "string" });
+`,
+		);
+		writeFileSync(
+			join(envDir, "server.ts"),
+			`import arkenv from "@arkenv/core";
+export const env = arkenv({ DATABASE_URL: "string" });
+`,
+		);
+		writeFileSync(
+			join(root, "index.ts"),
+			`import { env } from "./env/client";
+export const api = env.VITE_API_URL;
+`,
+		);
+		writeFileSync(join(root, ".env"), "VITE_API_URL=https://api.example.com\n");
+
+		const outDir = mkdtempSync(join(tmpdir(), "arkenv-vite-strict-out-"));
+		temps.push(outDir);
+
+		await vite.build({
+			mode: "test",
+			configFile: false,
+			root,
+			plugins: [arkenvPlugin()],
+			logLevel: "silent",
+			build: {
+				outDir,
+				write: true,
+				lib: {
+					entry: "index.ts",
+					formats: ["es"],
+					fileName: () => "bundle.js",
+				},
+			},
+		});
+
+		const bundle = readFileSync(join(outDir, "bundle.js"), "utf8");
+		expect(bundle).toContain("https://api.example.com");
+	});
+
+	it("passes through server schema in the SSR graph without blocking", async () => {
+		const root = mkdtempSync(join(tmpdir(), "arkenv-vite-strict-ssr-"));
+		temps.push(root);
+		const envDir = join(root, "env");
+		mkdirSync(envDir, { recursive: true });
+
+		const serverContent = `import arkenv from "@arkenv/core";
+export const env = arkenv({ DATABASE_URL: "string" });
+`;
+		writeFileSync(join(envDir, "client.ts"), "export const env = {};");
+		writeFileSync(join(envDir, "server.ts"), serverContent);
+
+		const plugin = arkenvPlugin();
+		const mockContext = {
+			meta: {
+				framework: "vite",
+				version: "1.0.0",
+				rollupVersion: "4.0.0",
+				viteVersion: "5.0.0",
+			},
+			error: () => {},
+			warn: () => {},
+			info: () => {},
+			debug: () => {},
+		} as any;
+
+		if (plugin.config && typeof plugin.config === "function") {
+			plugin.config.call(
+				mockContext,
+				{ root, envDir: root },
+				{ mode: "test", command: "build" },
+			);
+		}
+		if (plugin.configResolved && typeof plugin.configResolved === "function") {
+			await plugin.configResolved.call(mockContext, {
+				root,
+				envDir: root,
+				envPrefix: "VITE_",
+			} as any);
+		}
+
+		let resolveResult: any = "NOT_CALLED";
+		if (plugin.resolveId && typeof plugin.resolveId === "function") {
+			resolveResult = await (plugin.resolveId as any).call(
+				mockContext,
+				join(envDir, "server.ts"),
+				join(root, "index.ts"),
+				{ ssr: true },
+			);
+		}
+		expect(resolveResult).toBeNull();
+
+		let transformResult: any = "NOT_CALLED";
+		if (plugin.transform && typeof plugin.transform === "function") {
+			transformResult = await plugin.transform.call(
+				mockContext,
+				serverContent,
+				join(envDir, "server.ts"),
+				{ ssr: true } as any,
+			);
+		}
+		expect(transformResult).toBeNull();
 	});
 });

--- a/packages/vite-plugin/src/env-module.ts
+++ b/packages/vite-plugin/src/env-module.ts
@@ -1,15 +1,18 @@
 export {
 	assertTransformModeCall,
+	CLIENT_SECURITY_ERROR,
 	classifyEnvKeys,
 	filterEnvByPrefix,
 	generateClientEnvModule,
 	isDotEnvFile,
 	isEnvModuleId,
+	isServerSchemaImport,
 	isTransformModeCall,
 	loadValidatedEnv,
 	normalizeModuleId,
 	normalizePrefixes,
 	resolveEnvModulePath,
+	resolveLayout,
 	SCHEMA_DEFINE_REMOVED,
 	type TransformOptions as ViteTransformOptions,
 } from "@arkenv/build";

--- a/packages/vite-plugin/src/transform-plugin.ts
+++ b/packages/vite-plugin/src/transform-plugin.ts
@@ -1,12 +1,16 @@
 import fs from "node:fs";
+import path from "node:path";
 import {
+	CLIENT_SECURITY_ERROR,
 	classifyEnvKeys,
 	generateClientEnvModule,
 	isDotEnvFile,
 	isEnvModuleId,
+	isServerSchemaImport,
 	loadValidatedEnv,
 	normalizePrefixes,
 	resolveEnvModulePath,
+	resolveLayout,
 } from "@arkenv/build";
 import {
 	type ArkEnvLogOptions,
@@ -17,12 +21,12 @@ import { loadEnv, type Plugin } from "vite";
 import type { VitePluginFactoryConfig } from "./plugin-config";
 
 /**
- * Build the env-module transform plugin (client rewrite + SSR passthrough).
+ * Build the env-module transform plugin (client rewrite + SSR passthrough + strict layout import blocking).
  *
  * @param pluginName The Vite plugin name
  * @param transformOptions Plugin options including `schemaPath` / `clientPrefix`
  * @param factoryLogOptions Default logging options from the factory
- * @returns A Vite plugin that rewrites `env.ts` in the client graph
+ * @returns A Vite plugin that rewrites `env.ts` in the client graph and blocks server schema imports
  */
 export function createTransformPlugin(
 	pluginName: string,
@@ -31,6 +35,7 @@ export function createTransformPlugin(
 ): Plugin {
 	const {
 		schemaPath: schemaPathOption,
+		layout: layoutOption,
 		clientPrefix: clientPrefixOption,
 		...configWithoutTransformKeys
 	} = transformOptions;
@@ -40,7 +45,11 @@ export function createTransformPlugin(
 	const buildLog = resolveBuildLog({ ...factoryLogOptions, ...logOptions });
 
 	const state: {
+		resolvedLayout?: "simple" | "strict";
+		baseDir?: string;
 		schemaPath?: string;
+		clientPath?: string;
+		serverPath?: string;
 		prefixes: string[];
 		mode: string;
 		envDir: string;
@@ -60,17 +69,19 @@ export function createTransformPlugin(
 	 * Reload validated env values and key classification from the env module.
 	 */
 	const refreshTransformState = () => {
-		if (!state.schemaPath) return;
+		const targetPath =
+			state.resolvedLayout === "strict" ? state.clientPath : state.schemaPath;
+		if (!targetPath || !fs.existsSync(targetPath)) return;
 
 		const loaded = {
 			...loadEnv(state.mode, state.envDir, ""),
 			...(pluginConfig.env as Record<string, string | undefined> | undefined),
 		};
 
-		const validated = loadValidatedEnv(state.schemaPath, loaded, {
+		const validated = loadValidatedEnv(targetPath, loaded, {
 			prefix: "ArkEnv Vite plugin:",
 		});
-		const content = fs.readFileSync(state.schemaPath, "utf8");
+		const content = fs.readFileSync(targetPath, "utf8");
 		const { clientKeys, sharedKeys, serverKeys } = classifyEnvKeys(
 			content,
 			state.prefixes,
@@ -85,7 +96,7 @@ export function createTransformPlugin(
 		}
 
 		state.clientValues = clientValues;
-		state.serverKeys = serverKeys;
+		state.serverKeys = state.resolvedLayout === "strict" ? [] : serverKeys;
 	};
 
 	return {
@@ -113,16 +124,39 @@ export function createTransformPlugin(
 			);
 
 			try {
-				state.schemaPath = resolveEnvModulePath(
+				const discovered = resolveEnvModulePath(
 					resolved.root,
 					schemaPathOption,
 					"ArkEnv Vite plugin:",
 				);
+				const layoutResult = resolveLayout(discovered, layoutOption);
+				state.resolvedLayout = layoutResult.layout;
+				state.baseDir = layoutResult.baseDir;
+
+				if (state.resolvedLayout === "strict") {
+					state.clientPath = path.join(state.baseDir, "client.ts");
+					state.serverPath = path.join(state.baseDir, "server.ts");
+					state.schemaPath = state.clientPath;
+				} else {
+					state.schemaPath = discovered;
+				}
+
 				refreshTransformState();
 			} catch (error: unknown) {
 				buildLog.logBuildErrorWithCause("Environment validation failed", error);
 				throw error;
 			}
+		},
+		resolveId(id, importer, options) {
+			if (!options?.ssr && state.resolvedLayout === "strict" && state.baseDir) {
+				if (isServerSchemaImport(id, importer, state.baseDir, state.root)) {
+					if (this.error && typeof this.error === "function") {
+						this.error(CLIENT_SECURITY_ERROR);
+					}
+					throw new Error(CLIENT_SECURITY_ERROR);
+				}
+			}
+			return null;
 		},
 		/**
 		 * Rewrite the env module in the client graph only.
@@ -132,9 +166,26 @@ export function createTransformPlugin(
 		 * codegen, client-side re-validation, or `runtimeEnv` wiring here.
 		 */
 		transform(_code, id, options) {
+			if (options?.ssr) return null;
+
+			if (state.resolvedLayout === "strict" && state.baseDir) {
+				if (isServerSchemaImport(id, undefined, state.baseDir, state.root)) {
+					if (this.error && typeof this.error === "function") {
+						this.error(CLIENT_SECURITY_ERROR);
+					}
+					throw new Error(CLIENT_SECURITY_ERROR);
+				}
+				if (state.clientPath && isEnvModuleId(id, state.clientPath)) {
+					return {
+						code: generateClientEnvModule(state.clientValues, state.serverKeys),
+						map: null,
+					};
+				}
+				return null;
+			}
+
 			if (!state.schemaPath) return null;
 			if (!isEnvModuleId(id, state.schemaPath)) return null;
-			if (options?.ssr) return null;
 
 			return {
 				code: generateClientEnvModule(state.clientValues, state.serverKeys),
@@ -142,9 +193,10 @@ export function createTransformPlugin(
 			};
 		},
 		handleHotUpdate({ file, server }) {
-			if (!state.schemaPath) return;
-
-			const schemaChanged = isEnvModuleId(file, state.schemaPath);
+			const isStrict = state.resolvedLayout === "strict" && state.baseDir;
+			const schemaChanged = isStrict
+				? file.startsWith(state.baseDir as string)
+				: Boolean(state.schemaPath && isEnvModuleId(file, state.schemaPath));
 			const envFileChanged = isDotEnvFile(file);
 			if (!schemaChanged && !envFileChanged) return;
 
@@ -158,8 +210,11 @@ export function createTransformPlugin(
 				throw error;
 			}
 
+			const targetPath = isStrict ? state.clientPath : state.schemaPath;
+			if (!targetPath) return;
+
 			const modules = [
-				...(server.moduleGraph.getModulesByFile(state.schemaPath) ?? []),
+				...(server.moduleGraph.getModulesByFile(targetPath) ?? []),
 			];
 			for (const mod of modules) {
 				server.moduleGraph.invalidateModule(mod);


### PR DESCRIPTION
## Summary

Brings strict layout (`env/client.ts`, `env/server.ts`) support to Vite and Bun with compile-time import blocking, reusing the ADR 0013 / ADR 0016 security mechanisms and `@arkenv/build` layout resolution.

- **`@arkenv/build`**:
  - Exported `CLIENT_SECURITY_ERROR` and `isServerSchemaImport`.
  - Updated `resolveEnvModulePath` to discover and resolve strict layout directories.
  - Enhanced realpath normalization for symlinked directory environments.
  - Added `layout` configuration option to `TransformOptions`.
- **`@arkenv/vite-plugin`**:
  - Auto-resolves strict layout and inlines `client.ts` values into client graph.
  - Blocks non-SSR (client-graph) imports of server schema files at compile-time with `CLIENT_SECURITY_ERROR`.
  - Passes `server.ts` through in SSR graph for boot-time runtime validation.
- **`@arkenv/bun-plugin`**:
  - Auto-resolves strict layout in `build.onStart` and inlines `client.ts` in browser targets.
  - Intercepts and rejects server schema imports in browser bundles via `build.onResolve` and `build.onLoad`.
- **Changeset**:
  - Added changeset for `@arkenv/build`, `@arkenv/vite-plugin`, and `@arkenv/bun-plugin`.

Fixes #1330