### PR TITLE
feat: add arkenv check command

### DIFF
--- a/.changeset/arkenv-check-command.md
+++ b/.changeset/arkenv-check-command.md
@@ -1,7 +1,10 @@
 ---
 "arkenv": minor
+"@arkenv/core": patch
 ---
 
-#### Add `arkenv check` command to validate environment variables against schema
+#### Add `arkenv check` command and cross-module validation detection
 
-Add `arkenv check` CLI command to validate the active environment against the project's env schema, supporting `--schema` (`-s`), repeatable `--env-file`, `--json`, `--quiet`, and `--agent` with CI-friendly exit codes.
+- Add `arkenv check` CLI command to validate the active environment against the project's env schema, supporting `--schema` (`-s`), repeatable `--env-file`, `--json`, `--quiet`, and `--agent` with CI-friendly exit codes.
+- Add structural `ArkErrors` verification in `@arkenv/core` so cross-module-instance schema evaluation reliably surfaces validation issues.
+

--- a/.changeset/arkenv-check-command.md
+++ b/.changeset/arkenv-check-command.md
@@ -1,0 +1,7 @@
+---
+"arkenv": minor
+---
+
+#### Add `arkenv check` command to validate environment variables against schema
+
+Add `arkenv check` CLI command to validate the active environment against the project's env schema, supporting `--schema` (`-s`), repeatable `--env-file`, `--json`, `--quiet`, and `--agent` with CI-friendly exit codes.

--- a/apps/www/content/docs/reference/check.mdx
+++ b/apps/www/content/docs/reference/check.mdx
@@ -1,0 +1,145 @@
+---
+title: check
+description: Validate environment variables against the schema with CI-friendly exit codes.
+---
+
+`arkenv check` validates the active environment against your project's
+schema. Use it as a standalone verification step in CI/CD pipelines,
+local verification scripts, or pre-commit hooks.
+
+```package-install
+npx arkenv@latest check
+```
+
+```package-install
+npx arkenv@latest check --env-file .env.production
+```
+
+```package-install
+npx arkenv@latest check --schema ./src/env.ts --env-file .env --env-file .env.local
+```
+
+[Global flags](/docs/reference#global-flags) (`--quiet`, `--json`,
+`--agent`, `--help`) apply here too.
+
+## Usage
+
+```txt title="Terminal"
+arkenv check [options]
+```
+
+When the environment satisfies the schema, `check` prints a success line
+and exits with code `0`:
+
+```txt title="Terminal"
+✔ No issues found — your environment matches the schema
+```
+
+When validation fails, `check` outputs the formatted issues and exits
+with code `1`:
+
+```txt title="Terminal"
+Errors found while validating environment variables
+  DATABASE_URL must be a URL string (was [REDACTED])
+  PORT must be a number (was a string)
+```
+
+## Options
+
+These flags are specific to `check`.
+
+### `--schema <path>` / `-s`
+
+Explicit path to the schema module. Overrides `"arkenv"` in `package.json`
+and convention discovery.
+
+```package-install
+npx arkenv@latest check --schema ./src/config/env.ts
+```
+
+### `--env-file <file>`
+
+Load a `.env` file before validating. This flag is repeatable; multiple
+files are loaded in sequence with later files taking precedence over
+earlier ones.
+
+```package-install
+npx arkenv@latest check --env-file .env --env-file .env.local
+```
+
+Values from `--env-file` are merged over `process.env`. Missing files fail
+fast with a non-zero exit code. Parsing is literal plain dotenv syntax
+(no variable expansion).
+
+### `--json` / `-j`
+
+Output structured JSON. On success:
+
+```json
+{
+  "status": "success",
+  "message": "No issues found — your environment matches the schema",
+  "details": {
+    "keys": ["DATABASE_URL", "PORT"]
+  }
+}
+```
+
+On validation failure:
+
+```json
+{
+  "status": "error",
+  "code": "VALIDATION_FAILED",
+  "message": "Errors found while validating environment variables",
+  "issues": [
+    {
+      "path": "DATABASE_URL",
+      "message": "must be a URL string (was [REDACTED])",
+      "code": "INVALID_FORMAT"
+    }
+  ]
+}
+```
+
+### `--quiet` / `-q`
+
+Suppress normal console output. Exits `0` on success and `1` on failure.
+
+## CI/CD integration
+
+Add `arkenv check` to your CI workflow to ensure required environment
+variables are present before building or deploying.
+
+```yaml title=".github/workflows/ci.yml"
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  validate-env:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Validate environment
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          PORT: "3000"
+        run: pnpm exec arkenv check
+```
+
+## Next steps
+
+<Cards>
+  <Card href="/docs/validating-your-environment/error-reporting" title="Error reporting" description="Understand ArkEnv validation error formats and issue codes." />
+
+  <Card href="/docs/reference/init" title="init" description="Scaffold a project and schema files." />
+
+  <Card href="/docs/reference/options" title="options" description="Configuration options passed to arkenv()." />
+</Cards>

--- a/apps/www/content/docs/reference/index.mdx
+++ b/apps/www/content/docs/reference/index.mdx
@@ -28,6 +28,8 @@ The `arkenv` package is the CLI. Import validation from `@arkenv/core` or
 <Cards>
   <Card href="/docs/reference/init" title="init" description="Scaffold schemas, layouts, and hosting presets into a project." />
 
+  <Card href="/docs/reference/check" title="check" description="Validate the resolved environment against your schema with CI exit codes." />
+
   <Card href="/docs/reference/preset" title="preset" description="Apply, refresh, or remove hosting provider presets." />
 </Cards>
 

--- a/apps/www/content/docs/reference/meta.json
+++ b/apps/www/content/docs/reference/meta.json
@@ -9,6 +9,7 @@
 		"env",
 		"---Commands---",
 		"init",
+		"check",
 		"preset",
 
 		"---Packages---",

--- a/packages/arkenv/src/adapters/jiti-schema-loader/jiti-schema-loader.adapter.test.ts
+++ b/packages/arkenv/src/adapters/jiti-schema-loader/jiti-schema-loader.adapter.test.ts
@@ -263,4 +263,113 @@ describe("JitiSchemaLoaderAdapter", () => {
 		expect(result.code).toBe("MODULE_LOAD_FAILED");
 		expect(result.message).toContain("does not populate env values");
 	});
