### PR TITLE
ci: authenticate Turbo remote cache via GitHub OIDC

### DIFF
--- a/.github/actions/setup-turbo-remote-cache/action.yml
+++ b/.github/actions/setup-turbo-remote-cache/action.yml
@@ -1,0 +1,8 @@
+name: Set up Turborepo Remote Cache
+description: Exchange GitHub OIDC for a short-lived Vercel Remote Cache token
+runs:
+  using: composite
+  steps:
+    - uses: vercel/setup-turborepo-remote-cache-action@v1.1.0
+      with:
+        team: ${{ vars.TURBO_TEAM }}

--- a/.github/actions/setup-turbo-remote-cache/action.yml
+++ b/.github/actions/setup-turbo-remote-cache/action.yml
@@ -7,6 +7,10 @@ inputs:
 runs:
   using: composite
   steps:
+    # GitHub withholds OIDC on `pull_request` from forks; skip so turbo runs
+    # without cache (pre-OIDC behavior). `pull_request_target`, `push`, and
+    # `workflow_dispatch` still exchange a token.
     - uses: vercel/setup-turborepo-remote-cache-action@v1.1.0
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
       with:
         team: ${{ inputs.team }}

--- a/.github/actions/setup-turbo-remote-cache/action.yml
+++ b/.github/actions/setup-turbo-remote-cache/action.yml
@@ -1,8 +1,12 @@
 name: Set up Turborepo Remote Cache
 description: Exchange GitHub OIDC for a short-lived Vercel Remote Cache token
+inputs:
+  team:
+    description: Vercel team slug (`TURBO_TEAM`)
+    required: true
 runs:
   using: composite
   steps:
     - uses: vercel/setup-turborepo-remote-cache-action@v1.1.0
       with:
-        team: ${{ vars.TURBO_TEAM }}
+        team: ${{ inputs.team }}

--- a/.github/workflows/deploy-www-manual.yml
+++ b/.github/workflows/deploy-www-manual.yml
@@ -42,6 +42,8 @@ jobs:
           fetch-depth: 0
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - name: Resolve git metadata for the deployed commit
         id: meta
         run: |

--- a/.github/workflows/deploy-www-manual.yml
+++ b/.github/workflows/deploy-www-manual.yml
@@ -22,14 +22,16 @@ concurrency:
   group: deploy-www-manual-${{ inputs.target }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   Deploy-Manual:
     runs-on: ubuntu-latest
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       TARGET: ${{ inputs.target }}
       DEPLOY_SHA: ${{ inputs.sha }}
@@ -38,6 +40,8 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
           fetch-depth: 0
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
       - name: Resolve git metadata for the deployed commit
         id: meta
         run: |

--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -2,8 +2,6 @@ name: Deploy www (arkenv.js.org)
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 on:
   push:
     branches:
@@ -22,11 +20,17 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -31,6 +31,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -19,17 +19,18 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   pkg-pr-new:
     if: github.repository == 'yamcodes/arkenv'
     runs-on: ubuntu-latest
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/preview-www-default.yml
+++ b/.github/workflows/preview-www-default.yml
@@ -23,5 +23,9 @@ jobs:
     # or which branch the PR targets.
     # Fork authors cannot apply labels (triage+ required), so this is not self-serve spamable.
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'preview')
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     uses: ./.github/workflows/preview-www-reusable.yml
     secrets: inherit

--- a/.github/workflows/preview-www-labeled.yml
+++ b/.github/workflows/preview-www-labeled.yml
@@ -13,5 +13,9 @@ concurrency:
 jobs:
   Deploy-Preview:
     if: github.event.label.name == 'preview'
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     uses: ./.github/workflows/preview-www-reusable.yml
     secrets: inherit

