### PR TITLE
docs(adr): amend ADR 0025 with standard subpaths and modern support boundary (#1586)

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -32,11 +32,11 @@ ArkEnv’s pre-validation step that turns raw env strings into numbers, booleans
 *Avoid*: calling coercion a morph/transform, or calling a Zod `.transform` “coercion” unless the library’s own coerce helpers are meant
 
 **toJsonSchema** (escape hatch):
-Optional `@arkenv/standard` config callback that supplies JSON Schema for **coercion** when a Standard Schema library keeps conversion off the value (Valibot, Zod Mini, Zod v3). Fallback after on-value probes. Parameter is `StandardSchemaV1`; assert at the host converter.
-*Avoid*: per-key wrappers as the happy path; Valibot/Mini helpers or peers on `@arkenv/standard`; auto-detect by `vendor`; a bare `{ toJsonSchema }` function reference as the documented Valibot path
+Optional `@arkenv/standard` config callback that supplies JSON Schema for **coercion** when using custom converters or schema libraries not covered by first-class subpaths (`@arkenv/standard/valibot`, `@arkenv/standard/zod-mini`). Fallback after on-value probes. Parameter is `StandardSchemaV1`; assert at the host converter.
+*Avoid*: per-key wrappers as the happy path; auto-detect by `vendor`; documenting `toJsonSchema` as the primary Valibot getting-started path (use `@arkenv/standard/valibot` instead)
 
 **Engine** (`@arkenv/core` / `@arkenv/standard`):
-The two first-class validation entry points. Same `arkenv()` runtime options, errors, and framework plugins; different schema authoring style and peers. Prefer dual examples (Tabs) in docs over core-first prose with a Standard Schema appendix.
+The two first-class validation entry points. Same `arkenv()` runtime options, errors, and framework plugins; different schema authoring style and peers (`@arkenv/standard` offers dedicated `./valibot` and `./zod-mini` subpaths; classic Zod uses root `@arkenv/standard`). Prefer dual examples (Tabs) in docs over core-first prose with a Standard Schema appendix.
 *Avoid*: framing Standard Schema as migration-only or second-class
 
 **Schema/define path**:
@@ -177,7 +177,7 @@ A scroll-driven increase in **Glass material** opacity/blur so content sliding u
 
 - **Packages** (`packages/`) - Published npm packages
   - `@arkenv/core` - Core library package with native ArkType support
-  - `@arkenv/standard` - ArkType-free Standard Schema entrypoint
+  - `@arkenv/standard` - ArkType-free Standard Schema entrypoint (with `./valibot` and `./zod-mini` subpaths)
   - `@arkenv/vite-plugin` - Vite plugin package
   - `@arkenv/bun-plugin` - Bun plugin package
   - `@arkenv/nextjs` - Next.js integration package

--- a/docs/adr/0025-to-json-schema-escape-hatch.md
+++ b/docs/adr/0025-to-json-schema-escape-hatch.md
@@ -75,10 +75,10 @@ To restore DX symmetry across the Big Three validators while preserving engine p
 
 1. **First-Class Subpath Exports on `@arkenv/standard`:**
    - `import { arkenv } from "@arkenv/standard/valibot"`: Pre-configures coercion using `@valibot/to-json-schema` (`typeMode: "input"`, `target: "draft-07"`).
-   - `import { arkenv } from "@arkenv/standard/zod-mini"`: Pre-configures coercion using `zod-to-json-schema`.
+   - `import { arkenv } from "@arkenv/standard/zod-mini"`: Pre-configures coercion by calling `schema.toJSONSchema()` internally.
    - *Note on Zod*: Classic Zod already exposes JSON Schema on the value (ADR 0002), so root `import { arkenv } from "@arkenv/standard"` works zero-config out of the box. A redundant `@arkenv/standard/zod` alias is deferred to separate exploration.
 2. **Optional Peer Dependency Architecture:**
-   - `@valibot/to-json-schema` and `zod-to-json-schema` are declared under `peerDependencies` with `peerDependenciesMeta: { "...": { "optional": true } }`.
+   - `@valibot/to-json-schema` is declared under `peerDependencies` with `peerDependenciesMeta: { "@valibot/to-json-schema": { "optional": true } }`. (Zod Mini exposes `.toJSONSchema()` natively, requiring no additional converter peer).
    - The root import `import { arkenv } from "@arkenv/standard"` remains pure with zero runtime dependencies.
 3. **Hard Modern Support Boundary (No Root Shims):**
    - Subpaths are exposed strictly via the `package.json` `"exports"` field with `"files": ["dist"]`.

--- a/docs/adr/0025-to-json-schema-escape-hatch.md
+++ b/docs/adr/0025-to-json-schema-escape-hatch.md
@@ -18,13 +18,13 @@ Three layers compose (hat loop for [#1564](https://github.com/yamcodes/arkenv/is
 2. **How the callback is typed**
 3. **Where the wrapper lives** (inline vs helper vs library export vs CLI recipe)
 
-## Decision
+## Original Decision
 
 Ship **A6 + B6 + C1**:
 
 1. **Optional `toJsonSchema` callback** on `@arkenv/standard` config. Fallback after on-value probes. Not called when omitted, when `coerce` is `false`, or when JSON Schema was already read from the value. Return a plain object, `undefined` to skip that key, or throw / return a non-object to fail with `INVALID_SCHEMA`.
 2. **Public type is `(schema: StandardSchemaV1) => object | undefined`.** Docs and examples **always assert** at the host-converter call (`as v.GenericSchema`, `as z.ZodMiniType`, `as z.ZodTypeAny`), including Valibot-only maps. The cast is the converter boundary, not a tax for sibling keys. Adding classic Zod does not change the Valibot wrapper (Zod never reaches the callback).
-3. **Inline the wrapper** next to `arkenv()`. A named user-land helper is optional tuck-away.
+3. **Inline the wrapper** next to `arkenv()`. A named user-land helper is optional tuck-away. Do **not** export Valibot/Mini helpers from `@arkenv/standard`. Do **not** add `@arkenv/standard/valibot` (or similar) as the way to coerce Valibot.
 
 ```ts
 toJsonSchema: (schema) =>
@@ -33,6 +33,33 @@ toJsonSchema: (schema) =>
     target: "draft-07",
   }),
 ```
+
+## Original Rejected alternatives
+
+**Product**
+
+- Per-key `toStandardJsonSchema(...)` — scales linearly with pain; the hatch exists to avoid this.
+- Bare `{ toJsonSchema }` — Valibot default `typeMode: "ignore"` silently mis-coerces pipes.
+- Auto-detect by `vendor` / optional peer — Mini also reports `"zod"`; version lockstep; magic.
+- Vendor subpath as the *only* coerce path — fragments the engine (ADR 0007).
+
+**Typing**
+
+- `any` / `unknown` — dishonest or noisy.
+- `T[keyof T]` — Valibot-only is clean; **adding Zod pollutes the callback with a type that never arrives** (“I asserted Valibot so I could use Zod”).
+- `ToJsonSchemaInput<T>` (exclude on-value JSON Schema) — best tax fairness when it works; declined because “when do I need `as`?” depends on the map. Probe-mirroring types and plugin generic threading were not worth the teachability cost.
+
+**Placement**
+
+- Library-exported `valibotJsonSchema()` — same DX as a user helper, but `@arkenv/standard` cannot import Valibot without a peer or subpath. A dependency-free binder still needs the user to pass the converter in. This is the maintenance hell hosting presets refused (ADR 0018).
+- CLI `add to-json-schema` recipe — plausible later (emit into user source, no runtime package). Not required to close the hatch. Do not block on it.
+
+## Original Consequences
+
+- `@arkenv/standard` stays vendor-neutral: no Valibot/Mini peers, no converter options stuffed into the schema map.
+- Docs teach one sentence: ArkEnv passes a Standard Schema; host converters do not accept that type; assert at the call. Mix maps (Valibot + Mini) still need a vendor switch; that is “two converters,” not a typing phase of the moon.
+- Future architecture reviews should not re-suggest smart callback narrowing, auto-detect, or `@arkenv/valibot` helpers unless the teachability / packaging constraints change.
+- A CLI converter recipe remains open; it would copy ADR 0018’s “emit into user source” property, not ship a runtime helper package.
 
 ---
 
@@ -60,7 +87,7 @@ To restore DX symmetry across the Big Three validators while preserving engine p
 4. **Preserved Escape Hatch:**
    - The `toJsonSchema` callback remains fully supported on `@arkenv/standard` config as an escape hatch for custom schema transformers or long-tail validator libraries not covered by the subpaths.
 
-## Consequences
+### Consequences of Amendment
 
 - **Zero-Boilerplate Valibot DX:** Valibot users get identical one-liner DX (`import { arkenv } from "@arkenv/standard/valibot"`) without boilerplate in `env.ts`.
 - **Zero Runtime Bloat:** Root `@arkenv/standard` remains 100% dependency-free.

--- a/docs/adr/0025-to-json-schema-escape-hatch.md
+++ b/docs/adr/0025-to-json-schema-escape-hatch.md
@@ -1,8 +1,8 @@
-# ADR 0025: Optional `toJsonSchema` escape hatch (always-`as`)
+# ADR 0025: Optional `toJsonSchema` escape hatch (always-`as`) and subpath exports
 
 ## Status
 
-Accepted
+Amended (2026-08-24 by [#1586](https://github.com/yamcodes/arkenv/issues/1586))
 
 ## Context
 
@@ -24,7 +24,7 @@ Ship **A6 + B6 + C1**:
 
 1. **Optional `toJsonSchema` callback** on `@arkenv/standard` config. Fallback after on-value probes. Not called when omitted, when `coerce` is `false`, or when JSON Schema was already read from the value. Return a plain object, `undefined` to skip that key, or throw / return a non-object to fail with `INVALID_SCHEMA`.
 2. **Public type is `(schema: StandardSchemaV1) => object | undefined`.** Docs and examples **always assert** at the host-converter call (`as v.GenericSchema`, `as z.ZodMiniType`, `as z.ZodTypeAny`), including Valibot-only maps. The cast is the converter boundary, not a tax for sibling keys. Adding classic Zod does not change the Valibot wrapper (Zod never reaches the callback).
-3. **Inline the wrapper** next to `arkenv()`. A named user-land helper is optional tuck-away. Do **not** export Valibot/Mini helpers from `@arkenv/standard`. Do **not** add `@arkenv/standard/valibot` (or similar) as the way to coerce Valibot.
+3. **Inline the wrapper** next to `arkenv()`. A named user-land helper is optional tuck-away.
 
 ```ts
 toJsonSchema: (schema) =>
@@ -34,29 +34,36 @@ toJsonSchema: (schema) =>
   }),
 ```
 
-## Rejected alternatives
+---
 
-**Product**
+## Amendment (2026-08-24): First-Class Subpaths & Modern Support Boundary
 
-- Per-key `toStandardJsonSchema(...)` — scales linearly with pain; the hatch exists to avoid this.
-- Bare `{ toJsonSchema }` — Valibot default `typeMode: "ignore"` silently mis-coerces pipes.
-- Auto-detect by `vendor` / optional peer — Mini also reports `"zod"`; version lockstep; magic.
-- Vendor subpath as the *only* coerce path — fragments the engine (ADR 0007).
+### Context for Amendment
 
-**Typing**
+Valibot is a first-class validator promoted across the homepage hero and marketing surfaces alongside ArkType and Zod with the claim "No boilerplate." Requiring an inline `toJsonSchema` configuration block in user-land `env.ts` contradicts that DX guarantee.
 
-- `any` / `unknown` — dishonest or noisy.
-- `T[keyof T]` — Valibot-only is clean; **adding Zod pollutes the callback with a type that never arrives** (“I asserted Valibot so I could use Zod”).
-- `ToJsonSchemaInput<T>` (exclude on-value JSON Schema) — best tax fairness when it works; declined because “when do I need `as`?” depends on the map. Probe-mirroring types and plugin generic threading were not worth the teachability cost.
+To restore DX symmetry across the Big Three validators while preserving engine purity, we amend the packaging decision to introduce first-class subpath exports on `@arkenv/standard`.
 
-**Placement**
+### Amended Decision
 
-- Library-exported `valibotJsonSchema()` — same DX as a user helper, but `@arkenv/standard` cannot import Valibot without a peer or subpath. A dependency-free binder still needs the user to pass the converter in. This is the maintenance hell hosting presets refused (ADR 0018).
-- CLI `add to-json-schema` recipe — plausible later (emit into user source, no runtime package). Not required to close the hatch. Do not block on it.
+1. **First-Class Subpath Exports on `@arkenv/standard`:**
+   - `import { arkenv } from "@arkenv/standard/valibot"`: Pre-configures coercion using `@valibot/to-json-schema` (`typeMode: "input"`, `target: "draft-07"`).
+   - `import { arkenv } from "@arkenv/standard/zod-mini"`: Pre-configures coercion using `zod-to-json-schema`.
+   - *Note on Zod*: Classic Zod already exposes JSON Schema on the value (ADR 0002), so root `import { arkenv } from "@arkenv/standard"` works zero-config out of the box. A redundant `@arkenv/standard/zod` alias is deferred to separate exploration.
+2. **Optional Peer Dependency Architecture:**
+   - `@valibot/to-json-schema` and `zod-to-json-schema` are declared under `peerDependencies` with `peerDependenciesMeta: { "...": { "optional": true } }`.
+   - The root import `import { arkenv } from "@arkenv/standard"` remains pure with zero runtime dependencies.
+3. **Hard Modern Support Boundary (No Root Shims):**
+   - Subpaths are exposed strictly via the `package.json` `"exports"` field with `"files": ["dist"]`.
+   - We reject legacy root proxy shims (`valibot.d.ts`, `valibot.js`, `zod-mini.d.ts`, etc.) to maintain structural consistency with our existing framework packages (`@arkenv/nextjs`, `@arkenv/nuxt`, `@arkenv/vite-plugin`), which already rely strictly on `package.json` exports.
+   - Target consumers must use modern TypeScript module resolution (`moduleResolution: "bundler" | "node16" | "nodenext"`) and modern package managers (npm v7+, pnpm, yarn berry).
+4. **Preserved Escape Hatch:**
+   - The `toJsonSchema` callback remains fully supported on `@arkenv/standard` config as an escape hatch for custom schema transformers or long-tail validator libraries not covered by the subpaths.
 
 ## Consequences
 
-- `@arkenv/standard` stays vendor-neutral: no Valibot/Mini peers, no converter options stuffed into the schema map.
-- Docs teach one sentence: ArkEnv passes a Standard Schema; host converters do not accept that type; assert at the call. Mix maps (Valibot + Mini) still need a vendor switch; that is “two converters,” not a typing phase of the moon.
-- Future architecture reviews should not re-suggest smart callback narrowing, auto-detect, or `@arkenv/valibot` helpers unless the teachability / packaging constraints change.
-- A CLI converter recipe remains open; it would copy ADR 0018’s “emit into user source” property, not ship a runtime helper package.
+- **Zero-Boilerplate Valibot DX:** Valibot users get identical one-liner DX (`import { arkenv } from "@arkenv/standard/valibot"`) without boilerplate in `env.ts`.
+- **Zero Runtime Bloat:** Root `@arkenv/standard` remains 100% dependency-free.
+- **Pristine Package Footprint:** No legacy shim files in package roots; build outputs remain contained within `dist/`.
+- **Docs & CLI Alignment:** `arkenv init` scaffolds `@arkenv/standard/valibot` for Valibot and `@arkenv/standard` for Zod directly.
+

--- a/docs/adr/0025-to-json-schema-escape-hatch.md
+++ b/docs/adr/0025-to-json-schema-escape-hatch.md
@@ -66,4 +66,3 @@ To restore DX symmetry across the Big Three validators while preserving engine p
 - **Zero Runtime Bloat:** Root `@arkenv/standard` remains 100% dependency-free.
 - **Pristine Package Footprint:** No legacy shim files in package roots; build outputs remain contained within `dist/`.
 - **Docs & CLI Alignment:** `arkenv init` scaffolds `@arkenv/standard/valibot` for Valibot and `@arkenv/standard` for Zod directly.
-

--- a/docs/adr/0025-to-json-schema-escape-hatch.md
+++ b/docs/adr/0025-to-json-schema-escape-hatch.md
@@ -75,10 +75,10 @@ To restore DX symmetry across the Big Three validators while preserving engine p
 
 1. **First-Class Subpath Exports on `@arkenv/standard`:**
    - `import { arkenv } from "@arkenv/standard/valibot"`: Pre-configures coercion using `@valibot/to-json-schema` (`typeMode: "input"`, `target: "draft-07"`).
-   - `import { arkenv } from "@arkenv/standard/zod-mini"`: Pre-configures coercion by calling `schema.toJSONSchema()` internally.
+   - `import { arkenv } from "@arkenv/standard/zod-mini"`: Pre-configures coercion using `zod/mini`'s `toJSONSchema` helper (`io: "input"`, `target: "draft-07"`).
    - *Note on Zod*: Classic Zod already exposes JSON Schema on the value (ADR 0002), so root `import { arkenv } from "@arkenv/standard"` works zero-config out of the box. A redundant `@arkenv/standard/zod` alias is deferred to separate exploration.
 2. **Optional Peer Dependency Architecture:**
-   - `@valibot/to-json-schema` is declared under `peerDependencies` with `peerDependenciesMeta: { "@valibot/to-json-schema": { "optional": true } }`. (Zod Mini exposes `.toJSONSchema()` natively, requiring no additional converter peer).
+   - `@valibot/to-json-schema` is declared under `peerDependencies` with `peerDependenciesMeta: { "@valibot/to-json-schema": { "optional": true } }`. (Zod Mini uses `zod/mini`'s exported `toJSONSchema` helper without requiring an additional third-party package).
    - The root import `import { arkenv } from "@arkenv/standard"` remains pure with zero runtime dependencies.
 3. **Hard Modern Support Boundary (No Root Shims):**
    - Subpaths are exposed strictly via the `package.json` `"exports"` field with `"files": ["dist"]`.
@@ -92,4 +92,4 @@ To restore DX symmetry across the Big Three validators while preserving engine p
 - **Zero-Boilerplate Valibot DX:** Valibot users get identical one-liner DX (`import { arkenv } from "@arkenv/standard/valibot"`) without boilerplate in `env.ts`.
 - **Zero Runtime Bloat:** Root `@arkenv/standard` remains 100% dependency-free.
 - **Pristine Package Footprint:** No legacy shim files in package roots; build outputs remain contained within `dist/`.
-- **Docs & CLI Alignment:** `arkenv init` scaffolds `@arkenv/standard/valibot` for Valibot and `@arkenv/standard` for Zod directly.
+- **Docs & CLI Alignment:** `arkenv init` will scaffold `@arkenv/standard/valibot` for Valibot ([#1607](https://github.com/yamcodes/arkenv/issues/1607)) and `@arkenv/standard` for Zod directly.


### PR DESCRIPTION
## Summary

Closes #1586. Follow-up implementation tracked in #1607.

Amends [ADR 0025](https://github.com/yamcodes/arkenv/blob/v1/docs/adr/0025-to-json-schema-escape-hatch.md) to approve first-class subpath exports on `@arkenv/standard` (`./valibot`, `./zod-mini`) to provide zero-boilerplate coercion DX across the Big Three validators while strictly enforcing a modern support boundary.

*Note on Zod*: Classic Zod already works zero-config via root `@arkenv/standard` (introspection of JSON Schema on the value per ADR 0002). A redundant `@arkenv/standard/zod` alias is deferred to separate exploration (#1609).

## Changes

1. **[ADR 0025](docs/adr/0025-to-json-schema-escape-hatch.md)**:
   - Updated status to `Amended (2026-08-24 by #1586)`.
   - Preserved original decision, rejected alternatives, and consequences sections.
   - Added amendment section approving `@arkenv/standard/valibot` and `@arkenv/standard/zod-mini`.
   - Codified the hard modern support boundary (pure `package.json` `"exports"`, mandatory `moduleResolution: "bundler" | "node16" | "nodenext"`, and explicit rejection of legacy root proxy shims to match framework packages).
   - Documented the optional peer dependencies architecture (`peerDependenciesMeta: { "@valibot/to-json-schema": { "optional": true } }`) ensuring root `@arkenv/standard` remains 100% dependency-free.
   - Retained the `toJsonSchema` callback as an escape hatch for custom converters.

2. **[docs/CONTEXT.md](docs/CONTEXT.md)**:
   - Updated `toJsonSchema` glossary entry and `Engine` language definition to reflect subpath exports as the primary happy path.
   - Updated published packages list.

## Verification
- `pnpm check` (Biome lint, format, mdxlint, workspace validations) passed.
- `pnpm typecheck` passed (all 29 workspace tasks succeeded).