### PR TITLE
feat: implement @arkenv/standard subpaths for Valibot and Zod Mini

### DIFF
--- a/.changeset/standard-valibot-zod-mini-subpaths.md
+++ b/.changeset/standard-valibot-zod-mini-subpaths.md
@@ -1,0 +1,30 @@
+---
+"@arkenv/standard": minor
+"arkenv": minor
+---
+
+#### Add `@arkenv/standard/valibot` and `@arkenv/standard/zod-mini` subpaths
+
+Valibot and Zod Mini now have first-class imports that bind JSON Schema converters, so `v.number()` / Mini `z.boolean()` coerce without a manual `toJsonSchema` callback. Root `@arkenv/standard` stays dependency-free. `arkenv init` scaffolds `@arkenv/standard/valibot` for Valibot.
+
+```ts
+import { arkenv } from "@arkenv/standard/valibot";
+import * as v from "valibot";
+
+export const env = arkenv({
+  PORT: v.optional(v.number(), 3000),
+  DEBUG: v.optional(v.boolean(), false),
+});
+```
+
+```ts
+import { arkenv } from "@arkenv/standard/zod-mini";
+import * as z from "zod/mini";
+
+export const env = arkenv({
+  PORT: z.number(),
+  DEBUG: z.boolean(),
+});
+```
+
+Install `@valibot/to-json-schema` when using the Valibot subpath (optional peer). TypeScript must use `moduleResolution: "bundler" | "node16" | "nodenext"`.

--- a/.changeset/standard-valibot-zod-mini-subpaths.md
+++ b/.changeset/standard-valibot-zod-mini-subpaths.md
@@ -27,4 +27,4 @@ export const env = arkenv({
 });
 ```
 
-Install `@valibot/to-json-schema` when using the Valibot subpath (optional peer). TypeScript must use `moduleResolution: "bundler" | "node16" | "nodenext"`.
+Install `@valibot/to-json-schema` when using the Valibot subpath, and `zod` when using the Zod Mini subpath (both optional peers). TypeScript must use `moduleResolution: "bundler" | "node16" | "nodenext"`.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 > [!IMPORTANT]
 > You are viewing the **v1 branch**, a pre-release (alpha) version of ArkEnv. Track progress on the [v1 roadmap](https://github.com/yamcodes/arkenv/issues/683).
+>
+> TypeScript consumers must set `moduleResolution` to `"bundler"`, `"node16"`, or `"nodenext"`. Legacy `"node"` resolution does not load package `exports` subpaths such as `@arkenv/standard/valibot`.
 
 <div align="center">
   <a href="https://arkenv-v1.vercel.app/docs">Docs</a>

--- a/apps/www/content/docs/core-concepts/coercion.mdx
+++ b/apps/www/content/docs/core-concepts/coercion.mdx
@@ -89,17 +89,33 @@ Cookbook examples: [Coercion and parsing](/docs/validating-your-environment/coer
 <Callout type="info" title="Standard Schema ≠ Standard JSON Schema">
   Automatic coercion with `@arkenv/standard` needs [Standard JSON Schema
   v1](https://standardschema.dev/json-schema) on the value **or** a
-  [`toJsonSchema`](#valibot-tojsonschema) fallback. Those specs are orthogonal to
-  Standard Schema validation. Zod 4.2+ and VineJS 4.3+ put the converter on the
-  schema. Valibot keeps conversion in `@valibot/to-json-schema`; Zod Mini uses
-  `z.toJSONSchema`; Zod v3 typically uses `zod-to-json-schema`. Wire the callback
-  once (see [Valibot](/docs/guides/validators/valibot) and
-  [Zod](/docs/guides/validators/zod)).
+  converter. Those specs are orthogonal to Standard Schema validation. Zod
+  4.2+ and VineJS 4.3+ put the converter on the schema. Valibot and Zod Mini
+  use first-class subpaths (`@arkenv/standard/valibot`,
+  `@arkenv/standard/zod-mini`). Zod v3 typically uses `zod-to-json-schema`
+  through the [`toJsonSchema`](#valibot-tojsonschema) escape hatch. See
+  [Valibot](/docs/guides/validators/valibot) and
+  [Zod](/docs/guides/validators/zod).
 </Callout>
 
 ## Valibot (`toJsonSchema`)
 
-Pass an optional `toJsonSchema` callback for keys without Standard JSON Schema on the value. ArkEnv calls it when it can't read JSON Schema from that key:
+Prefer `@arkenv/standard/valibot` so `@valibot/to-json-schema` is bound for
+you (`typeMode: "input"`, `target: "draft-07"`):
+
+```ts title="./env.ts" twoslash
+import { arkenv } from "@arkenv/standard/valibot";
+import * as v from "valibot";
+
+export const env = arkenv({ PORT: v.number(), DEBUG: v.boolean() });
+```
+
+Install `@valibot/to-json-schema` yourself; it is an optional peer of
+`@arkenv/standard`. Recipe: [Valibot](/docs/guides/validators/valibot).
+
+The optional `toJsonSchema` callback on root `@arkenv/standard` remains the
+escape hatch for custom converters. ArkEnv calls it when it can't read JSON
+Schema from that key:
 
 ```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/standard";
