### PR TITLE
feat: ArkEnv Coding Agent Plugin with MCP server and security guardrails

### DIFF
--- a/.changeset/agent-plugin-mcp-audit.md
+++ b/.changeset/agent-plugin-mcp-audit.md
@@ -4,14 +4,13 @@
 
 #### Add a coding-agent plugin with MCP `init` and `audit` tools
 
-Ship `@arkenv/agent-plugin` so coding agents can install ArkEnv expertise via
-`npx plugins add yamcodes/arkenv` (the repo `marketplace.json` points at
-`packages/agent-plugin`). The package exposes `/arkenv:init`
+`@arkenv/agent-plugin` is now available for coding agents. Install it with
+`npx plugins add yamcodes/arkenv`. Compatible runtimes expose `/arkenv:init`
 (delegates to `arkenv init --agent`) and `/arkenv:audit` (TypeScript AST scan
 for raw `process.env` / `import.meta.env` access, client secret leaks, public
 prefix mistakes, and leftover v0 ambient `.d.ts` augmentations).
 
-Connect the stdio MCP server after publish:
+The stdio MCP server is available after publish:
 
 ```bash
 npx -y @arkenv/agent-plugin@alpha

--- a/.changeset/agent-plugin-mcp-audit.md
+++ b/.changeset/agent-plugin-mcp-audit.md
@@ -1,5 +1,5 @@
 ---
-"@arkenv/agent-plugin": minor
+"@arkenv/agent-plugin": patch
 ---
 
 #### Add a coding-agent plugin with MCP `init` and `audit` tools

--- a/.changeset/agent-plugin-mcp-audit.md
+++ b/.changeset/agent-plugin-mcp-audit.md
@@ -1,0 +1,25 @@
+---
+"@arkenv/agent-plugin": minor
+---
+
+#### Add a coding-agent plugin with MCP `init` and `audit` tools
+
+Ship `@arkenv/agent-plugin` so coding agents can install ArkEnv expertise via
+`npx plugins add arkenv/arkenv-plugin`. The package exposes `/arkenv:init`
+(delegates to `arkenv init --agent`) and `/arkenv:audit` (TypeScript AST scan
+for raw `process.env` / `import.meta.env` access, client secret leaks, public
+prefix mistakes, and leftover v0 ambient `.d.ts` augmentations).
+
+Connect the stdio MCP server:
+
+```bash
+npx -y @arkenv/agent-plugin
+```
+
+Audit a tree programmatically:
+
+```ts
+import { auditProject } from "@arkenv/agent-plugin";
+
+const { diagnostics } = await auditProject(".");
+```

--- a/.changeset/agent-plugin-mcp-audit.md
+++ b/.changeset/agent-plugin-mcp-audit.md
@@ -5,15 +5,16 @@
 #### Add a coding-agent plugin with MCP `init` and `audit` tools
 
 Ship `@arkenv/agent-plugin` so coding agents can install ArkEnv expertise via
-`npx plugins add arkenv/arkenv-plugin`. The package exposes `/arkenv:init`
+`npx plugins add yamcodes/arkenv` (the repo `marketplace.json` points at
+`packages/agent-plugin`). The package exposes `/arkenv:init`
 (delegates to `arkenv init --agent`) and `/arkenv:audit` (TypeScript AST scan
 for raw `process.env` / `import.meta.env` access, client secret leaks, public
 prefix mistakes, and leftover v0 ambient `.d.ts` augmentations).
 
-Connect the stdio MCP server:
+Connect the stdio MCP server after publish:
 
 ```bash
