### PR TITLE
fix(www): restore WCAG AA contrast on homepage marquee chips

### DIFF
--- a/apps/www/components/page/compatibility-rails.tsx
+++ b/apps/www/components/page/compatibility-rails.tsx
@@ -121,12 +121,10 @@ function MarqueeRow({
 							href={item.url}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-gray-500/5 dark:bg-gray-400/5 border border-gray-500/10 dark:border-gray-400/10 text-xs text-gray-500 dark:text-gray-400 transition-all hover:bg-gray-500/10 dark:hover:bg-gray-400/10 hover:border-gray-500/20 dark:hover:border-gray-400/20 hover:text-gray-600 dark:hover:text-gray-300 pointer-events-auto"
+							className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-gray-500/5 dark:bg-gray-400/5 border border-gray-500/10 dark:border-gray-400/10 text-xs text-gray-600 dark:text-gray-300 transition-all hover:bg-gray-500/10 dark:hover:bg-gray-400/10 hover:border-gray-500/20 dark:hover:border-gray-400/20 hover:text-gray-700 dark:hover:text-gray-200 pointer-events-auto"
 						>
-							<item.icon className="w-3.5 h-3.5 opacity-70 group-hover/rail:opacity-100 transition-opacity" />
-							<span className="font-medium tracking-tight opacity-80 group-hover/rail:opacity-100 transition-opacity">
-								{item.name}
-							</span>
+							<item.icon className="w-3.5 h-3.5" />
+							<span className="font-medium tracking-tight">{item.name}</span>
 						</a>
 					))}
 				</div>


### PR DESCRIPTION
## Summary
- Homepage `CompatibilityRails` chips used `opacity-80` / `opacity-70`, which dropped label contrast below WCAG 2 AA.
- That fails e2e smoke (`Route Smoke Test: /`) after `@axe-core/playwright` 4.11 → 4.13 in Renovate [#1657](https://github.com/yamcodes/arkenv/pull/1657).
- Remove the opacity fade and bump resting chip text to `text-gray-600` / `dark:text-gray-300`.

## Test plan
- [ ] CI e2e `Route Smoke Test: /` passes (no serious `color-contrast` on marquee labels)
- [ ] Spot-check homepage “Works with” / “Built for” rails in light + dark
- [ ] Re-run or rebase [#1657](https://github.com/yamcodes/arkenv/pull/1657) after merge


Made with [Cursor](https://cursor.com)