@@ -121,7 +137,6 @@ export const env = arkenv(
 - `target: "draft-07"` matches the JSON Schema draft ArkEnv expects.
 - `typeMode: "input"` coerces env strings toward the schema's input type. A bare `{ toJsonSchema }` function reference uses Valibot's default `typeMode: "ignore"`.
 - Valibot's converter does not accept Standard Schema, so assert `as v.GenericSchema` at the call — Valibot-only and Zod + Valibot use the same wrapper.
-- Install `@valibot/to-json-schema` yourself. `@arkenv/standard` does not depend on it.
 - Recipe: [Valibot](/docs/guides/validators/valibot).
 
 ### Zod v3
@@ -148,7 +163,13 @@ Recipe: [Zod](/docs/guides/validators/zod#zod-v3).
 
 ### Mixing with Zod Mini
 
-Zod Mini also keeps conversion off the value (`z.toJSONSchema`). Mini has no `~standard.jsonSchema` and no instance `.toJSONSchema()`. When both libraries miss JSON Schema, switch on `schema["~standard"].vendor` and return `undefined` for anything else. Mini reports vendor `"zod"`. Classic Zod keys never reach the callback at runtime. Assert at each host-converter call: `vendor` does not narrow Mini vs Valibot.
+Prefer `@arkenv/standard/zod-mini` for Mini-only maps. Mini has no
+`~standard.jsonSchema` and no instance `.toJSONSchema()`. When you mix
+Valibot and Mini on root `@arkenv/standard`, switch on
+`schema["~standard"].vendor` and return `undefined` for anything else. Mini
+reports vendor `"zod"`. Classic Zod keys never reach the callback at
+runtime. Assert at each host-converter call: `vendor` does not narrow Mini
+vs Valibot.
 
 ```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/standard";

--- a/apps/www/content/docs/core-concepts/standard-schema.mdx
+++ b/apps/www/content/docs/core-concepts/standard-schema.mdx
@@ -5,15 +5,15 @@ description: Choose between the ArkType core engine and the Standard Schema adap
 
 ArkEnv ships two engines. Both call `arkenv()`, share fail-fast errors, the coercion pipeline, and framework plugins. Shared [options](/docs/reference/options) (`env`, `coerce`, `safe`, …) apply to both. `toJsonSchema` is on `@arkenv/standard` only; ArkType already exposes JSON Schema. The engines also differ in schema style and peer dependencies.
 
-|                                             | [`@arkenv/core`](/docs/reference/core) | [`@arkenv/standard`](/docs/reference/standard)                             |
-| ------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------- |
-| Schema style                                | ArkType DSL strings + `type()`         | Per-key Standard Schema validators                                         |
-| Typical libraries                           | ArkType                                | Zod, Valibot, VineJS, Zod Mini, …                                          |
-| Runtime `dependencies`                      | None                                   | None                                                                       |
-| Peer `arktype`                              | Required                               | None                                                                       |
-| Env keywords (`string.host`, `number.port`) | Yes                                    | Use the validator’s own APIs                                               |
-| Coercion                                    | Built-in                               | Built-in when fields expose Standard JSON Schema v1, or via `toJsonSchema` |
-| Framework plugins                           | `@arkenv/nextjs`, …                    | Same packages via `/standard` subpaths                                     |
+|                                             | [`@arkenv/core`](/docs/reference/core) | [`@arkenv/standard`](/docs/reference/standard)                                                            |
+| ------------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Schema style                                | ArkType DSL strings + `type()`         | Per-key Standard Schema validators                                                                        |
+| Typical libraries                           | ArkType                                | Zod, Valibot, VineJS, Zod Mini, …                                                                         |
+| Runtime `dependencies`                      | None                                   | None                                                                                                      |
+| Peer `arktype`                              | Required                               | None                                                                                                      |
+| Env keywords (`string.host`, `number.port`) | Yes                                    | Use the validator’s own APIs                                                                              |
+| Coercion                                    | Built-in                               | Built-in when fields expose Standard JSON Schema v1, via `/valibot` or `/zod-mini`, or via `toJsonSchema` |
+| Framework plugins                           | `@arkenv/nextjs`, …                    | Same packages via `/standard` subpaths                                                                    |
 
 Pick the engine that matches the schema library you write. Cookbooks: [Validators](/docs/guides/validators).
 
@@ -77,15 +77,15 @@ Engines are separate packages so peer dependencies stay honest. Framework plugin
 
 [Standard Schema](https://standardschema.dev/) and [Standard JSON Schema](https://standardschema.dev/json-schema) are **orthogonal** specs: one is about validation, the other about converting a type to JSON Schema. A value can implement one, both, or neither.
 
-ArkEnv’s pre-coercion step for `@arkenv/standard` prefers **Standard JSON Schema v1** on the value (`~standard.jsonSchema.input` / `.output`). When a library keeps conversion outside the schema (Valibot, then Zod Mini), pass the optional [`toJsonSchema`](/docs/core-concepts/coercion#valibot-tojsonschema) escape hatch.
+ArkEnv’s pre-coercion step for `@arkenv/standard` prefers **Standard JSON Schema v1** on the value (`~standard.jsonSchema.input` / `.output`). When a library keeps conversion outside the schema, use a first-class subpath or the optional [`toJsonSchema`](/docs/core-concepts/coercion#valibot-tojsonschema) escape hatch.
 
-| Library                                        | How ArkEnv gets JSON Schema                                                                             |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Zod (v4.2+)                                    | On the value (Standard JSON Schema v1)                                                                  |
-| VineJS (v4.3+)                                 | On the value (Standard JSON Schema v1)                                                                  |
-| Valibot (v1.2+ with `@valibot/to-json-schema`) | Wire `toJsonSchema` (see [Valibot](/docs/guides/validators/valibot))                                    |
-| Zod Mini                                       | Wire `toJsonSchema` with `z.toJSONSchema` ([mixing](/docs/core-concepts/coercion#mixing-with-zod-mini)) |
-| Other Standard JSON Schema v1 validators       | On the value                                                                                            |
+| Library                                        | How ArkEnv gets JSON Schema                                                               |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Zod (v4.2+)                                    | On the value (Standard JSON Schema v1)                                                    |
+| VineJS (v4.3+)                                 | On the value (Standard JSON Schema v1)                                                    |
+| Valibot (v1.2+ with `@valibot/to-json-schema`) | `@arkenv/standard/valibot` (see [Valibot](/docs/guides/validators/valibot))               |
+| Zod Mini                                       | `@arkenv/standard/zod-mini` ([mixing](/docs/core-concepts/coercion#mixing-with-zod-mini)) |
+| Other Standard JSON Schema v1 validators       | On the value                                                                              |
 
 See [Coercion](/docs/core-concepts/coercion).
 

--- a/apps/www/content/docs/getting-started/installation.mdx
+++ b/apps/www/content/docs/getting-started/installation.mdx
@@ -35,3 +35,10 @@ If you aren't using ArkType, install
 ### Framework integrations
 
 Next.js, Nuxt, Vite, and Bun have **first-party** integrations. The CLI detects your stack and installs the matching one. To add them manually, see the [framework guides](/docs/guides/frameworks).
+
+## TypeScript module resolution
+
+`@arkenv/standard` subpath exports (`/valibot`, `/zod-mini`) and the
+framework plugin subpaths require modern TypeScript module resolution.
+Set `compilerOptions.moduleResolution` to `"bundler"`, `"node16"`, or
+`"nodenext"`. Legacy `"node"` resolution is not supported.

--- a/apps/www/content/docs/guides/validators/index.mdx
+++ b/apps/www/content/docs/guides/validators/index.mdx
@@ -11,5 +11,5 @@ these cookbooks show how to use the same library for environment variables.
 
   <Card href="/docs/guides/validators/zod" title="Zod" description="@arkenv/standard with Zod 4.2+, Zod Mini, or Zod v3." />
 
-  <Card href="/docs/guides/validators/valibot" title="Valibot" description="@arkenv/standard with Valibot and toJsonSchema." />
+  <Card href="/docs/guides/validators/valibot" title="Valibot" description="@arkenv/standard/valibot with zero-boilerplate coercion." />
 </Cards>

--- a/apps/www/content/docs/guides/validators/valibot.mdx
+++ b/apps/www/content/docs/guides/validators/valibot.mdx
@@ -1,68 +1,64 @@
 ---
 title: Valibot
-description: Validate environment variables with @arkenv/standard and Valibot.
+description: Validate environment variables with @arkenv/standard/valibot.
 ---
 
-Use `@arkenv/standard` to validate environment variables with Valibot. Valibot
-implements the Standard Schema specification. By providing the
-[`@valibot/to-json-schema`](https://valibot.dev/guides/json-schema/) converter
-through ArkEnv's `toJsonSchema` option, ArkEnv can inspect your schema and
-automatically coerce raw strings into numbers, booleans, and arrays.
+Use `@arkenv/standard/valibot` to validate environment variables with Valibot.
+Valibot implements the Standard Schema specification. The subpath pre-configures
+[`@valibot/to-json-schema`](https://valibot.dev/guides/json-schema/) so ArkEnv
+can inspect your schema and coerce raw strings into numbers, booleans, and
+arrays.
 
 For an overview of engine options, see
 [Choosing an engine](/docs/core-concepts/standard-schema).
 
 ## Installation
 
-Install `@arkenv/standard`, `valibot`, and the JSON Schema converter:
+Install `@arkenv/standard`, `valibot`, and the JSON Schema converter (an
+optional peer of `@arkenv/standard`):
 
 ```package-install
 npm i @arkenv/standard valibot @valibot/to-json-schema
 ```
 
+TypeScript must use `moduleResolution: "bundler" | "node16" | "nodenext"`.
+Subpath exports are not resolved under legacy `"node"` module resolution.
+
 ## Define your schema
 
-Declare environment variables in an `env.ts` file using Valibot schemas and
-configure `toJsonSchema`:
+Declare environment variables in an `env.ts` file using Valibot schemas:
 
 ```ts title="./env.ts" twoslash
-import arkenv from "@arkenv/standard";
+import { arkenv } from "@arkenv/standard/valibot";
 import * as v from "valibot";
-import { toJsonSchema } from "@valibot/to-json-schema";
 
-export const env = arkenv(
-  {
-    DATABASE_URL: v.pipe(v.string(), v.url()),
-    PORT: v.optional(v.number(), 3000),
-    DEBUG: v.optional(v.boolean(), false),
-    TAGS: v.optional(v.array(v.string()), []),
-    NODE_ENV: v.optional(
-      v.picklist(["development", "production", "test"]),
-      "development",
-    ),
-  },
-  {
-    toJsonSchema: (schema) =>
-      toJsonSchema(schema as v.GenericSchema, {
-        typeMode: "input",
-        target: "draft-07",
-      }),
-  },
-);
+export const env = arkenv({
+  DATABASE_URL: v.pipe(v.string(), v.url()),
+  PORT: v.optional(v.number(), 3000),
+  DEBUG: v.optional(v.boolean(), false),
+  TAGS: v.optional(v.array(v.string()), []),
+  NODE_ENV: v.optional(
+    v.picklist(["development", "production", "test"]),
+    "development",
+  ),
+});
 ```
+
+Use `v.number()` and `v.boolean()` directly. Manual `v.transform(Number)`
+steps are not required.
 
 ## JSON Schema configuration
 
-Because Valibot does not embed JSON Schema metadata directly on schema instances,
-the `toJsonSchema` callback converts schemas on demand:
+Valibot does not embed JSON Schema metadata on schema instances. The
+`/valibot` subpath calls `@valibot/to-json-schema` with:
 
-- `typeMode: "input"` ensures piped and transformed schemas are evaluated
-  according to their input types so strings can be properly coerced.
-- `target: "draft-07"` formats output to match the JSON Schema draft expected
-  by ArkEnv.
+- `typeMode: "input"` so piped and transformed schemas are evaluated
+  according to their input types and strings can be coerced
+- `target: "draft-07"` so output matches the JSON Schema draft ArkEnv expects
 
-With `toJsonSchema` configured, use `v.number()` and `v.boolean()` directly.
-Manual `v.transform(Number)` steps are not required.
+The root `toJsonSchema` callback remains available on `@arkenv/standard` for
+custom converters or mixed-validator maps. See
+[Coercion](/docs/core-concepts/coercion#valibot-tojsonschema).
 
 ## Defaults and optionals
 

--- a/apps/www/content/docs/guides/validators/zod.mdx
+++ b/apps/www/content/docs/guides/validators/zod.mdx
@@ -56,27 +56,23 @@ Zod methods for defaults and optional fields behave consistently with ArkEnv:
 ## Zod Mini
 
 [Zod Mini](https://zod.dev/packages/mini) (`import * as z from "zod/mini"`) omits
-embedded JSON Schema metadata from schema instances. To enable automatic coercion
-with Zod Mini, provide ArkEnv's `toJsonSchema` callback option:
+embedded JSON Schema metadata from schema instances. Import
+`@arkenv/standard/zod-mini` so Mini `z.number()` and `z.boolean()` coerce
+without a callback:
 
 ```ts title="./env.ts" twoslash
-import arkenv from "@arkenv/standard";
+import { arkenv } from "@arkenv/standard/zod-mini";
 import * as z from "zod/mini";
 
-export const env = arkenv(
-  {
-    PORT: z.number(),
-    DEBUG: z.boolean(),
-  },
-  {
-    toJsonSchema: (schema) =>
-      z.toJSONSchema(schema as z.ZodMiniType, {
-        io: "input",
-        target: "draft-07",
-      }),
-  },
-);
+export const env = arkenv({
+  PORT: z.number(),
+  DEBUG: z.boolean(),
+});
 ```
+
+TypeScript must use `moduleResolution: "bundler" | "node16" | "nodenext"`.
+The root `toJsonSchema` callback remains available for mixed maps; see
+[Coercion](/docs/core-concepts/coercion#mixing-with-zod-mini).
 
 ## Zod v3
 

--- a/apps/www/content/docs/reference/options.mdx
+++ b/apps/www/content/docs/reference/options.mdx
@@ -175,8 +175,9 @@ Schema on the value (Valibot, Zod Mini, Zod v3 via `zod-to-json-schema`,
 and similar). ArkEnv calls it per key when it can't read JSON Schema from
 that value.
 
-Wiring: [Valibot](/docs/guides/validators/valibot),
-[Zod](/docs/guides/validators/zod) (Mini and v3), and
+Wiring: prefer [`@arkenv/standard/valibot`](/docs/guides/validators/valibot)
+and [`@arkenv/standard/zod-mini`](/docs/guides/validators/zod#zod-mini).
+The callback remains the escape hatch for Zod v3 and mixed maps. See
 [Coercion](/docs/core-concepts/coercion#valibot-tojsonschema).
 
 ## Framework-only options

--- a/apps/www/content/docs/reference/standard.mdx
+++ b/apps/www/content/docs/reference/standard.mdx
@@ -66,7 +66,7 @@ These are the public names from `@arkenv/standard`.
 | --------------------------- | ---------------------------------------------------------------------------------- |
 | `@arkenv/standard`          | Root engine. Dependency-free. Classic Zod works zero-config.                       |
 | `@arkenv/standard/valibot`  | Same `arkenv`, pre-bound to `@valibot/to-json-schema`. Install that optional peer. |
-| `@arkenv/standard/zod-mini` | Same `arkenv`, pre-bound to `zod/mini`'s `toJSONSchema` helper.                    |
+| `@arkenv/standard/zod-mini` | Same `arkenv`, pre-bound to `zod/mini`'s `toJSONSchema` helper. `zod` is an optional peer. |
 
 ```ts title="./env.ts" twoslash
 import { arkenv } from "@arkenv/standard/valibot";

--- a/apps/www/content/docs/reference/standard.mdx
+++ b/apps/www/content/docs/reference/standard.mdx
@@ -62,10 +62,10 @@ These are the public names from `@arkenv/standard`.
 
 ### Subpaths
 
-| Import                      | Role                                                                               |
-| --------------------------- | ---------------------------------------------------------------------------------- |
-| `@arkenv/standard`          | Root engine. Dependency-free. Classic Zod works zero-config.                       |
-| `@arkenv/standard/valibot`  | Same `arkenv`, pre-bound to `@valibot/to-json-schema`. Install that optional peer. |
+| Import                      | Role                                                                                       |
+| --------------------------- | ------------------------------------------------------------------------------------------ |
+| `@arkenv/standard`          | Root engine. Dependency-free. Classic Zod works zero-config.                               |
+| `@arkenv/standard/valibot`  | Same `arkenv`, pre-bound to `@valibot/to-json-schema`. Install that optional peer.         |
 | `@arkenv/standard/zod-mini` | Same `arkenv`, pre-bound to `zod/mini`'s `toJSONSchema` helper. `zod` is an optional peer. |
 
 ```ts title="./env.ts" twoslash

--- a/apps/www/content/docs/reference/standard.mdx
+++ b/apps/www/content/docs/reference/standard.mdx
@@ -5,11 +5,14 @@ description: ArkType-free environment validation via Standard Schema.
 
 `@arkenv/standard` validates environment variables with any
 [Standard Schema](https://standardschema.dev/) validator (Zod, Valibot,
-and others). No runtime dependencies or peers. Install your validator
-yourself.
+and others). The root import has no runtime dependencies or peers. Install
+your validator yourself. Valibot and Zod Mini use optional subpaths that
+bind JSON Schema converters.
 
 Choose `@arkenv/core` when you want ArkType. Choose `@arkenv/standard`
 when you migrate from Zod/Valibot or keep the tree ArkType-free.
+
+TypeScript must use `moduleResolution: "bundler" | "node16" | "nodenext"`.
 
 ## Installation
 
@@ -37,13 +40,13 @@ export const env = arkenv({
 Both engines share `arkenv()` options, errors, and framework plugins.
 They differ in schema style and peers.
 
-|                                         | `@arkenv/core`              | `@arkenv/standard`                                                                                                                     |
-| --------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Validator                               | ArkType DSL + `type()`      | Standard Schema map only                                                                                                               |
-| Keywords (`string.host`, `number.port`) | Yes                         | No                                                                                                                                     |
-| Peer `arktype`                          | Required                    | None                                                                                                                                   |
-| [Options](/docs/reference/options)      | `ArkEnvConfig`              | `StandardEnvConfig` (`ArkEnvConfig` plus `toJsonSchema`)                                                                               |
-| Coercion                                | Built-in for ArkType shapes | Standard JSON Schema on the value, or [`toJsonSchema`](/docs/core-concepts/coercion#valibot-tojsonschema) for Valibot-style converters |
+|                                         | `@arkenv/core`              | `@arkenv/standard`                                                                                                                                   |
+| --------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Validator                               | ArkType DSL + `type()`      | Standard Schema map only                                                                                                                             |
+| Keywords (`string.host`, `number.port`) | Yes                         | No                                                                                                                                                   |
+| Peer `arktype`                          | Required                    | None                                                                                                                                                 |
+| [Options](/docs/reference/options)      | `ArkEnvConfig`              | `StandardEnvConfig` (`ArkEnvConfig` plus `toJsonSchema`)                                                                                             |
+| Coercion                                | Built-in for ArkType shapes | Standard JSON Schema on the value, or `@arkenv/standard/valibot` / `/zod-mini` / [`toJsonSchema`](/docs/core-concepts/coercion#valibot-tojsonschema) |
 
 ## Exports
 
@@ -56,6 +59,23 @@ These are the public names from `@arkenv/standard`.
 | `formatIssues`       | function                   | Format issues                                                |
 | `getSchemaKeys`      | function                   | List schema keys                                             |
 | Config / issue types | types                      | `StandardEnvConfig` extends core options with `toJsonSchema` |
+
+### Subpaths
+
+| Import                      | Role                                                                               |
+| --------------------------- | ---------------------------------------------------------------------------------- |
+| `@arkenv/standard`          | Root engine. Dependency-free. Classic Zod works zero-config.                       |
+| `@arkenv/standard/valibot`  | Same `arkenv`, pre-bound to `@valibot/to-json-schema`. Install that optional peer. |
+| `@arkenv/standard/zod-mini` | Same `arkenv`, pre-bound to `zod/mini`'s `toJSONSchema` helper.                    |
+
+```ts title="./env.ts" twoslash
+import { arkenv } from "@arkenv/standard/valibot";
+import * as v from "valibot";
+
+export const env = arkenv({
+  PORT: v.optional(v.number(), 3000),
+});
+```
 
 ## Framework `/standard` subpaths
 

--- a/apps/www/content/docs/validating-your-environment/coercion-and-parsing.mdx
+++ b/apps/www/content/docs/validating-your-environment/coercion-and-parsing.mdx
@@ -164,7 +164,7 @@ ArkEnv's built-in coercion still handles the common string-to-number and string-
 
 ## Coercion with Standard Schema validators
 
-The same `coerce` option works with `@arkenv/standard` when each field exposes [Standard JSON Schema v1](https://standardschema.dev/json-schema) on the value, not merely Standard Schema. Those specs are orthogonal. Zod 4.2+, VineJS 4.3+, and other libraries on the [compatible list](https://standardschema.dev/json-schema#what-schema-libraries-support-this-spec) qualify. Valibot keeps conversion in `@valibot/to-json-schema`; Zod Mini uses `z.toJSONSchema`; Zod v3 typically uses `zod-to-json-schema`. Wire the optional [`toJsonSchema`](/docs/core-concepts/coercion#valibot-tojsonschema) callback ([Valibot](/docs/guides/validators/valibot), [Zod](/docs/guides/validators/zod), [mixing with Zod Mini](/docs/core-concepts/coercion#mixing-with-zod-mini)).
+The same `coerce` option works with `@arkenv/standard` when each field exposes [Standard JSON Schema v1](https://standardschema.dev/json-schema) on the value, not merely Standard Schema. Those specs are orthogonal. Zod 4.2+, VineJS 4.3+, and other libraries on the [compatible list](https://standardschema.dev/json-schema#what-schema-libraries-support-this-spec) qualify. Valibot uses [`@arkenv/standard/valibot`](/docs/guides/validators/valibot); Zod Mini uses [`@arkenv/standard/zod-mini`](/docs/guides/validators/zod#zod-mini). Zod v3 typically uses `zod-to-json-schema` through the optional [`toJsonSchema`](/docs/core-concepts/coercion#valibot-tojsonschema) callback ([mixing with Zod Mini](/docs/core-concepts/coercion#mixing-with-zod-mini)).
 
 ```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/standard";

--- a/apps/www/content/docs/validating-your-environment/defining-types.mdx
+++ b/apps/www/content/docs/validating-your-environment/defining-types.mdx
@@ -48,7 +48,7 @@ Your schema is a map from env key names to validators. `@arkenv/core` uses the A
     });
     ```
 
-    Pass each field's schema as the map value for Valibot and other Standard Schema libraries. Valibot coercion: [Valibot](/docs/guides/validators/valibot). Package: [`@arkenv/standard`](/docs/reference/standard).
+    Pass each field's schema as the map value for Valibot and other Standard Schema libraries. Valibot: [`@arkenv/standard/valibot`](/docs/guides/validators/valibot). Package: [`@arkenv/standard`](/docs/reference/standard).
   </Tab>
 </Tabs>
 

--- a/apps/www/lib/twoslash-options.test.ts
+++ b/apps/www/lib/twoslash-options.test.ts
@@ -130,6 +130,34 @@ const db = env.DATABASE_URL;
 		expect(nuxtErrors).not.toContain(2307);
 	});
 
+	it("typechecks @arkenv/standard/valibot without a toJsonSchema callback", () => {
+		const result = twoslasher(
+			`import { arkenv } from "@arkenv/standard/valibot";
+import * as v from "valibot";
+
+export const env = arkenv({ PORT: v.number(), DEBUG: v.boolean() });
+`,
+			"ts",
+			arktypeTwoslashOptions.twoslashOptions,
+		);
+
+		expect(result.errors).toEqual([]);
+	});
+
+	it("typechecks @arkenv/standard/zod-mini without a toJsonSchema callback", () => {
+		const result = twoslasher(
+			`import { arkenv } from "@arkenv/standard/zod-mini";
+import * as z from "zod/mini";
+
+export const env = arkenv({ PORT: z.number(), DEBUG: z.boolean() });
+`,
+			"ts",
+			arktypeTwoslashOptions.twoslashOptions,
+		);
+
+		expect(result.errors).toEqual([]);
+	});
+
 	it("typechecks Valibot toJsonSchema with a GenericSchema assertion", () => {
 		const result = twoslasher(
 			`import arkenv from "@arkenv/standard";