-npx -y @arkenv/agent-plugin
+npx -y @arkenv/agent-plugin@alpha
 ```
 
 Audit a tree programmatically:

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -21,7 +21,7 @@
 		"@arkenv/core": "1.0.0-alpha.2",
 		"@repo/utils": "0.1.3",
 		"@arkenv/standard": "1.0.0-alpha.2",
-		"@arkenv/agent-plugin": "1.0.0-alpha.0",
+		"@arkenv/agent-plugin": "0.0.0",
 		"@repo/log": "0.0.1",
 		"@repo/dash": "0.0.0"
 	},

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -21,6 +21,7 @@
 		"@arkenv/core": "1.0.0-alpha.2",
 		"@repo/utils": "0.1.3",
 		"@arkenv/standard": "1.0.0-alpha.2",
+		"@arkenv/agent-plugin": "1.0.0-alpha.0",
 		"@repo/log": "0.0.1",
 		"@repo/dash": "0.0.0"
 	},

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
 			"name": "arkenv",
 			"source": "./packages/agent-plugin",
 			"description": "Canonical env object, init, and AST security audits for environment variables.",
-			"version": "1.0.0-alpha.0",
+			"version": "0.0.0",
 			"keywords": ["arkenv", "environment-variables", "mcp", "audit"]
 		}
 	]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+	"name": "arkenv",
+	"owner": {
+		"name": "Yam Borodetsky",
+		"url": "https://yam.codes"
+	},
+	"metadata": {
+		"description": "ArkEnv coding-agent plugins"
+	},
+	"plugins": [
+		{
+			"name": "arkenv",
+			"source": "./packages/agent-plugin",
+			"description": "Canonical env object, init, and AST security audits for environment variables.",
+			"version": "1.0.0-alpha.0",
+			"keywords": ["arkenv", "environment-variables", "mcp", "audit"]
+		}
+	]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ ArkEnv is a pnpm + Turborepo monorepo for a TypeScript env-var validation librar
 
 ### Services / apps
 
-- `packages/*` — the publishable library packages: `arkenv` (the CLI, in `packages/arkenv/`), `@arkenv/core` (core runtime, in `packages/core/`), `@arkenv/standard` (in `packages/standard/`), plus `@arkenv/nextjs`, `@arkenv/nuxt`, `@arkenv/vite-plugin`, `@arkenv/bun-plugin`, `@arkenv/build`, and `@arkenv/fumadocs-ui` (which live in the `nextjs/`, `nuxt/`, `vite-plugin/`, `bun-plugin/`, `build/`, and `fumadocs-ui/` directories), plus internal helpers under `packages/internal/*`. These are the core product.
+- `packages/*` — the publishable library packages: `arkenv` (the CLI, in `packages/arkenv/`), `@arkenv/core` (core runtime, in `packages/core/`), `@arkenv/standard` (in `packages/standard/`), plus `@arkenv/nextjs`, `@arkenv/nuxt`, `@arkenv/vite-plugin`, `@arkenv/bun-plugin`, `@arkenv/build`, `@arkenv/agent-plugin`, and `@arkenv/fumadocs-ui` (which live in the `nextjs/`, `nuxt/`, `vite-plugin/`, `bun-plugin/`, `build/`, `agent-plugin/`, and `fumadocs-ui/` directories), plus internal helpers under `packages/internal/*`. These are the core product.
 - `apps/www` — the documentation website (Next.js 16 + Fumadocs). This is the product app.
 - `apps/dash` — optional maintainer Dashfy dashboard (GitHub + npm). Not in CI. Run with `pnpm dash` (Vite on [http://localhost:3001](http://localhost:3001), Dashfy server on [http://127.0.0.1:5001](http://127.0.0.1:5001)). Copy `apps/dash/.env.example` to `apps/dash/.env` first.
 - `apps/playwright-www` — Playwright e2e suite targeting `www`.

--- a/apps/www/content/docs/faq.mdx
+++ b/apps/www/content/docs/faq.mdx
@@ -49,7 +49,7 @@ and guide your assistant through schema maintenance. See
 
 Vite and Bun use build plugins (`@arkenv/vite-plugin` and `@arkenv/bun-plugin`) that transform `env.ts` during bundling. Application code imports `@arkenv/core` (or `@arkenv/standard`), and the bundler rewrites client-side imports to inline public values and guard secrets.
 
-Next.js and Nuxt use host runtime adapters (such as codegen with conditional exports or Nitro runtime configuration hooks) that require dedicated framework entrypoints (`@arkenv/nextjs` and `@arkenv/nuxt`). See [Framework integration](/docs/validating-your-environment/framework-integration).
+Next.js and Nuxt use host runtime adapters (such as codegen with conditional exports or Nitro runtime configuration hooks) that require dedicated framework entrypoints (`@arkenv/nextjs` and `@arkenv/nuxt`). See [Integrations](/docs/validating-your-environment/framework-integration).
 
 ## Why are `@arkenv/core` and `@arkenv/standard` peer dependencies instead of bundled into framework packages?
 

--- a/apps/www/content/docs/guides/ai.mdx
+++ b/apps/www/content/docs/guides/ai.mdx
@@ -8,6 +8,29 @@ Cursor, and GitHub Copilot. ArkEnv provides capabilities that help assistants
 understand your environment schemas, scaffold configurations deterministically,
 and enforce client/server security boundaries.
 
+## Coding-agent plugin
+
+Install the ArkEnv plugin so Claude Code, Cursor, Codex, and other MCP
+clients get slash commands plus an AST auditor:
+
+```bash
+npx plugins add arkenv/arkenv-plugin
+```
+
+That exposes `/arkenv:init` (delegates to `arkenv init --agent`) and
+`/arkenv:audit` (flags raw `process.env` / `import.meta.env` access, server
+secrets in client modules, public-prefix mistakes, and leftover v0 ambient
+`.d.ts` files).
+
+Run the MCP server directly:
+
+```bash
+npx -y @arkenv/agent-plugin
+```
+
+See the [`@arkenv/agent-plugin` reference](/docs/reference/agent-plugin) for
+diagnostic shapes and the programmatic `auditProject` API.
+
 ## Agent skill
 
 [Agent Skills](https://agentskills.io) are an open standard that provide capabilities

--- a/apps/www/content/docs/guides/ai.mdx
+++ b/apps/www/content/docs/guides/ai.mdx
@@ -10,8 +10,13 @@ and enforce client/server security boundaries.
 
 ## Coding-agent plugin
 
-Install the ArkEnv plugin so Claude Code, Cursor, Codex, and other MCP
-clients get slash commands plus an AST auditor:
+The plugin and the skill coexist. Prefer the plugin on hosts that support
+it (Claude Code, Cursor, Codex, and other MCP clients). Keep the skill
+path below when your assistant only loads Agent Skills. Installing the
+plugin does not replace `npx skills add yamcodes/arkenv`.
+
+Install `@arkenv/agent-plugin` so those hosts get slash commands plus an
+AST auditor:
 
 ```bash
 npx plugins add yamcodes/arkenv
@@ -37,11 +42,11 @@ diagnostic shapes and the programmatic `auditProject` API.
 
 ## Agent skill
 
-[Agent Skills](https://agentskills.io) are an open standard that provide capabilities
-and domain expertise to AI coding assistants.
+[Agent Skills](https://agentskills.io) are an open standard that provide
+capabilities and domain expertise to AI coding assistants. Use this path
+when the host has no plugin or MCP install, or when you want both.
 
-You can install the official ArkEnv skill into your project using your package
-manager:
+Install the official ArkEnv skill into your project:
 
 ```package-install
 npx skills add yamcodes/arkenv
@@ -115,7 +120,7 @@ The complete text of all documentation pages is available in a single plain text
 <Cards>
   <Card href="/docs/guides/frameworks" title="Framework guides" description="Recipes for Next.js, Nuxt, Vite, and Bun." />
 
-  <Card href="/docs/validating-your-environment/framework-integration" title="Framework integration" description="Understand client/server security boundaries across hosts." />
+  <Card href="/docs/validating-your-environment/framework-integration" title="Integrations" description="Wire ArkEnv into Next.js, Nuxt, Vite, Bun, or coding agents." />
 
   <Card href="/docs/reference/init" title="init reference" description="Complete CLI flags, agent mode payloads, and error codes." />
 

--- a/apps/www/content/docs/guides/ai.mdx
+++ b/apps/www/content/docs/guides/ai.mdx
@@ -14,18 +14,22 @@ Install the ArkEnv plugin so Claude Code, Cursor, Codex, and other MCP
 clients get slash commands plus an AST auditor:
 
 ```bash
-npx plugins add arkenv/arkenv-plugin
+npx plugins add yamcodes/arkenv
 ```
 
-That exposes `/arkenv:init` (delegates to `arkenv init --agent`) and
+That command reads the repo's `marketplace.json` and installs
+`packages/agent-plugin` (not the root `skills/` tree). From a clone, use
+`npx plugins add ./packages/agent-plugin`.
+
+It exposes `/arkenv:init` (delegates to `arkenv init --agent`) and
 `/arkenv:audit` (flags raw `process.env` / `import.meta.env` access, server
 secrets in client modules, public-prefix mistakes, and leftover v0 ambient
 `.d.ts` files).
 
-Run the MCP server directly:
+Run the MCP server after the package is on npm (alpha tag):
 
 ```bash
-npx -y @arkenv/agent-plugin
+npx -y @arkenv/agent-plugin@alpha
 ```
 
 See the [`@arkenv/agent-plugin` reference](/docs/reference/agent-plugin) for

--- a/apps/www/content/docs/guides/frameworks/bun.mdx
+++ b/apps/www/content/docs/guides/frameworks/bun.mdx
@@ -8,7 +8,7 @@ public environment variables (prefixed with `BUN_PUBLIC_` by default). Plain Bun
 backend services do not need the plugin and can call `@arkenv/core` directly.
 
 For high-level architectural trade-offs, see
-[Framework integration](/docs/validating-your-environment/framework-integration).
+[Integrations](/docs/validating-your-environment/framework-integration).
 
 ## Quickstart
 

--- a/apps/www/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/www/content/docs/guides/frameworks/nextjs.mdx
@@ -8,7 +8,7 @@ generate typesafe accessors, and prevent server secrets from leaking into Client
 Components.
 
 For high-level architectural trade-offs, see
-[Framework integration](/docs/validating-your-environment/framework-integration).
+[Integrations](/docs/validating-your-environment/framework-integration).
 
 ## Quickstart
 

--- a/apps/www/content/docs/guides/frameworks/nuxt.mdx
+++ b/apps/www/content/docs/guides/frameworks/nuxt.mdx
@@ -8,7 +8,7 @@ routes, synchronize public keys with Nuxt runtime config, and keep server secret
 off the browser.
 
 For high-level architectural trade-offs, see
-[Framework integration](/docs/validating-your-environment/framework-integration).
+[Integrations](/docs/validating-your-environment/framework-integration).
 
 ## Quickstart
 

--- a/apps/www/content/docs/guides/frameworks/vite.mdx
+++ b/apps/www/content/docs/guides/frameworks/vite.mdx
@@ -9,7 +9,7 @@ receive public variables (prefixed with `VITE_` by default) while server secrets
 stay protected.
 
 For high-level architectural trade-offs, see
-[Framework integration](/docs/validating-your-environment/framework-integration).
+[Integrations](/docs/validating-your-environment/framework-integration).
 
 ## Quickstart
 

--- a/apps/www/content/docs/guides/index.mdx
+++ b/apps/www/content/docs/guides/index.mdx
@@ -9,7 +9,7 @@ In these guides, you'll find recipes for wiring `arkenv()` into the rest of
 your tooling.
 
 <Cards>
-  <Card href="/docs/guides/ai" title="Using AI with ArkEnv" description="Skills, prompts, .env.example sync, and assistant guardrails." />
+  <Card href="/docs/guides/ai" title="Using AI with ArkEnv" description="Plugin, MCP audit, skills, and assistant guardrails." />
 
   <Card href="/docs/guides/frameworks" title="Frameworks" description="Next.js, Nuxt, Vite, and Bun integrations." />
 

--- a/apps/www/content/docs/reference/agent-plugin.mdx
+++ b/apps/www/content/docs/reference/agent-plugin.mdx
@@ -10,16 +10,23 @@ projects and audits source for unvalidated env access.
 ## Install
 
 ```bash
-npx plugins add arkenv/arkenv-plugin
+npx plugins add yamcodes/arkenv
+```
+
+The ArkEnv repo's `marketplace.json` points that command at
+`packages/agent-plugin`. From a clone, install by path:
+
+```bash
+npx plugins add ./packages/agent-plugin
 ```
 
 This registers `/arkenv:init` and `/arkenv:audit` in compatible runtimes
 (Claude Code, Cursor, Codex, and other MCP clients).
 
-Connect the MCP server directly:
+Connect the MCP server after the package is published:
 
 ```bash
-npx -y @arkenv/agent-plugin
+npx -y @arkenv/agent-plugin@alpha
 ```
 
 Or add it to an MCP config:
@@ -29,7 +36,7 @@ Or add it to an MCP config:
   "mcpServers": {
     "arkenv": {
       "command": "npx",
-      "args": ["-y", "@arkenv/agent-plugin"]
+      "args": ["-y", "@arkenv/agent-plugin@alpha"]
     }
   }
 }

--- a/apps/www/content/docs/reference/agent-plugin.mdx
+++ b/apps/www/content/docs/reference/agent-plugin.mdx
@@ -1,0 +1,65 @@
+---
+title: "@arkenv/agent-plugin"
+description: Coding-agent plugin and MCP server for init and env audits.
+---
+
+`@arkenv/agent-plugin` is the installable ArkEnv plugin for coding agents.
+It ships slash commands, a bundled skill, and an MCP server that scaffolds
+projects and audits source for unvalidated env access.
+
+## Install
+
+```bash
+npx plugins add arkenv/arkenv-plugin
+```
+
+This registers `/arkenv:init` and `/arkenv:audit` in compatible runtimes
+(Claude Code, Cursor, Codex, and other MCP clients).
+
+Connect the MCP server directly:
+
+```bash
+npx -y @arkenv/agent-plugin
+```
+
+Or add it to an MCP config:
+
+```json
+{
+  "mcpServers": {
+    "arkenv": {
+      "command": "npx",
+      "args": ["-y", "@arkenv/agent-plugin"]
+    }
+  }
+}
+```
+
+## Commands
+
+### `/arkenv:init`
+
+Delegates to `npx arkenv@latest init --agent`. Parse JSON on stdout. Do not
+pass `--force` unless a refusal lists it in `retryWith`.
+
+### `/arkenv:audit`
+
+Runs the TypeScript AST auditor. Each diagnostic includes `file`, `line`,
+`character`, `severity`, `ruleId`, `message`, and `suggestedFix`.
+
+| `ruleId`             | Meaning                                             |
+| -------------------- | --------------------------------------------------- |
+| `unvalidated-access` | `process.env` or `import.meta.env` outside `env.ts` |
+| `secret-leak`        | Server-only key referenced from a client module     |
+| `prefix-violation`   | Public prefix on a secret-looking name              |
+| `legacy-ambient`     | v0 `ProcessEnv` / `ImportMetaEnv` `.d.ts` glob      |
+
+Valid `import { env } from "./env"` usage is not flagged.
+
+## Programmatic API
+
+```ts
+import { auditProject } from "@arkenv/agent-plugin";
+
+const { diagnostics } = await auditProject(".");
+```

--- a/apps/www/content/docs/reference/index.mdx
+++ b/apps/www/content/docs/reference/index.mdx
@@ -46,6 +46,8 @@ These pages cover the runtime engines and framework plugins.
   <Card href="/docs/reference/vite-plugin" title="@arkenv/vite-plugin" description="Validate in Vite and keep server keys off the client." />
 
   <Card href="/docs/reference/bun-plugin" title="@arkenv/bun-plugin" description="Validate Bun builds and isolate BUN_PUBLIC_ keys." />
+
+  <Card href="/docs/reference/agent-plugin" title="@arkenv/agent-plugin" description="Install the coding-agent plugin and MCP audit/init tools." />
 </Cards>
 
 ## Global flags

--- a/apps/www/content/docs/reference/meta.json
+++ b/apps/www/content/docs/reference/meta.json
@@ -17,6 +17,7 @@
 		"nextjs",
 		"nuxt",
 		"vite-plugin",
-		"bun-plugin"
+		"bun-plugin",
+		"agent-plugin"
 	]
 }

--- a/apps/www/content/docs/validating-your-environment/error-reporting.mdx
+++ b/apps/www/content/docs/validating-your-environment/error-reporting.mdx
@@ -103,5 +103,5 @@ Next.js, Nuxt, Vite, and Bun each enforce the boundary (runtime proxy, build-tim
 <Cards>
   <Card href="/docs/validating-your-environment/reusing-schemas" title="Reusing schemas" description="Share validation schemas across multiple applications and packages." />
 
-  <Card href="/docs/validating-your-environment/framework-integration" title="Framework integration" description="Connect ArkEnv to Next.js, Nuxt, Vite, or Bun." />
+  <Card href="/docs/validating-your-environment/framework-integration" title="Integrations" description="Connect ArkEnv to Next.js, Nuxt, Vite, Bun, or coding agents." />
 </Cards>

--- a/apps/www/content/docs/validating-your-environment/framework-integration.mdx
+++ b/apps/www/content/docs/validating-your-environment/framework-integration.mdx
@@ -1,11 +1,17 @@
 ---
-title: Framework integration
-description: Connect ArkEnv to Next.js, Nuxt, Vite, or Bun.
+title: Integrations
+description: Connect ArkEnv to Next.js, Nuxt, Vite, Bun, or coding agents.
 ---
 
-ArkEnv is built around a flat `arkenv()` call: one schema, one typed `env` object. Framework packages exist so that same call stays honest on each host. They add public-prefix rules, codegen, build plugins, and runtime guards so you do not invent a second API for Next.js or Vite. Radical simplicity at the call site; the integration absorbs the host's complexity.
+ArkEnv ships first-party packages for frameworks, bundlers, and coding
+agents. Validation hosts keep a flat `arkenv()` call honest: they add
+public-prefix rules, codegen, build plugins, and runtime guards so you
+do not invent a second API for Next.js or Vite. The coding-agent package
+is separate: it scaffolds and audits source. It does not validate env at
+runtime.
 
-Pick the package that matches your host, then follow the linked guide for layout details.
+Pick the package that matches your host, then follow the linked guide for
+layout details.
 
 ## Choose your stack
 
@@ -17,11 +23,15 @@ Pick the package that matches your host, then follow the linked guide for layout
   <Card href="/docs/guides/frameworks/vite" title="Vite" description="@arkenv/vite-plugin for build and dev validation of VITE_ keys." />
 
   <Card href="/docs/guides/frameworks/bun" title="Bun bundler / fullstack" description="@arkenv/bun-plugin for Bun bundler and fullstack apps that inline BUN_PUBLIC_ keys." />
+
+  <Card href="/docs/guides/ai" title="Coding agents" description="@arkenv/agent-plugin for slash commands and MCP. Skill-only hosts still use npx skills add." />
 </Cards>
 
 ## Install pattern
 
-Install a validation package (`@arkenv/core` + `arktype`, or `@arkenv/standard`) alongside the framework package:
+For Next.js, Nuxt, Vite, and Bun, install a validation package
+(`@arkenv/core` + `arktype`, or `@arkenv/standard`) alongside the host
+adapter:
 
 ```package-install
 # Next.js example
@@ -39,14 +49,21 @@ Scaffold with the CLI when you want files generated for you:
 npx arkenv@latest init
 ```
 
+Coding agents install `@arkenv/agent-plugin` through the plugin and MCP
+commands on the [AI guide](/docs/guides/ai). That package is not a
+validation adapter and has no `/standard` entry. See the
+[`@arkenv/agent-plugin` reference](/docs/reference/agent-plugin) for
+handshake details.
+
 ## What each integration adds
 
-| Host    | Package               | Boundary mechanism                                                               |
-| ------- | --------------------- | -------------------------------------------------------------------------------- |
-| Next.js | `@arkenv/nextjs`      | `withArkEnv` codegen, `NEXT_PUBLIC_*`, runtime proxy, optional strict file split |
-| Nuxt    | `@arkenv/nuxt`        | Nuxt module, `NUXT_PUBLIC_*`, client/server entrypoints                          |
-| Vite    | `@arkenv/vite-plugin` | Dev/build validation; only `VITE_*` (and optional `NODE_ENV`) reach the client   |
-| Bun     | `@arkenv/bun-plugin`  | Bun bundler / fullstack inlining for `BUN_PUBLIC_*`                              |
+| Host          | Package                 | Boundary mechanism                                                               |
+| ------------- | ----------------------- | -------------------------------------------------------------------------------- |
+| Next.js       | `@arkenv/nextjs`        | `withArkEnv` codegen, `NEXT_PUBLIC_*`, runtime proxy, optional strict file split |
+| Nuxt          | `@arkenv/nuxt`          | Nuxt module, `NUXT_PUBLIC_*`, client/server entrypoints                          |
+| Vite          | `@arkenv/vite-plugin`   | Dev/build validation; only `VITE_*` (and optional `NODE_ENV`) reach the client   |
+| Bun           | `@arkenv/bun-plugin`    | Bun bundler / fullstack inlining for `BUN_PUBLIC_*`                              |
+| Coding agents | `@arkenv/agent-plugin`  | Slash commands and MCP; audits source, does not validate at boot                 |
 
 Plain Node or Bun **as a runtime** (no browser bundle) can stay on `@arkenv/core` alone. The Bun plugin targets apps that ship client code through Bun's bundler or fullstack server, not Bun-as-Node replacements or Bun-as-package-manager.
 
@@ -108,4 +125,6 @@ validates them.
   <Card href="/docs/validating-your-environment/hosting-presets" title="Hosting presets" description="Pre-populate schemas with provider system environment variables." />
 
   <Card href="/docs/guides/frameworks" title="Framework guides" description="Step-by-step recipes for Next.js, Nuxt, Vite, and Bun." />
+
+  <Card href="/docs/guides/ai" title="Using AI with ArkEnv" description="Install the coding-agent plugin, MCP server, or skill." />
 </Cards>

--- a/apps/www/content/docs/validating-your-environment/framework-integration.mdx
+++ b/apps/www/content/docs/validating-your-environment/framework-integration.mdx
@@ -55,13 +55,13 @@ handshake details.
 
 ## What each integration adds
 
-| Host          | Package                 | Boundary mechanism                                                               |
-| ------------- | ----------------------- | -------------------------------------------------------------------------------- |
-| Next.js       | `@arkenv/nextjs`        | `withArkEnv` codegen, `NEXT_PUBLIC_*`, runtime proxy, optional strict file split |
-| Nuxt          | `@arkenv/nuxt`          | Nuxt module, `NUXT_PUBLIC_*`, client/server entrypoints                          |
-| Vite          | `@arkenv/vite-plugin`   | Dev/build validation; only `VITE_*` (and optional `NODE_ENV`) reach the client   |
-| Bun           | `@arkenv/bun-plugin`    | Bun bundler / fullstack inlining for `BUN_PUBLIC_*`                              |
-| Coding agents | `@arkenv/agent-plugin`  | Slash commands and MCP; audits source, does not validate at boot                 |
+| Host          | Package                | Boundary mechanism                                                               |
+| ------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Next.js       | `@arkenv/nextjs`       | `withArkEnv` codegen, `NEXT_PUBLIC_*`, runtime proxy, optional strict file split |
+| Nuxt          | `@arkenv/nuxt`         | Nuxt module, `NUXT_PUBLIC_*`, client/server entrypoints                          |
+| Vite          | `@arkenv/vite-plugin`  | Dev/build validation; only `VITE_*` (and optional `NODE_ENV`) reach the client   |
+| Bun           | `@arkenv/bun-plugin`   | Bun bundler / fullstack inlining for `BUN_PUBLIC_*`                              |
+| Coding agents | `@arkenv/agent-plugin` | Slash commands and MCP; audits source, does not validate at boot                 |
 
 Plain Node or Bun **as a runtime** (no browser bundle) can stay on `@arkenv/core` alone. The Bun plugin targets apps that ship client code through Bun's bundler or fullstack server, not Bun-as-Node replacements or Bun-as-package-manager.
 

--- a/apps/www/content/docs/validating-your-environment/index.mdx
+++ b/apps/www/content/docs/validating-your-environment/index.mdx
@@ -17,7 +17,7 @@ clear client/server split.
 <Callout type="info">
   ArkEnv validates and types your environment. Loading `.env` files is still
   your runtime or framework's job. See
-  [Framework integration](/docs/validating-your-environment/framework-integration).
+  [Integrations](/docs/validating-your-environment/framework-integration).
 </Callout>
 
 ## From schema to `env`
@@ -37,7 +37,7 @@ Start here if you're writing a schema for the first time.
 
   <Card href="/docs/validating-your-environment/reusing-schemas" title="6. Reusing schemas" description="Share one schema across runtimes and packages." />
 
-  <Card href="/docs/validating-your-environment/framework-integration" title="7. Framework integration" description="Wire ArkEnv into Next.js, Nuxt, Vite, or Bun." />
+  <Card href="/docs/validating-your-environment/framework-integration" title="7. Integrations" description="Wire ArkEnv into Next.js, Nuxt, Vite, Bun, or coding agents." />
 
   <Card href="/docs/validating-your-environment/hosting-presets" title="8. Hosting presets" description="Add Vercel, Netlify, Cloudflare, and other provider vars." />
 </Cards>

--- a/apps/www/content/docs/validating-your-environment/reusing-schemas.mdx
+++ b/apps/www/content/docs/validating-your-environment/reusing-schemas.mdx
@@ -155,7 +155,7 @@ Each app still owns its `env` export. Shared packages export schemas, not a proc
 ## Next steps
 
 <Cards>
-  <Card href="/docs/validating-your-environment/framework-integration" title="Framework integration" description="Connect ArkEnv to Next.js, Nuxt, Vite, or Bun." />
+  <Card href="/docs/validating-your-environment/framework-integration" title="Integrations" description="Connect ArkEnv to Next.js, Nuxt, Vite, Bun, or coding agents." />
 
   <Card href="/docs/validating-your-environment/hosting-presets" title="Hosting presets" description="Pre-populate provider environment variables for Vercel, Netlify, and Cloudflare." />
 </Cards>

--- a/apps/www/lib/docs-legacy-links.test.ts
+++ b/apps/www/lib/docs-legacy-links.test.ts
@@ -21,7 +21,7 @@ const SKIP_DIR_NAMES = new Set([
 function walk(dir: string): string[] {
 	const out: string[] = [];
 	for (const name of readdirSync(dir)) {
-		if (SKIP_DIR_NAMES.has(name)) continue;
+		if (SKIP_DIR_NAMES.has(name) || name.startsWith(".")) continue;
 		const path = join(dir, name);
 		const stat = statSync(path);
 		if (stat.isDirectory()) {

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -183,6 +183,7 @@ A scroll-driven increase in **Glass material** opacity/blur so content sliding u
   - `@arkenv/nextjs` - Next.js integration package
   - `@arkenv/nuxt` - Nuxt integration package
   - `arkenv` - Interactive CLI for scaffolding and project mutation
+  - `@arkenv/agent-plugin` - Coding-agent plugin and MCP server (`init`, `audit`)
 - **Apps** (`apps/`) - Applications and testing suites (not published)
   - `www` - Next.js documentation site
   - `playgrounds/*` - Test playgrounds for different runtimes

--- a/marketplace.json
+++ b/marketplace.json
@@ -12,7 +12,7 @@
 			"name": "arkenv",
 			"source": "./packages/agent-plugin",
 			"description": "Canonical env object, init, and AST security audits for environment variables.",
-			"version": "1.0.0-alpha.0",
+			"version": "0.0.0",
 			"keywords": ["arkenv", "environment-variables", "mcp", "audit"]
 		}
 	]

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,19 @@
+{
+	"name": "arkenv",
+	"owner": {
+		"name": "Yam Borodetsky",
+		"url": "https://yam.codes"
+	},
+	"metadata": {
+		"description": "ArkEnv coding-agent plugins"
+	},
+	"plugins": [
+		{
+			"name": "arkenv",
+			"source": "./packages/agent-plugin",
+			"description": "Canonical env object, init, and AST security audits for environment variables.",
+			"version": "1.0.0-alpha.0",
+			"keywords": ["arkenv", "environment-variables", "mcp", "audit"]
+		}
+	]
+}

--- a/packages/README.md
+++ b/packages/README.md
@@ -16,19 +16,19 @@ The `packages/` directory is the home for code modules that are shared across th
 
 ## Package directory
 
-| Directory                      | Package Name          | Type    | Description                                                                   |
-| :----------------------------- | :-------------------- | :------ | :---------------------------------------------------------------------------- |
-| [`core`](./core)               | `@arkenv/core`        | Public  | Core typesafe environment variable parser using ArkType.                      |
-| [`standard`](./standard)       | `@arkenv/standard`    | Public  | Dependency-free, typesafe environment variable parser using Standard Schema.  |
-| [`arkenv`](./arkenv)           | `arkenv`              | Public  | Scaffolding CLI tool (run via `npx arkenv` or installed as a dev dependency). |
-| [`vite-plugin`](./vite-plugin) | `@arkenv/vite-plugin` | Public  | Vite integration for build-time validation.                                   |
-| [`nextjs`](./nextjs)           | `@arkenv/nextjs`      | Public  | Next.js integration with automatic runtimeEnv code generation.                |
-| [`bun-plugin`](./bun-plugin)   | `@arkenv/bun-plugin`  | Public  | Bun integration for static env variable inlining.                             |
-| [`nuxt`](./nuxt)               | `@arkenv/nuxt`        | Public  | Nuxt integration for environment variable validation and injection.           |
-| [`fumadocs-ui`](./fumadocs-ui) | `@arkenv/fumadocs-ui` | Public  | Fumadocs UI components and utilities.                                         |
-| [`build`](./build)             | `@arkenv/build`         | Public  | Shared build and codegen utilities for framework plugins.                     |
+| Directory                        | Package Name           | Type    | Description                                                                   |
+| :------------------------------- | :--------------------- | :------ | :---------------------------------------------------------------------------- |
+| [`core`](./core)                 | `@arkenv/core`         | Public  | Core typesafe environment variable parser using ArkType.                      |
+| [`standard`](./standard)         | `@arkenv/standard`     | Public  | Dependency-free, typesafe environment variable parser using Standard Schema.  |
+| [`arkenv`](./arkenv)             | `arkenv`               | Public  | Scaffolding CLI tool (run via `npx arkenv` or installed as a dev dependency). |
+| [`vite-plugin`](./vite-plugin)   | `@arkenv/vite-plugin`  | Public  | Vite integration for build-time validation.                                   |
+| [`nextjs`](./nextjs)             | `@arkenv/nextjs`       | Public  | Next.js integration with automatic runtimeEnv code generation.                |
+| [`bun-plugin`](./bun-plugin)     | `@arkenv/bun-plugin`   | Public  | Bun integration for static env variable inlining.                             |
+| [`nuxt`](./nuxt)                 | `@arkenv/nuxt`         | Public  | Nuxt integration for environment variable validation and injection.           |
+| [`fumadocs-ui`](./fumadocs-ui)   | `@arkenv/fumadocs-ui`  | Public  | Fumadocs UI components and utilities.                                         |
+| [`build`](./build)               | `@arkenv/build`        | Public  | Shared build and codegen utilities for framework plugins.                     |
 | [`agent-plugin`](./agent-plugin) | `@arkenv/agent-plugin` | Public  | Coding-agent plugin and MCP server (`init`, `audit`).                         |
-| [`internal/`](./internal)      | `@repo/*`               | Private | Shared internal modules (types, scopes, keywords) used for building.          |
+| [`internal/`](./internal)        | `@repo/*`              | Private | Shared internal modules (types, scopes, keywords) used for building.          |
 
 ## Versioning & releases
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -26,8 +26,9 @@ The `packages/` directory is the home for code modules that are shared across th
 | [`bun-plugin`](./bun-plugin)   | `@arkenv/bun-plugin`  | Public  | Bun integration for static env variable inlining.                             |
 | [`nuxt`](./nuxt)               | `@arkenv/nuxt`        | Public  | Nuxt integration for environment variable validation and injection.           |
 | [`fumadocs-ui`](./fumadocs-ui) | `@arkenv/fumadocs-ui` | Public  | Fumadocs UI components and utilities.                                         |
-| [`build`](./build)             | `@arkenv/build`       | Public  | Shared build and codegen utilities for framework plugins.                     |
-| [`internal/`](./internal)      | `@repo/*`             | Private | Shared internal modules (types, scopes, keywords) used for building.          |
+| [`build`](./build)             | `@arkenv/build`         | Public  | Shared build and codegen utilities for framework plugins.                     |
+| [`agent-plugin`](./agent-plugin) | `@arkenv/agent-plugin` | Public  | Coding-agent plugin and MCP server (`init`, `audit`).                         |
+| [`internal/`](./internal)      | `@repo/*`               | Private | Shared internal modules (types, scopes, keywords) used for building.          |
 
 ## Versioning & releases
 

--- a/packages/agent-plugin/.claude-plugin/plugin.json
+++ b/packages/agent-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "arkenv",
-	"version": "1.0.0-alpha.0",
+	"version": "0.0.0",
 	"description": "ArkEnv coding-agent plugin: canonical env object, init, and AST security audits.",
 	"author": {
 		"name": "Yam Borodetsky",

--- a/packages/agent-plugin/.claude-plugin/plugin.json
+++ b/packages/agent-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+	"name": "arkenv",
+	"version": "1.0.0-alpha.0",
+	"description": "ArkEnv coding-agent plugin: canonical env object, init, and AST security audits.",
+	"author": {
+		"name": "Yam Borodetsky",
+		"url": "https://yam.codes"
+	}
+}

--- a/packages/agent-plugin/.cursor-plugin/plugin.json
+++ b/packages/agent-plugin/.cursor-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+	"name": "arkenv",
+	"version": "1.0.0-alpha.0",
+	"description": "ArkEnv coding-agent plugin: canonical env object, init, and AST security audits."
+}

--- a/packages/agent-plugin/.cursor-plugin/plugin.json
+++ b/packages/agent-plugin/.cursor-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
 	"name": "arkenv",
-	"version": "1.0.0-alpha.0",
+	"version": "0.0.0",
 	"description": "ArkEnv coding-agent plugin: canonical env object, init, and AST security audits."
 }

--- a/packages/agent-plugin/.mcp.json
+++ b/packages/agent-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+	"mcpServers": {
+		"arkenv": {
+			"command": "npx",
+			"args": ["-y", "@arkenv/agent-plugin"]
+		}
+	}
+}

--- a/packages/agent-plugin/.mcp.json
+++ b/packages/agent-plugin/.mcp.json
@@ -2,7 +2,7 @@
 	"mcpServers": {
 		"arkenv": {
 			"command": "npx",
-			"args": ["-y", "@arkenv/agent-plugin"]
+			"args": ["-y", "@arkenv/agent-plugin@alpha"]
 		}
 	}
 }

--- a/packages/agent-plugin/.plugin/plugin.json
+++ b/packages/agent-plugin/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "arkenv",
-	"version": "1.0.0-alpha.0",
+	"version": "0.0.0",
 	"description": "ArkEnv coding-agent plugin: canonical env object, init, and AST security audits.",
 	"author": {
 		"name": "Yam Borodetsky",

--- a/packages/agent-plugin/.plugin/plugin.json
+++ b/packages/agent-plugin/.plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+	"name": "arkenv",
+	"version": "1.0.0-alpha.0",
+	"description": "ArkEnv coding-agent plugin: canonical env object, init, and AST security audits.",
+	"author": {
+		"name": "Yam Borodetsky",
+		"url": "https://yam.codes"
+	},
+	"repository": "https://github.com/yamcodes/arkenv",
+	"homepage": "https://arkenv.js.org/docs/guides/ai",
+	"license": "MIT",
+	"keywords": ["arkenv", "environment-variables", "mcp", "audit"]
+}

--- a/packages/agent-plugin/CHANGELOG.md
+++ b/packages/agent-plugin/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @arkenv/agent-plugin

--- a/packages/agent-plugin/README.md
+++ b/packages/agent-plugin/README.md
@@ -1,0 +1,41 @@
+# @arkenv/agent-plugin
+
+Coding-agent plugin and MCP server for ArkEnv. It teaches assistants to use
+`import { env } from "./env"` and actively flags raw `process.env` /
+`import.meta.env` access, client-side secret leaks, public-prefix mistakes,
+and leftover v0 ambient `.d.ts` augmentations.
+
+## Install the plugin
+
+```bash
+npx plugins add arkenv/arkenv-plugin
+```
+
+Compatible agent runtimes expose `/arkenv:init` and `/arkenv:audit`.
+
+Until that GitHub shorthand is published, install from this monorepo:
+
+```bash
+npx plugins add yamcodes/arkenv
+```
+
+The plugin lives in `packages/agent-plugin` (discovered by a two-level scan).
+
+## MCP server
+
+```bash
+npx -y @arkenv/agent-plugin
+```
+
+Stdio MCP tools:
+
+- **`init`** — runs `arkenv init --agent` in `cwd`
+- **`audit`** — AST scan; returns `{ diagnostics: [{ file, line, character, severity, ruleId, message, suggestedFix }] }`
+
+## Programmatic audit
+
+```ts
+import { auditProject } from "@arkenv/agent-plugin";
+
+const { diagnostics } = await auditProject(process.cwd());
+```

--- a/packages/agent-plugin/README.md
+++ b/packages/agent-plugin/README.md
@@ -7,24 +7,35 @@ and leftover v0 ambient `.d.ts` augmentations.
 
 ## Install the plugin
 
-```bash
-npx plugins add arkenv/arkenv-plugin
-```
-
-Compatible agent runtimes expose `/arkenv:init` and `/arkenv:audit`.
-
-Until that GitHub shorthand is published, install from this monorepo:
+The monorepo lists this package in the root `marketplace.json`, so the plugins
+CLI installs `packages/agent-plugin` instead of treating the repo root's
+`skills/` tree as a plugin:
 
 ```bash
 npx plugins add yamcodes/arkenv
 ```
 
-The plugin lives in `packages/agent-plugin` (discovered by a two-level scan).
+From a local clone:
+
+```bash
+npx plugins add ./packages/agent-plugin
+```
+
+Compatible agent runtimes expose `/arkenv:init` and `/arkenv:audit`.
 
 ## MCP server
 
+After this package is published (alpha tag):
+
 ```bash
-npx -y @arkenv/agent-plugin
+npx -y @arkenv/agent-plugin@alpha
+```
+
+From a local clone, build first and point MCP at the bin:
+
+```bash
+pnpm --filter @arkenv/agent-plugin build
+node ./packages/agent-plugin/dist/bin.js
 ```
 
 Stdio MCP tools:

--- a/packages/agent-plugin/commands/audit.md
+++ b/packages/agent-plugin/commands/audit.md
@@ -1,0 +1,14 @@
+---
+description: Audit the repo for unvalidated env access and secret leaks.
+---
+
+Run an ArkEnv security audit of the current project.
+
+1. Prefer the MCP `audit` tool with `cwd` set to the project root. If MCP is unavailable, still prefer calling `audit` via MCP once the server is running (`npx -y @arkenv/agent-plugin`) rather than grepping.
+2. Treat each diagnostic as actionable: `file`, `line`, `character`, `severity`, `ruleId`, `message`, `suggestedFix`.
+3. Fix `unvalidated-access` by routing reads through `import { env } from "./env"`.
+4. Fix `secret-leak` by moving server keys off `"use client"` modules and client file trees.
+5. Fix `prefix-violation` by removing public prefixes (`NEXT_PUBLIC_`, `NUXT_PUBLIC_`, `VITE_`, `BUN_PUBLIC_`) from secret names.
+6. Fix `legacy-ambient` by deleting v0 `ProcessEnv` / `ImportMetaEnv` augmentations.
+
+Do not flag valid `import { env } from "./env"` usage. Do not rewrite the canonical env module's own schema definition into raw `process.env` reads.

--- a/packages/agent-plugin/commands/init.md
+++ b/packages/agent-plugin/commands/init.md
@@ -1,0 +1,12 @@
+---
+description: Scaffold ArkEnv with the CLI in agent mode.
+---
+
+Scaffold ArkEnv in the current project.
+
+1. Prefer the MCP `init` tool. If MCP is unavailable, run `npx arkenv@latest init --agent` in the project root.
+2. Parse JSON on stdout. Success is `"status": "success"`.
+3. On `"status": "error"`, branch on `code` and only retry with flags listed in `retryWith`. Never pass `--force` unless the user accepts that refusal.
+4. Do not hand-write `env.ts`, `env/client.ts`, or framework config unless init fails.
+
+After init, the only application surface is `import { env } from "./env"` (or `env/client.ts` / `env/server.ts` in strict layout). Do not read `process.env` or `import.meta.env` in application code. Do not add ambient `ProcessEnv` / `ImportMetaEnv` `.d.ts` augmentations.

--- a/packages/agent-plugin/package.json
+++ b/packages/agent-plugin/package.json
@@ -1,0 +1,67 @@
+{
+	"name": "@arkenv/agent-plugin",
+	"type": "module",
+	"version": "1.0.0-alpha.0",
+	"description": "ArkEnv coding-agent plugin with MCP tools for init and AST-based env audits",
+	"bin": {
+		"arkenv-agent-plugin": "./dist/bin.js"
+	},
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist",
+		"commands",
+		"skills",
+		".plugin",
+		".claude-plugin",
+		".cursor-plugin",
+		".mcp.json"
+	],
+	"scripts": {
+		"build": "tsdown",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest",
+		"test:run": "vitest run",
+		"clean": "rimraf dist node_modules",
+		"fix": "pnpm -w run fix"
+	},
+	"keywords": [
+		"arkenv",
+		"mcp",
+		"agent",
+		"plugin",
+		"environment-variables",
+		"audit",
+		"cli"
+	],
+	"license": "MIT",
+	"homepage": "https://arkenv.js.org/docs/guides/ai",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/yamcodes/arkenv.git",
+		"directory": "packages/agent-plugin"
+	},
+	"bugs": "https://github.com/yamcodes/arkenv/labels/skills",
+	"author": "Yam Borodetsky <yam@yam.codes>",
+	"publishConfig": {
+		"access": "public"
+	},
+	"dependencies": {
+		"@modelcontextprotocol/sdk": "^1.27.1",
+		"typescript": "catalog:"
+	},
+	"devDependencies": {
+		"@types/node": "catalog:",
+		"rimraf": "catalog:",
+		"tsdown": "catalog:",
+		"vitest": "catalog:"
+	}
+}

--- a/packages/agent-plugin/package.json
+++ b/packages/agent-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@arkenv/agent-plugin",
 	"type": "module",
-	"version": "1.0.0-alpha.0",
+	"version": "0.0.0",
 	"description": "ArkEnv coding-agent plugin with MCP tools for init and AST-based env audits",
 	"bin": {
 		"arkenv-agent-plugin": "./dist/bin.js"

--- a/packages/agent-plugin/skills/arkenv/SKILL.md
+++ b/packages/agent-plugin/skills/arkenv/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: arkenv
+description: "Use when setting up or changing environment variable validation with ArkEnv, or when application code reads process.env / import.meta.env. Enforce import { env } from \"./env\"."
+---
+
+# ArkEnv
+
+ArkEnv v1's only application surface is `import { env } from "./env"` (strict layout: `env/client.ts` and `env/server.ts`).
+
+- Runtime: `@arkenv/core` (ArkType) or `@arkenv/standard` (Zod, Valibot, Standard Schema).
+- CLI: `npx arkenv@latest init --agent`. Parse JSON on stdout. Never pass `--force` unless `retryWith` lists it after a refusal.
+- Do not read `process.env` or `import.meta.env` in application components.
+- Do not add ambient `.d.ts` `ProcessEnv` / `ImportMetaEnv` augmentations.
+- Public prefixes: `NEXT_PUBLIC_`, `NUXT_PUBLIC_`, `VITE_`, `BUN_PUBLIC_`. Never put secrets behind those prefixes.
+- Prefer MCP tools `init` and `audit` from this plugin (`/arkenv:init`, `/arkenv:audit`).

--- a/packages/agent-plugin/src/audit/rules.test.ts
+++ b/packages/agent-plugin/src/audit/rules.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+	hasPublicPrefix,
+	isClientFile,
+	isEnvModule,
+	isPrefixViolation,
+	looksLikeSecret,
+} from "./rules";
+
+describe("rules", () => {
+	it("classifies env modules", () => {
+		expect(isEnvModule("src/env.ts")).toBe(true);
+		expect(isEnvModule("env/client.ts")).toBe(true);
+		expect(isEnvModule("env/server.ts")).toBe(true);
+		expect(isEnvModule("env/internal/shared.ts")).toBe(true);
+		expect(isEnvModule("src/app.ts")).toBe(false);
+	});
+
+	it("detects client files", () => {
+		expect(isClientFile("header.tsx", `"use client";\nexport {}\n`)).toBe(true);
+		expect(isClientFile("widget.client.ts", "export {}\n")).toBe(true);
+		expect(isClientFile("server.ts", "export {}\n")).toBe(false);
+	});
+
+	it("detects public prefixes and secrets", () => {
+		expect(hasPublicPrefix("NEXT_PUBLIC_SITE_URL")).toBe(true);
+		expect(hasPublicPrefix("DATABASE_URL")).toBe(false);
+		expect(looksLikeSecret("DATABASE_URL")).toBe(true);
+		expect(looksLikeSecret("STRIPE_SECRET")).toBe(true);
+		expect(isPrefixViolation("NEXT_PUBLIC_DATABASE_URL")).toBe(true);
+		expect(isPrefixViolation("VITE_STRIPE_SECRET")).toBe(true);
+		expect(isPrefixViolation("NEXT_PUBLIC_SITE_URL")).toBe(false);
+	});
+});

--- a/packages/agent-plugin/src/audit/rules.ts
+++ b/packages/agent-plugin/src/audit/rules.ts
@@ -1,0 +1,133 @@
+export const PUBLIC_PREFIXES = [
+	"NEXT_PUBLIC_",
+	"NUXT_PUBLIC_",
+	"VITE_",
+	"BUN_PUBLIC_",
+] as const;
+
+const SECRET_NAME =
+	/(SECRET|TOKEN|PASSWORD|PRIVATE|CREDENTIAL|API_KEY)$|^(DATABASE_URL|REDIS_URL|DIRECT_URL|SHADOW_DATABASE_URL)$/i;
+
+const SKIP_DIR_NAMES = new Set([
+	"node_modules",
+	"dist",
+	".git",
+	"coverage",
+	".next",
+	".nuxt",
+	".output",
+	".turbo",
+	".source",
+	".vercel",
+	".cache",
+]);
+
+const SOURCE_EXT = /\.(?:[cm]?[jt]sx?|d\.ts)$/;
+
+/**
+ * Return whether `key` uses a framework public env prefix.
+ *
+ * @param key Environment variable name
+ * @returns True when the key is client-safe by prefix
+ */
+export function hasPublicPrefix(key: string): boolean {
+	return PUBLIC_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+/**
+ * Return whether `key` looks like a secret or server-only credential.
+ *
+ * @param key Environment variable name
+ * @returns True when the name matches secret heuristics
+ */
+export function looksLikeSecret(key: string): boolean {
+	return SECRET_NAME.test(key);
+}
+
+/**
+ * Return whether a public-prefixed key is a misplaced secret.
+ *
+ * @param key Environment variable name
+ * @returns True when a public prefix wraps a secret-looking name
+ */
+export function isPrefixViolation(key: string): boolean {
+	if (!hasPublicPrefix(key)) return false;
+	const stripped = PUBLIC_PREFIXES.reduce(
+		(name, prefix) =>
+			name.startsWith(prefix) ? name.slice(prefix.length) : name,
+		key,
+	);
+	return looksLikeSecret(stripped) || looksLikeSecret(key);
+}
+
+/**
+ * Return whether `filePath` is a canonical ArkEnv env module.
+ *
+ * @param filePath Absolute or repo-relative path
+ * @returns True for `env.ts` and strict-layout env files
+ */
+export function isEnvModule(filePath: string): boolean {
+	const normalized = filePath.replace(/\\/g, "/");
+	return (
+		/(?:^|\/)env\.(?:[cm]?[jt]sx?)$/.test(normalized) ||
+		/(?:^|\/)env\/(?:client|server|internal\/shared)\.(?:[cm]?[jt]sx?)$/.test(
+			normalized,
+		)
+	);
+}
+
+/**
+ * Return whether a directory name should be skipped while walking a project.
+ *
+ * @param name Directory basename
+ * @returns True when the directory is a build or vendor folder
+ */
+export function shouldSkipDir(name: string): boolean {
+	return SKIP_DIR_NAMES.has(name);
+}
+
+/**
+ * Return whether a file is a TypeScript or JavaScript source we should parse.
+ *
+ * @param filePath File path
+ * @returns True for JS/TS sources including declaration files
+ */
+export function isSourceFile(filePath: string): boolean {
+	return SOURCE_EXT.test(filePath.replace(/\\/g, "/"));
+}
+
+/**
+ * Return whether a file is treated as a client bundle (secret-leak surface).
+ *
+ * @param filePath File path
+ * @param source File contents
+ * @returns True for `"use client"` modules and `*.client.*` files
+ */
+export function isClientFile(filePath: string, source: string): boolean {
+	const normalized = filePath.replace(/\\/g, "/");
+	if (/(?:^|\/)[^/]+\.client\.(?:[cm]?[jt]sx?)$/.test(normalized)) {
+		return true;
+	}
+	const head = source.slice(0, 256).trimStart();
+	return (
+		head.startsWith('"use client"') ||
+		head.startsWith("'use client'") ||
+		head.startsWith("`use client`")
+	);
+}
+
+/**
+ * Return whether source still uses v0 ambient ProcessEnv / ImportMetaEnv
+ * augmentations.
+ *
+ * @param source File contents
+ * @returns True when a legacy ambient pattern is present
+ */
+export function hasLegacyAmbient(source: string): boolean {
+	return (
+		/ProcessEnvAugmented/.test(source) ||
+		/ImportMetaEnvAugmented/.test(source) ||
+		/interface\s+ProcessEnv\b/.test(source) ||
+		/interface\s+ImportMetaEnv\b/.test(source)
+	);
+}

--- a/packages/agent-plugin/src/audit/scan.test.ts
+++ b/packages/agent-plugin/src/audit/scan.test.ts
@@ -1,0 +1,154 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { auditProject, auditSource } from "./scan";
+
+const ROOT = "/repo";
+
+describe("auditSource", () => {
+	it("flags raw process.env access outside the env module", () => {
+		const diagnostics = auditSource(
+			ROOT,
+			path.join(ROOT, "src/app.ts"),
+			"export const url = process.env.DATABASE_URL;\n",
+		);
+		expect(diagnostics.some((d) => d.ruleId === "unvalidated-access")).toBe(
+			true,
+		);
+		const hit = diagnostics.find((d) => d.ruleId === "unvalidated-access");
+		expect(hit?.file).toBe(path.join("src", "app.ts"));
+		expect(hit?.line).toBe(1);
+		expect(hit?.suggestedFix).toContain("env.DATABASE_URL");
+	});
+
+	it("flags import.meta.env access outside the env module", () => {
+		const diagnostics = auditSource(
+			ROOT,
+			path.join(ROOT, "src/main.ts"),
+			"export const url = import.meta.env.VITE_API_URL;\n",
+		);
+		expect(diagnostics.some((d) => d.ruleId === "unvalidated-access")).toBe(
+			true,
+		);
+	});
+
+	it("does not flag process.env inside the canonical env module", () => {
+		const diagnostics = auditSource(
+			ROOT,
+			path.join(ROOT, "src/env.ts"),
+			`import arkenv from "@arkenv/core";
+export const env = arkenv({
+  DATABASE_URL: "string",
+});
+void process.env.DATABASE_URL;
+`,
+		);
+		expect(
+			diagnostics.filter((d) => d.ruleId === "unvalidated-access"),
+		).toEqual([]);
+	});
+
+	it('does not flag valid import { env } from "./env" on the server', () => {
+		const diagnostics = auditSource(
+			ROOT,
+			path.join(ROOT, "src/server.ts"),
+			`import { env } from "./env";
+export const url = env.DATABASE_URL;
+`,
+		);
+		expect(diagnostics).toEqual([]);
+	});
+
+	it("flags server secrets accessed in client components", () => {
+		const diagnostics = auditSource(
+			ROOT,
+			path.join(ROOT, "app/components/header.tsx"),
+			`"use client";
+import { env } from "./env";
+export function Header() {
+  return env.DATABASE_URL;
+}
+`,
+		);
+		expect(diagnostics.some((d) => d.ruleId === "secret-leak")).toBe(true);
+		expect(
+			diagnostics.find((d) => d.ruleId === "secret-leak")?.message,
+		).toContain("DATABASE_URL");
+	});
+
+	it("does not flag public-prefixed keys in client components", () => {
+		const diagnostics = auditSource(
+			ROOT,
+			path.join(ROOT, "app/components/banner.tsx"),
+			`"use client";
+import { env } from "./env";
+export function Banner() {
+  return env.NEXT_PUBLIC_SITE_URL;
+}
+`,
+		);
+		expect(diagnostics.filter((d) => d.ruleId === "secret-leak")).toEqual([]);
+		expect(
+			diagnostics.filter((d) => d.ruleId === "unvalidated-access"),
+		).toEqual([]);
+	});
+
+	it("flags public prefixes on secret-looking keys", () => {
+		const diagnostics = auditSource(
+			ROOT,
+			path.join(ROOT, "src/lib.ts"),
+			"export const leaked = process.env.NEXT_PUBLIC_DATABASE_URL;\n",
+		);
+		expect(diagnostics.some((d) => d.ruleId === "prefix-violation")).toBe(true);
+	});
+
+	it("flags public prefixes on secret-looking keys in env schemas", () => {
+		const diagnostics = auditSource(
+			ROOT,
+			path.join(ROOT, "src/env.ts"),
+			`export const env = arkenv({
+  NEXT_PUBLIC_DATABASE_URL: "string",
+});
+`,
+		);
+		expect(diagnostics.some((d) => d.ruleId === "prefix-violation")).toBe(true);
+	});
+
+	it("flags leftover v0 ambient ProcessEnv augmentations", () => {
+		const diagnostics = auditSource(
+			ROOT,
+			path.join(ROOT, "src/env.d.ts"),
+			`type ProcessEnvAugmented = import("@arkenv/nextjs").ProcessEnvAugmented<typeof import("./env").env>;
+declare namespace NodeJS {
+  interface ProcessEnv extends ProcessEnvAugmented {}
+}
+`,
+		);
+		expect(diagnostics.some((d) => d.ruleId === "legacy-ambient")).toBe(true);
+	});
+});
+
+describe("auditProject", () => {
+	it("walks a temp tree and reports process.env bypasses", async () => {
+		const dir = await mkdtemp(path.join(tmpdir(), "arkenv-audit-"));
+		await mkdir(path.join(dir, "src"));
+		await writeFile(
+			path.join(dir, "src/env.ts"),
+			`export const env = { DATABASE_URL: "x" };\n`,
+		);
+		await writeFile(
+			path.join(dir, "src/app.ts"),
+			"export const url = process.env.DATABASE_URL;\n",
+		);
+		const report = await auditProject(dir);
+		expect(
+			report.diagnostics.some(
+				(d) => d.ruleId === "unvalidated-access" && d.file.includes("app.ts"),
+			),
+		).toBe(true);
+		expect(report.diagnostics.some((d) => d.file.includes("env.ts"))).toBe(
+			false,
+		);
+	});
+});

--- a/packages/agent-plugin/src/audit/scan.ts
+++ b/packages/agent-plugin/src/audit/scan.ts
@@ -1,0 +1,293 @@
+import path from "node:path";
+import ts from "typescript";
+import {
+	hasLegacyAmbient,
+	hasPublicPrefix,
+	isClientFile,
+	isEnvModule,
+	isPrefixViolation,
+} from "./rules";
+import type { AuditDiagnostic, AuditReport } from "./types";
+import { collectSourceFiles } from "./walk";
+
+/**
+ * Audit a project tree for unvalidated env access, secret leaks, prefix
+ * violations, and leftover v0 ambient `.d.ts` augmentations.
+ *
+ * @param root Project root directory
+ * @returns Structured diagnostic report
+ */
+export async function auditProject(root: string): Promise<AuditReport> {
+	const files = await collectSourceFiles(root);
+	const diagnostics: AuditDiagnostic[] = [];
+	for (const file of files) {
+		diagnostics.push(...auditSource(root, file.filePath, file.source));
+	}
+	return { diagnostics };
+}
+
+/**
+ * Audit a single source string.
+ *
+ * @param root Project root used to relativize `file`
+ * @param filePath Absolute path of the file
+ * @param source File contents
+ * @returns Diagnostics for this file
+ */
+export function auditSource(
+	root: string,
+	filePath: string,
+	source: string,
+): AuditDiagnostic[] {
+	const relative = path.relative(root, filePath) || filePath;
+	const diagnostics: AuditDiagnostic[] = [];
+	const scriptKind = scriptKindFor(filePath);
+	const sf = ts.createSourceFile(
+		filePath,
+		source,
+		ts.ScriptTarget.Latest,
+		true,
+		scriptKind,
+	);
+	const envModule = isEnvModule(filePath);
+	const client = isClientFile(filePath, source);
+	const envImport = hasCanonicalEnvImport(sf);
+
+	if (hasLegacyAmbient(source)) {
+		const loc = locationOfLegacy(sf, source);
+		diagnostics.push({
+			file: relative,
+			line: loc.line,
+			character: loc.character,
+			severity: "error",
+			ruleId: "legacy-ambient",
+			message:
+				'Legacy ambient ProcessEnv / ImportMetaEnv augmentation. v1 uses `import { env } from "./env"` with no `.d.ts` glob.',
+			suggestedFix:
+				"Delete the ambient augmentation and import `{ env }` from the canonical env module instead.",
+		});
+	}
+
+	const visit = (node: ts.Node, parent: ts.Node | undefined): void => {
+		if (envModule) {
+			const schemaKey = objectLiteralEnvKey(node);
+			if (schemaKey && isPrefixViolation(schemaKey)) {
+				const { line, character } = sf.getLineAndCharacterOfPosition(
+					node.getStart(),
+				);
+				diagnostics.push({
+					file: relative,
+					line: line + 1,
+					character: character + 1,
+					severity: "error",
+					ruleId: "prefix-violation",
+					message: `Public prefix on secret-looking key '${schemaKey}'.`,
+					suggestedFix: `Rename '${schemaKey}' to a server-only key without NEXT_PUBLIC_, NUXT_PUBLIC_, VITE_, or BUN_PUBLIC_.`,
+				});
+			}
+		}
+
+		const envAccess = readEnvAccess(node, parent);
+		if (envAccess) {
+			const { key, via, pos } = envAccess;
+			const { line, character } = sf.getLineAndCharacterOfPosition(pos);
+			const loc = { line: line + 1, character: character + 1 };
+
+			if (key && isPrefixViolation(key)) {
+				diagnostics.push({
+					file: relative,
+					...loc,
+					severity: "error",
+					ruleId: "prefix-violation",
+					message: `Public prefix on secret-looking key '${key}'.`,
+					suggestedFix: `Move '${key}' to a server-only name without NEXT_PUBLIC_, NUXT_PUBLIC_, VITE_, or BUN_PUBLIC_, and keep it off the client schema.`,
+				});
+			}
+
+			if (via !== "env" && !envModule) {
+				diagnostics.push({
+					file: relative,
+					...loc,
+					severity: "error",
+					ruleId: "unvalidated-access",
+					message: `Unvalidated ${via} access${key ? ` of '${key}'` : ""}. Use the canonical env object.`,
+					suggestedFix: key
+						? `Replace with \`env.${key}\` after \`import { env } from "./env"\` (or env/client.ts / env/server.ts in strict layout).`
+						: 'Replace with `import { env } from "./env"` and read named keys from `env`.',
+				});
+			}
+
+			if (
+				client &&
+				key &&
+				!hasPublicPrefix(key) &&
+				!envModule &&
+				(via !== "env" || envImport)
+			) {
+				diagnostics.push({
+					file: relative,
+					...loc,
+					severity: "error",
+					ruleId: "secret-leak",
+					message: `Server-only key '${key}' referenced in a client module.`,
+					suggestedFix: `Keep '${key}' on the server entry. Expose a public-prefixed key if the client must read it.`,
+				});
+			}
+		}
+		ts.forEachChild(node, (child) => visit(child, node));
+	};
+
+	visit(sf, undefined);
+	return diagnostics;
+}
+
+type EnvVia = "process.env" | "import.meta.env" | "env";
+
+type EnvAccess = {
+	key: string | undefined;
+	via: EnvVia;
+	pos: number;
+};
+
+function objectLiteralEnvKey(node: ts.Node): string | undefined {
+	if (
+		!ts.isPropertyAssignment(node) &&
+		!ts.isShorthandPropertyAssignment(node)
+	) {
+		return undefined;
+	}
+	const name = node.name;
+	if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+		return name.text;
+	}
+	return undefined;
+}
+
+function isWrapperAccess(parent: ts.Node | undefined, node: ts.Node): boolean {
+	if (!parent) return false;
+	if (ts.isPropertyAccessExpression(parent) && parent.expression === node) {
+		return true;
+	}
+	if (ts.isElementAccessExpression(parent) && parent.expression === node) {
+		return true;
+	}
+	return false;
+}
+
+function readEnvAccess(
+	node: ts.Node,
+	parent: ts.Node | undefined,
+): EnvAccess | undefined {
+	if (ts.isPropertyAccessExpression(node)) {
+		if (isProcessEnvExpr(node.expression)) {
+			return {
+				key: node.name.text,
+				via: "process.env",
+				pos: node.getStart(),
+			};
+		}
+		if (isImportMetaEnvExpr(node.expression)) {
+			return {
+				key: node.name.text,
+				via: "import.meta.env",
+				pos: node.getStart(),
+			};
+		}
+		if (ts.isIdentifier(node.expression) && node.expression.text === "env") {
+			return { key: node.name.text, via: "env", pos: node.getStart() };
+		}
+	}
+
+	if (ts.isElementAccessExpression(node)) {
+		const key = stringLiteralKey(node.argumentExpression);
+		if (isProcessEnvExpr(node.expression)) {
+			return { key, via: "process.env", pos: node.getStart() };
+		}
+		if (isImportMetaEnvExpr(node.expression)) {
+			return { key, via: "import.meta.env", pos: node.getStart() };
+		}
+		if (ts.isIdentifier(node.expression) && node.expression.text === "env") {
+			return { key, via: "env", pos: node.getStart() };
+		}
+	}
+
+	if (isProcessEnvExpr(node) && !isWrapperAccess(parent, node)) {
+		return { key: undefined, via: "process.env", pos: node.getStart() };
+	}
+	if (isImportMetaEnvExpr(node) && !isWrapperAccess(parent, node)) {
+		return { key: undefined, via: "import.meta.env", pos: node.getStart() };
+	}
+
+	return undefined;
+}
+
+function isProcessEnvExpr(node: ts.Node): boolean {
+	return (
+		ts.isPropertyAccessExpression(node) &&
+		ts.isIdentifier(node.expression) &&
+		node.expression.text === "process" &&
+		node.name.text === "env"
+	);
+}
+
+function isImportMetaEnvExpr(node: ts.Node): boolean {
+	return (
+		ts.isPropertyAccessExpression(node) &&
+		ts.isMetaProperty(node.expression) &&
+		node.expression.keywordToken === ts.SyntaxKind.ImportKeyword &&
+		node.expression.name.text === "meta" &&
+		node.name.text === "env"
+	);
+}
+
+function stringLiteralKey(node: ts.Expression | undefined): string | undefined {
+	if (!node) return undefined;
+	if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+		return node.text;
+	}
+	return undefined;
+}
+
+function hasCanonicalEnvImport(sf: ts.SourceFile): boolean {
+	for (const stmt of sf.statements) {
+		if (!ts.isImportDeclaration(stmt) || !stmt.importClause) continue;
+		const spec = stmt.moduleSpecifier;
+		if (!ts.isStringLiteral(spec)) continue;
+		if (!/env(?:\/(?:client|server))?$/.test(spec.text.replace(/\\/g, "/"))) {
+			continue;
+		}
+		const named = stmt.importClause.namedBindings;
+		if (named && ts.isNamedImports(named)) {
+			if (named.elements.some((el) => el.name.text === "env")) return true;
+		}
+		if (stmt.importClause.name?.text === "env") return true;
+	}
+	return false;
+}
+
+function scriptKindFor(filePath: string): ts.ScriptKind {
+	if (filePath.endsWith(".tsx")) return ts.ScriptKind.TSX;
+	if (filePath.endsWith(".jsx")) return ts.ScriptKind.JSX;
+	if (
+		filePath.endsWith(".js") ||
+		filePath.endsWith(".mjs") ||
+		filePath.endsWith(".cjs")
+	) {
+		return ts.ScriptKind.JS;
+	}
+	return ts.ScriptKind.TS;
+}
+
+function locationOfLegacy(
+	sf: ts.SourceFile,
+	source: string,
+): { line: number; character: number } {
+	const idx = Math.max(
+		source.search(
+			/ProcessEnvAugmented|ImportMetaEnvAugmented|interface\s+ProcessEnv|interface\s+ImportMetaEnv/,
+		),
+		0,
+	);
+	const { line, character } = sf.getLineAndCharacterOfPosition(idx);
+	return { line: line + 1, character: character + 1 };
+}

