### PR TITLE
feat(vite-plugin): declare Vite-only compatibility for the plugin registry

### DIFF
--- a/.changeset/vite-plugin-registry-compat.md
+++ b/.changeset/vite-plugin-registry-compat.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/vite-plugin": patch
+---
+
+#### Declare Vite-only compatibility for the plugin registry
+
+Marked Rollup and Rolldown as incompatible in `compatiblePackages` with reason "Uses Vite-specific APIs". The plugin uses Vite `loadEnv` and the `config` hook, so it is not a standalone Rollup or Rolldown plugin.

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -53,6 +53,17 @@
 		"vite-plugin"
 	],
 	"license": "MIT",
+	"compatiblePackages": {
+		"schemaVersion": 1,
+		"rolldown": {
+			"type": "incompatible",
+			"reason": "Uses Vite-specific APIs"
+		},
+		"rollup": {
+			"type": "incompatible",
+			"reason": "Uses Vite-specific APIs"
+		}
+	},
 	"scripts": {
 		"build": "tsdown",
 		"typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Adds `compatiblePackages` on `@arkenv/vite-plugin` so [registry.vite.dev](https://registry.vite.dev/plugins?q=arkenv) shows **Uses Vite-specific APIs** for Rollup/Rolldown instead of **Unknown**.
- The plugin is Vite-only (`loadEnv` + the `config` hook). This is metadata only; no Rollup/Rolldown support.
- Patch changeset so `latest` can pick this up on the next 0.1.x publish (the public card indexes npm `latest`, currently 0.1.5). Same field already landed on `v1`.

## Test plan
- [ ] Confirm `packages/vite-plugin/package.json` has `compatiblePackages.rollup` and `.rolldown` as `incompatible` with reason `Uses Vite-specific APIs` (see [extended metadata](https://registry.vite.dev/guide/extended-metadata)).
- [ ] After merge + publish of `@arkenv/vite-plugin@0.1.6`, check [the registry card](https://registry.vite.dev/plugins?q=arkenv) no longer shows Unknown for Rollup/Rolldown.


Made with [Cursor](https://cursor.com)