+
+	describe("validate", () => {
+		it("validates an ArkType schema successfully against a matching environment", async () => {
+			const schemaPath = path.join(tempDir, "env.ts");
+			await fsp.writeFile(
+				schemaPath,
+				`
+				import arkenv from "@arkenv/core";
+				export const env = arkenv({
+					DATABASE_URL: "string",
+					PORT: "0 <= number.integer <= 65535 = 3000",
+				});
+				`,
+			);
+
+			const loader = new JitiSchemaLoaderAdapter({ jitiAliases });
+			const result = await loader.validate(
+				{ schemaPath },
+				{ DATABASE_URL: "postgres://localhost/db", PORT: "8080" },
+			);
+
+			expect(result.ok).toBe(true);
+		});
+
+		it("returns formatted issues when ArkType validation fails", async () => {
+			const schemaPath = path.join(tempDir, "env.ts");
+			await fsp.writeFile(
+				schemaPath,
+				`
+				import arkenv from "@arkenv/core";
+				export const env = arkenv({
+					DATABASE_URL: "string",
+					PORT: "number",
+				});
+				`,
+			);
+
+			const loader = new JitiSchemaLoaderAdapter({ jitiAliases });
+			const result = await loader.validate(
+				{ schemaPath },
+				{ DATABASE_URL: "postgres://localhost/db", PORT: "not-a-number" },
+			);
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.kind).toBe("validation");
+			if (result.kind === "validation") {
+				expect(result.issues.length).toBeGreaterThan(0);
+				expect(result.message).toContain(
+					"Errors found while validating environment variables",
+				);
+			}
+		});
+
+		it("validates a Zod Standard Schema successfully and fails on missing vars", async () => {
+			const schemaPath = path.join(tempDir, "env.ts");
+			await fsp.writeFile(
+				schemaPath,
+				`
+				import arkenv from "@arkenv/standard";
+				import { z } from "zod";
+				export const env = arkenv({
+					API_KEY: z.string(),
+					PORT: z.coerce.number().default(3000),
+				});
+				`,
+			);
+
+			const loader = new JitiSchemaLoaderAdapter({ jitiAliases });
+			const successResult = await loader.validate(
+				{ schemaPath },
+				{ API_KEY: "secret-key" },
+			);
+			expect(successResult.ok).toBe(true);
+
+			const failResult = await loader.validate({ schemaPath }, {});
+			expect(failResult.ok).toBe(false);
+			if (failResult.ok) return;
+			expect(failResult.kind).toBe("validation");
+			if (failResult.kind === "validation") {
+				expect(
+					failResult.issues.find((i) => i.path === "API_KEY"),
+				).toBeDefined();
+			}
+		});
+
+		it("restores process.env even if validation throws", async () => {
+			process.env.__TEST_PERSISTENT_ENV__ = "original-value";
+			const schemaPath = path.join(tempDir, "env.ts");
+			await fsp.writeFile(
+				schemaPath,
+				`
+				import arkenv from "@arkenv/core";
+				export const env = arkenv({
+					REQUIRED_VAR: "string",
+				});
+				`,
+			);
+
+			const loader = new JitiSchemaLoaderAdapter({ jitiAliases });
+			await loader.validate(
+				{ schemaPath },
+				{ __TEST_PERSISTENT_ENV__: "mutated-value" },
+			);
+
+			expect(process.env.__TEST_PERSISTENT_ENV__).toBe("original-value");
+			delete process.env.__TEST_PERSISTENT_ENV__;
+		});
+	});
 });

--- a/packages/arkenv/src/adapters/jiti-schema-loader/jiti-schema-loader.adapter.ts
+++ b/packages/arkenv/src/adapters/jiti-schema-loader/jiti-schema-loader.adapter.ts
@@ -1,3 +1,4 @@
+import type { EnvIssue } from "@repo/utils";
 import { beginSchemaCapture, endSchemaCapture } from "@repo/utils";
 import { createJiti } from "jiti";
 import { declaredKeysFromDefinitions } from "@/features/schema-loader";
@@ -6,10 +7,12 @@ import {
 	type SchemaLoaderPort,
 	type SchemaLoadResult,
 	type SchemaLoadTarget,
+	type SchemaValidationResult,
 } from "@/shared/ports";
 import {
 	formatModuleLoadFailedMessage,
 	formatNoSchemaMessage,
+	isEnvValidationCause,
 } from "./schema-load-errors";
 
 export type JitiSchemaLoaderOptions = {
@@ -57,6 +60,68 @@ export class JitiSchemaLoaderAdapter implements SchemaLoaderPort {
 				message: formatModuleLoadFailedMessage(target.schemaPath, cause),
 				cause,
 			};
+		}
+	}
+
+	/**
+	 * Validate a resolved environment dictionary against the schema module.
+	 *
+	 * @param target The schema module to load and evaluate
+	 * @param env The resolved environment dictionary to validate
+	 * @returns Success or discriminated validation / load failure
+	 */
+	async validate(
+		target: SchemaLoadTarget,
+		env: Record<string, string | undefined>,
+	): Promise<SchemaValidationResult> {
+		const savedEnv = { ...process.env };
+		for (const key of Object.keys(process.env)) {
+			if (!(key in env) || env[key] === undefined) {
+				delete process.env[key];
+			}
+		}
+		for (const [key, value] of Object.entries(env)) {
+			if (value !== undefined) {
+				process.env[key] = value;
+			}
+		}
+
+		try {
+			this.evaluateModule(target.schemaPath);
+			return { ok: true };
+		} catch (cause) {
+			if (isEnvValidationCause(cause)) {
+				const issues =
+					cause && typeof cause === "object" && "issues" in cause
+						? ((cause as { issues?: EnvIssue[] }).issues ?? [])
+						: [];
+				const message = cause instanceof Error ? cause.message : String(cause);
+				return {
+					ok: false,
+					kind: "validation",
+					message,
+					issues,
+				};
+			}
+
+			return {
+				ok: false,
+				kind: "load",
+				code: SCHEMA_LOAD_ERROR_CODES.MODULE_LOAD_FAILED,
+				message: formatModuleLoadFailedMessage(target.schemaPath, cause),
+				cause,
+			};
+		} finally {
+			for (const key of Object.keys(process.env)) {
+				if (!(key in savedEnv)) {
+					delete process.env[key];
+				}
+			}
+			for (const [key, value] of Object.entries(savedEnv)) {
+				if (value !== undefined) {
+					process.env[key] = value;
+				}
+			}
 		}
 	}
 

--- a/packages/arkenv/src/bin.ts
+++ b/packages/arkenv/src/bin.ts
@@ -20,9 +20,8 @@ async function main() {
 		}
 	}
 
-	const { cli, logger, initUseCase, presetUseCase, helpUseCase } = compose(
-		process.argv,
-	);
+	const { cli, logger, initUseCase, presetUseCase, helpUseCase, checkUseCase } =
+		compose(process.argv);
 	globalLogger = logger;
 
 	setupGracefulShutdown(logger);