--- a/apps/www/lib/twoslash-vfs.ts
+++ b/apps/www/lib/twoslash-vfs.ts
@@ -18,6 +18,12 @@ export const arktypeTwoslashVfs = {
 		paths: {
 			"@arkenv/core": [path.join(root, "packages/core/src/index.ts")],
 			"@arkenv/standard": [path.join(root, "packages/standard/src/index.ts")],
+			"@arkenv/standard/valibot": [
+				path.join(root, "packages/standard/src/valibot.ts"),
+			],
+			"@arkenv/standard/zod-mini": [
+				path.join(root, "packages/standard/src/zod-mini.ts"),
+			],
 			"@arkenv/nextjs": [path.join(root, "packages/nextjs/src/index.ts")],
 			"@arkenv/nextjs/server": [
 				path.join(root, "packages/nextjs/src/server.ts"),

--- a/examples/with-solid-start/package.json
+++ b/examples/with-solid-start/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"@arkenv/core": "1.0.0-alpha.5",
-		"@arkenv/vite-plugin": "1.0.0-alpha.10",
+		"@arkenv/vite-plugin": "1.0.0-alpha.11",
 		"@solidjs/start": "1.3.2",
 		"arktype": "^2.2.0",
 		"solid-js": "1.9.12",

--- a/examples/with-valibot/README.md
+++ b/examples/with-valibot/README.md
@@ -2,12 +2,12 @@
 
 This example demonstrates how to use ArkEnv with [Valibot](https://valibot.dev/) for validation, without ArkType.
 
-Because Valibot implements the [Standard Schema](https://standardschema.dev/) specification, its schemas can be passed straight to ArkEnv via the `@arkenv/standard` package. Valibot keeps JSON Schema conversion in [`@valibot/to-json-schema`](https://valibot.dev/guides/json-schema/) rather than on the schema itself, so this example wires ArkEnv's optional `toJsonSchema` escape hatch for automatic coercion.
+Because Valibot implements the [Standard Schema](https://standardschema.dev/) specification, its schemas can be passed straight to ArkEnv via `@arkenv/standard/valibot`. That subpath pre-configures [`@valibot/to-json-schema`](https://valibot.dev/guides/json-schema/) so `v.number()` and `v.boolean()` coerce automatically.
 
 ## What's inside?
 
-- Pure Valibot usage via `@arkenv/standard` (no ArkType dependency)
-- ArkEnv coercion for `v.number()` / `v.boolean()` via `toJsonSchema` + `@valibot/to-json-schema`
+- Pure Valibot usage via `@arkenv/standard/valibot` (no ArkType dependency)
+- Zero-boilerplate ArkEnv coercion for `v.number()` / `v.boolean()`
 - A minimal schema validating a URL, a port number, a hostname, and a boolean
 - Full TypeScript type inference for the validated environment
 
@@ -16,6 +16,8 @@ Because Valibot implements the [Standard Schema](https://standardschema.dev/) sp
 ### Prerequisites
 
 Make sure you have [Node.js](https://nodejs.org) installed. We recommend using [nvm](https://github.com/nvm-sh/nvm) to install it.
+
+TypeScript projects must use `moduleResolution: "bundler" | "node16" | "nodenext"`.
 
 ### Quickstart
 

--- a/examples/with-valibot/src/index.ts
+++ b/examples/with-valibot/src/index.ts
@@ -1,25 +1,15 @@
-import arkenv from "@arkenv/standard";
-import { toJsonSchema } from "@valibot/to-json-schema";
+import arkenv from "@arkenv/standard/valibot";
 import * as v from "valibot";
 
-const env = arkenv(
-	{
-		TEST_VALUE: v.pipe(v.string(), v.url()),
-		PORT: v.number(),
-		HOST: v.union([
-			v.literal("localhost"),
-			v.pipe(v.string(), v.regex(/^[a-zA-Z0-9.-]+$/)),
-		]),
-		DEBUG: v.boolean(),
-	},
-	{
-		toJsonSchema: (schema) =>
-			toJsonSchema(schema as v.GenericSchema, {
-				typeMode: "input",
-				target: "draft-07",
-			}),
-	},
-);
+const env = arkenv({
+	TEST_VALUE: v.pipe(v.string(), v.url()),
+	PORT: v.number(),
+	HOST: v.union([
+		v.literal("localhost"),
+		v.pipe(v.string(), v.regex(/^[a-zA-Z0-9.-]+$/)),
+	]),
+	DEBUG: v.boolean(),
+});
 
 console.log(`Value: ${String(env.TEST_VALUE)}`);
 console.log(`Type: ${typeof env.TEST_VALUE}`);

--- a/examples/with-vite-react/package.json
+++ b/examples/with-vite-react/package.json
@@ -12,7 +12,7 @@
 	},
 	"dependencies": {
 		"@arkenv/core": "1.0.0-alpha.5",
-		"@arkenv/vite-plugin": "1.0.0-alpha.10",
+		"@arkenv/vite-plugin": "1.0.0-alpha.11",
 		"arktype": "^2.2.0",
 		"react": "^19.2.5",
 		"react-dom": "^19.2.5"

--- a/packages/arkenv/src/features/scaffold/planner.test.ts
+++ b/packages/arkenv/src/features/scaffold/planner.test.ts
@@ -135,6 +135,24 @@ describe("Planner", () => {
 		expect(plan.install?.dependencies).toContain("arktype");
 	});
 
+	it("plans vanilla valibot with the JSON Schema converter peer", () => {
+		const state: CollectedState = {
+			...defaultState,
+			options: {
+				...defaultState.options,
+				validator: "valibot",
+			},
+		};
+		const plan = createPlan(state);
+		expect(plan.install?.dependencies).toContain("@arkenv/standard");
+		expect(plan.install?.dependencies).toContain("valibot");
+		expect(plan.install?.dependencies).toContain("@valibot/to-json-schema");
+		expect(plan.files[0]?.content).toContain(
+			'import { arkenv } from "@arkenv/standard/valibot"',
+		);
+		expect(plan.files[0]?.content).not.toContain("toJsonSchema");
+	});
+
 	it("plans for bun-fullstack framework with features", () => {
 		const state: CollectedState = {
 			...defaultState,

--- a/packages/arkenv/src/features/scaffold/planner.ts
+++ b/packages/arkenv/src/features/scaffold/planner.ts
@@ -311,6 +311,7 @@ export function createExistingProjectPlan(
 	const deps = [
 		...(basePkg ? [basePkg] : []),
 		options.validator,
+		...(options.validator === "valibot" ? ["@valibot/to-json-schema"] : []),
 		...frameworkStrategy.getDependencies(options),
 	];
 	if (

--- a/packages/arkenv/src/features/scaffold/validators.test.ts
+++ b/packages/arkenv/src/features/scaffold/validators.test.ts
@@ -317,7 +317,10 @@ describe("validators templates", () => {
 				shouldInstall: false,
 			};
 			const template = getSimpleTemplate(options);
-			expect(template).toContain('import arkenv from "@arkenv/standard"');
+			expect(template).toContain(
+				'import { arkenv } from "@arkenv/standard/valibot"',
+			);
+			expect(template).not.toContain("toJsonSchema");
 			expect(template).toContain('import * as v from "valibot"');
 			expect(template).toContain("v.integer()");
 			expect(template).toContain(
@@ -340,7 +343,10 @@ describe("validators templates", () => {
 				shouldInstall: false,
 			};
 			const template = getSimpleTemplate(options);
-			expect(template).toContain('import arkenv from "@arkenv/standard"');
+			expect(template).toContain(
+				'import { arkenv } from "@arkenv/standard/valibot"',
+			);
+			expect(template).not.toContain("toJsonSchema");
 			expect(template).toContain('import * as v from "valibot"');
 			expect(template).toContain("export const env = arkenv({");
 		});

--- a/packages/arkenv/src/features/scaffold/validators/dialects/valibot.ts
+++ b/packages/arkenv/src/features/scaffold/validators/dialects/valibot.ts
@@ -104,7 +104,7 @@ export const valibotDialect: Dialect = {
 
 	assembleVanilla(schemaFields) {
 		return dedent /* ts */`
-	import arkenv from "@arkenv/standard";
+	import { arkenv } from "@arkenv/standard/valibot";
 	import * as v from "valibot";
 
 	/**

--- a/packages/standard/package.json
+++ b/packages/standard/package.json
@@ -24,10 +24,14 @@
 		}
 	},
 	"peerDependencies": {
-		"@valibot/to-json-schema": "^1.0.0"
+		"@valibot/to-json-schema": "^1.0.0",
+		"zod": "^4.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@valibot/to-json-schema": {
+			"optional": true
+		},
+		"zod": {
 			"optional": true
 		}
 	},

--- a/packages/standard/package.json
+++ b/packages/standard/package.json
@@ -105,7 +105,8 @@
 			"limit": "4.5 kB",
 			"import": "*",
 			"ignore": [
-				"zod"
+				"zod",
+				"zod/mini"
 			]
 		}
 	]

--- a/packages/standard/package.json
+++ b/packages/standard/package.json
@@ -11,6 +11,24 @@
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"require": "./dist/index.cjs"
+		},
+		"./valibot": {
+			"types": "./dist/valibot.d.ts",
+			"import": "./dist/valibot.js",
+			"require": "./dist/valibot.cjs"
+		},
+		"./zod-mini": {
+			"types": "./dist/zod-mini.d.ts",
+			"import": "./dist/zod-mini.js",
+			"require": "./dist/zod-mini.cjs"
+		}
+	},
+	"peerDependencies": {
+		"@valibot/to-json-schema": "^1.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@valibot/to-json-schema": {
+			"optional": true
 		}
 	},
 	"scripts": {
@@ -71,6 +89,24 @@
 			"path": "dist/index.js",
 			"limit": "3.7 kB",
 			"import": "*"
+		},
+		{
+			"name": "@arkenv/standard/valibot",
+			"path": "dist/valibot.js",
+			"limit": "4.5 kB",
+			"import": "*",
+			"ignore": [
+				"@valibot/to-json-schema"
+			]
+		},
+		{
+			"name": "@arkenv/standard/zod-mini",
+			"path": "dist/zod-mini.js",
+			"limit": "4.5 kB",
+			"import": "*",
+			"ignore": [
+				"zod"
+			]
 		}
 	]
 }

--- a/packages/standard/src/bind-arkenv.ts
+++ b/packages/standard/src/bind-arkenv.ts
@@ -1,0 +1,28 @@
+import type { StandardSchemaV1 } from "@repo/types";
+import { arkenv as createArkEnv, type StandardEnvConfig } from "./index";
+
+type BoundArkEnv = typeof createArkEnv;
+
+/**
+ * Bind `arkenv` to a default `toJsonSchema` converter.
+ *
+ * Callers can still pass `toJsonSchema` to override the bound converter.
+ *
+ * @param defaultToJsonSchema Converter used when the call omits `toJsonSchema`
+ * @returns An `arkenv` function with the same public signature as the root export
+ */
+export function bindArkEnv(
+	defaultToJsonSchema: NonNullable<StandardEnvConfig["toJsonSchema"]>,
+): BoundArkEnv {
+	function boundArkEnv<
+		const T extends Record<string, StandardSchemaV1>,
+		const Safe extends boolean | undefined = undefined,
+	>(def: T, config?: Omit<StandardEnvConfig, "safe"> & { safe?: Safe }) {
+		return createArkEnv(def, {
+			...config,
+			toJsonSchema: config?.toJsonSchema ?? defaultToJsonSchema,
+		});
+	}
+
+	return boundArkEnv as BoundArkEnv;
+}

--- a/packages/standard/src/subpaths.test.ts
+++ b/packages/standard/src/subpaths.test.ts
@@ -1,0 +1,65 @@
+import * as v from "valibot";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import * as zMini from "zod/mini";
+import { arkenv as valibotArkenv } from "./valibot";
+import { arkenv as zodMiniArkenv } from "./zod-mini";
+
+describe("@arkenv/standard subpaths", () => {
+	it("coerces Valibot number and boolean fields without a toJsonSchema callback", () => {
+		const env = valibotArkenv(
+			{
+				PORT: v.number(),
+				DEBUG: v.boolean(),
+			},
+			{ env: { PORT: "3000", DEBUG: "true" } },
+		);
+
+		expectTypeOf(env.PORT).toBeNumber();
+		expectTypeOf(env.DEBUG).toBeBoolean();
+		expect(env.PORT).toBe(3000);
+		expect(env.DEBUG).toBe(true);
+	});
+
+	it("coerces Zod Mini number and boolean fields without a toJsonSchema callback", () => {
+		const env = zodMiniArkenv(
+			{
+				PORT: zMini.number(),
+				DEBUG: zMini.boolean(),
+			},
+			{ env: { PORT: "3000", DEBUG: "true" } },
+		);
+
+		expectTypeOf(env.PORT).toBeNumber();
+		expectTypeOf(env.DEBUG).toBeBoolean();
+		expect(env.PORT).toBe(3000);
+		expect(env.DEBUG).toBe(true);
+	});
+
+	it("lets Valibot callers override the bound toJsonSchema converter", () => {
+		expect(() =>
+			valibotArkenv(
+				{ PORT: v.number() },
+				{
+					env: { PORT: "3000" },
+					toJsonSchema: () => undefined,
+				},
+			),
+		).toThrow(
+			/Hint: coercion is enabled by default, but the validator for 'PORT' lacks Standard JSON Schema support/,
+		);
+	});
+
+	it("lets Zod Mini callers override the bound toJsonSchema converter", () => {
+		expect(() =>
+			zodMiniArkenv(
+				{ PORT: zMini.number() },
+				{
+					env: { PORT: "3000" },
+					toJsonSchema: () => undefined,
+				},
+			),
+		).toThrow(
+			/Hint: coercion is enabled by default, but the validator for 'PORT' lacks Standard JSON Schema support/,
+		);
+	});
+});

--- a/packages/standard/src/valibot.ts
+++ b/packages/standard/src/valibot.ts
@@ -1,0 +1,47 @@
+import { toJsonSchema } from "@valibot/to-json-schema";
+import { bindArkEnv } from "./bind-arkenv";
+import type { StandardEnvConfig } from "./index";
+
+const valibotToJsonSchema: NonNullable<StandardEnvConfig["toJsonSchema"]> = (
+	schema,
+) =>
+	toJsonSchema(schema as Parameters<typeof toJsonSchema>[0], {
+		typeMode: "input",
+		target: "draft-07",
+	});
+
+/**
+ * Parse and validate environment variables with Valibot.
+ *
+ * Pre-binds `@valibot/to-json-schema` (`typeMode: "input"`, `target: "draft-07"`)
+ * so `v.number()` and `v.boolean()` coerce without a manual `toJsonSchema`
+ * callback. Install `@valibot/to-json-schema` alongside `valibot`.
+ *
+ * @param def An object mapping variable names to Valibot schemas
+ * @param config Optional configuration. Pass `toJsonSchema` to override the bound converter
+ * @returns The validated environment variables, or a SafeArkEnvResult if `{ safe: true }` is configured
+ * @throws An {@link ArkEnvError} if validation fails and `safe` is not enabled
+ *
+ * @example
+ * ```ts
+ * import { arkenv } from "@arkenv/standard/valibot";
+ * import * as v from "valibot";
+ *
+ * const env = arkenv({
+ *   PORT: v.optional(v.number(), 3000),
+ *   DEBUG: v.optional(v.boolean(), false),
+ * });
+ * ```
+ */
+export const arkenv = bindArkEnv(valibotToJsonSchema);
+
+export {
+	ArkEnvError,
+	type EnvIssue,
+	formatIssues,
+	getSchemaKeys,
+	type SafeArkEnvResult,
+	type StandardEnvConfig,
+} from "./index";
+
+export default arkenv;

--- a/packages/standard/src/zod-mini.ts
+++ b/packages/standard/src/zod-mini.ts
@@ -15,7 +15,8 @@ const zodMiniToJsonSchema: NonNullable<StandardEnvConfig["toJsonSchema"]> = (
  *
  * Pre-binds `zod/mini`'s `toJSONSchema` helper (`io: "input"`, `target: "draft-07"`)
  * so Mini `z.number()` and `z.boolean()` coerce without a manual `toJsonSchema`
- * callback. Classic Zod should keep using `@arkenv/standard`.
+ * callback. Install `zod` (optional peer) and import Mini from `zod/mini`.
+ * Classic Zod should keep using `@arkenv/standard`.
  *
  * @param def An object mapping variable names to Zod Mini schemas
  * @param config Optional configuration. Pass `toJsonSchema` to override the bound converter

--- a/packages/standard/src/zod-mini.ts
+++ b/packages/standard/src/zod-mini.ts
@@ -1,0 +1,47 @@
+import { toJSONSchema } from "zod/mini";
+import { bindArkEnv } from "./bind-arkenv";
+import type { StandardEnvConfig } from "./index";
+
+const zodMiniToJsonSchema: NonNullable<StandardEnvConfig["toJsonSchema"]> = (
+	schema,
+) =>
+	toJSONSchema(schema as unknown as Parameters<typeof toJSONSchema>[0], {
+		io: "input",
+		target: "draft-07",
+	});
+
+/**
+ * Parse and validate environment variables with Zod Mini.
+ *
+ * Pre-binds `zod/mini`'s `toJSONSchema` helper (`io: "input"`, `target: "draft-07"`)
+ * so Mini `z.number()` and `z.boolean()` coerce without a manual `toJsonSchema`
+ * callback. Classic Zod should keep using `@arkenv/standard`.
+ *
+ * @param def An object mapping variable names to Zod Mini schemas
+ * @param config Optional configuration. Pass `toJsonSchema` to override the bound converter
+ * @returns The validated environment variables, or a SafeArkEnvResult if `{ safe: true }` is configured
+ * @throws An {@link ArkEnvError} if validation fails and `safe` is not enabled
+ *
+ * @example
+ * ```ts
+ * import { arkenv } from "@arkenv/standard/zod-mini";
+ * import * as z from "zod/mini";
+ *
+ * const env = arkenv({
+ *   PORT: z.number(),
+ *   DEBUG: z.boolean(),
+ * });
+ * ```
+ */
+export const arkenv = bindArkEnv(zodMiniToJsonSchema);
+
+export {
+	ArkEnvError,
+	type EnvIssue,
+	formatIssues,
+	getSchemaKeys,
+	type SafeArkEnvResult,
+	type StandardEnvConfig,
+} from "./index";
+
+export default arkenv;

--- a/packages/standard/tsdown.config.ts
+++ b/packages/standard/tsdown.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
 	fixedExtension: false,
 	deps: {
 		alwaysBundle: ["@repo/types", "@repo/utils"],
-		neverBundle: ["@valibot/to-json-schema", "zod"],
+		neverBundle: ["@valibot/to-json-schema", "zod", "zod/mini"],
 	},
 });

--- a/packages/standard/tsdown.config.ts
+++ b/packages/standard/tsdown.config.ts
@@ -1,11 +1,12 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	entry: ["src/index.ts"],
+	entry: ["src/index.ts", "src/valibot.ts", "src/zod-mini.ts"],
 	format: ["esm", "cjs"],
 	minify: true,
 	fixedExtension: false,
 	deps: {
 		alwaysBundle: ["@repo/types", "@repo/utils"],
+		neverBundle: ["@valibot/to-json-schema", "zod"],
 	},
 });

--- a/skills/arkenv/SKILL.md
+++ b/skills/arkenv/SKILL.md
@@ -170,6 +170,18 @@ export const env = arkenv({
 });
 ```
 
+Valibot uses the `/valibot` subpath (install `@valibot/to-json-schema` as well):
+
+```ts title="src/env.ts"
+import { arkenv } from "@arkenv/standard/valibot";
+import * as v from "valibot";
+
+export const env = arkenv({
+  PORT: v.optional(v.number(), 3000),
+  DATABASE_URL: v.pipe(v.string(), v.url()),
+});
+```
+
 ### Consuming `env` in Application Code
 
 Always import and read properties directly from the canonical `env` object:


### PR DESCRIPTION
Fixes #1607

## Summary
- Add `@arkenv/standard/valibot` and `@arkenv/standard/zod-mini` subpath exports that bind JSON Schema converters so `v.number()` / Mini `z.boolean()` coerce without a manual `toJsonSchema` block. Root `@arkenv/standard` stays dependency-free; `@valibot/to-json-schema` is an optional peer.
- Scaffold Valibot via `arkenv init` as `import { arkenv } from "@arkenv/standard/valibot"` and install the converter peer. Docs, README, the Valibot example, and the agent skill use the subpaths as the happy path.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run fix`
- [ ] Confirm `import { arkenv } from "@arkenv/standard/valibot"` coerces `v.number()` / `v.boolean()`
- [ ] Confirm `import { arkenv } from "@arkenv/standard/zod-mini"` coerces Mini number/boolean fields
- [ ] Confirm root `@arkenv/standard` still has no runtime converter dependency
- [ ] Confirm `arkenv init` Valibot vanilla template has no `toJsonSchema` callback


Made with [Cursor](https://cursor.com)