### PR TITLE
fix: Drop default z.coerce from Zod product samples

### DIFF
--- a/.changeset/drop-default-zcoerce-from-zod-samples.md
+++ b/.changeset/drop-default-zcoerce-from-zod-samples.md
@@ -1,0 +1,8 @@
+---
+"arkenv": patch
+"@arkenv/standard": patch
+---
+
+#### Drop default `z.coerce` from Zod product samples and scaffold templates
+
+Update CLI Zod dialect templates and `@arkenv/standard` JSDoc examples to use `z.number()` instead of `z.coerce.number()`, aligning with ArkEnv's pre-coercion behavior on Standard Schema inputs.

--- a/.changeset/drop-default-zcoerce-from-zod-samples.md
+++ b/.changeset/drop-default-zcoerce-from-zod-samples.md
@@ -5,4 +5,15 @@
 
 #### Drop default `z.coerce` from Zod product samples and scaffold templates
 
-Update CLI Zod dialect templates and `@arkenv/standard` JSDoc examples to use `z.number()` instead of `z.coerce.number()`, aligning with ArkEnv's pre-coercion behavior on Standard Schema inputs.
+Scaffolded Zod templates, `@arkenv/standard` JSDoc examples, and official example projects now declare numeric and boolean fields with `z.number()` and `z.boolean()` instead of `z.coerce.number()` or `z.coerce.boolean()`, reflecting ArkEnv's built-in pre-coercion for Standard Schema validators.
+
+```ts
+import arkenv from "@arkenv/standard";
+import { z } from "zod";
+
+export const env = arkenv({
+  PORT: z.number().default(3000),
+  DATABASE_URL: z.string().url(),
+  DEBUG: z.boolean().default(false),
+});
+```

--- a/.changeset/drop-default-zcoerce-from-zod-samples.md
+++ b/.changeset/drop-default-zcoerce-from-zod-samples.md
@@ -1,5 +1,6 @@
 ---
 "arkenv": patch
+"@arkenv/standard": patch
 ---
 
 #### Drop default `z.coerce` from Zod product samples and scaffold templates

--- a/.changeset/drop-default-zcoerce-from-zod-samples.md
+++ b/.changeset/drop-default-zcoerce-from-zod-samples.md
@@ -1,6 +1,5 @@
 ---
 "arkenv": patch
-"@arkenv/standard": patch
 ---
 
 #### Drop default `z.coerce` from Zod product samples and scaffold templates