@@ -43,6 +42,7 @@ async function main() {
 	const commands = {
 		init: () => initUseCase.execute(shake(cli.initInput)),
 		preset: () => presetUseCase.execute(cli.presetInput),
+		check: () => checkUseCase.execute(cli.checkInput),
 	} as const;
 
 	const handler = cli.command

--- a/packages/arkenv/src/cli/cli.test.ts
+++ b/packages/arkenv/src/cli/cli.test.ts
@@ -396,4 +396,61 @@ describe("CLI parser", () => {
 			});
 		});
 	});
+
+	describe("check command", () => {
+		it("should parse bare check command", () => {
+			const cli = new CLI(["node", "arkenv", "check"]);
+			expect(cli.command).toBe("check");
+			expect(cli.checkInput.schema).toBeUndefined();
+			expect(cli.checkInput.envFiles).toBeUndefined();
+			expect(cli.validationError).toBeUndefined();
+		});
+
+		it("should parse check with --schema and --env-file", () => {
+			const cli = new CLI([
+				"node",
+				"arkenv",
+				"check",
+				"--schema",
+				"./src/env.ts",
+				"--env-file",
+				".env.local",
+			]);
+			expect(cli.command).toBe("check");
+			expect(cli.checkInput.schema).toBe("./src/env.ts");
+			expect(cli.checkInput.envFiles).toEqual([".env.local"]);
+			expect(cli.validationError).toBeUndefined();
+		});
+
+		it("should parse multiple repeatable --env-file flags in sequence", () => {
+			const cli = new CLI([
+				"node",
+				"arkenv",
+				"check",
+				"--env-file",
+				".env",
+				"--env-file",
+				".env.local",
+				"--env-file",
+				".env.test",
+			]);
+			expect(cli.checkInput.envFiles).toEqual([
+				".env",
+				".env.local",
+				".env.test",
+			]);
+			expect(cli.validationError).toBeUndefined();
+		});
+
+		it("should parse short -s for --schema", () => {
+			const cli = new CLI(["node", "arkenv", "check", "-s", "./env.ts"]);
+			expect(cli.checkInput.schema).toBe("./env.ts");
+			expect(cli.validationError).toBeUndefined();
+		});
+
+		it("should reject positional arguments to check command", () => {
+			const cli = new CLI(["node", "arkenv", "check", "unexpected"]);
+			expect(cli.validationError).toBe("Unknown argument: unexpected");
+		});
+	});
 });

--- a/packages/arkenv/src/cli/cli.ts
+++ b/packages/arkenv/src/cli/cli.ts
@@ -4,6 +4,7 @@ import {
 	isHostPreset,
 	isHostProvider,
 } from "@/features/scaffold/presets";
+import type { CheckInput } from "./commands/check";
 import type { InitInput } from "./commands/init";
 import type { PresetInput } from "./commands/preset";
 
@@ -25,6 +26,8 @@ const FLAG_CONFIG = {
 	preset: { long: "--preset", short: "-P", kind: "value" },
 	hostPreset: { long: "--host-preset", short: "-H", kind: "value" },
 	file: { long: "--file", short: "", kind: "value" },
+	schema: { long: "--schema", short: "-s", kind: "value" },
+	envFile: { long: "--env-file", short: "", kind: "value" },
 } as const;
 
 const knownFlags = new Set<string>(
@@ -148,6 +151,10 @@ export class CLI {
 						}
 					}
 				}
+			} else if (this.command === "check") {
+				if (positionalArgs.length > 0) {
+					this.validationError = `Unknown argument: ${positionalArgs[0]}`;
+				}
 			} else {
 				if (positionalArgs.length > 1) {
 					this.validationError = `Unknown argument: ${positionalArgs[1]}`;
@@ -216,6 +223,16 @@ export class CLI {
 		return this.getFlagValue(flag.long, flag.short);
 	}
 
+	get schema(): string | undefined {
+		const flag = FLAG_CONFIG.schema;
+		return this.getFlagValue(flag.long, flag.short) ?? this.file;
+	}
+
+	get envFiles(): string[] {
+		const flag = FLAG_CONFIG.envFile;
+		return this.getFlagValues(flag.long, flag.short);
+	}
+
 	get hostPreset(): HostPreset | undefined {
 		const val =
 			this.getFlagValue(FLAG_CONFIG.preset.long, FLAG_CONFIG.preset.short) ??
@@ -280,6 +297,16 @@ export class CLI {
 		};
 	}
 
+	get checkInput(): CheckInput {
+		return {
+			...(this.schema !== undefined ? { schema: this.schema } : {}),
+			...(this.envFiles.length > 0 ? { envFiles: this.envFiles } : {}),
+			isQuiet: this.isQuiet,
+			isJson: this.isJson,
+			isAgent: this.isAgent,
+		};
+	}
+
 	/**
 	 * Returns the value passed to a long or short CLI flag.
 	 */
@@ -293,5 +320,22 @@ export class CLI {
 			return this.args[index + 1];
 		}
 		return undefined;
+	}
+
+	/**
+	 * Returns all values passed to a repeatable long or short CLI flag, in order.
+	 */
+	private getFlagValues(long: string, short?: string): string[] {
+		const values: string[] = [];
+		for (let i = 0; i < this.args.length - 1; i++) {
+			const arg = this.args[i];
+			if (
+				(arg === long || (Boolean(short) && arg === short)) &&
+				!this.args[i + 1].startsWith("-")
+			) {
+				values.push(this.args[i + 1]);
+			}
+		}
+		return values;
 	}
 }

