### PR TITLE
feat: Support function-form next.config in withArkEnv

### DIFF
--- a/.changeset/witharkenv-function-form.md
+++ b/.changeset/witharkenv-function-form.md
@@ -1,0 +1,16 @@
+---
+"@arkenv/nextjs": minor
+---
+
+#### Support function-form `next.config` in `withArkEnv`
+
+`withArkEnv` now accepts Next.js function-form configs (sync or async). The wrapper awaits the user's factory with the `phase` and context Next.js provides, then applies strict-layout and `.arkenv/` aliases to the resolved object.
+
+```ts
+import { withArkEnv } from "@arkenv/nextjs/config";
+
+export default withArkEnv(async (phase, { defaultConfig }) => ({
+	...defaultConfig,
+	reactStrictMode: phase !== "phase-test",
+}));
+```

--- a/.changeset/witharkenv-function-form.md
+++ b/.changeset/witharkenv-function-form.md
@@ -10,7 +10,7 @@
 import { withArkEnv } from "@arkenv/nextjs/config";
 
 export default withArkEnv(async (phase, { defaultConfig }) => ({
-	...defaultConfig,
-	reactStrictMode: phase !== "phase-test",
+  ...defaultConfig,
+  reactStrictMode: phase !== "phase-test",
 }));
 ```

--- a/apps/www/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/www/content/docs/guides/frameworks/nextjs.mdx
@@ -57,6 +57,19 @@ const nextConfig: NextConfig = {};
 export default withArkEnv(nextConfig);
 ```
 
+Function-form configs work too. `withArkEnv` awaits your factory, then applies
+aliases to the resolved object (including phase-dependent options):
+
+```ts title="./next.config.ts"
+import type { NextConfig } from "next";
+import { withArkEnv } from "@arkenv/nextjs/config";
+
+export default withArkEnv(async (phase, { defaultConfig }): Promise<NextConfig> => ({
+  ...defaultConfig,
+  reactStrictMode: phase !== "phase-test",
+}));
+```
+
 ## Schema layout
 
 ArkEnv supports two schema layouts depending on your team's isolation needs.

