### PR TITLE
Find package llms.txt folders by URL instead of Fumadocs $ref

### DIFF
--- a/apps/www/app/docs/[package]/llms.txt/route.test.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.test.ts
@@ -8,7 +8,7 @@ vi.mock("~/lib/source", () => ({
 			children: [
 				{
 					type: "folder",
-					$ref: "arkenv/meta.json",
+					$ref: { folder: "arkenv", meta: "arkenv/meta.json" },
 					children: [
 						{
 							type: "page",
@@ -24,8 +24,8 @@ vi.mock("~/lib/source", () => ({
 
 vi.mock("fumadocs-core/source", () => ({
 	llms: () => ({
-		indexNode: (node: any) =>
-			`Mocked Folder Index Content: ${node.$ref || node.name}`,
+		indexNode: (node: { $ref?: unknown; name?: string }) =>
+			`Mocked Folder Index Content: ${JSON.stringify(node.$ref) || node.name}`,
 	}),
 }));
 

--- a/apps/www/app/docs/[package]/llms.txt/route.test.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.test.ts
@@ -9,11 +9,31 @@ vi.mock("~/lib/source", () => ({
 				{
 					type: "folder",
 					$ref: { folder: "arkenv", meta: "arkenv/meta.json" },
+					index: {
+						type: "page",
+						url: "/docs/arkenv",
+						name: "ArkEnv",
+					},
 					children: [
 						{
 							type: "page",
-							url: "/docs/arkenv",
-							name: "ArkEnv",
+							url: "/docs/arkenv/quickstart",
+							name: "Quickstart",
+						},
+						{
+							type: "folder",
+							index: {
+								type: "page",
+								url: "/docs/arkenv/integrations",
+								name: "Integrations",
+							},
+							children: [
+								{
+									type: "page",
+									url: "/docs/arkenv/integrations/ide/vscode",
+									name: "VS Code",
+								},
+							],
 						},
 					],
 				},
@@ -24,8 +44,12 @@ vi.mock("~/lib/source", () => ({
 
 vi.mock("fumadocs-core/source", () => ({
 	llms: () => ({
-		indexNode: (node: { $ref?: unknown; name?: string }) =>
-			`Mocked Folder Index Content: ${JSON.stringify(node.$ref) || node.name}`,
+		indexNode: (node: {
+			$ref?: unknown;
+			name?: string;
+			index?: { url?: string };
+		}) =>
+			`Mocked Folder Index Content: ${node.index?.url ?? JSON.stringify(node.$ref) ?? node.name}`,
 	}),
 }));
 
@@ -45,7 +69,9 @@ describe("/docs/[package]/llms.txt route", () => {
 
 		const body = await response.text();
 		expect(body).toBeTypeOf("string");
-		expect(body).toContain("arkenv");
+		expect(body).toContain("/docs/arkenv");
+		// Must be the package folder (index.url), not a nested /docs/arkenv/… subtree
+		expect(body).not.toContain("/docs/arkenv/integrations");
 	});
 
 	it("should return 404 for a nonexistent package", async () => {

--- a/apps/www/app/docs/[package]/llms.txt/route.test.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.test.ts
@@ -81,9 +81,7 @@ describe("/docs/[package]/llms.txt route", () => {
 	});
 
 	it("should 404 when a package folder has no index and only nested pages", async () => {
-		const req = new Request(
-			"https://arkenv.js.org/docs/nested-only/llms.txt",
-		);
+		const req = new Request("https://arkenv.js.org/docs/nested-only/llms.txt");
 		const params = Promise.resolve({ package: "nested-only" });
 
 		await expect(GET(req, { params })).rejects.toThrow();

--- a/apps/www/app/docs/[package]/llms.txt/route.test.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.test.ts
@@ -20,18 +20,26 @@ vi.mock("~/lib/source", () => ({
 							url: "/docs/arkenv/quickstart",
 							name: "Quickstart",
 						},
+					],
+				},
+				// Index-less package: pages only under a subfolder. Root-only matching
+				// must 404; recursive descent would return the nested folder (200).
+				{
+					type: "folder",
+					$ref: { folder: "nested-only", meta: "nested-only/meta.json" },
+					children: [
 						{
 							type: "folder",
 							index: {
 								type: "page",
-								url: "/docs/arkenv/integrations",
-								name: "Integrations",
+								url: "/docs/nested-only/sub",
+								name: "Sub",
 							},
 							children: [
 								{
 									type: "page",
-									url: "/docs/arkenv/integrations/ide/vscode",
-									name: "VS Code",
+									url: "/docs/nested-only/sub/page",
+									name: "Page",
 								},
 							],
 						},
@@ -70,8 +78,15 @@ describe("/docs/[package]/llms.txt route", () => {
 		const body = await response.text();
 		expect(body).toBeTypeOf("string");
 		expect(body).toContain("/docs/arkenv");
-		// Must be the package folder (index.url), not a nested /docs/arkenv/… subtree
-		expect(body).not.toContain("/docs/arkenv/integrations");
+	});
+
+	it("should 404 when a package folder has no index and only nested pages", async () => {
+		const req = new Request(
+			"https://arkenv.js.org/docs/nested-only/llms.txt",
+		);
+		const params = Promise.resolve({ package: "nested-only" });
+
+		await expect(GET(req, { params })).rejects.toThrow();
 	});
 
 	it("should return 404 for a nonexistent package", async () => {

--- a/apps/www/app/docs/[package]/llms.txt/route.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.ts
@@ -9,7 +9,6 @@ export const revalidate = false;
  */
 type Node = {
 	type: "page" | "folder" | "separator";
-	$ref?: string;
 	url?: string;
 	index?: {
 		url: string;
@@ -31,15 +30,7 @@ function findFolder(nodes: Node[], packageSlug: string): Node | undefined {
 			if (node.index && node.index.url === `/docs/${packageSlug}`) {
 				return node;
 			}
-			// 2. Or, does its $ref contain the slug?
-			if (
-				node.$ref &&
-				(node.$ref === `${packageSlug}/meta.json` ||
-					node.$ref.startsWith(`${packageSlug}/`))
-			) {
-				return node;
-			}
-			// 3. Or, do any of its child pages have a URL that starts with `/docs/${packageSlug}`?
+			// 2. Or, do any of its child pages have a URL that starts with `/docs/${packageSlug}`?
 			const hasMatchingPage = node.children?.some(
 				(child) =>
 					child.type === "page" &&

--- a/apps/www/app/docs/[package]/llms.txt/route.ts
+++ b/apps/www/app/docs/[package]/llms.txt/route.ts
@@ -17,36 +17,35 @@ type Node = {
 };
 
 /**
- * Traverse the page tree nodes to find the folder corresponding to the package slug.
+ * Find the package folder among root page-tree children.
  *
- * @param nodes The page tree nodes to search
+ * Package docs folders are root children of the page tree
+ * (`content/docs/meta.json`). Each ships an `index.mdx`, matched via
+ * `index.url`. Direct child pages are a fallback. Do not descend into nested
+ * folders: a child folder can share the `/docs/${slug}/…` URL prefix and would
+ * truncate `llms.txt` to that subtree.
+ *
+ * @param nodes The root page tree children
  * @param packageSlug The package folder/slug name
  * @returns The matching Folder node, or undefined if not found
  */
 function findFolder(nodes: Node[], packageSlug: string): Node | undefined {
 	for (const node of nodes) {
-		if (node.type === "folder") {
-			// 1. If it has an index, does its index.url match `/docs/${packageSlug}`?
-			if (node.index && node.index.url === `/docs/${packageSlug}`) {
-				return node;
-			}
-			// 2. Or, do any of its child pages have a URL that starts with `/docs/${packageSlug}`?
-			const hasMatchingPage = node.children?.some(
-				(child) =>
-					child.type === "page" &&
-					child.url &&
-					(child.url === `/docs/${packageSlug}` ||
-						child.url.startsWith(`/docs/${packageSlug}/`)),
-			);
-			if (hasMatchingPage) {
-				return node;
-			}
-
-			// Recursively search children
-			if (node.children) {
-				const found = findFolder(node.children, packageSlug);
-				if (found) return found;
-			}
+		if (node.type !== "folder") {
+			continue;
+		}
+		if (node.index?.url === `/docs/${packageSlug}`) {
+			return node;
+		}
+		const hasMatchingPage = node.children?.some(
+			(child) =>
+				child.type === "page" &&
+				child.url &&
+				(child.url === `/docs/${packageSlug}` ||
+					child.url.startsWith(`/docs/${packageSlug}/`)),
+		);
+		if (hasMatchingPage) {
+			return node;
 		}
 	}
 	return undefined;


### PR DESCRIPTION
## Description

`/docs/[package]/llms.txt` walked Fumadocs page-tree folders by `$ref` as a string. `fumadocs-core` 16.12+ stores folder `$ref` as `{ folder, meta }`, so Next prerender throws `n.$ref.startsWith is not a function` (this is what reds [PR #1657](https://github.com/yamcodes/arkenv/pull/1657) `www#build`).

Match folders by public `index.url` / child page URLs only. `$ref` stays internal.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor

## Test plan

- [x] `pnpm --filter www exec vitest run "app/docs/[package]/llms.txt/route.test.ts"` (mock `$ref` is an object)
- [ ] CI `test-typesafety` / `www#build` on this branch
- [ ] After merge, rebase or re-run [PR #1657](https://github.com/yamcodes/arkenv/pull/1657) — Fumadocs bump should get past prerender; Biome 2.5 autofix is a separate issue

## Checklist

- [x] My code follows the code style of this project (double quotes, tabs, no parameter reassignment).
- [x] I have written sentence-case imperative commits / PR title (e.g. `Add support for custom error messages` - no `feat:`, no trailing period, capitalized).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have created a changeset using `pnpm changeset` (if this affects a published package).

### For v0 (dev) PRs:
- [ ] **Forward-Porting**: (For maintainers) Has this change been manually forward-ported to the `v1` branch?


Made with [Cursor](https://cursor.com)