--- a/packages/agent-plugin/src/audit/types.ts
+++ b/packages/agent-plugin/src/audit/types.ts
@@ -1,0 +1,31 @@
+export const RULE_IDS = [
+	"unvalidated-access",
+	"secret-leak",
+	"prefix-violation",
+	"legacy-ambient",
+] as const;
+
+export type RuleId = (typeof RULE_IDS)[number];
+
+export type DiagnosticSeverity = "error" | "warning";
+
+/**
+ * Structured diagnostic returned by the ArkEnv AST auditor and MCP `audit` tool.
+ */
+export type AuditDiagnostic = {
+	file: string;
+	line: number;
+	character: number;
+	severity: DiagnosticSeverity;
+	ruleId: RuleId;
+	message: string;
+	suggestedFix: string;
+};
+
+export type AuditReport = {
+	diagnostics: AuditDiagnostic[];
+};
+
+export type AuditOptions = {
+	root: string;
+};

--- a/packages/agent-plugin/src/audit/walk.ts
+++ b/packages/agent-plugin/src/audit/walk.ts
@@ -1,0 +1,35 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { isSourceFile, shouldSkipDir } from "./rules";
+
+export type ProjectFile = {
+	filePath: string;
+	source: string;
+};
+
+/**
+ * Recursively collect JS/TS source files under `root`.
+ *
+ * @param root Project directory
+ * @returns Source files with contents
+ */
+export async function collectSourceFiles(root: string): Promise<ProjectFile[]> {
+	const files: ProjectFile[] = [];
+	await walk(root, files);
+	return files;
+}
+
+async function walk(dir: string, files: ProjectFile[]): Promise<void> {
+	const entries = await readdir(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (shouldSkipDir(entry.name) || entry.name.startsWith(".")) continue;
+			await walk(full, files);
+			continue;
+		}
+		if (!isSourceFile(full)) continue;
+		const source = await readFile(full, "utf8");
+		files.push({ filePath: full, source });
+	}
+}