--- a/apps/www/content/docs/reference/nextjs.mdx
+++ b/apps/www/content/docs/reference/nextjs.mdx
@@ -49,6 +49,19 @@ const nextConfig: NextConfig = {};
 export default withArkEnv(nextConfig);
 ```
 
+Function-form `next.config` is supported. ArkEnv awaits the factory and applies
+aliases to the resolved object:
+
+```ts title="./next.config.ts"
+import type { NextConfig } from "next";
+import { withArkEnv } from "@arkenv/nextjs/config";
+
+export default withArkEnv(async (phase, { defaultConfig }): Promise<NextConfig> => ({
+  ...defaultConfig,
+  reactStrictMode: phase !== "phase-test",
+}));
+```
+
 Your app schema imports the generated factory:
 
 ```ts title="./env.ts"

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -32,6 +32,15 @@ const nextConfig: NextConfig = {
 export default withArkEnv(nextConfig);
 ```
 
+Function-form configs (sync or async) are supported:
+
+```typescript
+export default withArkEnv(async (phase, { defaultConfig }) => ({
+  ...defaultConfig,
+  reactStrictMode: phase !== "phase-test",
+}));
+```
+
 ### 2. Define your schema in `env.ts`
 
 Import `arkenv` from the generated `./generated/env.gen` file instead of the package:

--- a/packages/nextjs/src/config.test.ts
+++ b/packages/nextjs/src/config.test.ts
@@ -405,7 +405,7 @@ describe("withArkEnv wrapper", () => {
 
 		const wrapped = withArkEnv(
 			async (phase, { defaultConfig }) => ({
-				...(defaultConfig as Record<string, unknown>),
+				...defaultConfig,
 				reactStrictMode: phase !== "phase-test",
 			}),
 			{

--- a/packages/nextjs/src/config.test.ts
+++ b/packages/nextjs/src/config.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { closeWatcher } from "@arkenv/build";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 let useMockWatcher = false;
@@ -31,6 +32,7 @@ import {
 	runCodegen,
 	withArkEnv,
 } from "./config";
+import { withArkEnv as withArkEnvStandard } from "./standard/config";
 
 describe("config key extraction", () => {
 	it("should extract client and shared keys correctly", () => {
@@ -291,7 +293,8 @@ describe("withArkEnv wrapper", () => {
 	const tempDir = path.join(__dirname, "__temp_tests_wrapper__");
 	const schemaPath = path.join(tempDir, "env.ts");
 
-	afterEach(() => {
+	afterEach(async () => {
+		await closeWatcher();
 		if (fs.existsSync(tempDir)) {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -338,7 +341,7 @@ describe("withArkEnv wrapper", () => {
 		expect(resolvedWebpack?.resolve?.alias?.["@/.arkenv"]).toBe(genPath);
 	});
 
-	it("should support function-form nextConfig in both flat and strict layouts", () => {
+	it("should support sync function-form nextConfig in flat layout", async () => {
 		if (!fs.existsSync(tempDir)) {
 			fs.mkdirSync(tempDir, { recursive: true });
 		}
@@ -361,14 +364,223 @@ describe("withArkEnv wrapper", () => {
 		const wrapped = withArkEnv(functionConfig, {
 			schemaPath,
 			validate: false,
-		}) as any;
+		});
 
 		expect(typeof wrapped).toBe("function");
-		const resolved = wrapped("phase-production-build", {});
+		expect(fs.existsSync(path.join(tempDir, ".arkenv", "env.gen.ts"))).toBe(
+			false,
+		);
+
+		const resolved = (await wrapped("phase-production-build", {
+			defaultConfig: {},
+		})) as {
+			reactStrictMode: boolean;
+			customFlag: boolean;
+			turbopack?: { resolveAlias?: Record<string, unknown> };
+			webpack?: (config: unknown, context: unknown) => unknown;
+		};
 		expect(resolved.reactStrictMode).toBe(true);
 		expect(resolved.customFlag).toBe(true);
 		expect(resolved.turbopack?.resolveAlias?.["@/.arkenv"]).toBeDefined();
 		expect(typeof resolved.webpack).toBe("function");
+		expect(fs.existsSync(path.join(tempDir, ".arkenv", "env.gen.ts"))).toBe(
+			true,
+		);
+	});
+
+	it("should support async function-form nextConfig in flat layout", async () => {
+		if (!fs.existsSync(tempDir)) {
+			fs.mkdirSync(tempDir, { recursive: true });
+		}
+
+		fs.writeFileSync(
+			schemaPath,
+			`
+			export const env = arkenv({
+				client: { NEXT_PUBLIC_API_URL: "string" }
+			});
+			`,
+			"utf-8",
+		);
+
+		const wrapped = withArkEnv(
+			async (phase, { defaultConfig }) => ({
+				...(defaultConfig as Record<string, unknown>),
+				reactStrictMode: phase !== "phase-test",
+			}),
+			{
+				schemaPath,
+				validate: false,
+			},
+		);
+
+		const resolved = (await wrapped("phase-production-build", {
+			defaultConfig: { poweredByHeader: false },
+		})) as {
+			reactStrictMode: boolean;
+			poweredByHeader?: boolean;
+			turbopack?: { resolveAlias?: Record<string, unknown> };
+		};
+		expect(resolved.reactStrictMode).toBe(true);
+		expect(resolved.poweredByHeader).toBe(false);
+		expect(resolved.turbopack?.resolveAlias?.["@/.arkenv"]).toBeDefined();
+	});
+
+	it("should apply strict layout aliases for function-form nextConfig", async () => {
+		if (!fs.existsSync(tempDir)) {
+			fs.mkdirSync(tempDir, { recursive: true });
+		}
+
+		const strictBaseDir = path.join(tempDir, "env");
+		fs.mkdirSync(path.join(strictBaseDir, "internal"), { recursive: true });
+		fs.writeFileSync(
+			path.join(strictBaseDir, "internal", "shared.ts"),
+			`
+			import { type } from "@arkenv/core";
+			export const SharedSchema = type({
+				NODE_ENV: "string = 'development'",
+			});
+			`,
+			"utf-8",
+		);
+		fs.writeFileSync(
+			path.join(strictBaseDir, "client.ts"),
+			`
+			import arkenv from "@arkenv/nextjs/client";
+			import { SharedSchema } from "./internal/shared";
+			export const env = arkenv(
+				{ NEXT_PUBLIC_API_URL: "string = 'https://api.example.com'" },
+				{ extends: [SharedSchema], runtimeEnv: {} },
+			);
+			`,
+			"utf-8",
+		);
+		fs.writeFileSync(
+			path.join(strictBaseDir, "server.ts"),
+			`
+			import arkenv from "@arkenv/nextjs/server";
+			export const env = arkenv({ DATABASE_URL: "string" });
+			`,
+			"utf-8",
+		);
+
+		const wrapped = withArkEnv(
+			(phase: string) => ({ reactStrictMode: phase !== "phase-test" }),
+			{ schemaPath: strictBaseDir, validate: false },
+		);
+
+		const resolved = (await wrapped("phase-production-build", {
+			defaultConfig: {},
+		})) as {
+			reactStrictMode: boolean;
+			turbopack?: { resolveAlias?: Record<string, string> };
+			webpack?: (
+				config: unknown,
+				context: unknown,
+			) => {
+				resolve?: { alias?: Record<string, string> };
+				plugins?: unknown[];
+			};
+		};
+		expect(resolved.reactStrictMode).toBe(true);
+		expect(resolved.turbopack?.resolveAlias?.["#arkenv/client-env"]).toBe(
+			`./${path.relative(process.cwd(), path.join(strictBaseDir, "client.ts")).replace(/\\/g, "/")}`,
+		);
+
+		const webpackConfig = {
+			resolve: { alias: {} as Record<string, string> },
+			plugins: [] as unknown[],
+		};
+		class MockDefinePlugin {
+			definitions: Record<string, string>;
+			constructor(definitions: Record<string, string>) {
+				this.definitions = definitions;
+			}
+		}
+		const resolvedWebpack = resolved.webpack?.(webpackConfig, {
+			webpack: { DefinePlugin: MockDefinePlugin },
+		}) as {
+			resolve?: { alias?: Record<string, string> };
+			plugins?: unknown[];
+		};
+		expect(resolvedWebpack?.resolve?.alias?.["#arkenv/client-env"]).toBe(
+			path.join(strictBaseDir, "client.ts"),
+		);
+		expect(
+			resolvedWebpack?.plugins?.some(
+				(plugin: unknown) =>
+					plugin instanceof MockDefinePlugin &&
+					(plugin as MockDefinePlugin).definitions.__ARKENV_STRICT_LAYOUT__ ===
+						"true",
+			),
+		).toBe(true);
+	});
+
+	it("should start schema watch on function-form invocation in development", async () => {
+		useMockWatcher = true;
+		mockWatch.mockClear();
+		mockClose.mockClear();
+
+		if (!fs.existsSync(tempDir)) {
+			fs.mkdirSync(tempDir, { recursive: true });
+		}
+
+		fs.writeFileSync(
+			schemaPath,
+			`export const env = arkenv({ client: { NEXT_PUBLIC_API_URL: "string" } });`,
+			"utf-8",
+		);
+
+		const originalNodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = "development";
+
+		try {
+			const wrapped = withArkEnv(() => ({ reactStrictMode: true }), {
+				schemaPath,
+				validate: false,
+			});
+			expect(mockWatch).not.toHaveBeenCalled();
+
+			await wrapped("phase-development-server", { defaultConfig: {} });
+			expect(mockWatch).toHaveBeenCalledTimes(1);
+
+			await wrapped("phase-development-server", { defaultConfig: {} });
+			expect(mockWatch).toHaveBeenCalledTimes(2);
+			expect(mockClose).toHaveBeenCalledTimes(1);
+		} finally {
+			process.env.NODE_ENV = originalNodeEnv;
+			delete (globalThis as Record<string, unknown>).__arkenv_watcher__;
+			useMockWatcher = false;
+		}
+	});
+
+	it("should support function-form nextConfig from the Standard config entry", async () => {
+		if (!fs.existsSync(tempDir)) {
+			fs.mkdirSync(tempDir, { recursive: true });
+		}
+
+		fs.writeFileSync(
+			schemaPath,
+			`
+			export const env = arkenv({
+				client: { NEXT_PUBLIC_API_URL: "string" }
+			});
+			`,
+			"utf-8",
+		);
+
+		const wrapped = withArkEnvStandard(
+			(phase: string) => ({ reactStrictMode: phase !== "phase-test" }),
+			{ schemaPath, validate: false },
+		);
+		const resolved = (await wrapped("phase-production-build", {
+			defaultConfig: {},
+		})) as {
+			reactStrictMode: boolean;
+			turbopack?: { resolveAlias?: Record<string, unknown> };
+		};
+		expect(resolved.reactStrictMode).toBe(true);
+		expect(resolved.turbopack?.resolveAlias?.["@/.arkenv"]).toBeDefined();
 	});
 
 	it("should support strict layout auto-detection and generation", () => {

--- a/packages/nextjs/src/config/index.ts
+++ b/packages/nextjs/src/config/index.ts
@@ -3,5 +3,9 @@ import { extractClientKeys, extractSharedKeys } from "@arkenv/build";
 export { runCodegen } from "./codegen";
 export { extractKeys } from "./extract";
 export { setupArkEnv, withArkEnv } from "./setup";
-export type { ArkEnvConfigOptions } from "./types";
+export type {
+	ArkEnvConfigOptions,
+	NextConfigContext,
+	NextConfigFactory,
+} from "./types";
 export { extractClientKeys, extractSharedKeys };

--- a/packages/nextjs/src/config/setup.ts
+++ b/packages/nextjs/src/config/setup.ts
@@ -20,7 +20,11 @@ import {
 import { runCodegen } from "./codegen";
 import { normalizeLayout } from "./layout";
 import { applyStrictLayoutAliases } from "./strict-layout-aliases";
-import type { ArkEnvConfigOptions } from "./types";
+import type {
+	ArkEnvConfigOptions,
+	NextConfigContext,
+	NextConfigFactory,
+} from "./types";
 
 function resolveMockServerOnlyPath(moduleDir: string): string {
 	for (const base of [moduleDir, path.join(moduleDir, "..")]) {
@@ -260,97 +264,137 @@ export function setupArkEnv(
 	};
 }
 
+type AliasableNextConfig = Record<string, unknown> & {
+	turbopack?: {
+		resolveAlias?: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	webpack?: (webpackConfig: never, context: never) => unknown;
+};
+
 /**
- * Wrap a Next.js configuration object to automatically generate the `runtimeEnv`
- * block in `env.gen.ts`, register `#arkenv/client-env` in strict layout for auto-extend,
+ * Apply strict-layout and virtual `.arkenv/` aliases to a resolved Next.js config object.
+ *
+ * @param configObj The resolved Next.js configuration object
+ * @param options Optional configuration paths for schema and output files
+ * @param setup Result of `setupArkEnv` for the current invocation
+ * @returns The configuration object with webpack and Turbopack aliases
+ */
+function applyArkEnvAliases<T extends Record<string, unknown>>(
+	configObj: T,
+	options: ArkEnvConfigOptions | undefined,
+	setup: SetupResult,
+): T {
+	const { resolvedLayout, clientEnvPath, outputPath: targetGenPath } = setup;
+	let currentConfig = configObj as AliasableNextConfig;
+
+	if (resolvedLayout === "strict" && clientEnvPath) {
+		currentConfig = applyStrictLayoutAliases(
+			currentConfig as never,
+			clientEnvPath,
+			CLIENT_ENV_SPECIFIER,
+		) as AliasableNextConfig;
+	}
+
+	const rootDir = process.cwd();
+	const targetGenPathToUse =
+		targetGenPath ??
+		(options?.outputPath
+			? path.resolve(options.outputPath)
+			: path.join(rootDir, ".arkenv", "env.gen.ts"));
+	const relativeGenPath = `./${path.relative(rootDir, targetGenPathToUse).replace(/\\/g, "/")}`;
+
+	const turbopack = {
+		...currentConfig.turbopack,
+		resolveAlias: {
+			".arkenv/env.gen": relativeGenPath,
+			".arkenv/env.gen.ts": relativeGenPath,
+			".arkenv": relativeGenPath,
+			".arkenv/index": relativeGenPath,
+			".arkenv/index.ts": relativeGenPath,
+			"#arkenv/env": relativeGenPath,
+			"@/.arkenv": relativeGenPath,
+			"@/.arkenv/env.gen": relativeGenPath,
+			...currentConfig.turbopack?.resolveAlias,
+		},
+	};
+
+	const previousWebpack = currentConfig.webpack;
+	const webpack = (webpackConfig: never, context: never) => {
+		const resolvedConfig = webpackConfig as {
+			resolve?: { alias?: Record<string, unknown> };
+		};
+		resolvedConfig.resolve = resolvedConfig.resolve ?? {};
+		resolvedConfig.resolve.alias = {
+			...resolvedConfig.resolve.alias,
+			".arkenv/env.gen": targetGenPathToUse,
+			".arkenv/env.gen.ts": targetGenPathToUse,
+			".arkenv": targetGenPathToUse,
+			".arkenv/index": targetGenPathToUse,
+			".arkenv/index.ts": targetGenPathToUse,
+			"#arkenv/env": targetGenPathToUse,
+			"@/.arkenv": targetGenPathToUse,
+			"@/.arkenv/env.gen": targetGenPathToUse,
+		};
+		if (typeof previousWebpack === "function") {
+			return previousWebpack(resolvedConfig as never, context);
+		}
+		return resolvedConfig;
+	};
+
+	return {
+		...currentConfig,
+		turbopack,
+		webpack,
+	} as unknown as T;
+}
+
+/**
+ * Wrap a Next.js configuration object or function to generate `runtimeEnv` in
+ * `env.gen.ts`, register `#arkenv/client-env` in strict layout for auto-extend,
  * and configure Turbopack/Webpack aliases for virtualized `.arkenv/` placement.
  *
- * @param nextConfig The Next.js configuration object
+ * Function-form configs (sync or async) are preserved: ArkEnv awaits the user's
+ * factory, then applies aliases to the resolved object.
+ *
+ * @param nextConfig The Next.js configuration object or `(phase, context)` factory
  * @param options Optional configuration paths for schema and output files
- * @returns The Next.js configuration object with configured aliases
+ * @returns The Next.js configuration object, or an async factory that resolves to it
  * @throws An error if the schema file cannot be found or if code generation fails
+ *
+ * @example
+ * ```ts
+ * export default withArkEnv({ reactStrictMode: true });
+ *
+ * export default withArkEnv(async (phase, { defaultConfig }) => ({
+ *   ...defaultConfig,
+ *   reactStrictMode: phase !== "phase-test",
+ * }));
+ * ```
  */
-export function withArkEnv<T>(nextConfig: T, options?: ArkEnvConfigOptions): T {
-	const {
-		resolvedLayout,
-		clientEnvPath,
-		outputPath: targetGenPath,
-	} = setupArkEnv(options);
-
-	const applyVirtualAliases = (configObj: any) => {
-		const rootDir = process.cwd();
-
-		const targetGenPathToUse =
-			targetGenPath ??
-			(options?.outputPath
-				? path.resolve(options.outputPath)
-				: path.join(rootDir, ".arkenv", "env.gen.ts"));
-
-		const relativeGenPath =
-			"./" + path.relative(rootDir, targetGenPathToUse).replace(/\\/g, "/");
-
-		const turbopack = {
-			...configObj?.turbopack,
-			resolveAlias: {
-				".arkenv/env.gen": relativeGenPath,
-				".arkenv/env.gen.ts": relativeGenPath,
-				".arkenv": relativeGenPath,
-				".arkenv/index": relativeGenPath,
-				".arkenv/index.ts": relativeGenPath,
-				"#arkenv/env": relativeGenPath,
-				"@/.arkenv": relativeGenPath,
-				"@/.arkenv/env.gen": relativeGenPath,
-				...configObj?.turbopack?.resolveAlias,
-			},
-		};
-
-		const webpack = (webpackConfig: any, context: any) => {
-			webpackConfig.resolve = webpackConfig.resolve || {};
-			webpackConfig.resolve.alias = {
-				...webpackConfig.resolve.alias,
-				".arkenv/env.gen": targetGenPathToUse,
-				".arkenv/env.gen.ts": targetGenPathToUse,
-				".arkenv": targetGenPathToUse,
-				".arkenv/index": targetGenPathToUse,
-				".arkenv/index.ts": targetGenPathToUse,
-				"#arkenv/env": targetGenPathToUse,
-				"@/.arkenv": targetGenPathToUse,
-				"@/.arkenv/env.gen": targetGenPathToUse,
-			};
-			if (typeof configObj?.webpack === "function") {
-				return configObj.webpack(webpackConfig, context);
-			}
-			return webpackConfig;
-		};
-
-		return {
-			...configObj,
-			turbopack,
-			webpack,
-		};
-	};
-
-	const applyAllAliases = (configObj: any) => {
-		let currentConfig = configObj;
-		if (resolvedLayout === "strict" && clientEnvPath) {
-			currentConfig = applyStrictLayoutAliases(
-				currentConfig as Record<string, unknown>,
-				clientEnvPath,
-				CLIENT_ENV_SPECIFIER,
-			);
-		}
-		return applyVirtualAliases(currentConfig);
-	};
-
+export function withArkEnv<T extends Record<string, unknown>>(
+	nextConfig: NextConfigFactory<T>,
+	options?: ArkEnvConfigOptions,
+): (phase: string, context: NextConfigContext) => Promise<T>;
+export function withArkEnv<T extends Record<string, unknown>>(
+	nextConfig: T,
+	options?: ArkEnvConfigOptions,
+): T;
+export function withArkEnv<T extends Record<string, unknown>>(
+	nextConfig: T | NextConfigFactory<T>,
+	options?: ArkEnvConfigOptions,
+): T | ((phase: string, context: NextConfigContext) => Promise<T>) {
 	if (typeof nextConfig === "function") {
-		return ((phase: any, context: any) => {
-			const resolved = (nextConfig as any)(phase, context);
-			return applyAllAliases(resolved);
-		}) as unknown as T;
+		return async (phase: string, context: NextConfigContext) => {
+			const setup = setupArkEnv(options);
+			const resolved = await nextConfig(phase, context);
+			return applyArkEnvAliases(resolved, options, setup);
+		};
 	}
 
 	if (nextConfig && typeof nextConfig === "object") {
-		return applyAllAliases(nextConfig) as T;
+		const setup = setupArkEnv(options);
+		return applyArkEnvAliases(nextConfig, options, setup);
 	}
 
 	return nextConfig;

--- a/packages/nextjs/src/config/setup.ts
+++ b/packages/nextjs/src/config/setup.ts
@@ -280,7 +280,7 @@ type AliasableNextConfig = Record<string, unknown> & {
  * @param setup Result of `setupArkEnv` for the current invocation
  * @returns The configuration object with webpack and Turbopack aliases
  */
-function applyArkEnvAliases<T extends Record<string, unknown>>(
+function applyArkEnvAliases<T extends object>(
 	configObj: T,
 	options: ArkEnvConfigOptions | undefined,
 	setup: SetupResult,
@@ -372,15 +372,15 @@ function applyArkEnvAliases<T extends Record<string, unknown>>(
  * }));
  * ```
  */
-export function withArkEnv<T extends Record<string, unknown>>(
+export function withArkEnv<T extends object>(
 	nextConfig: NextConfigFactory<T>,
 	options?: ArkEnvConfigOptions,
 ): (phase: string, context: NextConfigContext) => Promise<T>;
-export function withArkEnv<T extends Record<string, unknown>>(
+export function withArkEnv<T extends object>(
 	nextConfig: T,
 	options?: ArkEnvConfigOptions,
 ): T;
-export function withArkEnv<T extends Record<string, unknown>>(
+export function withArkEnv<T extends object>(
 	nextConfig: T | NextConfigFactory<T>,
 	options?: ArkEnvConfigOptions,
 ): T | ((phase: string, context: NextConfigContext) => Promise<T>) {

--- a/packages/nextjs/src/config/strict-layout-aliases.ts
+++ b/packages/nextjs/src/config/strict-layout-aliases.ts
@@ -142,11 +142,8 @@ export function applyStrictLayoutAliases<T extends NextConfigLike>(
 			}
 		: undefined;
 
-	// NOTE: `nextConfig` is spread as a plain object below. Only the object-form
-	// of `next.config` is supported here — a callable/function-form config would
-	// lose its call signature when spread, silently dropping any phase-dependent
-	// logic. Callers are responsible for dereferencing a callable config before
-	// passing it to this function. Full callable-form support is tracked separately.
+	// Spread as a plain object. Callers must pass a resolved config object —
+	// `withArkEnv` awaits function-form `next.config` before calling this.
 	const result: Record<string, unknown> = {
 		...nextConfig,
 		webpack,

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -3,8 +3,8 @@ import type { Logger, LogLevel } from "@repo/log";
 /**
  * Context object Next.js passes to a function-form `next.config`.
  *
- * `defaultConfig` is `{}` so it is spreadable (unlike `unknown` or `object`)
- * while remaining a supertype of Next.js's `NextConfig` interface.
+ * `defaultConfig` is `{}` so callers can spread it while remaining a
+ * supertype of Next.js's `NextConfig` interface.
  */
 export type NextConfigContext = {
 	defaultConfig: {};

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -10,9 +10,10 @@ export type NextConfigContext = {
 /**
  * Function-form Next.js config: sync or async, receiving the current phase.
  */
-export type NextConfigFactory<
-	T extends Record<string, unknown> = Record<string, unknown>,
-> = (phase: string, context: NextConfigContext) => T | Promise<T>;
+export type NextConfigFactory<T extends object = object> = (
+	phase: string,
+	context: NextConfigContext,
+) => T | Promise<T>;
 
 /**
  * Configuration options for the ArkEnv Next.js integration.

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -1,6 +1,20 @@
 import type { Logger, LogLevel } from "@repo/log";
 
 /**
+ * Context object Next.js passes to a function-form `next.config`.
+ */
+export type NextConfigContext = {
+	defaultConfig: unknown;
+};
+
+/**
+ * Function-form Next.js config: sync or async, receiving the current phase.
+ */
+export type NextConfigFactory<
+	T extends Record<string, unknown> = Record<string, unknown>,
+> = (phase: string, context: NextConfigContext) => T | Promise<T>;
+
+/**
  * Configuration options for the ArkEnv Next.js integration.
  *
  * @example

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -2,9 +2,12 @@ import type { Logger, LogLevel } from "@repo/log";
 
 /**
  * Context object Next.js passes to a function-form `next.config`.
+ *
+ * `defaultConfig` is `{}` so it is spreadable (unlike `unknown` or `object`)
+ * while remaining a supertype of Next.js's `NextConfig` interface.
  */
 export type NextConfigContext = {
-	defaultConfig: unknown;
+	defaultConfig: {};
 };
 
 /**

--- a/packages/nextjs/src/standard/config.ts
+++ b/packages/nextjs/src/standard/config.ts
@@ -1,18 +1,31 @@
 import {
 	type ArkEnvConfigOptions,
+	type NextConfigContext,
+	type NextConfigFactory,
 	withArkEnv as originalWithArkEnv,
 } from "@/config";
 
 /**
- * Wrap a Next.js configuration object to automatically generate the `runtimeEnv` block in `env.gen.ts` (Standard Mode).
+ * Wrap a Next.js configuration object or function to generate `env.gen.ts` (Standard Mode).
  *
- * @param nextConfig The Next.js configuration object or function
+ * @param nextConfig The Next.js configuration object or `(phase, context)` factory
  * @param options Optional configuration paths for schema and output files
- * @returns The Next.js configuration object unchanged
+ * @returns The Next.js configuration object, or an async factory that resolves to it
  */
-export function withArkEnv<T>(nextConfig: T, options?: ArkEnvConfigOptions): T {
-	return originalWithArkEnv(nextConfig, {
+export function withArkEnv<T extends Record<string, unknown>>(
+	nextConfig: NextConfigFactory<T>,
+	options?: ArkEnvConfigOptions,
+): (phase: string, context: NextConfigContext) => Promise<T>;
+export function withArkEnv<T extends Record<string, unknown>>(
+	nextConfig: T,
+	options?: ArkEnvConfigOptions,
+): T;
+export function withArkEnv<T extends Record<string, unknown>>(
+	nextConfig: T | NextConfigFactory<T>,
+	options?: ArkEnvConfigOptions,
+): T | ((phase: string, context: NextConfigContext) => Promise<T>) {
+	return originalWithArkEnv(nextConfig as T, {
 		...options,
 		standard: true,
-	});
+	}) as T | ((phase: string, context: NextConfigContext) => Promise<T>);
 }

--- a/packages/nextjs/src/standard/config.ts
+++ b/packages/nextjs/src/standard/config.ts
@@ -12,15 +12,15 @@ import {
  * @param options Optional configuration paths for schema and output files
  * @returns The Next.js configuration object, or an async factory that resolves to it
  */
-export function withArkEnv<T extends Record<string, unknown>>(
+export function withArkEnv<T extends object>(
 	nextConfig: NextConfigFactory<T>,
 	options?: ArkEnvConfigOptions,
 ): (phase: string, context: NextConfigContext) => Promise<T>;
-export function withArkEnv<T extends Record<string, unknown>>(
+export function withArkEnv<T extends object>(
 	nextConfig: T,
 	options?: ArkEnvConfigOptions,
 ): T;
-export function withArkEnv<T extends Record<string, unknown>>(
+export function withArkEnv<T extends object>(
 	nextConfig: T | NextConfigFactory<T>,
 	options?: ArkEnvConfigOptions,
 ): T | ((phase: string, context: NextConfigContext) => Promise<T>) {

--- a/packages/nextjs/src/type-regression.test-d.ts
+++ b/packages/nextjs/src/type-regression.test-d.ts
@@ -5,6 +5,7 @@ import { describe, expectTypeOf, it } from "vitest";
 // was accidentally re-introduced.
 // @ts-expect-error `type` is not exported from @arkenv/nextjs/client — import from @arkenv/core
 import { type as typeFromClient } from "./client";
+import { withArkEnv } from "./config";
 // @ts-expect-error `Infer` is not exported from @arkenv/nextjs root — import from @arkenv/core
 import type { Infer as InferFromRoot } from "./index";
 // @ts-expect-error `type` is not exported from @arkenv/nextjs root — import from @arkenv/core
@@ -16,6 +17,7 @@ import { type as typeFromReactServer } from "./react-server";
 // @ts-expect-error `type` is not exported from @arkenv/nextjs/server — import from @arkenv/core
 import { type as typeFromServer } from "./server";
 import arkenvStandard from "./standard";
+import { withArkEnv as withArkEnvStandard } from "./standard/config";
 
 void typeFromClient;
 void typeFromRoot;
@@ -210,5 +212,58 @@ describe("@arkenv/nextjs server auto-extend types (strict layout)", () => {
 		expectTypeOf(env.DATABASE_URL).toBeString();
 		expectTypeOf(env.NEXT_PUBLIC_API_URL).toBeString();
 		expectTypeOf(env.CUSTOM_CLIENT).toBeString();
+	});
+});
+
+describe("withArkEnv config overloads", () => {
+	it("preserves object-form nextConfig fields", () => {
+		const wrap = () => withArkEnv({ reactStrictMode: true as const });
+		expectTypeOf(wrap).returns.toEqualTypeOf<{ reactStrictMode: true }>();
+	});
+
+	it("returns an async factory for sync function-form nextConfig", () => {
+		const wrap = () =>
+			withArkEnv((phase: string) => ({
+				reactStrictMode: phase !== "phase-test",
+			}));
+		expectTypeOf(wrap).returns.toMatchTypeOf<
+			(
+				phase: string,
+				context: { defaultConfig: unknown },
+			) => Promise<{ reactStrictMode: boolean }>
+		>();
+	});
+
+	it("returns an async factory for async function-form nextConfig", () => {
+		const wrap = () =>
+			withArkEnv(async (phase: string, { defaultConfig }) => ({
+				...(defaultConfig as { poweredByHeader?: boolean }),
+				reactStrictMode: phase !== "phase-test",
+			}));
+		expectTypeOf(wrap).returns.toMatchTypeOf<
+			(
+				phase: string,
+				context: { defaultConfig: unknown },
+			) => Promise<{ poweredByHeader?: boolean; reactStrictMode: boolean }>
+		>();
+	});
+
+	it("matches overloads on the Standard config entry", () => {
+		const wrapObject = () =>
+			withArkEnvStandard({ reactStrictMode: true as const });
+		expectTypeOf(wrapObject).returns.toEqualTypeOf<{
+			reactStrictMode: true;
+		}>();
+
+		const wrapFunction = () =>
+			withArkEnvStandard(async (phase: string) => ({
+				reactStrictMode: phase !== "phase-test",
+			}));
+		expectTypeOf(wrapFunction).returns.toMatchTypeOf<
+			(
+				phase: string,
+				context: { defaultConfig: unknown },
+			) => Promise<{ reactStrictMode: boolean }>
+		>();
 	});
 });

--- a/packages/nextjs/src/type-regression.test-d.ts
+++ b/packages/nextjs/src/type-regression.test-d.ts
@@ -221,6 +221,15 @@ describe("withArkEnv config overloads", () => {
 		expectTypeOf(wrap).returns.toEqualTypeOf<{ reactStrictMode: true }>();
 	});
 
+	it("accepts Next.js NextConfig without a string index signature", () => {
+		type NextConfigLike = {
+			reactStrictMode?: boolean;
+			distDir?: string;
+		};
+		const wrap = () => withArkEnv({} as NextConfigLike);
+		expectTypeOf(wrap).returns.toEqualTypeOf<NextConfigLike>();
+	});
+
 	it("returns an async factory for sync function-form nextConfig", () => {
 		const wrap = () =>
 			withArkEnv((phase: string) => ({

--- a/packages/nextjs/src/type-regression.test-d.ts
+++ b/packages/nextjs/src/type-regression.test-d.ts
@@ -222,10 +222,14 @@ describe("withArkEnv config overloads", () => {
 	});
 
 	it("accepts Next.js NextConfig without a string index signature", () => {
-		type NextConfigLike = {
+		// Must be an interface: type aliases get an implicit index signature, so they
+		// would not catch a `Record<string, unknown>` constraint the way Next 16's
+		// bare `interface NextConfig` does.
+		// biome-ignore lint/style/useConsistentTypeDefinitions: match NextConfig (interface, no index signature)
+		interface NextConfigLike {
 			reactStrictMode?: boolean;
 			distDir?: string;
-		};
+		}
 		const wrap = () => withArkEnv({} as NextConfigLike);
 		expectTypeOf(wrap).returns.toEqualTypeOf<NextConfigLike>();
 	});
@@ -238,7 +242,7 @@ describe("withArkEnv config overloads", () => {
 		expectTypeOf(wrap).returns.toMatchTypeOf<
 			(
 				phase: string,
-				context: { defaultConfig: unknown },
+				context: { defaultConfig: {} },
 			) => Promise<{ reactStrictMode: boolean }>
 		>();
 	});
@@ -246,14 +250,31 @@ describe("withArkEnv config overloads", () => {
 	it("returns an async factory for async function-form nextConfig", () => {
 		const wrap = () =>
 			withArkEnv(async (phase: string, { defaultConfig }) => ({
-				...(defaultConfig as { poweredByHeader?: boolean }),
+				...defaultConfig,
 				reactStrictMode: phase !== "phase-test",
 			}));
 		expectTypeOf(wrap).returns.toMatchTypeOf<
 			(
 				phase: string,
-				context: { defaultConfig: unknown },
-			) => Promise<{ poweredByHeader?: boolean; reactStrictMode: boolean }>
+				context: { defaultConfig: {} },
+			) => Promise<{ reactStrictMode: boolean }>
+		>();
+	});
+
+	it("typechecks the docs function-form snippet with a NextConfig-like return", () => {
+		// biome-ignore lint/style/useConsistentTypeDefinitions: match NextConfig (interface, no index signature)
+		interface NextConfigLike {
+			reactStrictMode?: boolean;
+		}
+		const wrap = () =>
+			withArkEnv(
+				async (phase: string, { defaultConfig }): Promise<NextConfigLike> => ({
+					...defaultConfig,
+					reactStrictMode: phase !== "phase-test",
+				}),
+			);
+		expectTypeOf(wrap).returns.toMatchTypeOf<
+			(phase: string, context: { defaultConfig: {} }) => Promise<NextConfigLike>
 		>();
 	});
 
@@ -271,7 +292,7 @@ describe("withArkEnv config overloads", () => {
 		expectTypeOf(wrapFunction).returns.toMatchTypeOf<
 			(
 				phase: string,
-				context: { defaultConfig: unknown },
+				context: { defaultConfig: {} },
 			) => Promise<{ reactStrictMode: boolean }>
 		>();
 	});


### PR DESCRIPTION
Fixes #1606

`withArkEnv` now accepts Next.js function-form configs (sync or async). The wrapper runs `setupArkEnv` when Next.js invokes the factory, awaits the user's config, then applies strict-layout and `.arkenv/` aliases to the resolved object so phase-dependent options are no longer dropped.

## Test plan
- [ ] `withArkEnv((phase) => config)` returns a callable async factory and preserves phase branching
- [ ] `withArkEnv(async (phase, context) => config)` awaits the user factory
- [ ] Strict layout function-form configs still get `#arkenv/client-env` webpack/Turbopack aliases
- [ ] Flat layout function-form configs still get virtual `.arkenv/` aliases without client-env wiring
- [ ] `@arkenv/nextjs/standard/config` matches the same overloads
- [ ] Type-regression tests for object-form vs function-form overloads


Made with [Cursor](https://cursor.com)