--- a/examples/basic-js/package-lock.json
+++ b/examples/basic-js/package-lock.json
@@ -6,7 +6,7 @@
 		"": {
 			"name": "arkenv-example-basic-js",
 			"dependencies": {
-				"@arkenv/core": "1.0.0-alpha.5",
+				"@arkenv/core": "1.0.0-alpha.6",
 				"arktype": "^2.2.0"
 			},
 			"engines": {
@@ -29,9 +29,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@arkenv/core": {
-			"version": "1.0.0-alpha.5",
-			"resolved": "https://registry.npmjs.org/@arkenv/core/-/core-1.0.0-alpha.5.tgz",
-			"integrity": "sha512-CsEVK2emt5AnxwnRULBgInbqOvrLVpYcVwg1EHdj0qo7RyQaZeHxPjVBrwkxT+rpEez/JT7MWiTYCsqK+iswlg==",
+			"version": "1.0.0-alpha.6",
+			"resolved": "https://registry.npmjs.org/@arkenv/core/-/core-1.0.0-alpha.6.tgz",
+			"integrity": "sha512-k0YEcFpYLCK01QkiFQl6RqPMp09JhnxtMW+b6KXAiAf3M+DCyWIfBbgtP4c6bbWjrzRVJsspMGppTEkWPIMgNg==",
 			"license": "MIT",
 			"peerDependencies": {
 				"arktype": "^2.1.22"

--- a/examples/basic-js/package.json
+++ b/examples/basic-js/package.json
@@ -8,7 +8,7 @@
 		"clean": "rimraf dist node_modules"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.5",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"arktype": "^2.2.0"
 	},
 	"engines": {

--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -6,7 +6,7 @@
 		"": {
 			"name": "arkenv-example-basic",
 			"dependencies": {
-				"@arkenv/core": "1.0.0-alpha.5",
+				"@arkenv/core": "1.0.0-alpha.6",
 				"arktype": "^2.2.0",
 				"zod": "^4.4.1"
 			},
@@ -36,9 +36,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@arkenv/core": {
-			"version": "1.0.0-alpha.5",
-			"resolved": "https://registry.npmjs.org/@arkenv/core/-/core-1.0.0-alpha.5.tgz",
-			"integrity": "sha512-CsEVK2emt5AnxwnRULBgInbqOvrLVpYcVwg1EHdj0qo7RyQaZeHxPjVBrwkxT+rpEez/JT7MWiTYCsqK+iswlg==",
+			"version": "1.0.0-alpha.6",
+			"resolved": "https://registry.npmjs.org/@arkenv/core/-/core-1.0.0-alpha.6.tgz",
+			"integrity": "sha512-k0YEcFpYLCK01QkiFQl6RqPMp09JhnxtMW+b6KXAiAf3M+DCyWIfBbgtP4c6bbWjrzRVJsspMGppTEkWPIMgNg==",
 			"license": "MIT",
 			"peerDependencies": {
 				"arktype": "^2.1.22"

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -9,7 +9,7 @@
 		"clean": "rimraf dist node_modules"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.5",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"arktype": "^2.2.0",
 		"zod": "^4.4.1"
 	},

--- a/examples/mix-and-match/package-lock.json
+++ b/examples/mix-and-match/package-lock.json
@@ -6,7 +6,7 @@
 		"": {
 			"name": "arkenv-example-mix-and-match",
 			"dependencies": {
-				"@arkenv/core": "1.0.0-alpha.5",
+				"@arkenv/core": "1.0.0-alpha.6",
 				"valibot": "^1.3.1",
 				"zod": "^4.4.1"
 			},
@@ -34,9 +34,9 @@
 			"peer": true
 		},
 		"node_modules/@arkenv/core": {
-			"version": "1.0.0-alpha.5",
-			"resolved": "https://registry.npmjs.org/@arkenv/core/-/core-1.0.0-alpha.5.tgz",
-			"integrity": "sha512-CsEVK2emt5AnxwnRULBgInbqOvrLVpYcVwg1EHdj0qo7RyQaZeHxPjVBrwkxT+rpEez/JT7MWiTYCsqK+iswlg==",
+			"version": "1.0.0-alpha.6",
+			"resolved": "https://registry.npmjs.org/@arkenv/core/-/core-1.0.0-alpha.6.tgz",
+			"integrity": "sha512-k0YEcFpYLCK01QkiFQl6RqPMp09JhnxtMW+b6KXAiAf3M+DCyWIfBbgtP4c6bbWjrzRVJsspMGppTEkWPIMgNg==",
 			"license": "MIT",
 			"peerDependencies": {
 				"arktype": "^2.1.22"

--- a/examples/mix-and-match/package.json
+++ b/examples/mix-and-match/package.json
@@ -10,7 +10,7 @@
 		"clean": "rimraf dist node_modules"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.5",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"valibot": "^1.3.1",
 		"zod": "^4.4.1"
 	},

--- a/examples/with-bun-react/bun.lock
+++ b/examples/with-bun-react/bun.lock
@@ -6,7 +6,7 @@
       "name": "arkenv-example-with-bun-react",
       "dependencies": {
         "@arkenv/bun-plugin": "1.0.0-alpha.10",
-        "@arkenv/core": "1.0.0-alpha.5",
+        "@arkenv/core": "1.0.0-alpha.6",
         "arktype": "^2.2.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -28,7 +28,7 @@
 
     "@arkenv/bun-plugin": ["@arkenv/bun-plugin@1.0.0-alpha.10", "", { "dependencies": { "@arkenv/build": "0.1.0-alpha.3", "jiti": "2.7.0" }, "peerDependencies": { "@arkenv/core": "^1.0.0", "@arkenv/standard": "^1.0.0", "arktype": "^2.1.22", "bun": "^1.0.0" }, "optionalPeers": ["@arkenv/core", "@arkenv/standard", "arktype"] }, "sha512-VnRA2HzloJ86/00pGw+iU1rwB2UC+ZaTMKm4L7JuSpWfayaCGLkttiEq+hzQJuuc8J+x4zicUpo7AAzkKA+n6w=="],
 
-    "@arkenv/core": ["@arkenv/core@1.0.0-alpha.5", "", { "peerDependencies": { "arktype": "^2.1.22" } }, "sha512-CsEVK2emt5AnxwnRULBgInbqOvrLVpYcVwg1EHdj0qo7RyQaZeHxPjVBrwkxT+rpEez/JT7MWiTYCsqK+iswlg=="],
+    "@arkenv/core": ["@arkenv/core@1.0.0-alpha.6", "", { "peerDependencies": { "arktype": "^2.1.22" } }, "sha512-k0YEcFpYLCK01QkiFQl6RqPMp09JhnxtMW+b6KXAiAf3M+DCyWIfBbgtP4c6bbWjrzRVJsspMGppTEkWPIMgNg=="],
 
     "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-qAS6Hg8Q14ckfBuqJ2Zh7gBQSVSUHeibSq4OFqBTv6DzyJuxYlr0sdYQzmYmnbPxbqobekqUDTa/4XEaqRi7vg=="],
 

--- a/examples/with-bun-react/package.json
+++ b/examples/with-bun-react/package.json
@@ -12,7 +12,7 @@
 	},
 	"dependencies": {
 		"@arkenv/bun-plugin": "1.0.0-alpha.10",
-		"@arkenv/core": "1.0.0-alpha.5",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"arktype": "^2.2.0",
 		"react": "^19.2.5",
 		"react-dom": "^19.2.5"

--- a/examples/with-bun/bun.lock
+++ b/examples/with-bun/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "arkenv-example-with-bun",
       "dependencies": {
-        "@arkenv/core": "1.0.0-alpha.5",
+        "@arkenv/core": "1.0.0-alpha.6",
         "arktype": "^2.2.0",
       },
       "devDependencies": {
@@ -20,7 +20,7 @@
 
     "@ark/util": ["@ark/util@0.56.0", "", {}, "sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA=="],
 
-    "@arkenv/core": ["@arkenv/core@1.0.0-alpha.5", "", { "peerDependencies": { "arktype": "^2.1.22" } }, "sha512-CsEVK2emt5AnxwnRULBgInbqOvrLVpYcVwg1EHdj0qo7RyQaZeHxPjVBrwkxT+rpEez/JT7MWiTYCsqK+iswlg=="],
+    "@arkenv/core": ["@arkenv/core@1.0.0-alpha.6", "", { "peerDependencies": { "arktype": "^2.1.22" } }, "sha512-k0YEcFpYLCK01QkiFQl6RqPMp09JhnxtMW+b6KXAiAf3M+DCyWIfBbgtP4c6bbWjrzRVJsspMGppTEkWPIMgNg=="],
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 

--- a/examples/with-bun/package.json
+++ b/examples/with-bun/package.json
@@ -10,7 +10,7 @@
 		"clean": "rimraf dist node_modules"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.5",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"arktype": "^2.2.0"
 	},
 	"devDependencies": {

--- a/examples/with-nextjs-strict/package.json
+++ b/examples/with-nextjs-strict/package.json
@@ -8,8 +8,8 @@
 		"start": "next start"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.5",
-		"@arkenv/nextjs": "1.0.0-alpha.11",
+		"@arkenv/core": "1.0.0-alpha.6",
+		"@arkenv/nextjs": "1.0.0-alpha.12",
 		"arktype": "^2.2.0",
 		"next": "^16.2.6",
 		"react": "^19.2.5",

--- a/examples/with-nextjs/package.json
+++ b/examples/with-nextjs/package.json
@@ -8,8 +8,8 @@
 		"start": "next start"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.5",
-		"@arkenv/nextjs": "1.0.0-alpha.11",
+		"@arkenv/core": "1.0.0-alpha.6",
+		"@arkenv/nextjs": "1.0.0-alpha.12",
 		"arktype": "^2.2.0",
 		"next": "^16.2.6",
 		"react": "^19.2.5",

--- a/examples/with-nuxt-strict/package.json
+++ b/examples/with-nuxt-strict/package.json
@@ -10,7 +10,7 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.5",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"@arkenv/nuxt": "1.0.0-alpha.13",
 		"arktype": "^2.2.0",
 		"nuxt": "^4.4.8"

--- a/examples/with-nuxt/package.json
+++ b/examples/with-nuxt/package.json
@@ -10,7 +10,7 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.5",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"@arkenv/nuxt": "1.0.0-alpha.13",
 		"arktype": "^2.2.0",
 		"nuxt": "^4.4.8"

--- a/examples/with-solid-start/package.json
+++ b/examples/with-solid-start/package.json
@@ -8,7 +8,7 @@
 		"start": "vinxi start"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.5",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"@arkenv/vite-plugin": "1.0.0-alpha.11",
 		"@solidjs/start": "1.3.2",
 		"arktype": "^2.2.0",

--- a/examples/with-vite-react-zod/README.md
+++ b/examples/with-vite-react-zod/README.md
@@ -15,10 +15,10 @@ import arkenv from "@arkenv/standard";
 import { z } from "zod";
 
 export const env = arkenv({
-  PORT: z.coerce.number().default(3000),
+  PORT: z.number().default(3000),
   VITE_MY_VAR: z.string().default("hello"),
-  VITE_MY_NUMBER: z.coerce.number().default(42),
-  VITE_MY_BOOLEAN: z.coerce.boolean().default(true),
+  VITE_MY_NUMBER: z.number().default(42),
+  VITE_MY_BOOLEAN: z.boolean().default(true),
 });
 
 export default env;

--- a/examples/with-vite-react-zod/src/env.ts
+++ b/examples/with-vite-react-zod/src/env.ts
@@ -2,10 +2,10 @@ import arkenv from "@arkenv/standard";
 import { z } from "zod";
 
 export const env = arkenv({
-	PORT: z.coerce.number().default(3000),
+	PORT: z.number().default(3000),
 	VITE_MY_VAR: z.string().default("hello"),
-	VITE_MY_NUMBER: z.coerce.number().default(42),
-	VITE_MY_BOOLEAN: z.coerce.boolean().default(true),
+	VITE_MY_NUMBER: z.number().default(42),
+	VITE_MY_BOOLEAN: z.boolean().default(true),
 });
 
 export default env;

--- a/examples/with-vite-react/package.json
+++ b/examples/with-vite-react/package.json
@@ -11,7 +11,7 @@
 		"clean": "rimraf dist node_modules"
 	},
 	"dependencies": {
-		"@arkenv/core": "1.0.0-alpha.5",
+		"@arkenv/core": "1.0.0-alpha.6",
 		"@arkenv/vite-plugin": "1.0.0-alpha.11",
 		"arktype": "^2.2.0",
 		"react": "^19.2.5",

--- a/examples/with-zod/src/index.ts
+++ b/examples/with-zod/src/index.ts
@@ -3,7 +3,7 @@ import z from "zod";
 
 const env = arkenv({
 	TEST_VALUE: z.url(),
-	PORT: z.coerce.number(),
+	PORT: z.number(),
 	HOST: z.literal("localhost").or(z.hostname()),
 });
 

--- a/packages/arkenv/src/adapters/jiti-schema-loader/jiti-schema-loader.adapter.test.ts
+++ b/packages/arkenv/src/adapters/jiti-schema-loader/jiti-schema-loader.adapter.test.ts
@@ -170,7 +170,7 @@ describe("JitiSchemaLoaderAdapter", () => {
 			const shared = { DATABASE_URL: z.string() };
 			export const env = arkenv({
 				...shared,
-				PORT: z.coerce.number().default(3000),
+				PORT: z.number().default(3000),
 			});
 			`,
 		);

--- a/packages/arkenv/src/features/scaffold/validators/dialects/zod.ts
+++ b/packages/arkenv/src/features/scaffold/validators/dialects/zod.ts
@@ -18,7 +18,7 @@ export const zodDialect: Dialect = {
 			return `${key}: z.enum(["development", "production", "test"]).default("development"),`;
 		}
 		if (role === "server" && key === "PORT") {
-			return "PORT: z.coerce.number().int().min(1).max(65535).default(3000),";
+			return "PORT: z.number().int().min(1).max(65535).default(3000),";
 		}
 		const preset = tryFormatPresetFieldValue(
 			zodDialect,
@@ -45,7 +45,7 @@ export const zodDialect: Dialect = {
 	},
 
 	defaultSimpleSchemaFields: `\t\tNODE_ENV: z.enum(["development", "production", "test"]).default("development"),
-		PORT: z.coerce.number().int().min(1).max(65535).default(3000),`,
+		PORT: z.number().int().min(1).max(65535).default(3000),`,
 
 	formatSimpleSchemaFields(keys, clientPrefix = "", hostPreset = undefined) {
 		return keys

--- a/packages/core/src/infer.test-d.ts
+++ b/packages/core/src/infer.test-d.ts
@@ -36,7 +36,7 @@ describe("Infer<T> Type Helper", () => {
 
 	it("infers types from a Zod schema", () => {
 		const schema = z.object({
-			PORT: z.coerce.number(),
+			PORT: z.number(),
 			HOST: z.string(),
 			DEBUG: z.boolean().optional(),
 		});
@@ -68,7 +68,7 @@ describe("arkenv Type Inference with Zod", () => {
 
 	it("infers types correctly with arkenv/standard", () => {
 		const schema = {
-			PORT: z.coerce.number(),
+			PORT: z.number(),
 			HOST: z.string(),
 		};
 

--- a/packages/standard/src/index.ts
+++ b/packages/standard/src/index.ts
@@ -49,7 +49,7 @@ type StandardEnvOutput<T extends Record<string, StandardSchemaV1>> = {
  * import { z } from "zod";
  *
  * const env = arkenv({
- *   PORT: z.coerce.number(),
+ *   PORT: z.number(),
  *   HOST: z.string(),
  * });
  * ```

--- a/skills/arkenv/SKILL.md
+++ b/skills/arkenv/SKILL.md
@@ -163,7 +163,7 @@ import arkenv from "@arkenv/standard";
 import { z } from "zod";
 
 export const env = arkenv({
-  PORT: z.coerce.number().default(3000),
+  PORT: z.number().default(3000),
   DATABASE_URL: z.string(),
   VITE_API_URL: z.string().url(),
   NODE_ENV: z.enum(["development", "production", "test"]).default("development"),


### PR DESCRIPTION
Fixes #1630

- Update CLI Zod templates to generate `z.number()` instead of `z.coerce.number()` for numeric fields.
- Update `@arkenv/standard` JSDoc example and skill documentation to use `z.number()` on the happy path.
- Remove redundant `z.coerce` from Zod examples and playgrounds.
- Add changeset for `arkenv` and `@arkenv/cli`.