### PR TITLE
fix(cli): scaffold Valibot PORT as v.number()

### DIFF
--- a/.changeset/valibot-scaffold-port-wrapper.md
+++ b/.changeset/valibot-scaffold-port-wrapper.md
@@ -1,0 +1,16 @@
+---
+"arkenv": patch
+---
+
+#### Scaffold Valibot `PORT` as `v.number()` instead of a string transform
+
+`arkenv init` with Valibot already imports `@arkenv/standard/valibot`, which binds `@valibot/to-json-schema` for coercion. Generate `PORT` as a numeric schema so the wrapper can coerce `"3000"` instead of requiring `v.transform(Number)`.
+
+```ts
+import { arkenv } from "@arkenv/standard/valibot";
+import * as v from "valibot";
+
+export const env = arkenv({
+  PORT: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),
+});
+```

--- a/packages/arkenv/src/adapters/jiti-schema-loader/jiti-schema-loader.adapter.test.ts
+++ b/packages/arkenv/src/adapters/jiti-schema-loader/jiti-schema-loader.adapter.test.ts
@@ -108,7 +108,7 @@ describe("JitiSchemaLoaderAdapter", () => {
 			import * as v from "valibot";
 			export const env = arkenv({
 				HOST: v.optional(v.string(), "localhost"),
-				PORT: v.fallback(v.pipe(v.string(), v.transform(Number)), 3000),
+				PORT: v.optional(v.number(), 3000),
 			});
 			`,
 		);

--- a/packages/arkenv/src/features/scaffold/validators.test.ts
+++ b/packages/arkenv/src/features/scaffold/validators.test.ts
@@ -327,7 +327,7 @@ describe("validators templates", () => {
 				'v.optional(v.picklist(["development", "production", "test"]), "development")',
 			);
 			expect(template).toContain(
-				"v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000)",
+				"v.optional(v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000)",
 			);
 			expect(template).toContain("export const env = arkenv({");
 			expect(template).not.toContain("export const Env =");

--- a/packages/arkenv/src/features/scaffold/validators/dialects/valibot.ts
+++ b/packages/arkenv/src/features/scaffold/validators/dialects/valibot.ts
@@ -18,7 +18,7 @@ export const valibotDialect: Dialect = {
 			return `${key}: v.optional(v.picklist(["development", "production", "test"]), "development"),`;
 		}
 		if (role === "server" && key === "PORT") {
-			return "PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),";
+			return "PORT: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),";
 		}
 		const preset = tryFormatPresetFieldValue(
 			valibotDialect,
@@ -45,7 +45,7 @@ export const valibotDialect: Dialect = {
 	},
 
 	defaultSimpleSchemaFields: `\t\tNODE_ENV: v.optional(v.picklist(["development", "production", "test"]), "development"),
-		PORT: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),`,
+		PORT: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(65535)), 3000),`,
 
 	formatSimpleSchemaFields(keys, clientPrefix = "", hostPreset = undefined) {
 		return keys

--- a/packages/standard/src/subpaths.test.ts
+++ b/packages/standard/src/subpaths.test.ts
@@ -20,6 +20,19 @@ describe("@arkenv/standard subpaths", () => {
 		expect(env.DEBUG).toBe(true);
 	});
 
+	it("applies the CLI Valibot PORT schema default and coerces a string env value", () => {
+		const port = v.optional(
+			v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(65535)),
+			3000,
+		);
+
+		const withDefault = valibotArkenv({ PORT: port }, { env: {} });
+		expect(withDefault.PORT).toBe(3000);
+
+		const coerced = valibotArkenv({ PORT: port }, { env: { PORT: "3000" } });
+		expect(coerced.PORT).toBe(3000);
+	});
+
 	it("coerces Zod Mini number and boolean fields without a toJsonSchema callback", () => {
 		const env = zodMiniArkenv(
 			{


### PR DESCRIPTION
## Summary
- `arkenv init` with Valibot already imports `@arkenv/standard/valibot`, which binds `@valibot/to-json-schema` so `v.number()` coerces env strings.
- The generated `PORT` field still used `v.pipe(v.string(), v.transform(Number), …)`, which fights that wrapper. Scaffold `PORT` as a numeric schema instead (same range/default as before).
- The `examples/with-valibot` example on `v1` already used the wrapper + `v.number()`; this aligns the CLI with it.

## Test plan
- [x] `pnpm --filter arkenv exec vitest run src/features/scaffold/validators.test.ts`
- [ ] Confirm a Valibot `arkenv init` env file imports `@arkenv/standard/valibot` and has `PORT: v.optional(v.pipe(v.number(), …), 3000)`
- [ ] `PORT=3000` boots without a manual transform


Made with [Cursor](https://cursor.com)