--- a/packages/agent-plugin/src/bin.ts
+++ b/packages/agent-plugin/src/bin.ts
@@ -1,4 +1,14 @@
 #!/usr/bin/env node
 import { startMcpServer } from "./mcp/server";
 
-await startMcpServer();
+/**
+ * Start the ArkEnv MCP server over stdio.
+ */
+function main(): void {
+	void startMcpServer().catch((error: unknown) => {
+		console.error(error);
+		process.exitCode = 1;
+	});
+}
+
+main();

--- a/packages/agent-plugin/src/bin.ts
+++ b/packages/agent-plugin/src/bin.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { startMcpServer } from "./mcp/server";
+
+await startMcpServer();

--- a/packages/agent-plugin/src/index.ts
+++ b/packages/agent-plugin/src/index.ts
@@ -1,0 +1,21 @@
+export {
+	hasPublicPrefix,
+	isClientFile,
+	isEnvModule,
+	isPrefixViolation,
+	looksLikeSecret,
+} from "./audit/rules";
+export { auditProject, auditSource } from "./audit/scan";
+export type {
+	AuditDiagnostic,
+	AuditReport,
+	RuleId,
+} from "./audit/types";
+export { initProject } from "./mcp/init";
+export { createMcpServer, startMcpServer } from "./mcp/server";
+export {
+	AUDIT_TOOL_NAME,
+	INIT_TOOL_NAME,
+	runAuditTool,
+	runInitTool,
+} from "./mcp/tools";

