### PR TITLE
feat: (v1) Auto-extend client env in Next.js strict layout via virtual module alias

### DIFF
--- a/.changeset/nextjs-strict-auto-extend.md
+++ b/.changeset/nextjs-strict-auto-extend.md
@@ -1,0 +1,18 @@
+---
+"@arkenv/nextjs": minor
+"arkenv": minor
+---
+
+#### Auto-extend client env in Next.js strict layout
+
+`@arkenv/nextjs/server` (and the Standard Schema server entry) now merges the client env automatically in strict layout when `extends` is omitted. `withArkEnv` registers a `#arkenv/client-env` alias (webpack + Turbopack) pointing at your `env/client.ts`.
+
+```ts
+import arkenv from "@arkenv/nextjs/server";
+
+export const env = arkenv({
+	DATABASE_URL: "string",
+});
+```
+
+Pass an explicit `extends` list (including `extends: []`) to opt out. Flat/simple layout is unchanged. CLI strict scaffolds and docs match the simplified server template.

--- a/.changeset/nextjs-strict-auto-extend.md
+++ b/.changeset/nextjs-strict-auto-extend.md
@@ -11,7 +11,7 @@
 import arkenv from "@arkenv/nextjs/server";
 
 export const env = arkenv({
-	DATABASE_URL: "string",
+  DATABASE_URL: "string",
 });
 ```
 

--- a/apps/playgrounds/nextjs-strict/README.md
+++ b/apps/playgrounds/nextjs-strict/README.md
@@ -34,23 +34,20 @@ The example defines the environment schema across three split files in the `env/
    ```
 
 3. **Server variables**: `env/server.ts`
+
    ```ts
    import arkenv from "@arkenv/nextjs/server";
-   import { env as clientEnv } from "./client";
 
-   export const env = arkenv(
-       {
-           DATABASE_URL: "string = 'postgres://localhost:5432/mydb'",
-       },
-       {
-           extends: [clientEnv],
-       },
-   );
+   export const env = arkenv({
+       DATABASE_URL: "string = 'postgres://localhost:5432/mydb'",
+   });
    ```
+
+   Omitting `extends` auto-merges the client env via the `#arkenv/client-env` alias registered by `withArkEnv`. Pass an explicit `extends` list to opt out.
 
 ### Configuration Wrapper
 
-The Next.js configuration `next.config.ts` wraps the config object with `withArkEnv` from `@arkenv/nextjs/config`. This statically scans the split files in `env/` and automatically generates the `env/generated/env.gen.ts` file containing the pre-filled `runtimeEnv` block.
+The Next.js configuration `next.config.ts` wraps the config object with `withArkEnv` from `@arkenv/nextjs/config`. This statically scans the split files in `env/`, generates the `env/generated/env.gen.ts` file containing the pre-filled `runtimeEnv` block, and registers the `#arkenv/client-env` alias for server auto-extend.
 
 ## Usage in Components
 

--- a/apps/playgrounds/nextjs-strict/env/server.ts
+++ b/apps/playgrounds/nextjs-strict/env/server.ts
@@ -1,11 +1,5 @@
 import arkenv from "@arkenv/nextjs/server";
-import { env as clientEnv } from "./client";
 
-export const env = arkenv(
-	{
-		DATABASE_URL: "string = 'postgres://localhost:5432/mydb'",
-	},
-	{
-		extends: [clientEnv],
-	},
-);
+export const env = arkenv({
+	DATABASE_URL: "string = 'postgres://localhost:5432/mydb'",
+});

--- a/apps/www/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/www/content/docs/guides/frameworks/nextjs.mdx
@@ -91,6 +91,47 @@ npx arkenv@latest init --strict
 This generates `env/client.ts`, `env/server.ts`, and `env/internal/shared.ts`.
 Learn more in [Client vs. server](/docs/validating-your-environment/client-vs-server).
 
+#### Auto-extending client env in strict layout
+
+With `withArkEnv` registered in `next.config`, the server entry (`env/server.ts`)
+automatically merges the client env when `extends` is omitted:
+
+```ts title="./env/server.ts" twoslash
+// @filename: /env/server.ts
+// ---cut---
+import arkenv from "@arkenv/nextjs/server";
+
+export const env = arkenv({
+	DATABASE_URL: "string",
+});
+// env includes DATABASE_URL + everything from env/client.ts
+```
+
+To opt out — or compose a different list — pass an explicit `extends`:
+
+```ts title="./env/server.ts" twoslash
+// @filename: /env/client.ts
+import type { type as at, distill } from "arktype";
+export const env = {} as Readonly<distill.Out<at.infer<{ NEXT_PUBLIC_API_URL: "string" }>>>;
+
+// @filename: /env/server.ts
+// ---cut---
+import arkenv from "@arkenv/nextjs/server";
+import { env as clientEnv } from "./client";
+
+export const env = arkenv(
+	{
+		DATABASE_URL: "string",
+	},
+	{
+		extends: [clientEnv], // explicit list — auto-merge is skipped
+	},
+);
+```
+
+Passing `extends: []` opts out entirely and includes no extended env.
+
+
 ## Standard Schema
 
 If you aren't using ArkType, import `withArkEnv` from the `/standard/config`

--- a/apps/www/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/www/content/docs/guides/frameworks/nextjs.mdx
@@ -102,7 +102,7 @@ automatically merges the client env when `extends` is omitted:
 import arkenv from "@arkenv/nextjs/server";
 
 export const env = arkenv({
-	DATABASE_URL: "string",
+  DATABASE_URL: "string",
 });
 // env includes DATABASE_URL + everything from env/client.ts
 ```
@@ -120,17 +120,16 @@ import arkenv from "@arkenv/nextjs/server";
 import { env as clientEnv } from "./client";
 
 export const env = arkenv(
-	{
-		DATABASE_URL: "string",
-	},
-	{
-		extends: [clientEnv], // explicit list — auto-merge is skipped
-	},
+  {
+    DATABASE_URL: "string",
+  },
+  {
+    extends: [clientEnv], // explicit list — auto-merge is skipped
+  },
 );
 ```
 
 Passing `extends: []` opts out entirely and includes no extended env.
-
 
 ## Standard Schema
 

--- a/examples/with-nextjs-strict/README.md
+++ b/examples/with-nextjs-strict/README.md
@@ -34,23 +34,20 @@ The example defines the environment schema across three split files in the `env/
    ```
 
 3. **Server variables**: `env/server.ts`
+
    ```ts
    import arkenv from "@arkenv/nextjs/server";
-   import { env as clientEnv } from "./client";
 
-   export const env = arkenv(
-       {
-           DATABASE_URL: "string = 'postgres://localhost:5432/mydb'",
-       },
-       {
-           extends: [clientEnv],
-       },
-   );
+   export const env = arkenv({
+       DATABASE_URL: "string = 'postgres://localhost:5432/mydb'",
+   });
    ```
+
+   Omitting `extends` auto-merges the client env via the `#arkenv/client-env` alias registered by `withArkEnv`. Pass an explicit `extends` list to opt out.
 
 ### Configuration Wrapper
 
-The Next.js configuration `next.config.ts` wraps the config object with `withArkEnv` from `@arkenv/nextjs/config`. This statically scans the split files in `env/` and automatically generates the `env/generated/env.gen.ts` file containing the pre-filled `runtimeEnv` block.
+The Next.js configuration `next.config.ts` wraps the config object with `withArkEnv` from `@arkenv/nextjs/config`. This statically scans the split files in `env/`, generates the `env/generated/env.gen.ts` file containing the pre-filled `runtimeEnv` block, and registers the `#arkenv/client-env` alias for server auto-extend.
 
 ## Usage in Components
 