--- a/.github/workflows/preview-www-reusable.yml
+++ b/.github/workflows/preview-www-reusable.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -23,6 +24,8 @@ jobs:
           # ref so fork commits resolve and base history remains available for turbo.
           ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/head', github.event.pull_request.number) || github.sha }}
           persist-credentials: false
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
       - name: Set Turbo base/head for PRs
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
@@ -40,7 +43,6 @@ jobs:
       - name: Check if www is affected
         id: affected
         env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
@@ -79,7 +81,6 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
         run: node scripts/vercel-wrapper.cjs build --token="$VERCEL_TOKEN"
       - name: Deploy Project Artifacts to Vercel
         if: steps.affected.outputs.is_affected == 'true'

--- a/.github/workflows/preview-www-reusable.yml
+++ b/.github/workflows/preview-www-reusable.yml
@@ -26,6 +26,8 @@ jobs:
           persist-credentials: false
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - name: Set Turbo base/head for PRs
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,6 @@ jobs:
     # See docs/adr/0006-branching-and-release-flow.md.
     if: github.event.sender.login != 'autofix-ci[bot]'
     runs-on: ubuntu-latest
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - name: Generate GitHub App Token
         id: generate-token
@@ -37,6 +34,9 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
+
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -48,6 +48,8 @@ jobs:
           fetch-depth: 0 # Full history needed for change detection
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -7,6 +7,11 @@ on:
       - "packages/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
 jobs:
   changes:
     if: github.repository == 'yamcodes/arkenv'
@@ -29,8 +34,6 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     steps:
       - name: Generate GitHub App Token
@@ -43,6 +46,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Full history needed for change detection
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -54,6 +59,4 @@ jobs:
         uses: ./.github/actions/size-limit
         with:
           github_token: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
-          turbo_token: ${{ secrets.TURBO_TOKEN }}
-          turbo_team: ${{ vars.TURBO_TEAM }}
           filter: "./packages/*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+permissions:
+  contents: read
+  id-token: write
+  actions: write
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -26,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -48,6 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -64,6 +69,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -84,6 +91,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -110,6 +119,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
       - name: Set Turbo base/head for PRs
         if: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -155,6 +166,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2 # for checking against dev and for following the PR history
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
       - name: Set Turbo base/head for PRs
         if: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -206,6 +219,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2 # for checking against dev and for following the PR history
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
       - name: Set Turbo base/head for PRs
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -53,6 +55,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -71,6 +75,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -93,6 +99,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -121,6 +129,8 @@ jobs:
           fetch-depth: 2
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - name: Set Turbo base/head for PRs
         if: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -168,6 +178,8 @@ jobs:
           fetch-depth: 2 # for checking against dev and for following the PR history
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - name: Set Turbo base/head for PRs
         if: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -221,6 +233,8 @@ jobs:
           fetch-depth: 2 # for checking against dev and for following the PR history
       - name: Set up Turborepo Remote Cache
         uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - name: Set Turbo base/head for PRs
         if: ${{ github.event_name == 'pull_request' }}
         run: |


### PR DESCRIPTION
## Summary
- Fixes #1106 by exchanging GitHub OIDC for a short-lived Vercel Remote Cache token instead of `secrets.TURBO_TOKEN`.
- Shared composite `.github/actions/setup-turbo-remote-cache` runs after checkout on every job that invokes Turbo (`test`, release, deploy, preview, size-limit, pkg.pr.new).
- Default branch is `dev`, so merging into `v1` will not auto-close the issue.

Assumes the Vercel Turborepo CLI OIDC policy for `yamcodes/arkenv` and `TURBO_TEAM` are already set. After this PR’s **test** logs show `Remote caching enabled` and no `Insufficient permissions to write to remote cache`, delete the `TURBO_TOKEN` GitHub secret.

## Test plan
- [ ] PR `test` workflow: setup step succeeds
- [ ] Turbo logs `Remote caching enabled`
- [ ] No `Insufficient permissions to write to remote cache` on `test` / `test-build` / `test-e2e`
- [ ] Optional: re-run the same workflow on this SHA and look for remote cache hits across jobs (not only later steps in one job)


Made with [Cursor](https://cursor.com)