--- a/packages/agent-plugin/src/mcp/init.ts
+++ b/packages/agent-plugin/src/mcp/init.ts
@@ -1,0 +1,91 @@
+import { spawn } from "node:child_process";
+import { access } from "node:fs/promises";
+import path from "node:path";
+
+export type InitResult = {
+	status: "success" | "error";
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+	command: string;
+	args: string[];
+};
+
+export type SpawnFn = (
+	command: string,
+	args: string[],
+	options: { cwd: string },
+) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+
+/**
+ * Scaffold ArkEnv in `cwd` by delegating to `arkenv init --agent`.
+ *
+ * @param cwd Project directory
+ * @param extraArgs Extra CLI flags (for example `["--force"]` after a refusal)
+ * @param spawnFn Optional spawn implementation (tests)
+ * @returns Captured CLI stdout/stderr and exit status
+ */
+export async function initProject(
+	cwd: string,
+	extraArgs: string[] = [],
+	spawnFn: SpawnFn = spawnProcess,
+): Promise<InitResult> {
+	const { command, prefixArgs } = await resolveArkEnvCommand(cwd);
+	const args = [...prefixArgs, "init", "--agent", ...extraArgs];
+	const result = await spawnFn(command, args, { cwd });
+	return {
+		status: result.exitCode === 0 ? "success" : "error",
+		exitCode: result.exitCode,
+		stdout: result.stdout,
+		stderr: result.stderr,
+		command,
+		args,
+	};
+}
+
+/**
+ * Resolve the local `arkenv` binary or fall back to `npx arkenv@latest`.
+ *
+ * @param cwd Project directory
+ * @returns Command plus args that precede `init`
+ */
+export async function resolveArkEnvCommand(
+	cwd: string,
+): Promise<{ command: string; prefixArgs: string[] }> {
+	const fromEnv = process.env.ARKENV_BIN;
+	if (fromEnv) {
+		return { command: fromEnv, prefixArgs: [] };
+	}
+	const localBin = path.join(cwd, "node_modules", ".bin", "arkenv");
+	try {
+		await access(localBin);
+		return { command: localBin, prefixArgs: [] };
+	} catch {
+		return { command: "npx", prefixArgs: ["--yes", "arkenv@latest"] };
+	}
+}
+
+function spawnProcess(
+	command: string,
+	args: string[],
+	options: { cwd: string },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd: options.cwd,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		child.stdout.on("data", (chunk: Buffer | string) => {
+			stdout += String(chunk);
+		});
+		child.stderr.on("data", (chunk: Buffer | string) => {
+			stderr += String(chunk);
+		});
+		child.on("error", reject);
+		child.on("close", (code) => {
+			resolve({ stdout, stderr, exitCode: code ?? 1 });
+		});
+	});
+}