--- a/examples/with-nextjs-strict/env/server.ts
+++ b/examples/with-nextjs-strict/env/server.ts
@@ -1,11 +1,5 @@
 import arkenv from "@arkenv/nextjs/server";
-import { env as clientEnv } from "./client";
 
-export const env = arkenv(
-	{
-		DATABASE_URL: "string = 'postgres://localhost:5432/mydb'",
-	},
-	{
-		extends: [clientEnv],
-	},
-);
+export const env = arkenv({
+	DATABASE_URL: "string = 'postgres://localhost:5432/mydb'",
+});

--- a/packages/arkenv/src/features/scaffold/validators.test.ts
+++ b/packages/arkenv/src/features/scaffold/validators.test.ts
@@ -395,7 +395,10 @@ describe("validators templates", () => {
 			expect(templates.client).not.toContain(
 				"NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,",
 			);
-			expect(templates.server).toContain("extends: [clientEnv],");
+			expect(templates.server).not.toContain("extends: [clientEnv]");
+			expect(templates.server).not.toContain(
+				'import { env as clientEnv } from "./client"',
+			);
 		});
 
 		it("returns strict templates with custom nextjsImportPath", () => {
@@ -435,7 +438,30 @@ describe("validators templates", () => {
 			expect(templates.client).toContain(
 				"NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,",
 			);
-			expect(templates.server).toContain("extends: [clientEnv],");
+			expect(templates.server).not.toContain("extends: [clientEnv]");
+			expect(templates.server).not.toContain(
+				'import { env as clientEnv } from "./client"',
+			);
+		});
+
+		it("returns simplified Next.js strict server template without manual extends", () => {
+			const options = {
+				validator: "arktype" as const,
+				framework: "nextjs" as const,
+				path: "env.ts",
+				language: "ts" as const,
+				shouldUpdateTsConfig: false,
+				shouldInstall: false,
+			};
+			const templates = getStrictTemplates(options);
+			expect(templates.server).toContain(
+				'import arkenv from "@arkenv/nextjs/server"',
+			);
+			expect(templates.server).not.toContain("extends: [clientEnv]");
+			expect(templates.server).not.toContain(
+				'import { env as clientEnv } from "./client"',
+			);
+			expect(templates.server).toContain("export const env = arkenv(");
 		});
 
 		it("returns simplified Nuxt strict server template without manual extends", () => {

--- a/packages/arkenv/src/features/scaffold/validators/assemble-strict.ts
+++ b/packages/arkenv/src/features/scaffold/validators/assemble-strict.ts
@@ -107,6 +107,11 @@ export function assembleStrictFromDialect(
 	const serverObject = formatSchemaObject(serverFields, "\t\t");
 	const extra = dialect.strictExtraImports;
 
+	const autoExtendServerFrameworks = new Set(["nuxt", "nextjs"]);
+	const usesServerAutoExtend = autoExtendServerFrameworks.has(
+		context.framework,
+	);
+
 	const nuxtClientTemplate = `import arkenv from "${clientImportPath}";
 ${extra}
 export const env = arkenv(
@@ -161,14 +166,13 @@ export const SharedSchema = ${dialect.wrapSharedSchema(sharedObject)};`,
 					? nuxtClientTemplate
 					: manualClientNoCodegen,
 
-			server:
-				context.framework === "nuxt"
-					? `import arkenv from "${pkgName}/server";
+			server: usesServerAutoExtend
+				? `import arkenv from "${pkgName}/server";
 ${extra}
 export const env = arkenv(
 	${serverObject},
 );`
-					: `import arkenv from "${pkgName}/server";
+				: `import arkenv from "${pkgName}/server";
 ${extra}import { env as clientEnv } from "./client";
 
 export const env = arkenv(

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -135,6 +135,13 @@
 	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
+	"imports": {
+		"#arkenv/client-env": {
+			"types": "./dist/empty-client-env.d.ts",
+			"import": "./dist/empty-client-env.js",
+			"require": "./dist/empty-client-env.cjs"
+		}
+	},
 	"size-limit": [
 		{
 			"name": "@arkenv/nextjs",
@@ -173,7 +180,7 @@
 		{
 			"name": "@arkenv/nextjs/config",
 			"path": "dist/config/index.js",
-			"limit": "4 kB",
+			"limit": "6 kB",
 			"import": "*",
 			"ignore": [
 				"next",

--- a/packages/nextjs/src/arkenv-client-env.d.ts
+++ b/packages/nextjs/src/arkenv-client-env.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Ambient fallback for the `#arkenv/client-env` virtual module.
+ *
+ * In Next.js strict layout, `withArkEnv` aliases this specifier to the
+ * project's `env/client.ts`, so consumer TypeScript resolves the real `env`
+ * type. Outside that wiring, `ClientEnv` stays empty (and is augmentable in
+ * tests) so package typechecks remain green.
+ */
+declare module "#arkenv/client-env" {
+	// biome-ignore lint/style/useConsistentTypeDefinitions: declaration merging requires an interface
+	interface ClientEnv {}
+	export const env: ClientEnv;
+}

--- a/packages/nextjs/src/auto-extend.ts
+++ b/packages/nextjs/src/auto-extend.ts
@@ -1,0 +1,31 @@
+import type { FlatSchemaOptions } from "./arkenv-internal";
+import { isStrictLayoutActive } from "./strict-client-env";
+
+/**
+ * Apply strict-layout auto-extend when `extends` is omitted.
+ *
+ * @param optionsOrIsServer Flat options, legacy boolean, or undefined
+ * @param resolveExtendTarget Lazy resolver for the default extend target
+ * @returns Options with auto-extend applied when appropriate
+ */
+export function withAutoExtend(
+	optionsOrIsServer: FlatSchemaOptions | boolean | null | undefined,
+	resolveExtendTarget: () => unknown,
+): FlatSchemaOptions | boolean | null | undefined {
+	if (typeof optionsOrIsServer === "boolean") {
+		return optionsOrIsServer;
+	}
+
+	if (optionsOrIsServer != null && "extends" in optionsOrIsServer) {
+		return optionsOrIsServer;
+	}
+
+	if (!isStrictLayoutActive()) {
+		return optionsOrIsServer;
+	}
+
+	return {
+		...(optionsOrIsServer ?? {}),
+		extends: [resolveExtendTarget()],
+	};
+}

--- a/packages/nextjs/src/config.test.ts
+++ b/packages/nextjs/src/config.test.ts
@@ -400,7 +400,7 @@ describe("withArkEnv wrapper", () => {
 		expect(outputConfig).not.toBe(inputConfig);
 		expect(outputConfig.reactStrictMode).toBe(true);
 		expect(typeof outputConfig.webpack).toBe("function");
-		expect(outputConfig.env?.__ARKENV_STRICT_LAYOUT__).toBe("true");
+		expect(outputConfig.env?.ARKENV_STRICT_LAYOUT).toBe("true");
 		expect(outputConfig.turbopack?.resolveAlias?.["#arkenv/client-env"]).toBe(
 			path.join(strictBaseDir, "client.ts"),
 		);

--- a/packages/nextjs/src/config.test.ts
+++ b/packages/nextjs/src/config.test.ts
@@ -377,11 +377,76 @@ describe("withArkEnv wrapper", () => {
 		const outputConfig = withArkEnv(inputConfig, {
 			schemaPath: strictBaseDir,
 			validate: false,
-		});
+		}) as {
+			reactStrictMode: boolean;
+			webpack?: (
+				config: {
+					resolve?: { alias?: Record<string, string> };
+					plugins?: unknown[];
+				},
+				context: {
+					webpack: { DefinePlugin: new (d: Record<string, string>) => unknown };
+				},
+			) => {
+				resolve?: { alias?: Record<string, string> };
+				plugins?: unknown[];
+			};
+			env?: Record<string, string>;
+			turbopack?: { resolveAlias?: Record<string, string> };
+			experimental?: { turbo?: { resolveAlias?: Record<string, string> } };
+		};
 
-		expect(outputConfig).toBe(inputConfig);
+		// Strict layout returns a new config with webpack/turbopack aliases.
+		expect(outputConfig).not.toBe(inputConfig);
+		expect(outputConfig.reactStrictMode).toBe(true);
+		expect(typeof outputConfig.webpack).toBe("function");
+		expect(outputConfig.env?.__ARKENV_STRICT_LAYOUT__).toBe("true");
+		expect(outputConfig.turbopack?.resolveAlias?.["#arkenv/client-env"]).toBe(
+			path.join(strictBaseDir, "client.ts"),
+		);
+		expect(
+			outputConfig.experimental?.turbo?.resolveAlias?.["#arkenv/client-env"],
+		).toBe(path.join(strictBaseDir, "client.ts"));
+
+		const webpackConfig = {
+			resolve: { alias: {} as Record<string, string> },
+			plugins: [] as unknown[],
+		};
+		class MockDefinePlugin {
+			definitions: Record<string, string>;
+			constructor(definitions: Record<string, string>) {
+				this.definitions = definitions;
+			}
+		}
+		const resolvedWebpack = outputConfig.webpack?.(webpackConfig, {
+			webpack: { DefinePlugin: MockDefinePlugin },
+		});
+		expect(resolvedWebpack?.resolve?.alias?.["#arkenv/client-env"]).toBe(
+			path.join(strictBaseDir, "client.ts"),
+		);
+		expect(
+			resolvedWebpack?.plugins?.some(
+				(plugin: unknown) =>
+					plugin instanceof MockDefinePlugin &&
+					(plugin as MockDefinePlugin).definitions.__ARKENV_STRICT_LAYOUT__ ===
+						"true",
+			),
+		).toBe(true);
+
 		const genPath = path.join(strictBaseDir, "generated", "env.gen.ts");
 		expect(fs.existsSync(genPath)).toBe(true);
+		const ambientPath = path.join(
+			strictBaseDir,
+			"generated",
+			"arkenv-client-env.d.ts",
+		);
+		expect(fs.existsSync(ambientPath)).toBe(true);
+		expect(fs.readFileSync(ambientPath, "utf-8")).toContain(
+			'declare module "#arkenv/client-env"',
+		);
+		expect(fs.readFileSync(ambientPath, "utf-8")).toContain(
+			'export { env } from "../client"',
+		);
 
 		const generatedContent = fs.readFileSync(genPath, "utf-8");
 		expect(generatedContent).toContain("export function arkenv<");

--- a/packages/nextjs/src/config/codegen.ts
+++ b/packages/nextjs/src/config/codegen.ts
@@ -8,6 +8,7 @@ import {
 import { resolveBuildLog } from "@repo/log";
 import { extractKeys } from "./extract";
 import {
+	generateClientEnvAmbientDeclaration,
 	generateClientFactoryCode,
 	generateFactoryCode,
 	generateFlatFactoryCode,
@@ -103,5 +104,22 @@ export function runCodegen(
 
 	if (shouldWrite) {
 		fs.writeFileSync(outputPath, generatedCode, "utf-8");
+	}
+
+	if (resolvedLayout === "strict" && baseDir) {
+		const ambientPath = path.join(
+			path.dirname(outputPath),
+			"arkenv-client-env.d.ts",
+		);
+		const ambientCode = generateClientEnvAmbientDeclaration();
+		let shouldWriteAmbient = true;
+		if (fs.existsSync(ambientPath)) {
+			if (fs.readFileSync(ambientPath, "utf-8") === ambientCode) {
+				shouldWriteAmbient = false;
+			}
+		}
+		if (shouldWriteAmbient) {
+			fs.writeFileSync(ambientPath, ambientCode, "utf-8");
+		}
 	}
 }

--- a/packages/nextjs/src/config/generate.ts
+++ b/packages/nextjs/src/config/generate.ts
@@ -103,6 +103,20 @@ export function arkenv<
 ${GENERATED_FOOTER}`;
 }
 
+/**
+ * Ambient module declaration so `#arkenv/client-env` resolves to the project's
+ * `env/client.ts` for `AutoClientEnv` type inference on `@arkenv/nextjs/server`.
+ *
+ * @returns Generated `.d.ts` source
+ */
+export function generateClientEnvAmbientDeclaration(): string {
+	return `${GENERATED_HEADER}
+declare module "#arkenv/client-env" {
+	export { env } from "../client";
+}
+`;
+}
+
 export function generateClientFactoryCode(
 	clientKeys: string[],
 	sharedKeys: string[],

--- a/packages/nextjs/src/config/setup.ts
+++ b/packages/nextjs/src/config/setup.ts
@@ -13,7 +13,10 @@ import {
 	resolveLoggerFromOptions,
 } from "@repo/log";
 import { createJiti } from "jiti";
-import { CLIENT_ENV_SPECIFIER, missingClientTsError } from "../strict-client-env";
+import {
+	CLIENT_ENV_SPECIFIER,
+	missingClientTsError,
+} from "../strict-client-env";
 import { runCodegen } from "./codegen";
 import { normalizeLayout } from "./layout";
 import { applyStrictLayoutAliases } from "./strict-layout-aliases";

--- a/packages/nextjs/src/config/setup.ts
+++ b/packages/nextjs/src/config/setup.ts
@@ -13,7 +13,7 @@ import {
 	resolveLoggerFromOptions,
 } from "@repo/log";
 import { createJiti } from "jiti";
-import { CLIENT_ENV_SPECIFIER } from "../strict-client-env";
+import { CLIENT_ENV_SPECIFIER, missingClientTsError } from "../strict-client-env";
 import { runCodegen } from "./codegen";
 import { normalizeLayout } from "./layout";
 import { applyStrictLayoutAliases } from "./strict-layout-aliases";
@@ -103,6 +103,10 @@ export function setupArkEnv(
 		resolvedLayout === "strict" && baseDir
 			? path.join(baseDir, "client.ts")
 			: undefined;
+
+	if (clientEnvPath && !fs.existsSync(clientEnvPath)) {
+		throw new Error(missingClientTsError(clientEnvPath, baseDir!));
+	}
 
 	const defaultOutputDir =
 		resolvedLayout === "strict" && baseDir ? baseDir : path.dirname(schemaPath);
@@ -239,7 +243,7 @@ export function setupArkEnv(
  * block in `env.gen.ts` and, in strict layout, register the `#arkenv/client-env`
  * alias so `@arkenv/nextjs/server` can auto-extend the client env.
  *
- * @param nextConfig The Next.js configuration object or function
+ * @param nextConfig The Next.js configuration object (object-form only; function-form configs are not yet supported — see follow-up issue)
  * @param options Optional configuration paths for schema and output files
  * @returns The Next.js configuration object (with strict-layout aliases when applicable)
  * @throws An error if the schema file cannot be found or if code generation fails

--- a/packages/nextjs/src/config/setup.ts
+++ b/packages/nextjs/src/config/setup.ts
@@ -13,8 +13,10 @@ import {
 	resolveLoggerFromOptions,
 } from "@repo/log";
 import { createJiti } from "jiti";
+import { CLIENT_ENV_SPECIFIER } from "../strict-client-env";
 import { runCodegen } from "./codegen";
 import { normalizeLayout } from "./layout";
+import { applyStrictLayoutAliases } from "./strict-layout-aliases";
 import type { ArkEnvConfigOptions } from "./types";
 
 function resolveMockServerOnlyPath(moduleDir: string): string {
@@ -32,6 +34,21 @@ function resolveMockServerOnlyPath(moduleDir: string): string {
 	return path.join(moduleDir, "mock-server-only.js");
 }
 
+function resolveEmptyClientEnvPath(moduleDir: string): string {
+	for (const base of [moduleDir, path.join(moduleDir, "..")]) {
+		const tsPath = path.join(base, "empty-client-env.ts");
+		if (fs.existsSync(tsPath)) {
+			return tsPath;
+		}
+		const jsPath = path.join(base, "empty-client-env.js");
+		if (fs.existsSync(jsPath)) {
+			return jsPath;
+		}
+	}
+
+	return path.join(moduleDir, "empty-client-env.js");
+}
+
 function schemaPathExists(schemaPath: string): boolean {
 	if (fs.existsSync(schemaPath)) return true;
 
@@ -42,17 +59,24 @@ function schemaPathExists(schemaPath: string): boolean {
 	return fs.existsSync(baseWithoutExt);
 }
 
+type SetupResult = {
+	resolvedLayout: "flat" | "strict" | "simple";
+	baseDir: string | undefined;
+	clientEnvPath: string | undefined;
+};
+
 /**
  * Run ArkEnv codegen and setup without wrapping nextConfig.
  *
  * @param options Optional configuration paths for schema and output files
  * @param internalOptions Optional configuration for internal testing hooks
+ * @returns Resolved layout paths used by `withArkEnv` for alias registration
  * @throws An error if the schema file cannot be found or if code generation fails
  */
 export function setupArkEnv(
 	options?: ArkEnvConfigOptions,
 	internalOptions?: { _jitiAliases?: Record<string, string> },
-): void {
+): SetupResult {
 	const buildLog = resolveBuildLog(options);
 
 	const schemaPath = options?.schemaPath
@@ -74,6 +98,11 @@ export function setupArkEnv(
 		schemaPath,
 		normalizedLayout,
 	);
+
+	const clientEnvPath =
+		resolvedLayout === "strict" && baseDir
+			? path.join(baseDir, "client.ts")
+			: undefined;
 
 	const defaultOutputDir =
 		resolvedLayout === "strict" && baseDir ? baseDir : path.dirname(schemaPath);
@@ -106,8 +135,13 @@ export function setupArkEnv(
 
 	const runValidation = options?.validate ?? true;
 	if (runValidation) {
+		const g = globalThis as {
+			__arkenv_force_server__?: boolean;
+			__ARKENV_STRICT_LAYOUT__?: boolean;
+			__ARKENV_CLIENT_ENV__?: unknown;
+		};
 		try {
-			(globalThis as any).__arkenv_force_server__ = true;
+			g.__arkenv_force_server__ = true;
 			const fileToEvaluate =
 				resolvedLayout === "strict" && baseDir
 					? path.join(baseDir, "server.ts")
@@ -121,11 +155,16 @@ export function setupArkEnv(
 						: "";
 			const dir = path.dirname(filenameForJiti);
 			const mockServerOnlyPath = resolveMockServerOnlyPath(dir);
+			const emptyClientEnvPath = resolveEmptyClientEnvPath(dir);
 
 			const aliases: Record<string, string> = {
 				"server-only": mockServerOnlyPath,
 				"./script": mockServerOnlyPath,
 				"./script.tsx": mockServerOnlyPath,
+				[CLIENT_ENV_SPECIFIER]:
+					clientEnvPath && fs.existsSync(clientEnvPath)
+						? clientEnvPath
+						: emptyClientEnvPath,
 				...internalOptions?._jitiAliases,
 			};
 
@@ -135,6 +174,17 @@ export function setupArkEnv(
 				tsconfigPaths: true,
 				alias: aliases,
 			});
+
+			if (resolvedLayout === "strict" && clientEnvPath) {
+				g.__ARKENV_STRICT_LAYOUT__ = true;
+				const clientMod = jiti(clientEnvPath) as {
+					env?: unknown;
+					default?: { env?: unknown };
+				};
+				g.__ARKENV_CLIENT_ENV__ =
+					clientMod.env ?? clientMod.default?.env ?? clientMod;
+			}
+
 			jiti(fileToEvaluate);
 		} catch (error: unknown) {
 			buildLog.logBuildError("Environment validation failed:");
@@ -144,7 +194,9 @@ export function setupArkEnv(
 			buildLog.logBuildErrorBlankLine();
 			process.exit(1);
 		} finally {
-			delete (globalThis as any).__arkenv_force_server__;
+			delete g.__arkenv_force_server__;
+			delete g.__ARKENV_STRICT_LAYOUT__;
+			delete g.__ARKENV_CLIENT_ENV__;
 		}
 	}
 
@@ -174,17 +226,34 @@ export function setupArkEnv(
 			resolveLoggerFromOptions(options),
 		);
 	}
+
+	return {
+		resolvedLayout,
+		baseDir,
+		clientEnvPath,
+	};
 }
 
 /**
- * Wrap a Next.js configuration object to automatically generate the `runtimeEnv` block in `env.gen.ts`.
+ * Wrap a Next.js configuration object to automatically generate the `runtimeEnv`
+ * block in `env.gen.ts` and, in strict layout, register the `#arkenv/client-env`
+ * alias so `@arkenv/nextjs/server` can auto-extend the client env.
  *
  * @param nextConfig The Next.js configuration object or function
  * @param options Optional configuration paths for schema and output files
- * @returns The Next.js configuration object unchanged
+ * @returns The Next.js configuration object (with strict-layout aliases when applicable)
  * @throws An error if the schema file cannot be found or if code generation fails
  */
 export function withArkEnv<T>(nextConfig: T, options?: ArkEnvConfigOptions): T {
-	setupArkEnv(options);
+	const { resolvedLayout, clientEnvPath } = setupArkEnv(options);
+
+	if (resolvedLayout === "strict" && clientEnvPath) {
+		return applyStrictLayoutAliases(
+			nextConfig as Record<string, unknown>,
+			clientEnvPath,
+			CLIENT_ENV_SPECIFIER,
+		) as T;
+	}
+
 	return nextConfig;
 }

--- a/packages/nextjs/src/config/strict-layout-aliases.ts
+++ b/packages/nextjs/src/config/strict-layout-aliases.ts
@@ -1,0 +1,147 @@
+import type { CLIENT_ENV_SPECIFIER } from "../strict-client-env";
+
+type WebpackConfigLike = {
+	resolve?: {
+		alias?:
+			| Record<string, string | false | string[]>
+			| Array<{ name: string; alias: string | false | string[] }>;
+	};
+	plugins?: unknown[];
+};
+
+type WebpackLike = {
+	DefinePlugin: new (definitions: Record<string, string>) => unknown;
+};
+
+type WebpackContextLike = {
+	webpack?: WebpackLike;
+};
+
+type TurbopackResolveAlias = Record<string, string | string[]>;
+
+type NextConfigLike = {
+	webpack?: (
+		config: WebpackConfigLike,
+		context: WebpackContextLike,
+	) => WebpackConfigLike | undefined;
+	turbopack?: {
+		resolveAlias?: TurbopackResolveAlias;
+		[key: string]: unknown;
+	};
+	experimental?: {
+		turbo?: {
+			resolveAlias?: TurbopackResolveAlias;
+			[key: string]: unknown;
+		};
+		[key: string]: unknown;
+	};
+	env?: Record<string, string | undefined>;
+	[key: string]: unknown;
+};
+
+/**
+ * Merge `#arkenv/client-env` into a webpack `resolve.alias` value (object or array form).
+ *
+ * @param alias Existing webpack resolve.alias
+ * @param specifier Virtual module specifier
+ * @param target Absolute path to the project client env module
+ * @returns Updated alias value
+ */
+function mergeWebpackAlias(
+	alias:
+		| Record<string, string | false | string[]>
+		| Array<{ name: string; alias: string | false | string[] }>
+		| undefined,
+	specifier: string,
+	target: string,
+):
+	| Record<string, string | false | string[]>
+	| Array<{ name: string; alias: string | false | string[] }> {
+	if (Array.isArray(alias)) {
+		const next = alias.filter((entry) => entry.name !== specifier);
+		next.push({ name: specifier, alias: target });
+		return next;
+	}
+	return {
+		...(alias ?? {}),
+		[specifier]: target,
+	};
+}
+
+/**
+ * Apply webpack + Turbopack aliases and a compile-time strict-layout flag.
+ *
+ * Chains any existing `webpack` function on the user config. Turbopack aliases
+ * are written to both `turbopack.resolveAlias` (Next 15+) and
+ * `experimental.turbo.resolveAlias` for older configs.
+ *
+ * @param nextConfig User Next.js config object
+ * @param clientEnvPath Absolute path to `env/client.ts`
+ * @param specifier Virtual module specifier (typically `#arkenv/client-env`)
+ * @returns Next config with strict-layout alias wiring
+ */
+export function applyStrictLayoutAliases<T extends NextConfigLike>(
+	nextConfig: T,
+	clientEnvPath: string,
+	specifier: typeof CLIENT_ENV_SPECIFIER | string = "#arkenv/client-env",
+): T {
+	const previousWebpack = nextConfig.webpack;
+
+	const webpack = (config: WebpackConfigLike, context: WebpackContextLike) => {
+		const resolved = previousWebpack
+			? (previousWebpack(config, context) ?? config)
+			: config;
+		resolved.resolve = resolved.resolve ?? {};
+		resolved.resolve.alias = mergeWebpackAlias(
+			resolved.resolve.alias,
+			specifier,
+			clientEnvPath,
+		);
+
+		const DefinePlugin = context.webpack?.DefinePlugin;
+		if (DefinePlugin) {
+			resolved.plugins = resolved.plugins ?? [];
+			resolved.plugins.push(
+				new DefinePlugin({
+					__ARKENV_STRICT_LAYOUT__: JSON.stringify(true),
+				}),
+			);
+		}
+
+		return resolved;
+	};
+
+	const existingTurbopack = nextConfig.turbopack ?? {};
+	const existingExperimental = nextConfig.experimental ?? {};
+	const existingTurbo = existingExperimental.turbo ?? {};
+
+	const turbopackResolveAlias: TurbopackResolveAlias = {
+		...(existingTurbopack.resolveAlias ?? {}),
+		[specifier]: clientEnvPath,
+	};
+	const experimentalTurboResolveAlias: TurbopackResolveAlias = {
+		...(existingTurbo.resolveAlias ?? {}),
+		[specifier]: clientEnvPath,
+	};
+
+	return {
+		...nextConfig,
+		webpack,
+		// Turbopack / non-webpack paths: surface the flag via Next env inlining.
+		env: {
+			...(nextConfig.env ?? {}),
+			__ARKENV_STRICT_LAYOUT__: "true",
+		},
+		turbopack: {
+			...existingTurbopack,
+			resolveAlias: turbopackResolveAlias,
+		},
+		experimental: {
+			...existingExperimental,
+			turbo: {
+				...existingTurbo,
+				resolveAlias: experimentalTurboResolveAlias,
+			},
+		},
+	} as T;
+}

--- a/packages/nextjs/src/config/strict-layout-aliases.ts
+++ b/packages/nextjs/src/config/strict-layout-aliases.ts
@@ -124,6 +124,11 @@ export function applyStrictLayoutAliases<T extends NextConfigLike>(
 		[specifier]: clientEnvPath,
 	};
 
+	// NOTE: `nextConfig` is spread as a plain object below. Only the object-form
+	// of `next.config` is supported here — a callable/function-form config would
+	// lose its call signature when spread, silently dropping any phase-dependent
+	// logic. Callers are responsible for dereferencing a callable config before
+	// passing it to this function. Full callable-form support is tracked separately.
 	return {
 		...nextConfig,
 		webpack,

--- a/packages/nextjs/src/config/strict-layout-aliases.ts
+++ b/packages/nextjs/src/config/strict-layout-aliases.ts
@@ -128,9 +128,12 @@ export function applyStrictLayoutAliases<T extends NextConfigLike>(
 		...nextConfig,
 		webpack,
 		// Turbopack / non-webpack paths: surface the flag via Next env inlining.
+		// Note: Next.js forbids keys with __ prefix in nextConfig.env, so we use
+		// ARKENV_STRICT_LAYOUT (no underscores) here. The webpack DefinePlugin
+		// path uses __ARKENV_STRICT_LAYOUT__ as a compile-time literal, which is fine.
 		env: {
 			...(nextConfig.env ?? {}),
-			__ARKENV_STRICT_LAYOUT__: "true",
+			ARKENV_STRICT_LAYOUT: "true",
 		},
 		turbopack: {
 			...existingTurbopack,

--- a/packages/nextjs/src/empty-client-env.ts
+++ b/packages/nextjs/src/empty-client-env.ts
@@ -1,0 +1,6 @@
+/**
+ * Empty client env used when `#arkenv/client-env` is imported outside strict
+ * layout (so the server entry can keep a static import without the bundler
+ * failing to resolve the virtual specifier).
+ */
+export const env = {};

--- a/packages/nextjs/src/server-auto-extend.test.ts
+++ b/packages/nextjs/src/server-auto-extend.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { ENV_KEYS, EXTENDED_ENV } from "./arkenv-internal";
+import { arkenv as serverArkenv } from "./server";
+import { arkenv as standardServerArkenv } from "./standard/server";
+
+const mockSchema = <TOutput>(outputValue: TOutput) => ({
+	"~standard": {
+		version: 1 as const,
+		vendor: "mock",
+		types: {} as { input: unknown; output: TOutput },
+		validate: (value: unknown) => ({
+			value: value === undefined ? outputValue : value,
+		}),
+	},
+});
+
+function createMockClientEnv(values: Record<string, unknown>) {
+	const keys = new Set(Object.keys(values));
+	return new Proxy(values, {
+		get(target, prop) {
+			if (prop === EXTENDED_ENV) return target;
+			if (prop === ENV_KEYS) return keys;
+			return Reflect.get(target, prop);
+		},
+	});
+}
+
+describe("server auto-extend in strict layout", () => {
+	afterEach(() => {
+		delete (globalThis as { __ARKENV_STRICT_LAYOUT__?: boolean })
+			.__ARKENV_STRICT_LAYOUT__;
+		delete (globalThis as { __ARKENV_CLIENT_ENV__?: unknown })
+			.__ARKENV_CLIENT_ENV__;
+		delete process.env.__ARKENV_STRICT_LAYOUT__;
+		delete process.env.DATABASE_URL;
+		delete process.env.NEXT_PUBLIC_API_URL;
+		delete process.env.NODE_ENV;
+	});
+
+	it("auto-extends from injected client env when extends is omitted", () => {
+		(
+			globalThis as { __ARKENV_STRICT_LAYOUT__?: boolean }
+		).__ARKENV_STRICT_LAYOUT__ = true;
+		(globalThis as { __ARKENV_CLIENT_ENV__?: unknown }).__ARKENV_CLIENT_ENV__ =
+			createMockClientEnv({
+				NEXT_PUBLIC_API_URL: "https://api.example.com",
+				NODE_ENV: "development",
+			});
+		process.env.DATABASE_URL = "postgres://localhost/db";
+
+		const env = serverArkenv({
+			DATABASE_URL: "string",
+		});
+
+		expect(env.DATABASE_URL).toBe("postgres://localhost/db");
+		expect((env as Record<string, unknown>).NEXT_PUBLIC_API_URL).toBe(
+			"https://api.example.com",
+		);
+		expect((env as Record<string, unknown>).NODE_ENV).toBe("development");
+	});
+
+	it("does not auto-extend without the strict layout flag", () => {
+		(globalThis as { __ARKENV_CLIENT_ENV__?: unknown }).__ARKENV_CLIENT_ENV__ =
+			createMockClientEnv({
+				NEXT_PUBLIC_API_URL: "https://api.example.com",
+			});
+		process.env.DATABASE_URL = "postgres://localhost/db";
+
+		const env = serverArkenv({
+			DATABASE_URL: "string",
+		});
+
+		expect(env.DATABASE_URL).toBe("postgres://localhost/db");
+		expect(
+			() => (env as { NEXT_PUBLIC_API_URL?: string }).NEXT_PUBLIC_API_URL,
+		).toThrow(/not defined in the schema/);
+	});
+
+	it("lets explicit extends override auto-extend", () => {
+		(
+			globalThis as { __ARKENV_STRICT_LAYOUT__?: boolean }
+		).__ARKENV_STRICT_LAYOUT__ = true;
+		(globalThis as { __ARKENV_CLIENT_ENV__?: unknown }).__ARKENV_CLIENT_ENV__ =
+			createMockClientEnv({
+				NEXT_PUBLIC_API_URL: "https://auto.example.com",
+				NODE_ENV: "production",
+			});
+		process.env.DATABASE_URL = "postgres://localhost/db";
+
+		const manualClient = createMockClientEnv({
+			NEXT_PUBLIC_API_URL: "https://manual.example.com",
+			NODE_ENV: "test",
+		});
+
+		const env = serverArkenv(
+			{ DATABASE_URL: "string" },
+			{ extends: [manualClient] },
+		);
+
+		expect(env.DATABASE_URL).toBe("postgres://localhost/db");
+		expect((env as Record<string, unknown>).NEXT_PUBLIC_API_URL).toBe(
+			"https://manual.example.com",
+		);
+		expect((env as Record<string, unknown>).NODE_ENV).toBe("test");
+	});
+
+	it("treats extends: [] as an opt-out of auto-extend", () => {
+		(
+			globalThis as { __ARKENV_STRICT_LAYOUT__?: boolean }
+		).__ARKENV_STRICT_LAYOUT__ = true;
+		(globalThis as { __ARKENV_CLIENT_ENV__?: unknown }).__ARKENV_CLIENT_ENV__ =
+			createMockClientEnv({
+				NEXT_PUBLIC_API_URL: "https://auto.example.com",
+			});
+		process.env.DATABASE_URL = "postgres://localhost/db";
+
+		const env = serverArkenv({ DATABASE_URL: "string" }, { extends: [] });
+
+		expect(env.DATABASE_URL).toBe("postgres://localhost/db");
+		expect(
+			() => (env as { NEXT_PUBLIC_API_URL?: string }).NEXT_PUBLIC_API_URL,
+		).toThrow(/not defined in the schema/);
+	});
+
+	it("detects strict layout via process.env.__ARKENV_STRICT_LAYOUT__", () => {
+		process.env.__ARKENV_STRICT_LAYOUT__ = "true";
+		(globalThis as { __ARKENV_CLIENT_ENV__?: unknown }).__ARKENV_CLIENT_ENV__ =
+			createMockClientEnv({
+				NEXT_PUBLIC_API_URL: "https://api.example.com",
+			});
+		process.env.DATABASE_URL = "postgres://localhost/db";
+
+		const env = serverArkenv({
+			DATABASE_URL: "string",
+		});
+
+		expect((env as Record<string, unknown>).NEXT_PUBLIC_API_URL).toBe(
+			"https://api.example.com",
+		);
+	});
+
+	it("has parity auto-extend on @arkenv/nextjs/standard/server", () => {
+		(
+			globalThis as { __ARKENV_STRICT_LAYOUT__?: boolean }
+		).__ARKENV_STRICT_LAYOUT__ = true;
+		(globalThis as { __ARKENV_CLIENT_ENV__?: unknown }).__ARKENV_CLIENT_ENV__ =
+			createMockClientEnv({
+				NEXT_PUBLIC_API_URL: "https://api.example.com",
+				NODE_ENV: "development",
+			});
+		process.env.DATABASE_URL = "postgres://localhost/db";
+
+		const env = standardServerArkenv({
+			DATABASE_URL: mockSchema(""),
+		});
+
+		expect(env.DATABASE_URL).toBe("postgres://localhost/db");
+		expect((env as Record<string, unknown>).NEXT_PUBLIC_API_URL).toBe(
+			"https://api.example.com",
+		);
+		expect((env as Record<string, unknown>).NODE_ENV).toBe("development");
+	});
+});

--- a/packages/nextjs/src/server-auto-extend.test.ts
+++ b/packages/nextjs/src/server-auto-extend.test.ts
@@ -34,7 +34,7 @@ describe("server auto-extend in strict layout", () => {
 			.__ARKENV_STRICT_LAYOUT__;
 		delete (globalThis as { __ARKENV_CLIENT_ENV__?: unknown })
 			.__ARKENV_CLIENT_ENV__;
-		delete process.env.__ARKENV_STRICT_LAYOUT__;
+		delete process.env.ARKENV_STRICT_LAYOUT;
 		delete process.env.DATABASE_URL;
 		delete process.env.NEXT_PUBLIC_API_URL;
 		delete process.env.NODE_ENV;
@@ -125,8 +125,8 @@ describe("server auto-extend in strict layout", () => {
 		).toThrow(/not defined in the schema/);
 	});
 
-	it("detects strict layout via process.env.__ARKENV_STRICT_LAYOUT__", () => {
-		process.env.__ARKENV_STRICT_LAYOUT__ = "true";
+	it("detects strict layout via process.env.ARKENV_STRICT_LAYOUT", () => {
+		process.env.ARKENV_STRICT_LAYOUT = "true";
 		(globalThis as { __ARKENV_CLIENT_ENV__?: unknown }).__ARKENV_CLIENT_ENV__ =
 			createMockClientEnv({
 				NEXT_PUBLIC_API_URL: "https://api.example.com",

--- a/packages/nextjs/src/server.ts
+++ b/packages/nextjs/src/server.ts
@@ -4,22 +4,52 @@ import { arkenv as coreArkenv, getSchemaKeys } from "@arkenv/core";
 import type { $ } from "@repo/scope";
 import type { Dict, SchemaShape } from "@repo/types";
 import type { type as at, distill } from "arktype";
+// Static import so webpack/Turbopack can resolve the alias at bundle time.
+// Outside strict layout the package `imports` map points this at empty-client-env.
+import { env as importedClientEnv } from "#arkenv/client-env";
 import { arkenvInternal } from "./arkenv-internal";
+import { withAutoExtend } from "./auto-extend";
+import { resolveStrictClientEnv } from "./strict-client-env";
 import type { MergeExtends } from "./types";
 
 /**
+ * Client env type auto-merged in Next.js strict layout when `extends` is omitted.
+ */
+type AutoClientEnv = typeof import("#arkenv/client-env") extends {
+	env: infer E;
+}
+	? E
+	: {};
+
+/**
  * Create a validated, typesafe environment configuration for Next.js applications (Server entry point).
+ *
+ * With `withArkEnv` in strict layout, omitting `extends` includes the client
+ * env by default. Any explicit `extends` is used as-is and opts out of that
+ * default; pass `extends: []` to include no extended env.
  */
 export function arkenv<
 	const TSchema extends SchemaShape = {},
 	const TExtends extends readonly unknown[] = [],
 >(
 	schema: EnvSchema<TSchema>,
-	options?: {
-		extends?: [...TExtends];
+	options: {
+		/**
+		 * Explicit envs to extend. Providing this option opts out of the default
+		 * strict-layout client merge; use `[]` to include no extended env.
+		 */
+		extends: [...TExtends];
 		runtimeEnv?: Dict<string>;
 	},
 ): Readonly<distill.Out<at.infer<TSchema, $>> & MergeExtends<TExtends>>;
+
+export function arkenv<const TSchema extends SchemaShape = {}>(
+	schema: EnvSchema<TSchema>,
+	options?: {
+		extends?: undefined;
+		runtimeEnv?: Dict<string>;
+	},
+): Readonly<distill.Out<at.infer<TSchema, $>> & AutoClientEnv>;
 
 /**
  * @deprecated Use the unified flat layout signature instead: `arkenv(schema, options)`
@@ -62,7 +92,9 @@ export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
 
 	return arkenvInternal(
 		schemaOrOptions,
-		optionsOrIsServer,
+		withAutoExtend(optionsOrIsServer, () =>
+			resolveStrictClientEnv(importedClientEnv),
+		),
 		{ isServer: true, strictLayout: "server" },
 		coreArkenv,
 		getSchemaKeys,

--- a/packages/nextjs/src/standard/server.ts
+++ b/packages/nextjs/src/standard/server.ts
@@ -1,34 +1,79 @@
 import "server-only";
 import { arkenv as coreArkenv, getSchemaKeys } from "@arkenv/standard";
 import type { Dict, StandardSchemaV1 } from "@repo/types";
+// Static import so webpack/Turbopack can resolve the alias at bundle time.
+// Outside strict layout the package `imports` map points this at empty-client-env.
+import { env as importedClientEnv } from "#arkenv/client-env";
 import { arkenvInternal } from "@/arkenv-internal";
+import { withAutoExtend } from "@/auto-extend";
+import { resolveStrictClientEnv } from "@/strict-client-env";
+import type { MergeExtends } from "@/types";
+
+/**
+ * Client env type auto-merged in Next.js strict layout when `extends` is omitted.
+ */
+type AutoClientEnv = typeof import("#arkenv/client-env") extends {
+	env: infer E;
+}
+	? E
+	: {};
 
 /**
  * Create a validated, typesafe environment configuration for Next.js applications (Server entry point, Standard Mode).
+ *
+ * With `withArkEnv` in strict layout, omitting `extends` includes the client
+ * env by default. Any explicit `extends` is used as-is and opts out of that
+ * default; pass `extends: []` to include no extended env.
  */
+export function arkenv<
+	const TSchema extends Record<string, StandardSchemaV1> = {},
+	const TExtends extends readonly unknown[] = [],
+>(
+	schema: TSchema,
+	options: {
+		/**
+		 * Explicit envs to extend. Providing this option opts out of the default
+		 * strict-layout client merge; use `[]` to include no extended env.
+		 */
+		extends: [...TExtends];
+		runtimeEnv?: Dict<string>;
+	},
+): Readonly<
+	{
+		[K in keyof TSchema]: StandardSchemaV1.InferOutput<TSchema[K]>;
+	} & MergeExtends<TExtends>
+>;
+
 export function arkenv<
 	const TSchema extends Record<string, StandardSchemaV1> = {},
 >(
 	schema: TSchema,
 	options?: {
-		extends?: readonly unknown[];
+		extends?: undefined;
 		runtimeEnv?: Dict<string>;
 	},
-): Readonly<{ [K in keyof TSchema]: StandardSchemaV1.InferOutput<TSchema[K]> }>;
+): Readonly<
+	{
+		[K in keyof TSchema]: StandardSchemaV1.InferOutput<TSchema[K]>;
+	} & AutoClientEnv
+>;
 
 export function arkenv<
 	const TServer extends Record<string, StandardSchemaV1> = {},
 	const TShared extends Record<string, StandardSchemaV1> = {},
+	const TExtends extends readonly unknown[] = [],
 >(options: {
 	server?: TServer;
 	shared?: TShared;
-	extends?: readonly unknown[];
+	extends?: [...TExtends];
 	runtimeEnv?: Record<keyof TShared, string | undefined> & Dict<string>;
-}): Readonly<{
-	[K in keyof (TServer & TShared)]: StandardSchemaV1.InferOutput<
-		(TServer & TShared)[K]
-	>;
-}>;
+}): Readonly<
+	{
+		[K in keyof (TServer & TShared)]: StandardSchemaV1.InferOutput<
+			(TServer & TShared)[K]
+		>;
+	} & MergeExtends<TExtends>
+>;
 
 export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
 	const isLegacy =
@@ -55,8 +100,10 @@ export function arkenv(schemaOrOptions: any, optionsOrIsServer?: any): any {
 
 	return arkenvInternal(
 		schemaOrOptions,
-		optionsOrIsServer,
-		{ isServer: true },
+		withAutoExtend(optionsOrIsServer, () =>
+			resolveStrictClientEnv(importedClientEnv),
+		),
+		{ isServer: true, strictLayout: "server" },
 		coreArkenv,
 		getSchemaKeys,
 	);

--- a/packages/nextjs/src/strict-client-env.ts
+++ b/packages/nextjs/src/strict-client-env.ts
@@ -1,0 +1,82 @@
+import { formatBuildError } from "@repo/log";
+
+export const CLIENT_ENV_SPECIFIER = "#arkenv/client-env";
+
+export const UNRESOLVED_CLIENT_ENV_ERROR =
+	"[arkenv] Could not resolve #arkenv/client-env.\n" +
+	"Ensure withArkEnv is registered in next.config and env/client.ts exists,\n" +
+	"or pass extends: [clientEnv] explicitly.";
+
+declare const __ARKENV_STRICT_LAYOUT__: boolean | undefined;
+
+type GlobalStrictState = {
+	__ARKENV_STRICT_LAYOUT__?: boolean;
+	__ARKENV_CLIENT_ENV__?: unknown;
+};
+
+/**
+ * Report whether Next.js strict layout auto-extend is active.
+ *
+ * Prefers the bundler `define` flag when present; falls back to the
+ * `globalThis` marker set during Jiti build-time validation, then to
+ * `process.env.__ARKENV_STRICT_LAYOUT__` injected via `nextConfig.env`
+ * (Turbopack and other non-DefinePlugin paths).
+ *
+ * @returns `true` when strict-layout auto-extend should run
+ */
+export function isStrictLayoutActive(): boolean {
+	if (
+		typeof __ARKENV_STRICT_LAYOUT__ !== "undefined" &&
+		__ARKENV_STRICT_LAYOUT__
+	) {
+		return true;
+	}
+	if ((globalThis as GlobalStrictState).__ARKENV_STRICT_LAYOUT__ === true) {
+		return true;
+	}
+	return process.env.__ARKENV_STRICT_LAYOUT__ === "true";
+}
+
+/**
+ * Resolve the auto-extend client env for strict layout.
+ *
+ * Prefers the Jiti validation injection on `globalThis`, then falls back to
+ * the statically imported `#arkenv/client-env` module (aliased by `withArkEnv`).
+ * Never uses `node:module` / `createRequire`.
+ *
+ * @param importedClientEnv The `env` export from `#arkenv/client-env`
+ * @returns The client env object to pass through `extends`
+ * @throws An arkenv-specific error when no client env is available in strict mode
+ */
+export function resolveStrictClientEnv(importedClientEnv: unknown): unknown {
+	const injected = (globalThis as GlobalStrictState).__ARKENV_CLIENT_ENV__;
+	if (injected !== undefined) {
+		return injected;
+	}
+
+	if (importedClientEnv !== undefined && importedClientEnv !== null) {
+		return importedClientEnv;
+	}
+
+	throw new Error(UNRESOLVED_CLIENT_ENV_ERROR);
+}
+
+/**
+ * Build the fail-fast error for a missing strict-layout `client.ts`.
+ *
+ * @param clientPath The absolute path where `client.ts` was expected
+ * @param baseDir The strict layout base directory
+ * @returns A formatted ArkEnv build error message
+ */
+export function missingClientTsError(
+	clientPath: string,
+	baseDir: string,
+): string {
+	return formatBuildError(
+		`Strict layout requires "client.ts" but it was not found at "${clientPath}".\n` +
+			`Expected strict layout structure under "${baseDir}":\n` +
+			"  ├── internal/shared.ts\n" +
+			"  ├── client.ts\n" +
+			"  └── server.ts",
+	);
+}

--- a/packages/nextjs/src/strict-client-env.ts
+++ b/packages/nextjs/src/strict-client-env.ts
@@ -19,7 +19,7 @@ type GlobalStrictState = {
  *
  * Prefers the bundler `define` flag when present; falls back to the
  * `globalThis` marker set during Jiti build-time validation, then to
- * `process.env.__ARKENV_STRICT_LAYOUT__` injected via `nextConfig.env`
+ * `process.env.ARKENV_STRICT_LAYOUT` injected via `nextConfig.env`
  * (Turbopack and other non-DefinePlugin paths).
  *
  * @returns `true` when strict-layout auto-extend should run
@@ -34,7 +34,7 @@ export function isStrictLayoutActive(): boolean {
 	if ((globalThis as GlobalStrictState).__ARKENV_STRICT_LAYOUT__ === true) {
 		return true;
 	}
-	return process.env.__ARKENV_STRICT_LAYOUT__ === "true";
+	return process.env.ARKENV_STRICT_LAYOUT === "true";
 }
 
 /**

--- a/packages/nextjs/src/type-regression.test-d.ts
+++ b/packages/nextjs/src/type-regression.test-d.ts
@@ -173,3 +173,42 @@ describe("@arkenv/nextjs type regression", () => {
 		env.DATABASE_URL;
 	});
 });
+
+declare module "#arkenv/client-env" {
+	// biome-ignore lint/style/useConsistentTypeDefinitions: declaration merging requires an interface
+	interface ClientEnv {
+		NEXT_PUBLIC_API_URL: string;
+		NODE_ENV: string;
+	}
+}
+
+describe("@arkenv/nextjs server auto-extend types (strict layout)", () => {
+	it("includes auto-extended client keys in type when extends is omitted", () => {
+		// Import via require-cast so the module augmentation above is in scope
+		const { arkenv: serverArkenv } =
+			require("./server") as typeof import("./server");
+		const env = serverArkenv({ DATABASE_URL: "string" });
+
+		expectTypeOf(env.DATABASE_URL).toBeString();
+		expectTypeOf(env.NEXT_PUBLIC_API_URL).toBeString();
+		expectTypeOf(env.NODE_ENV).toBeString();
+	});
+
+	it("keeps explicit extends override types", () => {
+		const { arkenv: serverArkenv } =
+			require("./server") as typeof import("./server");
+		const clientEnv = {
+			NEXT_PUBLIC_API_URL: "https://api.example.com",
+			CUSTOM_CLIENT: "value",
+		};
+
+		const env = serverArkenv(
+			{ DATABASE_URL: "string" },
+			{ extends: [clientEnv] },
+		);
+
+		expectTypeOf(env.DATABASE_URL).toBeString();
+		expectTypeOf(env.NEXT_PUBLIC_API_URL).toBeString();
+		expectTypeOf(env.CUSTOM_CLIENT).toBeString();
+	});
+});

--- a/packages/nextjs/src/validation.test.ts
+++ b/packages/nextjs/src/validation.test.ts
@@ -400,6 +400,27 @@ describe("build-time environment validation", () => {
 
 			expect(exitSpy).toHaveBeenCalledWith(1);
 		});
+		it("should throw a friendly error when strict layout is missing client.ts", () => {
+			// Only server.ts present — client.ts is intentionally absent
+			fs.writeFileSync(
+				serverPath,
+				`
+				import arkenv from "${path.resolve(__dirname, "./server.ts")}";
+				export const env = arkenv({
+					DATABASE_URL: "string",
+				});
+				`,
+				"utf-8",
+			);
+
+			expect(() => {
+				setupArkEnv({
+					schemaPath: strictBaseDir,
+					outputPath: strictOutputPath,
+					layout: "strict",
+				});
+			}).toThrow(/client\.ts/);
+		});
 	});
 
 	describe("codegen option", () => {

--- a/packages/nextjs/src/validation.test.ts
+++ b/packages/nextjs/src/validation.test.ts
@@ -268,6 +268,70 @@ describe("build-time environment validation", () => {
 			expect(exitSpy).not.toHaveBeenCalled();
 		});
 
+		it("should pass strict layout validation when server omits extends (auto-extend)", () => {
+			fs.writeFileSync(
+				sharedPath,
+				`
+				import { type } from "@arkenv/core";
+				export const SharedSchema = type({
+					NODE_ENV: "'development' | 'production'",
+				});
+				`,
+				"utf-8",
+			);
+
+			fs.writeFileSync(
+				clientPath,
+				`
+				import arkenv from "./generated/env.gen";
+				import { SharedSchema } from "./internal/shared";
+				export const env = arkenv({
+					NEXT_PUBLIC_API_URL: "string",
+				}, {
+					extends: [SharedSchema],
+					runtimeEnv: {
+						NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+						NODE_ENV: process.env.NODE_ENV,
+					}
+				});
+				`,
+				"utf-8",
+			);
+
+			fs.writeFileSync(
+				serverPath,
+				`
+				import arkenv from "${path.resolve(__dirname, "./server.ts")}";
+				export const env = arkenv({
+					DATABASE_URL: "string",
+				});
+				`,
+				"utf-8",
+			);
+
+			process.env.DATABASE_URL = "postgres://localhost/db";
+			process.env.NEXT_PUBLIC_API_URL = "https://api.example.com";
+			process.env.NODE_ENV = "development";
+
+			setupArkEnv({
+				schemaPath: strictBaseDir,
+				outputPath: strictOutputPath,
+				layout: "strict",
+				validate: false,
+			});
+
+			expect(() => {
+				setupArkEnv({
+					schemaPath: strictBaseDir,
+					outputPath: strictOutputPath,
+					layout: "strict",
+					validate: true,
+				});
+			}).not.toThrow();
+
+			expect(exitSpy).not.toHaveBeenCalled();
+		});
+
 		it("should exit build when a server variable is missing in strict layout", () => {
 			fs.writeFileSync(
 				sharedPath,

--- a/packages/nextjs/tsdown.config.ts
+++ b/packages/nextjs/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 		"src/server.ts",
 		"src/client.ts",
 		"src/mock-server-only.ts",
+		"src/empty-client-env.ts",
 		"src/standard/index.ts",
 		"src/standard/server.ts",
 		"src/standard/client.ts",
@@ -20,5 +21,6 @@ export default defineConfig({
 	sourcemap: true,
 	deps: {
 		alwaysBundle: ["@repo/log", "@repo/types", "@repo/utils"],
+		neverBundle: ["#arkenv/client-env"],
 	},
 });

--- a/packages/nextjs/vitest.config.ts
+++ b/packages/nextjs/vitest.config.ts
@@ -19,6 +19,10 @@ export default defineProject({
 				find: /^arkenv$/,
 				replacement: path.resolve(__dirname, "../arkenv/src/index.ts"),
 			},
+			{
+				find: "#arkenv/client-env",
+				replacement: path.resolve(__dirname, "./src/empty-client-env.ts"),
+			},
 		],
 	},
 });


### PR DESCRIPTION
Fixes #1403

Ports Nuxt #1401 auto-extend to Next.js: `withArkEnv` registers `#arkenv/client-env`; server entries merge client env when `extends` is omitted.