--- a/packages/arkenv/src/cli/commands/check.test.ts
+++ b/packages/arkenv/src/cli/commands/check.test.ts
@@ -1,0 +1,295 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+	LoggerPort,
+	ProjectScannerPort,
+	SchemaLoaderPort,
+	WorkspacePort,
+} from "@/shared/ports";
+import { CheckUseCase } from "./check";
+
+describe("CheckUseCase", () => {
+	let logger: LoggerPort;
+	let workspace: WorkspacePort;
+	let scanner: ProjectScannerPort;
+	let schemaLoader: SchemaLoaderPort;
+	let useCase: CheckUseCase;
+
+	beforeEach(() => {
+		logger = {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			success: vi.fn(),
+			step: vi.fn(),
+			note: vi.fn(),
+			log: vi.fn(),
+			spinner: vi.fn(),
+			json: vi.fn(),
+			cancel: vi.fn(),
+			fatal: vi.fn(() => {
+				throw new Error("fatal");
+			}),
+			refuse: vi.fn(),
+			finish: vi.fn(),
+			flush: vi.fn(),
+			interactiveStdout: vi.fn(),
+			stdio: "inherit" as const,
+		};
+
+		workspace = {
+			exists: vi.fn(async () => true),
+			readFile: vi.fn(async () => ""),
+			writeFile: vi.fn(async () => {}),
+			mkdir: vi.fn(async () => {}),
+			execute: vi.fn(async () => {}),
+		} as unknown as WorkspacePort;
+
+		scanner = {
+			isEmptyDirectory: vi.fn(async () => false),
+			hasPackageJson: vi.fn(async () => true),
+			findTsConfig: vi.fn(async () => null),
+			loadTsConfig: vi.fn(async () => ({
+				path: "",
+				raw: {},
+				parsed: {},
+				compilerOptions: {},
+			})),
+			getEnvExampleKeys: vi.fn(async () => null),
+			suggestDefaultEnvPath: vi.fn(async () => "./src/env.ts"),
+			checkTsConfig: vi.fn(async () => ({ status: "strict" as const })),
+			checkRequirements: vi.fn(async () => []),
+			detectFramework: vi.fn(async () => "vanilla" as const),
+			detectBunFeatures: vi.fn(async () => []),
+			detectPackageManager: vi.fn(async () => "npm" as const),
+			hasSkill: vi.fn(async () => false),
+			checkGitStatus: vi.fn(async () => ({ status: "clean" as const })),
+			findPackageJson: vi.fn(async () => "/app/package.json"),
+			readArkenvConfig: vi.fn(async () => null),
+		};
+
+		schemaLoader = {
+			load: vi.fn(async () => ({
+				ok: true as const,
+				keys: [
+					{ name: "DATABASE_URL", schema: undefined, hasDefault: false },
+					{ name: "PORT", schema: undefined, hasDefault: true },
+				],
+				schema: {},
+			})),
+			validate: vi.fn(async () => ({ ok: true as const })),
+		};
+
+		useCase = new CheckUseCase(logger, workspace, scanner, schemaLoader);
+	});
+
+	it("returns true and logs success when environment is valid", async () => {
+		const result = await useCase.execute({
+			schema: "./src/env.ts",
+		});
+
+		expect(result).toBe(true);
+		expect(logger.success).toHaveBeenCalledWith(
+			"No issues found — your environment matches the schema",
+		);
+		expect(schemaLoader.validate).toHaveBeenCalledWith(
+			{ schemaPath: path.resolve(process.cwd(), "./src/env.ts") },
+			expect.any(Object),
+		);
+	});
+
+	it("emits structured JSON on success when isJson is enabled", async () => {
+		const result = await useCase.execute({
+			schema: "./src/env.ts",
+			isJson: true,
+		});
+
+		expect(result).toBe(true);
+		expect(logger.json).toHaveBeenCalledWith({
+			status: "success",
+			message: "No issues found — your environment matches the schema",
+			details: {
+				keys: ["DATABASE_URL", "PORT"],
+			},
+		});
+	});
+
+	it("fails and logs error when schema file does not exist", async () => {
+		vi.mocked(workspace.exists).mockResolvedValue(false);
+
+		const result = await useCase.execute({
+			schema: "./src/missing-env.ts",
+		});
+
+		expect(result).toBe(false);
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.stringContaining("Schema file not found"),
+		);
+	});
+
+	it("emits structured error when schema file is missing in JSON mode", async () => {
+		vi.mocked(workspace.exists).mockResolvedValue(false);
+
+		const result = await useCase.execute({
+			schema: "./src/missing-env.ts",
+			isJson: true,
+		});
+
+		expect(result).toBe(false);
+		expect(logger.json).toHaveBeenCalledWith({
+			status: "error",
+			code: "SCHEMA_NOT_FOUND",
+			message: expect.stringContaining("Schema file not found"),
+		});
+	});
+
+	it("discovers schema file from package.json arkenv config", async () => {
+		vi.mocked(scanner.readArkenvConfig).mockResolvedValue({
+			schema: "./custom/my-env.ts",
+			layout: "flat",
+		});
+
+		const result = await useCase.execute({});
+
+		expect(result).toBe(true);
+		expect(schemaLoader.validate).toHaveBeenCalledWith(
+			{ schemaPath: path.resolve(process.cwd(), "./custom/my-env.ts") },
+			expect.any(Object),
+		);
+	});
+
+	it("fails when an explicitly provided --env-file does not exist", async () => {
+		vi.mocked(workspace.exists).mockImplementation(async (p) => {
+			return !p.endsWith(".env.local");
+		});
+
+		const result = await useCase.execute({
+			schema: "./src/env.ts",
+			envFiles: [".env.local"],
+		});
+
+		expect(result).toBe(false);
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.stringContaining("Environment file not found"),
+		);
+	});
+
+	it("emits ENV_FILE_NOT_FOUND error in JSON mode when --env-file is missing", async () => {
+		vi.mocked(workspace.exists).mockImplementation(async (p) => {
+			return !p.endsWith(".env.local");
+		});
+
+		const result = await useCase.execute({
+			schema: "./src/env.ts",
+			envFiles: [".env.local"],
+			isJson: true,
+		});
+
+		expect(result).toBe(false);
+		expect(logger.json).toHaveBeenCalledWith({
+			status: "error",
+			code: "ENV_FILE_NOT_FOUND",
+			message: expect.stringContaining("Environment file not found"),
+		});
+	});
+
+	it("loads and merges multiple --env-file flags in sequence", async () => {
+		vi.mocked(workspace.readFile).mockImplementation(async (filePath) => {
+			if (filePath.endsWith(".env.base")) {
+				return "PORT=3000\nHOST=localhost\nDEBUG=false";
+			}
+			if (filePath.endsWith(".env.override")) {
+				return "PORT=8080\nDEBUG=true";
+			}
+			return "";
+		});
+
+		const result = await useCase.execute({
+			schema: "./src/env.ts",
+			envFiles: [".env.base", ".env.override"],
+		});
+
+		expect(result).toBe(true);
+		expect(schemaLoader.validate).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.objectContaining({
+				PORT: "8080",
+				HOST: "localhost",
+				DEBUG: "true",
+			}),
+		);
+	});
+
+	it("fails when schemaLoader.load fails under capture mode", async () => {
+		vi.mocked(schemaLoader.load).mockResolvedValue({
+			ok: false,
+			code: "NO_SCHEMA",
+			message: "No arkenv() schema found",
+		});
+
+		const result = await useCase.execute({
+			schema: "./src/env.ts",
+		});
+
+		expect(result).toBe(false);
+		expect(logger.error).toHaveBeenCalledWith("No arkenv() schema found");
+		expect(schemaLoader.validate).not.toHaveBeenCalled();
+	});
+
+	it("fails and logs formatted error when validation fails", async () => {
+		vi.mocked(schemaLoader.validate).mockResolvedValue({
+			ok: false,
+			kind: "validation",
+			message:
+				"Errors found while validating environment variables\n  PORT must be a number",
+			issues: [
+				{
+					path: "PORT",
+					message: "must be a number",
+					code: "INVALID_TYPE",
+				},
+			],
+		});
+
+		const result = await useCase.execute({
+			schema: "./src/env.ts",
+		});
+
+		expect(result).toBe(false);
+		expect(logger.log).toHaveBeenCalledWith(
+			"Errors found while validating environment variables\n  PORT must be a number",
+		);
+	});
+
+	it("emits VALIDATION_FAILED with issues array in JSON mode", async () => {
+		const issues = [
+			{
+				path: "PORT",
+				message: "must be a number (was a string)",
+				code: "INVALID_TYPE" as const,
+			},
+		];
+
+		vi.mocked(schemaLoader.validate).mockResolvedValue({
+			ok: false,
+			kind: "validation",
+			message:
+				"Errors found while validating environment variables\n  PORT must be a number",
+			issues,
+		});
+
+		const result = await useCase.execute({
+			schema: "./src/env.ts",
+			isJson: true,
+		});
+
+		expect(result).toBe(false);
+		expect(logger.json).toHaveBeenCalledWith({
+			status: "error",
+			code: "VALIDATION_FAILED",
+			message: "Errors found while validating environment variables",
+			issues,
+		});
+	});
+});

