### PR TITLE
fix(www): point Roadmap links at v1 /roadmap

### DIFF
--- a/apps/www/app/(home)/layout.tsx
+++ b/apps/www/app/(home)/layout.tsx
@@ -18,7 +18,7 @@ export default function Layout({ children }: { children: ReactNode }) {
 							{ text: "Documentation", url: "/docs/arkenv" },
 							{
 								text: "Roadmap",
-								url: "https://github.com/yamcodes/arkenv/issues/683",
+								url: "https://arkenv-v1.vercel.app/roadmap",
 							},
 						]}
 						actions={[

--- a/apps/www/app/docs/layout.tsx
+++ b/apps/www/app/docs/layout.tsx
@@ -48,7 +48,7 @@ export default function Layout({ children }: { children: ReactNode }) {
 									{ text: "Documentation", url: "/docs" },
 									{
 										text: "Roadmap",
-										url: "https://github.com/yamcodes/arkenv/issues/683",
+										url: "https://arkenv-v1.vercel.app/roadmap",
 									},
 								]}
 								actions={[

--- a/apps/www/content/docs/arkenv/faq.mdx
+++ b/apps/www/content/docs/arkenv/faq.mdx
@@ -144,4 +144,4 @@ Yes. ArkEnv is optimized for modern development workflows and features a **dedic
 
 Yes. ArkEnv is tested rigorously and carries **zero external dependencies**, eliminating supply-chain vulnerabilities. The core runtime is a tiny \~2 kB gzipped. The actual parsing mechanism is handled by your chosen validation library, and ArkEnv is designed to [**fail fast**](/docs/arkenv#fail-fast) — validating **early, at build time and startup**. This means a misconfiguration (or a server-side variable leaking to the client) is caught **before** your app ever serves traffic, so a broken build never ships to production in the first place.
 
-ArkEnv is currently in v0 (roadmap towards v1 [here](https://github.com/yamcodes/arkenv/issues/683)), and fully compliant with [Semantic Versioning 2.0.0](https://semver.org/). The core library is used in production and not expected to change meaningfully.
+ArkEnv is currently in v0 (roadmap towards v1 [here](https://arkenv-v1.vercel.app/roadmap)), and fully compliant with [Semantic Versioning 2.0.0](https://semver.org/). The core library is used in production and not expected to change meaningfully.


### PR DESCRIPTION
## Summary
- Home + docs header Roadmap links now go to https://arkenv-v1.vercel.app/roadmap instead of closed #683
- FAQ “roadmap towards v1” link updated to match

## Test plan
- [ ] On a `dev` preview, click Roadmap in home and docs headers → opens the v1 roadmap page
- [ ] FAQ SemVer section link matches


Made with [Cursor](https://cursor.com)