### PR TITLE
chore(renovate): disable Dependency Dashboard issue

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,12 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended"],
+	"extends": ["config:recommended", ":disableDependencyDashboard"],
 	"ignorePaths": ["**/node_modules/**"],
 	"schedule": ["on friday"],
 	"vulnerabilityAlerts": {
 		"enabled": true
 	},
 	"osvVulnerabilityAlerts": true,
-	"dependencyDashboard": true,
 	"updateInternalDeps": true,
 	"timezone": "Asia/Almaty",
 	"lockFileMaintenance": {


### PR DESCRIPTION
## Summary
- Disable Renovate's GitHub Dependency Dashboard via the `:disableDependencyDashboard` preset (overrides `config:recommended`).
- Remove the explicit `dependencyDashboard: true` flag from `.github/renovate.json`.
- Dependency updates continue on the existing Friday schedule; management moves to the [Mend portal](https://developer.mend.io/github/yamcodes/arkenv).

## Test plan
- [ ] Merge to `dev`
- [ ] After Renovate picks up the config, close [#4](https://github.com/yamcodes/arkenv/issues/4) (Dependency Dashboard)
- [ ] Confirm Renovate does not reopen the dashboard issue on the next run
- [ ] Confirm scheduled update PRs still open as expected


Made with [Cursor](https://cursor.com)