### PR TITLE
ci: authenticate Turbo remote cache via GitHub OIDC

### DIFF
--- a/.github/actions/setup-turbo-remote-cache/action.yml
+++ b/.github/actions/setup-turbo-remote-cache/action.yml
@@ -1,0 +1,16 @@
+name: Set up Turborepo Remote Cache
+description: Exchange GitHub OIDC for a short-lived Vercel Remote Cache token
+inputs:
+  team:
+    description: Vercel team slug (`TURBO_TEAM`)
+    required: true
+runs:
+  using: composite
+  steps:
+    # GitHub withholds OIDC on `pull_request` from forks; skip so turbo runs
+    # without cache (pre-OIDC behavior). `pull_request_target`, `push`, and
+    # `workflow_dispatch` still exchange a token.
+    - uses: vercel/setup-turborepo-remote-cache-action@v1.1.0
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
+      with:
+        team: ${{ inputs.team }}

--- a/.github/workflows/deploy-www-manual.yml
+++ b/.github/workflows/deploy-www-manual.yml
@@ -22,14 +22,16 @@ concurrency:
   group: deploy-www-manual-${{ inputs.target }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   Deploy-Manual:
     runs-on: ubuntu-latest
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       TARGET: ${{ inputs.target }}
       DEPLOY_SHA: ${{ inputs.sha }}
@@ -38,6 +40,10 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
           fetch-depth: 0
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - name: Resolve git metadata for the deployed commit
         id: meta
         run: |

--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -2,8 +2,6 @@ name: Deploy www (arkenv.js.org)
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 on:
   push:
     branches:
@@ -22,11 +20,19 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -19,17 +19,19 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   pkg-pr-new:
     if: github.repository == 'yamcodes/arkenv'
     runs-on: ubuntu-latest
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/preview-www-default.yml
+++ b/.github/workflows/preview-www-default.yml
@@ -23,5 +23,9 @@ jobs:
     # or which branch the PR targets.
     # Fork authors cannot apply labels (triage+ required), so this is not self-serve spamable.
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'preview')
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     uses: ./.github/workflows/preview-www-reusable.yml
     secrets: inherit

--- a/.github/workflows/preview-www-labeled.yml
+++ b/.github/workflows/preview-www-labeled.yml
@@ -13,5 +13,9 @@ concurrency:
 jobs:
   Deploy-Preview:
     if: github.event.label.name == 'preview'
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     uses: ./.github/workflows/preview-www-reusable.yml
     secrets: inherit

--- a/.github/workflows/preview-www-reusable.yml
+++ b/.github/workflows/preview-www-reusable.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -23,6 +24,10 @@ jobs:
           # ref so fork commits resolve and base history remains available for turbo.
           ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/head', github.event.pull_request.number) || github.sha }}
           persist-credentials: false
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - name: Set Turbo base/head for PRs
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
@@ -40,7 +45,6 @@ jobs:
       - name: Check if www is affected
         id: affected
         env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
@@ -79,7 +83,6 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
         run: node scripts/vercel-wrapper.cjs build --token="$VERCEL_TOKEN"
       - name: Deploy Project Artifacts to Vercel
         if: steps.affected.outputs.is_affected == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,6 @@ jobs:
     # See docs/adr/0006-branching-and-release-flow.md.
     if: github.event.sender.login != 'autofix-ci[bot]'
     runs-on: ubuntu-latest
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - name: Generate GitHub App Token
         id: generate-token
@@ -37,6 +34,10 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -7,6 +7,11 @@ on:
       - "packages/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
 jobs:
   changes:
     if: github.repository == 'yamcodes/arkenv'
@@ -29,8 +34,6 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     steps:
       - name: Generate GitHub App Token
@@ -43,6 +46,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Full history needed for change detection
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -54,6 +61,4 @@ jobs:
         uses: ./.github/actions/size-limit
         with:
           github_token: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
-          turbo_token: ${{ secrets.TURBO_TOKEN }}
-          turbo_team: ${{ vars.TURBO_TEAM }}
           filter: "./packages/*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+permissions:
+  contents: read
+  id-token: write
+  actions: write
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -26,6 +27,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -48,6 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -64,6 +73,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -84,6 +97,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -110,6 +127,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - name: Set Turbo base/head for PRs
         if: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -155,6 +176,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2 # for checking against dev and for following the PR history
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - name: Set Turbo base/head for PRs
         if: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -206,6 +231,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2 # for checking against dev and for following the PR history
+      - name: Set up Turborepo Remote Cache
+        uses: ./.github/actions/setup-turbo-remote-cache
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - name: Set Turbo base/head for PRs
         if: ${{ github.event_name == 'pull_request' }}
         run: |


### PR DESCRIPTION
## Summary
- Port of [#1644](https://github.com/yamcodes/arkenv/pull/1644) (OIDC Turbo remote cache) onto default branch `dev`. Pattern-matched, not cherry-picked — package layout and workflows differ between `v1` and `dev`.
- Shared composite `.github/actions/setup-turbo-remote-cache` exchanges GitHub OIDC for a short-lived Vercel Remote Cache token after checkout on every job that runs Turbo.
- [#1106](https://github.com/yamcodes/arkenv/issues/1106) is already closed from the `v1` merge; this extends the same fix to `dev` (and thus `main` deploys). Do **not** delete the `TURBO_TOKEN` GitHub secret until this PR merges. After both `v1` and `dev` use OIDC, the secret can go.

Assumes the Vercel Turborepo CLI OIDC policy for `yamcodes/arkenv` and `TURBO_TEAM` are already set (same as #1644).

## Test plan
- [ ] PR `test` workflow: setup step succeeds
- [ ] Turbo logs `Remote caching enabled`
- [ ] No `Insufficient permissions to write to remote cache` on `test` / `test-build` / `test-e2e`
- [ ] Optional: re-run the same workflow on this SHA and look for remote cache hits across jobs


Made with [Cursor](https://cursor.com)