--- a/packages/agent-plugin/src/mcp/server.ts
+++ b/packages/agent-plugin/src/mcp/server.ts
@@ -4,6 +4,7 @@ import {
 	CallToolRequestSchema,
 	ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { version } from "../../package.json";
 import {
 	AUDIT_TOOL_NAME,
 	INIT_TOOL_NAME,
@@ -45,7 +46,7 @@ const INIT_INPUT_SCHEMA = {
  */
 export function createMcpServer(): Server {
 	const server = new Server(
-		{ name: "arkenv", version: "1.0.0-alpha.0" },
+		{ name: "arkenv", version },
 		{ capabilities: { tools: {} } },
 	);
 

--- a/packages/agent-plugin/src/mcp/server.ts
+++ b/packages/agent-plugin/src/mcp/server.ts
@@ -1,0 +1,101 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+	CallToolRequestSchema,
+	ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+	AUDIT_TOOL_NAME,
+	INIT_TOOL_NAME,
+	runAuditTool,
+	runInitTool,
+} from "./tools";
+
+const AUDIT_INPUT_SCHEMA = {
+	type: "object",
+	properties: {
+		cwd: {
+			type: "string",
+			description:
+				"Project root to scan. Defaults to the current working directory.",
+		},
+	},
+} as const;
+
+const INIT_INPUT_SCHEMA = {
+	type: "object",
+	properties: {
+		cwd: {
+			type: "string",
+			description: "Project root. Defaults to the current working directory.",
+		},
+		extraArgs: {
+			type: "array",
+			items: { type: "string" },
+			description:
+				"Extra CLI flags such as --force after a documented refusal.",
+		},
+	},
+} as const;
+
+/**
+ * Create the ArkEnv MCP server with `audit` and `init` tools.
+ *
+ * @returns Configured MCP server (not yet connected)
+ */
+export function createMcpServer(): Server {
+	const server = new Server(
+		{ name: "arkenv", version: "1.0.0-alpha.0" },
+		{ capabilities: { tools: {} } },
+	);
+
+	server.setRequestHandler(ListToolsRequestSchema, async () => ({
+		tools: [
+			{
+				name: AUDIT_TOOL_NAME,
+				description:
+					"Scan the project for unvalidated process.env / import.meta.env access, server secrets in client modules, public-prefix violations, and leftover v0 ambient .d.ts augmentations.",
+				inputSchema: AUDIT_INPUT_SCHEMA,
+			},
+			{
+				name: INIT_TOOL_NAME,
+				description:
+					"Scaffold ArkEnv by running `arkenv init --agent`. Never pass --force unless a previous refusal listed it in retryWith.",
+				inputSchema: INIT_INPUT_SCHEMA,
+			},
+		],
+	}));
+
+	server.setRequestHandler(CallToolRequestSchema, async (request) => {
+		const args = (request.params.arguments ?? {}) as {
+			cwd?: string;
+			extraArgs?: string[];
+		};
+		if (request.params.name === AUDIT_TOOL_NAME) {
+			return runAuditTool(args.cwd ?? process.cwd());
+		}
+		if (request.params.name === INIT_TOOL_NAME) {
+			return runInitTool(args.cwd ?? process.cwd(), args.extraArgs ?? []);
+		}
+		return {
+			content: [
+				{
+					type: "text" as const,
+					text: `Unknown tool: ${request.params.name}`,
+				},
+			],
+			isError: true,
+		};
+	});
+
+	return server;
+}
+
+/**
+ * Connect the MCP server over stdio.
+ */
+export async function startMcpServer(): Promise<void> {
+	const server = createMcpServer();
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
+}

--- a/packages/agent-plugin/src/mcp/tools.test.ts
+++ b/packages/agent-plugin/src/mcp/tools.test.ts
@@ -1,0 +1,55 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { initProject } from "./init";
+import { createMcpServer } from "./server";
+import { AUDIT_TOOL_NAME, INIT_TOOL_NAME, runAuditTool } from "./tools";
+
+describe("initProject", () => {
+	it("delegates to arkenv init --agent", async () => {
+		const result = await initProject(
+			"/tmp/project",
+			[],
+			async (command, args, options) => {
+				expect(args).toContain("init");
+				expect(args).toContain("--agent");
+				expect(options.cwd).toBe("/tmp/project");
+				return {
+					command,
+					stdout: JSON.stringify({ status: "success" }),
+					stderr: "",
+					exitCode: 0,
+				};
+			},
+		);
+		expect(result.status).toBe("success");
+		expect(result.args).toContain("init");
+		expect(result.args).toContain("--agent");
+	});
+});
+
+describe("MCP tools", () => {
+	it("audit tool returns structured diagnostics JSON", async () => {
+		const dir = await mkdtemp(path.join(tmpdir(), "arkenv-mcp-"));
+		await writeFile(
+			path.join(dir, "app.ts"),
+			"export const url = process.env.DATABASE_URL;\n",
+		);
+		const result = await runAuditTool(dir);
+		const report = JSON.parse(result.content[0]?.text ?? "{}") as {
+			diagnostics: Array<{ ruleId: string; line: number; file: string }>;
+		};
+		expect(
+			report.diagnostics.some((d) => d.ruleId === "unvalidated-access"),
+		).toBe(true);
+		expect(report.diagnostics[0]?.line).toBeGreaterThan(0);
+	});
+
+	it("createMcpServer registers audit and init tools", () => {
+		const server = createMcpServer();
+		expect(server).toBeDefined();
+		expect(AUDIT_TOOL_NAME).toBe("audit");
+		expect(INIT_TOOL_NAME).toBe("init");
+	});
+});

--- a/packages/agent-plugin/src/mcp/tools.ts
+++ b/packages/agent-plugin/src/mcp/tools.ts
@@ -1,0 +1,42 @@
+import { auditProject } from "../audit/scan";
+import type { AuditReport } from "../audit/types";
+import { initProject } from "./init";
+
+export const AUDIT_TOOL_NAME = "audit";
+export const INIT_TOOL_NAME = "init";
+
+export type ToolContent = {
+	content: Array<{ type: "text"; text: string }>;
+	isError?: boolean;
+};
+
+/**
+ * Run the MCP `audit` tool against a project root.
+ *
+ * @param cwd Directory to scan (defaults to `process.cwd()`)
+ * @returns MCP content wrapping a structured {@link AuditReport}
+ */
+export async function runAuditTool(cwd = process.cwd()): Promise<ToolContent> {
+	const report: AuditReport = await auditProject(cwd);
+	return {
+		content: [{ type: "text", text: JSON.stringify(report, null, 2) }],
+	};
+}
+
+/**
+ * Run the MCP `init` tool by delegating to `arkenv init --agent`.
+ *
+ * @param cwd Project directory
+ * @param extraArgs Extra CLI flags
+ * @returns MCP content wrapping the CLI JSON / logs
+ */
+export async function runInitTool(
+	cwd = process.cwd(),
+	extraArgs: string[] = [],
+): Promise<ToolContent> {
+	const result = await initProject(cwd, extraArgs);
+	return {
+		content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+		...(result.status === "error" ? { isError: true } : {}),
+	};
+}

--- a/packages/agent-plugin/tsconfig.json
+++ b/packages/agent-plugin/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"target": "es2020",
+		"module": "preserve",
+		"strict": true,
+		"esModuleInterop": true,
+		"moduleResolution": "bundler",
+		"skipLibCheck": true,
+		"exactOptionalPropertyTypes": true,
+		"noImplicitAny": true,
+		"noEmit": true,
+		"outDir": "dist",
+		"resolveJsonModule": true,
+		"rootDir": "src",
+		"declaration": true,
+		"declarationMap": true,
+		"types": ["node"]
+	},
+	"include": ["src"]
+}

--- a/packages/agent-plugin/tsdown.config.ts
+++ b/packages/agent-plugin/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/index.ts", "src/bin.ts"],
+	format: ["esm", "cjs"],
+	platform: "node",
+	minify: false,
+	fixedExtension: false,
+	shims: true,
+});