--- a/packages/arkenv/src/cli/commands/check.ts
+++ b/packages/arkenv/src/cli/commands/check.ts
@@ -1,0 +1,224 @@
+import path from "node:path";
+import { parseDotenv } from "@/features/check/dotenv";
+import type {
+	LoggerPort,
+	ProjectScannerPort,
+	SchemaLoaderPort,
+	WorkspacePort,
+} from "@/shared/ports";
+
+/**
+ * Input parameters for the `check` CLI command.
+ */
+export type CheckInput = {
+	/**
+	 * Explicit path to the schema module (overrides package.json or convention discovery).
+	 */
+	schema?: string | undefined;
+	/**
+	 * List of `.env` file paths to load in sequence (later files overwrite earlier ones).
+	 */
+	envFiles?: string[] | undefined;
+	/**
+	 * Suppress console output.
+	 */
+	isQuiet?: boolean | undefined;
+	/**
+	 * Emit machine-readable JSON output.
+	 */
+	isJson?: boolean | undefined;
+	/**
+	 * Run in agent mode (implies `--quiet`, `--json`, `--yes`).
+	 */
+	isAgent?: boolean | undefined;
+	/**
+	 * Working directory to resolve paths from (defaults to `process.cwd()`).
+	 */
+	cwd?: string | undefined;
+};
+
+/**
+ * Use case for validating environment variables against a project's schema.
+ */
+export class CheckUseCase {
+	/**
+	 * Creates a new CheckUseCase instance.
+	 *
+	 * @param logger Port for console logging and structured reporting
+	 * @param workspace Port for reading files and checking filesystem existence
+	 * @param scanner Port for scanning project configuration and detecting schema paths
+	 * @param schemaLoader Port for importing, capturing, and validating schemas
+	 */
+	constructor(
+		private readonly logger: LoggerPort,
+		private readonly workspace: WorkspacePort,
+		private readonly scanner: ProjectScannerPort,
+		private readonly schemaLoader: SchemaLoaderPort,
+	) {}
+
+	/**
+	 * Execute environment variable validation against the project schema.
+	 *
+	 * @param input Configuration options and overrides for the check command
+	 * @returns `true` if the environment is valid; `false` otherwise
+	 */
+	async execute(input: CheckInput): Promise<boolean> {
+		const cwd = input.cwd ?? process.cwd();
+		const isJson = Boolean(input.isJson || input.isAgent);
+
+		// 1. Locate schema file
+		const schemaPath = await this.resolveSchemaPath(cwd, input.schema);
+		if (!schemaPath) {
+			const message = input.schema
+				? `Schema file not found at "${path.resolve(cwd, input.schema)}".`
+				: "Could not locate your schema file. Add an 'arkenv' entry to package.json or specify --schema <path>.";
+			this.logger.error(message);
+			if (isJson) {
+				this.logger.json({
+					status: "error",
+					code: "SCHEMA_NOT_FOUND",
+					message,
+				});
+			}
+			return false;
+		}
+
+		// 2. Resolve environment variables
+		const resolvedEnv: Record<string, string | undefined> = {
+			...process.env,
+		};
+
+		if (input.envFiles && input.envFiles.length > 0) {
+			for (const envFile of input.envFiles) {
+				const resolvedEnvPath = path.resolve(cwd, envFile);
+				if (!(await this.workspace.exists(resolvedEnvPath))) {
+					const message = `Environment file not found at "${resolvedEnvPath}".`;
+					this.logger.error(message);
+					if (isJson) {
+						this.logger.json({
+							status: "error",
+							code: "ENV_FILE_NOT_FOUND",
+							message,
+						});
+					}
+					return false;
+				}
+
+				const content = await this.workspace.readFile(resolvedEnvPath);
+				const parsed = parseDotenv(content);
+				Object.assign(resolvedEnv, parsed);
+			}
+		}
+
+		// 3. Inspect schema under capture mode to verify validity and extract keys
+		const loadResult = await this.schemaLoader.load({ schemaPath });
+		if (!loadResult.ok) {
+			this.logger.error(loadResult.message);
+			if (isJson) {
+				this.logger.json({
+					status: "error",
+					code: loadResult.code,
+					message: loadResult.message,
+				});
+			}
+			return false;
+		}
+
+		// 4. Validate resolved environment against schema
+		const validationResult = await this.schemaLoader.validate(
+			{ schemaPath },
+			resolvedEnv,
+		);
+
+		if (!validationResult.ok) {
+			if (validationResult.kind === "validation") {
+				if (isJson) {
+					this.logger.json({
+						status: "error",
+						code: "VALIDATION_FAILED",
+						message: "Errors found while validating environment variables",
+						issues: validationResult.issues,
+					});
+				} else {
+					this.logger.log(validationResult.message.trimEnd());
+				}
+				return false;
+			}
+
+			// kind === "load"
+			this.logger.error(validationResult.message);
+			if (isJson) {
+				this.logger.json({
+					status: "error",
+					code: validationResult.code,
+					message: validationResult.message,
+				});
+			}
+			return false;
+		}
+
+		// 5. Report success
+		const successMessage =
+			"No issues found — your environment matches the schema";
+		if (isJson) {
+			this.logger.json({
+				status: "success",
+				message: successMessage,
+				details: {
+					keys: loadResult.keys.map((k) => k.name),
+				},
+			});
+		} else {
+			this.logger.success(successMessage);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Find the absolute path to the project's schema file.
+	 *
+	 * @param cwd Current working directory
+	 * @param schemaOverride Optional explicit schema file path passed via CLI
+	 * @returns Absolute path to existing schema file, or `null` if not found
+	 */
+	private async resolveSchemaPath(
+		cwd: string,
+		schemaOverride?: string,
+	): Promise<string | null> {
+		if (schemaOverride) {
+			const resolved = path.resolve(cwd, schemaOverride);
+			return (await this.workspace.exists(resolved)) ? resolved : null;
+		}
+
+		// Check package.json arkenv config
+		if (typeof this.scanner.readArkenvConfig === "function") {
+			const arkenvConfig = await this.scanner.readArkenvConfig(cwd);
+			if (arkenvConfig) {
+				const resolved = path.resolve(cwd, arkenvConfig.schema);
+				if (await this.workspace.exists(resolved)) {
+					return resolved;
+				}
+			}
+		}
+
+		// Fallback to convention locations
+		const candidates = [
+			path.resolve(cwd, "env.ts"),
+			path.resolve(cwd, "src/env.ts"),
+		];
+
+		const suggested = await this.scanner.suggestDefaultEnvPath(cwd);
+		if (suggested) {
+			candidates.unshift(path.resolve(cwd, suggested));
+		}
+
+		for (const candidate of candidates) {
+			if (await this.workspace.exists(candidate)) {
+				return candidate;
+			}
+		}
+
+		return null;
+	}
+}

--- a/packages/arkenv/src/cli/commands/help.ts
+++ b/packages/arkenv/src/cli/commands/help.ts
@@ -39,6 +39,10 @@ export class HelpUseCase {
 				right: "Set up ArkEnv in your project",
 			},
 			{
+				left: "arkenv check",
+				right: "Validate the environment against the schema",
+			},
+			{
 				left: "arkenv preset apply [provider]",
 				right:
 					"Apply or refresh hosting provider preset (vercel, netlify, cloudflare, railway, render, fly)",
@@ -94,6 +98,19 @@ export class HelpUseCase {
 			},
 		];
 
+		const checkOptions: HelpItem[] = [
+			{
+				left: "--schema, -s <path>",
+				right:
+					"Path to schema file (overrides package.json or convention discovery)",
+			},
+			{
+				left: "--env-file <file>",
+				right:
+					"Path to .env file to load (repeatable; merged in order over process.env)",
+			},
+		];
+
 		const presetOptions: HelpItem[] = [
 			{
 				left: "--file <path>",
@@ -116,6 +133,10 @@ export class HelpUseCase {
 		}
 		this.logger.log(`\n${pc.bold("init options:")}`);
 		for (const line of formatColumns(initOptions)) {
+			this.logger.log(line);
+		}
+		this.logger.log(`\n${pc.bold("check options:")}`);
+		for (const line of formatColumns(checkOptions)) {
 			this.logger.log(line);
 		}
 		this.logger.log(`\n${pc.bold("preset options:")}`);

--- a/packages/arkenv/src/cli/commands/index.ts
+++ b/packages/arkenv/src/cli/commands/index.ts
@@ -1,3 +1,4 @@
+export * from "./check";
 export * from "./help";
 export * from "./init";
 export * from "./preset";

--- a/packages/arkenv/src/cli/composition.ts
+++ b/packages/arkenv/src/cli/composition.ts
@@ -5,7 +5,12 @@ import {
 	NodeWorkspace,
 } from "@/adapters";
 import { CLI } from "./cli";
-import { HelpUseCase, InitUseCase, PresetUseCase } from "./commands";
+import {
+	CheckUseCase,
+	HelpUseCase,
+	InitUseCase,
+	PresetUseCase,
+} from "./commands";
 
 /**
  * Bootstraps the application's dependency graph by composing
@@ -25,6 +30,12 @@ export function compose(argv: string[]) {
 	const initUseCase = new InitUseCase(logger, workspace, prompt, scanner);
 	const presetUseCase = new PresetUseCase(logger, workspace, prompt, scanner);
 	const helpUseCase = new HelpUseCase(logger);
+	const checkUseCase = new CheckUseCase(
+		logger,
+		workspace,
+		scanner,
+		schemaLoader,
+	);
 
 	return {
 		cli,
@@ -34,6 +45,7 @@ export function compose(argv: string[]) {
 		initUseCase,
 		presetUseCase,
 		helpUseCase,
+		checkUseCase,
 		schemaLoader,
 	};
 }

--- a/packages/arkenv/src/features/check/dotenv.test.ts
+++ b/packages/arkenv/src/features/check/dotenv.test.ts
@@ -45,22 +45,32 @@ export HOST=localhost
 GREETING="Hello\\nWorld"
 TABBED="A\\tB"
 QUOTED="He said \\"Hello\\""
+ESCAPED_SLASH="C:\\\\Program Files\\\\App"
+ESCAPED_NEWLINE_LITERAL="Literal\\\\nNotNewline"
+TRAILING_SLASH="EndingWithSlash\\\\"
 `;
 		expect(parseDotenv(content)).toEqual({
 			GREETING: "Hello\nWorld",
 			TABBED: "A\tB",
 			QUOTED: 'He said "Hello"',
+			ESCAPED_SLASH: "C:\\Program Files\\App",
+			ESCAPED_NEWLINE_LITERAL: "Literal\\nNotNewline",
+			TRAILING_SLASH: "EndingWithSlash\\",
 		});
 	});
 
-	it("handles single-quoted and backtick strings literally", () => {
+	it("handles single-quoted and backtick strings literally including backslashes", () => {
 		const content = `
 RAW_URL='https://example.com?a=1&b=2'
 BACKTICK=\`simple value\`
+TRAILING_BACKSLASH='C:\\Windows\\'
+LITERAL_ESCAPE='Hello\\nWorld'
 `;
 		expect(parseDotenv(content)).toEqual({
 			RAW_URL: "https://example.com?a=1&b=2",
 			BACKTICK: "simple value",
+			TRAILING_BACKSLASH: "C:\\Windows\\",
+			LITERAL_ESCAPE: "Hello\\nWorld",
 		});
 	});
 

--- a/packages/arkenv/src/features/check/dotenv.test.ts
+++ b/packages/arkenv/src/features/check/dotenv.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { parseDotenv } from "./dotenv";
+
+describe("parseDotenv", () => {
+	it("parses simple key-value pairs", () => {
+		const content = `
+PORT=3000
+HOST=localhost
+DEBUG=true
+`;
+		expect(parseDotenv(content)).toEqual({
+			PORT: "3000",
+			HOST: "localhost",
+			DEBUG: "true",
+		});
+	});
+
+	it("ignores comments and blank lines", () => {
+		const content = `
+# This is a comment
+PORT=3000
+
+# Another comment
+HOST=localhost
+`;
+		expect(parseDotenv(content)).toEqual({
+			PORT: "3000",
+			HOST: "localhost",
+		});
+	});
+
+	it("handles export prefix", () => {
+		const content = `
+export PORT=3000
+export HOST=localhost
+`;
+		expect(parseDotenv(content)).toEqual({
+			PORT: "3000",
+			HOST: "localhost",
+		});
+	});
+
+	it("handles double-quoted strings with escape sequences", () => {
+		const content = `
+GREETING="Hello\\nWorld"
+TABBED="A\\tB"
+QUOTED="He said \\"Hello\\""
+`;
+		expect(parseDotenv(content)).toEqual({
+			GREETING: "Hello\nWorld",
+			TABBED: "A\tB",
+			QUOTED: 'He said "Hello"',
+		});
+	});
+
+	it("handles single-quoted and backtick strings literally", () => {
+		const content = `
+RAW_URL='https://example.com?a=1&b=2'
+BACKTICK=\`simple value\`
+`;
+		expect(parseDotenv(content)).toEqual({
+			RAW_URL: "https://example.com?a=1&b=2",
+			BACKTICK: "simple value",
+		});
+	});
+
+	it("handles multiline quoted values", () => {
+		const content = `
+PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA
+-----END RSA PRIVATE KEY-----"
+ANOTHER_VAR=value
+`;
+		expect(parseDotenv(content)).toEqual({
+			PRIVATE_KEY: `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA
+-----END RSA PRIVATE KEY-----`,
+			ANOTHER_VAR: "value",
+		});
+	});
+
+	it("strips trailing inline comments on unquoted values", () => {
+		const content = `
+PORT=3000 # The server port
+DATABASE_URL=postgres://localhost:5432/db # Primary database
+`;
+		expect(parseDotenv(content)).toEqual({
+			PORT: "3000",
+			DATABASE_URL: "postgres://localhost:5432/db",
+		});
+	});
+
+	it("preserves hash inside quoted values", () => {
+		const content = `
+COLOR="#ff0000"
+HASH_IN_SINGLE='#abcdef'
+`;
+		expect(parseDotenv(content)).toEqual({
+			COLOR: "#ff0000",
+			HASH_IN_SINGLE: "#abcdef",
+		});
+	});
+
+	it("handles empty values", () => {
+		const content = `
+EMPTY=
+EMPTY_QUOTED=""
+`;
+		expect(parseDotenv(content)).toEqual({
+			EMPTY: "",
+			EMPTY_QUOTED: "",
+		});
+	});
+
+	it("overwrites duplicate keys with later values", () => {
+		const content = `
+PORT=3000
+PORT=8080
+`;
+		expect(parseDotenv(content)).toEqual({
+			PORT: "8080",
+		});
+	});
+});

--- a/packages/arkenv/src/features/check/dotenv.ts
+++ b/packages/arkenv/src/features/check/dotenv.ts
@@ -1,20 +1,44 @@
 /**
  * Unescape double-quoted string escape sequences.
  *
+ * Uses a single-pass token replacement so escaped backslashes (`\\`)
+ * are preserved correctly and do not interfere with subsequent escape sequences.
+ *
  * @param value The raw string inside double quotes
  * @returns The unescaped string
  */
 function unescapeDoubleQuoted(value: string): string {
-	return value
-		.replace(/\\n/g, "\n")
-		.replace(/\\r/g, "\r")
-		.replace(/\\t/g, "\t")
-		.replace(/\\"/g, '"')
-		.replace(/\\\\/g, "\\");
+	return value.replace(/\\([nrtbfv0"\\])/g, (_, match: string) => {
+		switch (match) {
+			case "n":
+				return "\n";
+			case "r":
+				return "\r";
+			case "t":
+				return "\t";
+			case "b":
+				return "\b";
+			case "f":
+				return "\f";
+			case "v":
+				return "\v";
+			case "0":
+				return "\0";
+			case '"':
+				return '"';
+			case "\\":
+				return "\\";
+			default:
+				return `\\${match}`;
+		}
+	});
 }
 
 /**
  * Find the index of an unescaped closing quote matching the delimiter.
+ *
+ * In double quotes (`"`), a backslash (`\`) escapes the following character.
+ * In single quotes (`'`) and backticks (``` ` ```), backslashes are treated as literal characters.
  *
  * @param text Text to search
  * @param quote The quote character (`"`, `'`, or '`')
@@ -22,8 +46,8 @@ function unescapeDoubleQuoted(value: string): string {
  */
 function findClosingQuote(text: string, quote: string): number {
 	for (let i = 0; i < text.length; i++) {
-		if (text[i] === "\\") {
-			i++; // skip next character (escaped)
+		if (quote === '"' && text[i] === "\\") {
+			i++; // skip next character (escaped in double quotes)
 			continue;
 		}
 		if (text[i] === quote) {

--- a/packages/arkenv/src/features/check/dotenv.ts
+++ b/packages/arkenv/src/features/check/dotenv.ts
@@ -1,0 +1,125 @@
+/**
+ * Unescape double-quoted string escape sequences.
+ *
+ * @param value The raw string inside double quotes
+ * @returns The unescaped string
+ */
+function unescapeDoubleQuoted(value: string): string {
+	return value
+		.replace(/\\n/g, "\n")
+		.replace(/\\r/g, "\r")
+		.replace(/\\t/g, "\t")
+		.replace(/\\"/g, '"')
+		.replace(/\\\\/g, "\\");
+}
+
+/**
+ * Find the index of an unescaped closing quote matching the delimiter.
+ *
+ * @param text Text to search
+ * @param quote The quote character (`"`, `'`, or '`')
+ * @returns The 0-based index of the matching closing quote, or -1 if not found
+ */
+function findClosingQuote(text: string, quote: string): number {
+	for (let i = 0; i < text.length; i++) {
+		if (text[i] === "\\") {
+			i++; // skip next character (escaped)
+			continue;
+		}
+		if (text[i] === quote) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+/**
+ * Parse plain `.env` file content into key-value pairs.
+ *
+ * Conforms to standard dotenv syntax:
+ * - Ignores empty lines and `#` comments
+ * - Supports optional `export ` prefix
+ * - Supports single (`'`), double (`"`), and backtick (``` ` ```) quotes
+ * - Supports multiline quoted values
+ * - Strips inline comments on unquoted values (`KEY=val # comment`)
+ * - Does not perform variable expansion (literal values)
+ *
+ * @param content The `.env` file content string
+ * @returns A dictionary of parsed environment variables
+ */
+export function parseDotenv(content: string): Record<string, string> {
+	const result: Record<string, string> = {};
+	const lines = content.split(/\r?\n/);
+
+	let currentKey: string | null = null;
+	let currentValue = "";
+	let inQuoteChar: string | null = null;
+
+	for (let i = 0; i < lines.length; i++) {
+		const rawLine = lines[i];
+
+		if (inQuoteChar !== null) {
+			const closingIdx = findClosingQuote(rawLine, inQuoteChar);
+			if (closingIdx !== -1) {
+				currentValue += "\n" + rawLine.slice(0, closingIdx);
+				const finalVal =
+					inQuoteChar === '"'
+						? unescapeDoubleQuoted(currentValue)
+						: currentValue;
+				if (currentKey !== null) {
+					result[currentKey] = finalVal;
+				}
+				currentKey = null;
+				currentValue = "";
+				inQuoteChar = null;
+			} else {
+				currentValue += "\n" + rawLine;
+			}
+			continue;
+		}
+
+		let line = rawLine.trimStart();
+		if (!line || line.startsWith("#")) {
+			continue;
+		}
+
+		if (line.startsWith("export ")) {
+			line = line.slice(7).trimStart();
+		}
+
+		const eqIdx = line.indexOf("=");
+		if (eqIdx === -1) {
+			continue;
+		}
+
+		const key = line.slice(0, eqIdx).trim();
+		if (!key || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+			continue;
+		}
+
+		let val = line.slice(eqIdx + 1).trimStart();
+
+		const firstChar = val[0];
+		if (firstChar === '"' || firstChar === "'" || firstChar === "`") {
+			const afterFirst = val.slice(1);
+			const closingIdx = findClosingQuote(afterFirst, firstChar);
+			if (closingIdx !== -1) {
+				const inner = afterFirst.slice(0, closingIdx);
+				result[key] = firstChar === '"' ? unescapeDoubleQuoted(inner) : inner;
+			} else {
+				currentKey = key;
+				currentValue = afterFirst;
+				inQuoteChar = firstChar;
+			}
+		} else {
+			// Unquoted: strip trailing inline comments
+			const commentIdx = val.indexOf(" #");
+			if (commentIdx !== -1) {
+				val = val.slice(0, commentIdx);
+			}
+			result[key] = val.trimEnd();
+		}
+	}
+
+	return result;
+}

--- a/packages/arkenv/src/shared/ports/schema-loader.port.ts
+++ b/packages/arkenv/src/shared/ports/schema-loader.port.ts
@@ -1,3 +1,4 @@
+import type { EnvIssue } from "@repo/utils";
 import type { DeclaredSchemaKey } from "@/features/schema-loader";
 
 /**
@@ -45,6 +46,29 @@ export type SchemaLoadFailure = {
 
 export type SchemaLoadResult = SchemaLoadSuccess | SchemaLoadFailure;
 
+export type SchemaValidationSuccess = {
+	ok: true;
+};
+
+export type SchemaValidationFailure =
+	| {
+			ok: false;
+			kind: "validation";
+			message: string;
+			issues: EnvIssue[];
+	  }
+	| {
+			ok: false;
+			kind: "load";
+			code: SchemaLoadErrorCode;
+			message: string;
+			cause?: unknown;
+	  };
+
+export type SchemaValidationResult =
+	| SchemaValidationSuccess
+	| SchemaValidationFailure;
+
 /**
  * Load a user's schema module and return declared keys without validating env.
  */
@@ -60,4 +84,16 @@ export type SchemaLoaderPort = {
 	 * @returns A discriminated success or structured error result
 	 */
 	load(target: SchemaLoadTarget): Promise<SchemaLoadResult>;
+
+	/**
+	 * Validate a resolved environment dictionary against the schema module.
+	 *
+	 * @param target The schema module to load and evaluate
+	 * @param env The resolved environment dictionary to validate
+	 * @returns Success or discriminated validation / load failure
+	 */
+	validate(
+		target: SchemaLoadTarget,
+		env: Record<string, string | undefined>,
+	): Promise<SchemaValidationResult>;
 };

--- a/packages/arkenv/src/smoke.test.ts
+++ b/packages/arkenv/src/smoke.test.ts
@@ -128,4 +128,37 @@ describe("cli smoke tests", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	it("check command returns non-zero when schema is missing", async () => {
+		const uuid = Math.random().toString(36).substring(7);
+		const tempDir = path.resolve(__dirname, `../tmp-smoke-check-${uuid}`);
+		await fs.mkdir(tempDir, { recursive: true });
+
+		try {
+			await expect(
+				exec(`node ${cliPath} check`, { cwd: tempDir }),
+			).rejects.toMatchObject({
+				code: 1,
+			});
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("check --agent returns structured SCHEMA_NOT_FOUND error on missing schema", async () => {
+		const uuid = Math.random().toString(36).substring(7);
+		const tempDir = path.resolve(__dirname, `../tmp-smoke-check-${uuid}`);
+		await fs.mkdir(tempDir, { recursive: true });
+
+		try {
+			const res = await exec(`node ${cliPath} check --agent`, {
+				cwd: tempDir,
+			}).catch((err) => err);
+
+			expect(res.code).toBe(1);
+			expect(res.stdout).toContain('"code": "SCHEMA_NOT_FOUND"');
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/core/src/arktype/index.ts
+++ b/packages/core/src/arktype/index.ts
@@ -211,8 +211,14 @@ export function parse<const T extends SchemaShape>(
 	const validatedEnv = schemaWithKeys(coercedEnv);
 
 	// In ArkType 2.x, calling a type as a function returns the validated data or ArkErrors.
-	if (validatedEnv instanceof ArkErrors) {
-		throw new ArkEnvError(arkErrorsToIssues(validatedEnv, config));
+	if (
+		validatedEnv instanceof ArkErrors ||
+		(validatedEnv &&
+			typeof validatedEnv === "object" &&
+			"byPath" in validatedEnv &&
+			typeof (validatedEnv as any).byPath === "object")
+	) {
+		throw new ArkEnvError(arkErrorsToIssues(validatedEnv as ArkErrors, config));
 	}
 
 	return validatedEnv;


### PR DESCRIPTION
Fixes #962

### Summary
Adds the `arkenv check` command to validate the active environment against the project's env schema, supporting `--schema` (`-s`), repeatable `--env-file`, `--json`, `--quiet`, and `--agent` with CI-friendly exit codes (`0` on success, `1` on error).

### Changes
- **Zero-Dependency Dotenv Parser**: Added `parseDotenv` in `packages/arkenv/src/features/check/dotenv.ts` with test coverage for comments, quotes, multiline values, and `export` prefixes.
- **Schema Validation Port & Adapter**: Extended `SchemaLoaderPort` with `validate(target, env)` and implemented runtime validation in `JitiSchemaLoaderAdapter` with strict `process.env` isolation in `try ... finally`.
- **Check Command**: Implemented `CheckUseCase` handling schema discovery, sequential `.env` loading, validation, formatted error output, and structured JSON results.
- **CLI & Dispatch**: Added `--schema` and `--env-file` flags to `CLI`, wired `CheckUseCase` in `composition.ts` and `bin.ts`, and updated help text.
- **Docs & Changeset**: Added `reference/check.mdx` documentation, updated navigation, and added a changeset for `arkenv`.