--- a/packages/agent-plugin/vitest.config.ts
+++ b/packages/agent-plugin/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+	test: {
+		name: "@arkenv/agent-plugin",
+		include: ["**/*.{test,spec,test-d}.?(c|m)[jt]s?(x)"],
+		unstubEnvs: true,
+		restoreMocks: true,
+		unstubGlobals: true,
+	},
+	resolve: {
+		tsconfigPaths: true,
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -887,6 +887,28 @@ importers:
         specifier: 3.25.2
         version: 3.25.2(zod@4.4.1)
 
+  packages/agent-plugin:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.1
+        version: 1.30.0(zod@4.4.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/arkenv:
     dependencies:
       '@clack/prompts':
@@ -1553,10 +1575,6 @@ packages:
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-string-parser@8.0.0-rc.4':
-    resolution: {integrity: sha512-dluR3v287dp6YPF57kyKKrHPKffUeuxH1zQcF1WD30TeFzWXhDiVi1U6PkqaDB0++H1PeCwRhmYl4DvoerlPIw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-string-parser@8.0.0-rc.6':
     resolution: {integrity: sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==}
@@ -2537,6 +2555,12 @@ packages:
     resolution: {integrity: sha512-GksCmUpS8kypatNTEYxfTrcodZIdKXmQMO8pRwGqf4Q108zX6STTfqH6kjtczgw1b/6ZicsmUCIBM0Tf6SbVeA==}
     engines: {node: '>=20.0.0'}
 
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@hookform/resolvers@5.9.1':
     resolution: {integrity: sha512-7b7vsbraJxKgjVSA1Nur9tLwj539WGJUBLA7QNvXnFoT2pM5Z7G+6rlukk4B2/QrTZy6huRtH6wKeESPKuIr6w==}
     peerDependencies:
@@ -2877,6 +2901,16 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: 4.4.1
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -6531,6 +6565,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -6853,6 +6891,10 @@ packages:
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -6906,6 +6948,10 @@ packages:
     resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
     engines: {node: '>= 0.8'}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   c12@3.3.4:
     resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
     peerDependencies:
@@ -6921,6 +6967,14 @@ packages:
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
@@ -7135,6 +7189,14 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   content-type@2.1.0:
     resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
     engines: {node: '>=18'}
@@ -7150,6 +7212,10 @@ packages:
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -7493,6 +7559,10 @@ packages:
       oxc-resolver:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
@@ -7595,6 +7665,10 @@ packages:
   errx@0.1.0:
     resolution: {integrity: sha512-fZmsRiDNv07K6s2KkKFTiD2aIvECa7++PKyD5NC32tpRw46qZA3sOz+aM+/V9V0GDHxVTKLziveV4JhzBHDp9Q==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
@@ -7604,6 +7678,10 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -7765,6 +7843,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -7776,6 +7862,16 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -7889,6 +7985,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.8.0:
     resolution: {integrity: sha512-JtyUgATO7qxRp2zKhrmWof74Mqxc1ikbwpwMY97p8ipuTj2QtreA4gK2JNAF6SOqqHnYYkwMUvsgQVi2AJxIyw==}
     engines: {node: '>=20'}
@@ -7932,6 +8032,10 @@ packages:
 
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -8156,12 +8260,20 @@ packages:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
   get-port-please@3.2.0:
     resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
@@ -8219,6 +8331,10 @@ packages:
     resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
     engines: {node: '>=20'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
@@ -8238,6 +8354,10 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
@@ -8278,6 +8398,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  hono@4.13.4:
+    resolution: {integrity: sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==}
+    engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -8418,6 +8542,14 @@ packages:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
     engines: {node: '>=12.22.0'}
 
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   ipaddr.js@2.5.0:
     resolution: {integrity: sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==}
     engines: {node: '>= 10'}
@@ -8515,6 +8647,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
@@ -8602,6 +8737,9 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  jose@6.2.10:
+    resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -8656,6 +8794,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -8908,6 +9049,10 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdast-util-directive@3.1.0:
     resolution: {integrity: sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==}
 
@@ -8972,9 +9117,17 @@ packages:
     resolution: {integrity: sha512-EEOFUOYM1VPPqW/l1WyTxEiL8N1+LBNSBpzPk/Aq4z8UkfA19Abo75pK3qRZAi3MEW9NHK49+Fz0BdRrwLVzaQ==}
     hasBin: true
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
   merge-anything@5.1.7:
     resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
     engines: {node: '>=12.13'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -9243,6 +9396,10 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -9378,6 +9535,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   obliterator@2.0.5:
     resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
@@ -9589,6 +9750,9 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -9653,6 +9817,10 @@ packages:
   pino@9.14.0:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -9965,6 +10133,10 @@ packages:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -9974,6 +10146,10 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -10000,6 +10176,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
@@ -10361,6 +10541,10 @@ packages:
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -10512,6 +10696,22 @@ packages:
   shiki@4.0.2:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -11079,6 +11279,10 @@ packages:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   type-level-regexp@0.1.17:
     resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
 
@@ -11216,6 +11420,10 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unplugin-utils@0.3.1:
     resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
@@ -12029,8 +12237,8 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -12145,8 +12353,6 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-string-parser@8.0.0-rc.4': {}
-
   '@babel/helper-string-parser@8.0.0-rc.6': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -12256,8 +12462,8 @@ snapshots:
 
   '@babel/types@8.0.0-rc.3':
     dependencies:
-      '@babel/helper-string-parser': 8.0.0-rc.4
-      '@babel/helper-validator-identifier': 8.0.0-rc.3
+      '@babel/helper-string-parser': 8.0.0-rc.6
+      '@babel/helper-validator-identifier': 8.0.0-rc.6
 
   '@babel/types@8.0.0-rc.6':
     dependencies:
@@ -13066,6 +13272,10 @@ snapshots:
       date-fns: 4.4.0
       pretty-bytes: 7.1.0
 
+  '@hono/node-server@2.1.1(hono@4.13.4)':
+    dependencies:
+      hono: 4.13.4
+
   '@hookform/resolvers@5.9.1(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(arktype@2.2.0)(react-hook-form@7.85.0(react@19.2.5))(valibot@1.3.1(typescript@6.0.3))(zod@4.4.1)':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -13338,6 +13548,28 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.1)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.4)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.6.2(express@5.2.1)
+      hono: 4.13.4
+      jose: 6.2.10
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.1
+      zod-to-json-schema: 3.25.2(zod@4.4.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17470,6 +17702,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.1.0
+
   acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -17790,6 +18027,20 @@ snapshots:
 
   birpc@4.0.0: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   bottleneck@2.19.5: {}
@@ -17859,6 +18110,8 @@ snapshots:
 
   bytes-iec@3.1.1: {}
 
+  bytes@3.1.2: {}
+
   c12@3.3.4(magicast@0.5.2):
     dependencies:
       chokidar: 5.0.0
@@ -17879,6 +18132,16 @@ snapshots:
   cac@6.7.14: {}
 
   cac@7.0.0: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   camelcase@5.3.1: {}
 
@@ -18088,6 +18351,10 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   content-type@2.1.0: {}
 
   convert-source-map@2.0.0: {}
@@ -18097,6 +18364,8 @@ snapshots:
   cookie-es@2.0.1: {}
 
   cookie-es@3.1.1: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
 
@@ -18387,6 +18656,12 @@ snapshots:
     optionalDependencies:
       oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
@@ -18491,11 +18766,17 @@ snapshots:
 
   errx@0.1.0: {}
 
+  es-define-property@1.0.1: {}
+
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -18759,6 +19040,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -18774,6 +19061,47 @@ snapshots:
   exit@0.1.2: {}
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.6.2(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   exsolve@1.0.8: {}
 
@@ -18894,6 +19222,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.8.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -18931,6 +19270,8 @@ snapshots:
       fd-package-json: 2.0.0
 
   forwarded-parse@2.1.2: {}
+
+  forwarded@0.2.0: {}
 
   fraction.js@5.3.4: {}
 
@@ -19145,9 +19486,27 @@ snapshots:
 
   get-east-asian-width@1.5.0: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
 
   get-port-please@3.2.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-stream@8.0.1: {}
 
@@ -19217,6 +19576,8 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.4.0
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
@@ -19250,6 +19611,8 @@ snapshots:
       uncrypto: 0.1.3
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
 
   hasown@2.0.3:
     dependencies:
@@ -19370,6 +19733,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  hono@4.13.4: {}
 
   hookable@5.5.3: {}
 
@@ -19519,6 +19884,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ip-address@10.5.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   ipaddr.js@2.5.0: {}
 
   iron-webcrypto@1.2.1: {}
@@ -19586,6 +19955,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -19660,6 +20031,8 @@ snapshots:
 
   jju@1.4.0: {}
 
+  jose@6.2.10: {}
+
   joycon@3.1.1: {}
 
   js-tokens@10.0.0: {}
@@ -19722,6 +20095,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -19973,6 +20348,8 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  math-intrinsics@1.1.0: {}
+
   mdast-util-directive@3.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -20177,9 +20554,13 @@ snapshots:
       - bluebird
       - supports-color
 
+  media-typer@1.1.1: {}
+
   merge-anything@5.1.7:
     dependencies:
       is-what: 4.1.16
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -20571,6 +20952,10 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
+
+  negotiator@1.1.0:
+    dependencies:
+      content-type: 2.1.0
 
   neo-async@2.6.2: {}
 
@@ -21168,6 +21553,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   obliterator@2.0.5: {}
 
   obug@2.1.1: {}
@@ -21444,7 +21831,7 @@ snapshots:
       ky: 1.14.3
       registry-auth-token: 5.1.1
       registry-url: 6.0.1
-      semver: 7.7.4
+      semver: 7.8.3
 
   package-manager-detector@0.2.11:
     dependencies:
@@ -21501,6 +21888,8 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -21573,6 +21962,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 3.2.0
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -21881,6 +22272,11 @@ snapshots:
       '@types/node': 25.6.0
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
 
   pump@3.0.4:
@@ -21889,6 +22285,11 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   quansync@0.2.11: {}
 
@@ -21905,6 +22306,13 @@ snapshots:
   radix3@1.1.2: {}
 
   range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc9@3.0.1:
     dependencies:
@@ -22381,6 +22789,16 @@ snapshots:
 
   rou3@0.8.1: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   run-async@2.4.1: {}
@@ -22434,7 +22852,7 @@ snapshots:
 
   sembear@0.7.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.3
 
   semver@6.3.1: {}
 
@@ -22579,6 +22997,34 @@ snapshots:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -23111,6 +23557,12 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
+
   type-level-regexp@0.1.17: {}
 
   typedarray@0.0.6: {}
@@ -23297,6 +23749,8 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
+
+  unpipe@1.0.0: {}
 
   unplugin-utils@0.3.1:
     dependencies:


### PR DESCRIPTION
Fixes #1611

## Summary
- Add published `@arkenv/agent-plugin` with plugin manifests (Claude Code, Cursor, generic `.plugin`) and slash commands `/arkenv:init` and `/arkenv:audit`.
- Ship a stdio MCP server whose `init` tool delegates to `arkenv init --agent` and whose `audit` tool returns structured AST diagnostics (`file`, `line`, `character`, `severity`, `ruleId`, `message`, `suggestedFix`).
- Detect raw `process.env` / `import.meta.env` bypasses, server secrets in `"use client"` modules, public prefixes on secret-looking keys, and leftover v0 ambient `.d.ts` augmentations — without flagging valid `import { env } from "./env"`.
- Document install via `npx plugins add arkenv/arkenv-plugin` in the AI guide and a new reference page.

## Test plan
- [x] Unit tests for AST rules (bypass, client leak, valid `env` import, prefix, legacy ambient)
- [x] MCP `audit` tool returns JSON diagnostics
- [x] `pnpm run typecheck`
- [x] `pnpm run test -- --run`
- [x] `pnpm run check`


Made with [Cursor](https://cursor.com)