### PR TITLE
feat(www): polish roadmap topics, titles, and hero chip

### DIFF
--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -1884,24 +1884,50 @@
 }
 
 /* Edge fades: bottom when more below, top once scrolled away from the start */
-.home-aurora__mvp-body[data-fade-top="true"]::before,
-.home-aurora__mvp-body[data-fade-bottom="true"]::after {
+.home-aurora__mvp-body::before,
+.home-aurora__mvp-body::after {
 	content: "";
 	position: absolute;
 	inset-inline: 0;
-	height: 2.75rem;
+	height: 3rem;
 	pointer-events: none;
 	z-index: 1;
+	opacity: 0;
+	transition: opacity 0.35s var(--ease-out);
 }
 
-.home-aurora__mvp-body[data-fade-top="true"]::before {
+.home-aurora__mvp-body::before {
 	top: 0;
-	background: linear-gradient(to top, transparent, var(--color-paper-2));
+	/* Avoid color-mix(…, transparent) in oklch — it muddies into magenta.
+	   Steeper than a pure linear: solid paper arrives sooner near the edge. */
+	background: linear-gradient(
+		to top,
+		transparent 0%,
+		var(--color-paper-2) 80%,
+		var(--color-paper-2) 100%
+	);
 }
 
-.home-aurora__mvp-body[data-fade-bottom="true"]::after {
+.home-aurora__mvp-body::after {
 	bottom: 0;
-	background: linear-gradient(to bottom, transparent, var(--color-paper-2));
+	background: linear-gradient(
+		to bottom,
+		transparent 0%,
+		var(--color-paper-2) 80%,
+		var(--color-paper-2) 100%
+	);
+}
+
+.home-aurora__mvp-body[data-fade-top="true"]::before,
+.home-aurora__mvp-body[data-fade-bottom="true"]::after {
+	opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.home-aurora__mvp-body::before,
+	.home-aurora__mvp-body::after {
+		transition: none;
+	}
 }
 
 .home-aurora__mvp-pane {

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -1900,22 +1900,12 @@
 	top: 0;
 	/* Avoid color-mix(…, transparent) in oklch — it muddies into magenta.
 	   Steeper than a pure linear: solid paper arrives sooner near the edge. */
-	background: linear-gradient(
-		to top,
-		transparent 0%,
-		var(--color-paper-2) 80%,
-		var(--color-paper-2) 100%
-	);
+	background: linear-gradient(to top, transparent 0%, var(--color-paper-2) 80%, var(--color-paper-2) 100%);
 }
 
 .home-aurora__mvp-body::after {
 	bottom: 0;
-	background: linear-gradient(
-		to bottom,
-		transparent 0%,
-		var(--color-paper-2) 80%,
-		var(--color-paper-2) 100%
-	);
+	background: linear-gradient(to bottom, transparent 0%, var(--color-paper-2) 80%, var(--color-paper-2) 100%);
 }
 
 .home-aurora__mvp-body[data-fade-top="true"]::before,

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -1857,23 +1857,51 @@
 	min-width: 0;
 	overflow: auto;
 	overscroll-behavior: contain;
-	scrollbar-width: none;
-	-ms-overflow-style: none;
+	scrollbar-width: thin;
+	scrollbar-color: color-mix(in oklch, var(--color-muted) 55%, transparent) transparent;
 }
 
 .home-aurora__mvp-scroll::-webkit-scrollbar {
-	display: none;
+	width: 0.5rem;
+	height: 0.5rem;
 }
 
-.home-aurora__mvp-body[data-overflow="true"]::after {
+.home-aurora__mvp-scroll::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+.home-aurora__mvp-scroll::-webkit-scrollbar-thumb {
+	border-radius: var(--radius-pill);
+	background: color-mix(in oklch, var(--color-muted) 45%, transparent);
+	border: 2px solid transparent;
+	background-clip: padding-box;
+}
+
+.home-aurora__mvp-scroll::-webkit-scrollbar-thumb:hover {
+	background: color-mix(in oklch, var(--color-muted) 70%, transparent);
+	background-clip: padding-box;
+	border: 2px solid transparent;
+}
+
+/* Edge fades: bottom when more below, top once scrolled away from the start */
+.home-aurora__mvp-body[data-fade-top="true"]::before,
+.home-aurora__mvp-body[data-fade-bottom="true"]::after {
 	content: "";
 	position: absolute;
 	inset-inline: 0;
-	bottom: 0;
 	height: 2.75rem;
 	pointer-events: none;
-	background: linear-gradient(to bottom, transparent, var(--color-paper-2));
 	z-index: 1;
+}
+
+.home-aurora__mvp-body[data-fade-top="true"]::before {
+	top: 0;
+	background: linear-gradient(to top, transparent, var(--color-paper-2));
+}
+
+.home-aurora__mvp-body[data-fade-bottom="true"]::after {
+	bottom: 0;
+	background: linear-gradient(to bottom, transparent, var(--color-paper-2));
 }
 
 .home-aurora__mvp-pane {

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -39,7 +39,10 @@ export default async function HomePage() {
 						className="home-aurora__badge rise"
 						style={{ animationDelay: "40ms" }}
 					>
-						<RoadmapProgressCard percent={roadmap.percent} />
+						<RoadmapProgressCard
+							percent={roadmap.percent}
+							stale={roadmap.stale}
+						/>
 					</div>
 					<div className="home-aurora__hero-copy">
 						<h1 id="home-hero" className="home-aurora__tagline">

--- a/apps/www/app/(home)/roadmap/page.tsx
+++ b/apps/www/app/(home)/roadmap/page.tsx
@@ -2,6 +2,7 @@ import "./roadmap.css";
 import type { Metadata } from "next";
 import { SiteFooter } from "~/components/site-footer";
 import { fetchRoadmap } from "~/lib/roadmap/fetch-roadmap";
+import { groupByTopic } from "~/lib/roadmap/topics";
 import type { RoadmapItem } from "~/lib/roadmap/types";
 
 export const metadata: Metadata = {
@@ -68,6 +69,36 @@ function RoadmapRow({ item }: { item: RoadmapItem }) {
 	);
 }
 
+function RoadmapTopicGroups({
+	items,
+	sectionId,
+}: {
+	items: RoadmapItem[];
+	sectionId: string;
+}) {
+	const groups = groupByTopic(items);
+	return (
+		<div className="roadmap-page__topics">
+			{groups.map(({ topic, items: topicItems }) => {
+				const topicId = `${sectionId}-${topic.toLowerCase()}`;
+				return (
+					<div key={topic} className="roadmap-page__topic">
+						<h3 id={topicId} className="roadmap-page__topic-title">
+							{topic}
+							<span className="roadmap-page__count">{topicItems.length}</span>
+						</h3>
+						<ul className="roadmap-page__list" aria-labelledby={topicId}>
+							{topicItems.map((item) => (
+								<RoadmapRow key={item.id} item={item} />
+							))}
+						</ul>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
 export default async function RoadmapPage() {
 	const roadmap = await fetchRoadmap();
 	const openItems = roadmap.items.filter((item) => !item.done);
@@ -105,11 +136,7 @@ export default async function RoadmapPage() {
 							Up next
 							<span className="roadmap-page__count">{openItems.length}</span>
 						</h2>
-						<ul className="roadmap-page__list">
-							{openItems.map((item) => (
-								<RoadmapRow key={item.id} item={item} />
-							))}
-						</ul>
+						<RoadmapTopicGroups items={openItems} sectionId="roadmap-open" />
 					</section>
 				) : null}
 
@@ -122,11 +149,7 @@ export default async function RoadmapPage() {
 							Done
 							<span className="roadmap-page__count">{doneItems.length}</span>
 						</h2>
-						<ul className="roadmap-page__list">
-							{doneItems.map((item) => (
-								<RoadmapRow key={item.id} item={item} />
-							))}
-						</ul>
+						<RoadmapTopicGroups items={doneItems} sectionId="roadmap-done" />
 					</section>
 				) : null}
 			</article>

--- a/apps/www/app/(home)/roadmap/roadmap.css
+++ b/apps/www/app/(home)/roadmap/roadmap.css
@@ -1,4 +1,4 @@
-/* Roadmap page — home chrome, checklist */
+/* Roadmap page — home chrome, checklist; type scale matches docs (#nd-page) */
 
 .roadmap-page {
 	display: flex;
@@ -10,6 +10,14 @@
 	width: 100%;
 	margin-inline: 0;
 	box-sizing: border-box;
+	/* Same Geist “book” rendering as docs article titles */
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	text-rendering: optimizeLegibility;
+	font-feature-settings:
+		"calt" 0,
+		"rlig",
+		"ss11";
 }
 
 .roadmap-page__header {
@@ -18,15 +26,16 @@
 	gap: var(--space-sm);
 }
 
-.roadmap-page__title-heading {
+.roadmap-page h1.roadmap-page__title-heading {
 	margin: 0;
 	font-family: var(--font-display);
-	font-size: var(--text-display-s);
+	/* Match #nd-page h1 — beats .home-aurora :is(h1,h2,h3) { font-weight: 600 } */
+	font-size: 2.5rem;
 	font-weight: 450;
-	line-height: 1.15;
-	letter-spacing: var(--text-heading-tracking);
+	line-height: 3rem;
+	letter-spacing: -0.05em;
+	overflow-wrap: normal;
 	color: var(--color-ink);
-	font-feature-settings: var(--font-feature-sans);
 }
 
 .roadmap-page__stale a {
@@ -48,25 +57,51 @@
 	color: var(--color-cmd);
 }
 
-.roadmap-page__section-title {
+.roadmap-page h2.roadmap-page__section-title {
 	display: flex;
 	align-items: baseline;
 	gap: var(--space-xs);
 	margin: 0 0 var(--space-sm);
-	font-size: var(--text-md);
+	font-family: var(--font-display);
+	/* Match .prose h2 — beats home-aurora h2 { font-weight: 600 } */
+	font-size: 1.5rem;
 	font-weight: 450;
-	letter-spacing: var(--text-heading-tracking);
+	line-height: 2rem;
+	letter-spacing: -0.04em;
+	overflow-wrap: normal;
 	color: var(--color-ink);
-	font-feature-settings: var(--font-feature-sans);
 }
 
 .roadmap-page__count {
 	font-family: var(--font-mono);
 	font-feature-settings: var(--font-feature-mono);
 	font-variant-numeric: tabular-nums;
-	font-size: var(--text-sm);
+	font-size: 0.875rem;
 	font-weight: 400;
+	line-height: 1;
 	color: var(--color-muted);
+	letter-spacing: 0;
+}
+
+.roadmap-page__topics {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-lg);
+}
+
+.roadmap-page h3.roadmap-page__topic-title {
+	display: flex;
+	align-items: baseline;
+	gap: var(--space-xs);
+	margin: 0 0 var(--space-2xs);
+	font-family: var(--font-display);
+	/* Match .prose h3 — beats home-aurora h3 { font-weight: 600 } */
+	font-size: 1.25rem;
+	font-weight: 450;
+	line-height: 1.625rem;
+	letter-spacing: -0.02em;
+	overflow-wrap: normal;
+	color: var(--color-ink-2);
 }
 
 .roadmap-page__list {
@@ -99,15 +134,20 @@
 	border: var(--rule-hair) solid var(--color-rule);
 	border-radius: var(--radius-sm);
 	background: transparent;
-	color: var(--color-accent-ink);
+	color: var(--color-muted);
+	opacity: 0.55;
+	cursor: default;
+	pointer-events: none;
 }
 
 .roadmap-page__check--done {
-	border-color: var(--color-accent);
-	background: var(--color-accent);
+	border-color: var(--color-muted);
+	background: var(--color-muted);
+	color: var(--color-paper);
 	font-size: 0.7rem;
 	font-weight: 600;
 	line-height: 1;
+	opacity: 0.45;
 }
 
 .roadmap-page__link {
@@ -133,11 +173,6 @@
 }
 
 .roadmap-page__link--static {
-	cursor: default;
-	color: var(--color-ink);
-}
-
-.roadmap-page__link--static:hover {
 	color: var(--color-ink);
 }
 

--- a/apps/www/components/announcement-badge.tsx
+++ b/apps/www/components/announcement-badge.tsx
@@ -8,6 +8,7 @@ export function AnnouncementBadge({
 	arrow = true,
 	new: newBadge = false,
 	href,
+	"aria-label": ariaLabel,
 	children,
 }: PropsWithChildren<{
 	/**
@@ -22,9 +23,18 @@ export function AnnouncementBadge({
 	 * The link to navigate to when clicking the badge.
 	 */
 	href: ArkenvUrl;
+	/**
+	 * Optional accessible name when children are visual-only (e.g. a meter).
+	 */
+	"aria-label"?: string;
 }>) {
 	return (
-		<Link href={href} data-no-underline className="home-aurora__announce">
+		<Link
+			href={href}
+			data-no-underline
+			className="home-aurora__announce"
+			aria-label={ariaLabel}
+		>
 			{newBadge ? (
 				<NewBadge className="home-aurora__announce-new rounded-full" />
 			) : null}

--- a/apps/www/components/page/hero-mvp-example-view.test.tsx
+++ b/apps/www/components/page/hero-mvp-example-view.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { HeroMvpExampleView } from "./hero-mvp-example-view";
 import {
 	HERO_MVP_HOSTS,
@@ -52,6 +52,20 @@ function renderView() {
 	);
 }
 
+
+function mockScrollOverflow(overflow: boolean) {
+	const scrollTop = { value: 0, writable: true, configurable: true };
+	vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(100);
+	vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(
+		overflow ? 240 : 100,
+	);
+	Object.defineProperty(HTMLElement.prototype, "scrollTop", scrollTop);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
 describe("HeroMvpExampleView", () => {
 	it("starts on ArkType with validator tabs and no host switcher", () => {
 		renderView();
@@ -95,6 +109,7 @@ describe("HeroMvpExampleView", () => {
 			screen.getByRole("tabpanel").querySelector("[data-active='true']"),
 		).not.toHaveTextContent("VITE_API_URL");
 
+		mockScrollOverflow(true);
 		await user.click(screen.getByRole("tab", { name: "Valibot" }));
 		expect(
 			screen.getByRole("tabpanel").querySelector("[data-active='true']"),
@@ -106,6 +121,11 @@ describe("HeroMvpExampleView", () => {
 			"data-overflow",
 			"true",
 		);
+		expect(screen.getByRole("tabpanel")).toHaveAttribute(
+			"data-fade-bottom",
+			"true",
+		);
+		expect(screen.getByRole("tabpanel")).not.toHaveAttribute("data-fade-top");
 	});
 
 	it("copies the visible tab source", async () => {

--- a/apps/www/components/page/hero-mvp-example-view.tsx
+++ b/apps/www/components/page/hero-mvp-example-view.tsx
@@ -24,6 +24,27 @@ type HeroMvpExampleViewProps = {
 	examples: HeroMvpExample[];
 };
 
+type ScrollEdgeFades = {
+	overflow: boolean;
+	fadeTop: boolean;
+	fadeBottom: boolean;
+};
+
+function readScrollEdgeFades(scroll: HTMLElement): ScrollEdgeFades {
+	const canScroll = scroll.scrollHeight > scroll.clientHeight + 1;
+	if (!canScroll) {
+		return { overflow: false, fadeTop: false, fadeBottom: false };
+	}
+	const atTop = scroll.scrollTop <= 1;
+	const atBottom =
+		scroll.scrollTop + scroll.clientHeight >= scroll.scrollHeight - 1;
+	return {
+		overflow: true,
+		fadeTop: !atTop,
+		fadeBottom: !atBottom,
+	};
+}
+
 /**
  * Validator tabs over a vanilla env.ts window. Hosts live in the ticker, not here.
  */
@@ -31,12 +52,38 @@ export function HeroMvpExampleView({ examples }: HeroMvpExampleViewProps) {
 	const { validator, setValidator } = useHeroPlayground();
 	const baseId = useId();
 	const bodyRef = useRef<HTMLDivElement>(null);
+	const scrollRef = useRef<HTMLDivElement>(null);
 	const panes = examples.filter((item) => item.host === "vanilla");
-	// biome-ignore lint/correctness/useExhaustiveDependencies: tab switch must reset shared pane scroll
+
 	useLayoutEffect(() => {
 		const body = bodyRef.current;
-		if (body) body.scrollTop = 0;
+		const scroll = scrollRef.current;
+		if (!body || !scroll) return;
+
+		const applyFades = () => {
+			const edges = readScrollEdgeFades(scroll);
+			if (edges.overflow) body.dataset.overflow = "true";
+			else delete body.dataset.overflow;
+			if (edges.fadeTop) body.dataset.fadeTop = "true";
+			else delete body.dataset.fadeTop;
+			if (edges.fadeBottom) body.dataset.fadeBottom = "true";
+			else delete body.dataset.fadeBottom;
+		};
+
+		scroll.scrollTop = 0;
+		applyFades();
+		scroll.addEventListener("scroll", applyFades, { passive: true });
+		const ro = new ResizeObserver(applyFades);
+		ro.observe(scroll);
+		for (const child of scroll.children) {
+			if (child instanceof HTMLElement) ro.observe(child);
+		}
+		return () => {
+			scroll.removeEventListener("scroll", applyFades);
+			ro.disconnect();
+		};
 	}, [validator]);
+
 	if (panes.length === 0) return null;
 	const panelId = `${baseId}-panel`;
 	const active = panes.find((item) => item.validator === validator) ?? panes[0];
@@ -62,12 +109,12 @@ export function HeroMvpExampleView({ examples }: HeroMvpExampleViewProps) {
 			<figure className="home-aurora__code-window home-aurora__mvp-frame">
 				<WindowChrome title="./env.ts" copyText={active.code} />
 				<div
+					ref={bodyRef}
 					role="tabpanel"
 					id={panelId}
 					className="home-aurora__mvp-body"
-					data-overflow={active.validator === "valibot" ? "true" : undefined}
 				>
-					<div ref={bodyRef} className="home-aurora__mvp-scroll">
+					<div ref={scrollRef} className="home-aurora__mvp-scroll">
 						{panes.map((item) => {
 							const active = item.validator === validator;
 							return (

--- a/apps/www/components/page/roadmap-progress-card.css
+++ b/apps/www/components/page/roadmap-progress-card.css
@@ -1,46 +1,20 @@
-/* Roadmap progress chip — announcement-badge chrome, green bar fill */
+/* Progress meter inside AnnouncementBadge — chrome/arrow live on the badge */
 
 .roadmap-progress-card {
 	display: inline-flex;
 	align-items: center;
 	gap: 0.55rem;
-	padding: 0.3rem 0.7rem 0.3rem 0.75rem;
-	border-radius: var(--radius-pill);
-	border: var(--rule-hair) solid color-mix(in oklch, var(--color-accent) 35%, transparent);
-	background: color-mix(in oklch, var(--color-accent) 10%, transparent);
-	color: var(--color-ink);
+	min-width: 0;
 	font-family: var(--font-mono);
 	font-feature-settings: var(--font-feature-mono);
-	font-size: 0.8rem;
-	font-weight: 500;
 	font-variant-numeric: tabular-nums;
 	letter-spacing: 0.02em;
 	line-height: 1;
-	text-decoration: none;
-	backdrop-filter: blur(8px);
-	max-width: 100%;
-	min-width: 0;
-	white-space: nowrap;
-	box-sizing: border-box;
-	transition:
-		background-color var(--dur-micro) var(--ease-out),
-		border-color var(--dur-micro) var(--ease-out);
-}
-
-.roadmap-progress-card:hover {
-	background: color-mix(in oklch, var(--color-accent) 16%, transparent);
-	border-color: color-mix(in oklch, var(--color-accent) 50%, transparent);
-}
-
-.roadmap-progress-card:focus-visible {
-	outline: 2px solid var(--color-focus);
-	outline-offset: 2px;
 }
 
 .roadmap-progress-card__label,
 .roadmap-progress-card__pct {
 	flex: none;
-	color: var(--color-ink);
 }
 
 .roadmap-progress-card__track {
@@ -53,6 +27,10 @@
 	border-radius: var(--radius-pill);
 	background: color-mix(in oklch, var(--color-accent) 18%, var(--color-paper));
 	overflow: hidden;
+}
+
+.roadmap-progress-card__track--stale {
+	background: color-mix(in oklch, var(--color-muted) 28%, var(--color-paper));
 }
 
 .roadmap-progress-card__fill {

--- a/apps/www/components/page/roadmap-progress-card.test.tsx
+++ b/apps/www/components/page/roadmap-progress-card.test.tsx
@@ -13,4 +13,14 @@ describe("RoadmapProgressCard", () => {
 		expect(screen.getByText("v1.0")).toBeInTheDocument();
 		expect(screen.getByText("94%")).toBeInTheDocument();
 	});
+
+	it("hides the percent when GitHub data is stale", () => {
+		render(<RoadmapProgressCard percent={0} stale />);
+
+		expect(
+			screen.getByRole("link", { name: "v1 roadmap (progress unavailable)" }),
+		).toHaveAttribute("href", "/roadmap");
+		expect(screen.getByText("v1.0")).toBeInTheDocument();
+		expect(screen.queryByText("0%")).not.toBeInTheDocument();
+	});
 });

--- a/apps/www/components/page/roadmap-progress-card.tsx
+++ b/apps/www/components/page/roadmap-progress-card.tsx
@@ -1,42 +1,56 @@
-import Link from "next/link";
+import { AnnouncementBadge } from "~/components/announcement-badge";
 import "./roadmap-progress-card.css";
 
 /**
- * Compact v1 progress chip (Drizzle-style). Links to `/roadmap`.
+ * v1 progress chip in the hero announcement slot. Uses `AnnouncementBadge`
+ * for chrome + arrow; only the meter content is custom.
+ *
+ * When `stale`, the extras-only fallback would otherwise report `0%` — show a
+ * neutral track with no percent so the marketing hero does not claim a wrong number.
  */
 export function RoadmapProgressCard({
 	percent,
+	stale = false,
 	label = "v1.0",
 }: {
 	percent: number;
+	/**
+	 * True when GitHub could not be reached (`fetchRoadmap` extras-only fallback).
+	 */
+	stale?: boolean;
 	/**
 	 * Left-side version label (monospace).
 	 */
 	label?: string;
 }) {
 	const clamped = Math.max(0, Math.min(100, Math.round(percent)));
+	const ariaLabel = stale
+		? "v1 roadmap (progress unavailable)"
+		: `v1 roadmap ${clamped}% complete`;
 
 	return (
-		<Link
-			href="/roadmap"
-			className="roadmap-progress-card"
-			aria-label={`v1 roadmap ${clamped}% complete`}
-		>
-			<span className="roadmap-progress-card__label">{label}</span>
-			<span
-				className="roadmap-progress-card__track"
-				role="progressbar"
-				aria-valuemin={0}
-				aria-valuemax={100}
-				aria-valuenow={clamped}
-				aria-hidden="true"
-			>
+		<AnnouncementBadge href="/roadmap" aria-label={ariaLabel}>
+			<span className="roadmap-progress-card">
+				<span className="roadmap-progress-card__label">{label}</span>
 				<span
-					className="roadmap-progress-card__fill"
-					style={{ width: `${clamped}%` }}
-				/>
+					className={
+						stale
+							? "roadmap-progress-card__track roadmap-progress-card__track--stale"
+							: "roadmap-progress-card__track"
+					}
+					aria-hidden="true"
+				>
+					{stale ? null : (
+						<span
+							className="roadmap-progress-card__fill"
+							style={{ width: `${clamped}%` }}
+						/>
+					)}
+				</span>
+				{stale ? null : (
+					<span className="roadmap-progress-card__pct">{clamped}%</span>
+				)}
 			</span>
-			<span className="roadmap-progress-card__pct">{clamped}%</span>
-		</Link>
+		</AnnouncementBadge>
 	);
 }

--- a/apps/www/components/site-footer.tsx
+++ b/apps/www/components/site-footer.tsx
@@ -1,7 +1,6 @@
 import { DiscordListItem } from "~/components/discord-list-item";
 import { Logo } from "~/components/page/logo";
 import { getGithubRepoUrl } from "~/lib/github-links";
-import { STACKBLITZ_PLAYGROUND_URL } from "~/lib/stackblitz";
 
 /**
  * Shared site footer used on the home page and docs.
@@ -49,19 +48,7 @@ export function SiteFooter({
 					<h3 id="footer-resources">Resources</h3>
 					<ul>
 						<li>
-							<a
-								href={STACKBLITZ_PLAYGROUND_URL}
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								Playground
-							</a>
-						</li>
-						<li>
 							<a href="/docs">Docs</a>
-						</li>
-						<li>
-							<a href="/roadmap">Roadmap</a>
 						</li>
 						<li>
 							<a

--- a/apps/www/lib/roadmap/config.ts
+++ b/apps/www/lib/roadmap/config.ts
@@ -1,3 +1,5 @@
+import type { RoadmapTopic } from "~/lib/roadmap/topics";
+
 /**
  * Manual roadmap rows that are not GitHub issues (launch gates, audits).
  * Milestone issues remain the source of truth for tracked work; these append.
@@ -9,6 +11,7 @@ export type RoadmapExtra = {
 	id: string;
 	title: string;
 	done: boolean;
+	topic: RoadmapTopic;
 };
 
 /**
@@ -36,25 +39,30 @@ export const ROADMAP_EXTRAS: readonly RoadmapExtra[] = [
 		id: "parity-audit",
 		title: "Final v0 parity audit",
 		done: false,
+		topic: "Core",
 	},
 	{
 		id: "readme-prod-links",
 		title: "Update README links from alpha to production",
 		done: false,
+		topic: "Docs",
 	},
 	{
 		id: "changelog-epoch",
 		title: "Prepend changelog epoch warnings",
 		done: false,
+		topic: "Docs",
 	},
 	{
 		id: "release-v1",
 		title: "Release v1",
 		done: false,
+		topic: "Core",
 	},
 	{
 		id: "v1-announcement",
 		title: "Document v1 announcement",
 		done: false,
+		topic: "Docs",
 	},
 ];

--- a/apps/www/lib/roadmap/fetch-roadmap.test.ts
+++ b/apps/www/lib/roadmap/fetch-roadmap.test.ts
@@ -4,9 +4,24 @@ vi.mock("~/lib/roadmap/config", () => ({
 	ROADMAP_MILESTONE_NUMBER: 1,
 	ROADMAP_EXCLUDE_ISSUE_NUMBERS: new Set([683, 1306, 1590]),
 	ROADMAP_EXTRAS: [
-		{ id: "zebra-first", title: "Zebra launch step", done: false },
-		{ id: "alpha-second", title: "Alpha launch step", done: false },
-		{ id: "done-extra", title: "Already done extra", done: true },
+		{
+			id: "zebra-first",
+			title: "Zebra launch step",
+			done: false,
+			topic: "Core",
+		},
+		{
+			id: "alpha-second",
+			title: "Alpha launch step",
+			done: false,
+			topic: "Docs",
+		},
+		{
+			id: "done-extra",
+			title: "Already done extra",
+			done: true,
+			topic: "Docs",
+		},
 	],
 }));
 
@@ -46,15 +61,25 @@ describe("fetchRoadmap", () => {
 						},
 						{
 							number: 10,
-							title: "Open work",
+							title: "(v1) Open work",
 							state: "open",
 							html_url: "https://github.com/yamcodes/arkenv/issues/10",
+							labels: [{ name: "@arkenv/nextjs" }],
 						},
 						{
 							number: 9,
 							title: "Shipped work",
 							state: "closed",
 							html_url: "https://github.com/yamcodes/arkenv/issues/9",
+							labels: [{ name: "docs" }],
+						},
+						{
+							number: 1259,
+							title: "documentation",
+							state: "closed",
+							html_url: "https://github.com/yamcodes/arkenv/issues/1259",
+							parent_issue_url:
+								"https://api.github.com/repos/yamcodes/arkenv/issues/1241",
 						},
 						{
 							number: 11,
@@ -73,7 +98,8 @@ describe("fetchRoadmap", () => {
 		const roadmap = await fetchRoadmap();
 
 		expect(roadmap.stale).toBe(false);
-		expect(roadmap.totalCount).toBe(5); // 2 issues + 3 extras (meta issues + PR skipped)
+		expect(roadmap.totalCount).toBe(5); // 2 issues + 3 extras (meta, PR, sub-issue skipped)
+		expect(roadmap.items.map((item) => item.id)).not.toContain("issue:1259");
 		expect(roadmap.doneCount).toBe(2);
 		expect(roadmap.percent).toBe(40);
 		// Open issues first, then extras in config order (not alphabetical).
@@ -84,6 +110,13 @@ describe("fetchRoadmap", () => {
 			"issue:9",
 			"extra:done-extra",
 		]);
+		expect(roadmap.items.find((i) => i.id === "issue:10")).toMatchObject({
+			title: "Open work",
+			topic: "Integrations",
+		});
+		expect(roadmap.items.find((i) => i.id === "issue:9")).toMatchObject({
+			topic: "Docs",
+		});
 	});
 
 	it("keeps milestone issues when only meta fails", async () => {

--- a/apps/www/lib/roadmap/fetch-roadmap.ts
+++ b/apps/www/lib/roadmap/fetch-roadmap.ts
@@ -3,10 +3,7 @@ import {
 	ROADMAP_EXTRAS,
 	ROADMAP_MILESTONE_NUMBER,
 } from "~/lib/roadmap/config";
-import {
-	displayTitle,
-	topicFromIssue,
-} from "~/lib/roadmap/topics";
+import { displayTitle, topicFromIssue } from "~/lib/roadmap/topics";
 import type { RoadmapData, RoadmapItem } from "~/lib/roadmap/types";
 import { breakDownGithubUrl } from "~/lib/utils/github";
 

--- a/apps/www/lib/roadmap/fetch-roadmap.ts
+++ b/apps/www/lib/roadmap/fetch-roadmap.ts
@@ -3,6 +3,10 @@ import {
 	ROADMAP_EXTRAS,
 	ROADMAP_MILESTONE_NUMBER,
 } from "~/lib/roadmap/config";
+import {
+	displayTitle,
+	topicFromIssue,
+} from "~/lib/roadmap/topics";
 import type { RoadmapData, RoadmapItem } from "~/lib/roadmap/types";
 import { breakDownGithubUrl } from "~/lib/utils/github";
 
@@ -19,6 +23,12 @@ type GitHubIssue = {
 	title: string;
 	state: "open" | "closed";
 	html_url: string;
+	labels?: Array<string | { name: string }>;
+	/**
+	 * Present when this issue is a GitHub sub-issue of another issue.
+	 * Sub-issues are omitted from the public roadmap (parents only).
+	 */
+	parent_issue_url?: string | null;
 	pull_request?: unknown;
 };
 
@@ -44,6 +54,12 @@ function repoCoords(): { owner: string; repo: string } {
 	const githubUrl =
 		process.env.NEXT_PUBLIC_GITHUB_URL ?? "https://github.com/yamcodes/arkenv";
 	return breakDownGithubUrl(githubUrl);
+}
+
+function labelNames(issue: GitHubIssue): string[] {
+	return (issue.labels ?? []).map((label) =>
+		typeof label === "string" ? label : label.name,
+	);
 }
 
 /**
@@ -77,7 +93,9 @@ async function fetchMilestoneIssues(
 		if (batch.length < 100) break;
 		page += 1;
 	}
-	return issues.filter((issue) => issue.pull_request == null);
+	return issues.filter(
+		(issue) => issue.pull_request == null && issue.parent_issue_url == null,
+	);
 }
 
 async function fetchMilestoneMeta(
@@ -105,6 +123,7 @@ function extrasAsItems(): RoadmapItem[] {
 		id: `extra:${extra.id}`,
 		title: extra.title,
 		done: extra.done,
+		topic: extra.topic,
 	}));
 }
 
@@ -129,13 +148,17 @@ function sortItems(items: RoadmapItem[]): RoadmapItem[] {
 function issuesToItems(issues: GitHubIssue[]): RoadmapItem[] {
 	return issues
 		.filter((issue) => !ROADMAP_EXCLUDE_ISSUE_NUMBERS.has(issue.number))
-		.map((issue) => ({
-			id: `issue:${issue.number}`,
-			title: issue.title,
-			done: issue.state === "closed",
-			href: issue.html_url,
-			number: issue.number,
-		}));
+		.map((issue) => {
+			const labels = labelNames(issue);
+			return {
+				id: `issue:${issue.number}`,
+				title: displayTitle(issue.title),
+				done: issue.state === "closed",
+				topic: topicFromIssue(labels, issue.title),
+				href: issue.html_url,
+				number: issue.number,
+			};
+		});
 }
 
 function withProgress(

--- a/apps/www/lib/roadmap/topics.test.ts
+++ b/apps/www/lib/roadmap/topics.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	displayTitle,
-	groupByTopic,
-	topicFromIssue,
-} from "./topics";
+import { displayTitle, groupByTopic, topicFromIssue } from "./topics";
 
 describe("displayTitle", () => {
 	it("strips (v1) markers and category prefixes, then capitalizes", () => {
@@ -58,16 +54,14 @@ describe("topicFromIssue", () => {
 				'(v1) RFC: Revisit Valibot DX so "No boilerplate" stays honest',
 			),
 		).toBe("Standard");
-		expect(
-			topicFromIssue([], "Validator mode (make ArkType optional)"),
-		).toBe("Standard");
+		expect(topicFromIssue([], "Validator mode (make ArkType optional)")).toBe(
+			"Standard",
+		);
 	});
 
 	it("falls back to Core", () => {
 		expect(topicFromIssue([], "Unify error normalization")).toBe("Core");
-		expect(
-			topicFromIssue(["arkenv"], "Coercion (string→number)"),
-		).toBe("Core");
+		expect(topicFromIssue(["arkenv"], "Coercion (string→number)")).toBe("Core");
 	});
 
 	it("infers Integrations from conventional-commit scopes", () => {

--- a/apps/www/lib/roadmap/topics.test.ts
+++ b/apps/www/lib/roadmap/topics.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+	displayTitle,
+	groupByTopic,
+	topicFromIssue,
+} from "./topics";
+
+describe("displayTitle", () => {
+	it("strips (v1) markers and category prefixes, then capitalizes", () => {
+		expect(displayTitle("(v1) docs: populate Getting started")).toBe(
+			"Populate Getting started",
+		);
+		expect(displayTitle("(v1) docs: populate Core concepts pages")).toBe(
+			"Populate Core concepts pages",
+		);
+		expect(displayTitle("feat(nuxt): introduce @arkenv/nuxt package")).toBe(
+			"Introduce @arkenv/nuxt package",
+		);
+		expect(displayTitle("RFC(v1): Replace strict layout")).toBe(
+			"RFC: Replace strict layout",
+		);
+		expect(displayTitle("Coercion (string→number)")).toBe(
+			"Coercion (string→number)",
+		);
+	});
+});
+
+describe("topicFromIssue", () => {
+	it("prefers integration package labels", () => {
+		expect(
+			topicFromIssue(["@arkenv/nextjs", "docs"], "(v1) docs-ish next work"),
+		).toBe("Integrations");
+	});
+
+	it("maps CLI labels and CLI-ish titles", () => {
+		expect(topicFromIssue(["@arkenv/cli"], "hosting presets Phase 4")).toBe(
+			"CLI",
+		);
+		expect(topicFromIssue([], "Harden CLI runtime import guard")).toBe("CLI");
+		expect(
+			topicFromIssue(["arkenv"], "(v1) Forward-port hosting presets"),
+		).toBe("CLI");
+	});
+
+	it("maps docs / www / fumadocs to Docs", () => {
+		expect(topicFromIssue(["docs", "www"], "populate Core concepts")).toBe(
+			"Docs",
+		);
+		expect(
+			topicFromIssue(["www", "@arkenv/fumadocs-ui"], "Fix bad search UX"),
+		).toBe("Docs");
+	});
+
+	it("maps @arkenv/standard label and Standard Schema titles", () => {
+		expect(
+			topicFromIssue(
+				["@arkenv/standard"],
+				'(v1) RFC: Revisit Valibot DX so "No boilerplate" stays honest',
+			),
+		).toBe("Standard");
+		expect(
+			topicFromIssue([], "Validator mode (make ArkType optional)"),
+		).toBe("Standard");
+	});
+
+	it("falls back to Core", () => {
+		expect(topicFromIssue([], "Unify error normalization")).toBe("Core");
+		expect(
+			topicFromIssue(["arkenv"], "Coercion (string→number)"),
+		).toBe("Core");
+	});
+
+	it("infers Integrations from conventional-commit scopes", () => {
+		expect(
+			topicFromIssue([], "feat(nuxt): introduce @arkenv/nuxt package"),
+		).toBe("Integrations");
+	});
+});
+
+describe("groupByTopic", () => {
+	it("keeps ROADMAP_TOPICS order and drops empty buckets", () => {
+		const groups = groupByTopic([
+			{ id: "a", topic: "Docs" as const },
+			{ id: "b", topic: "Core" as const },
+			{ id: "c", topic: "Docs" as const },
+		]);
+		expect(groups.map((g) => g.topic)).toEqual(["Core", "Docs"]);
+		expect(groups[0]?.items.map((i) => i.id)).toEqual(["b"]);
+		expect(groups[1]?.items.map((i) => i.id)).toEqual(["a", "c"]);
+	});
+});

--- a/apps/www/lib/roadmap/topics.ts
+++ b/apps/www/lib/roadmap/topics.ts
@@ -1,0 +1,117 @@
+/**
+ * Public roadmap topic buckets (≤5). Derived from GitHub package/docs labels
+ * with light title heuristics when labels are missing or ambiguous.
+ */
+export const ROADMAP_TOPICS = [
+	"Core",
+	"Standard",
+	"Integrations",
+	"CLI",
+	"Docs",
+] as const;
+
+export type RoadmapTopic = (typeof ROADMAP_TOPICS)[number];
+
+const INTEGRATION_LABELS = new Set([
+	"@arkenv/nextjs",
+	"@arkenv/nuxt",
+	"@arkenv/vite-plugin",
+	"@arkenv/bun-plugin",
+]);
+
+const CLI_LABELS = new Set(["@arkenv/cli"]);
+
+const STANDARD_LABELS = new Set(["@arkenv/standard"]);
+
+const DOCS_LABELS = new Set([
+	"docs",
+	"www",
+	"marketing",
+	"@arkenv/fumadocs-ui",
+]);
+
+/**
+ * Strip repetitive milestone markers and conventional-commit category
+ * prefixes from titles shown on `/roadmap`. Raw GitHub titles are unchanged
+ * on GitHub itself.
+ *
+ * Examples: `(v1) docs: populate…` → `Populate…`; `feat(nuxt): add…` → `Add…`.
+ */
+export function displayTitle(title: string): string {
+	const cleaned = title
+		.replace(/\s*RFC\s*\(\s*v1\s*\)\s*:/gi, "RFC:")
+		.replace(/\(\s*v1\s*\)/gi, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+		.replace(/^[a-z][\w-]*(?:\([^)]*\))?:\s*/, "")
+		.trim();
+	if (cleaned.length === 0) return cleaned;
+	return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+/**
+ * Map an issue’s labels (and title fallbacks) to a roadmap topic.
+ *
+ * Priority: Integrations packages → CLI → Docs → Standard (title) → Core.
+ * The bare `arkenv` label alone is not CLI (it was used product-wide); it
+ * only tips CLI when the title mentions CLI / preset / scaffold work.
+ */
+export function topicFromIssue(
+	labels: readonly string[],
+	title: string,
+): RoadmapTopic {
+	if (labels.some((label) => INTEGRATION_LABELS.has(label))) {
+		return "Integrations";
+	}
+
+	if (labels.some((label) => CLI_LABELS.has(label))) {
+		return "CLI";
+	}
+	if (/\bCLI\b|arkenv init|scaffold|FrameworkStrategy/i.test(title)) {
+		return "CLI";
+	}
+	// Historic `arkenv` label was product-wide; only tip CLI for preset work.
+	if (labels.includes("arkenv") && /\bpresets?\b/i.test(title)) {
+		return "CLI";
+	}
+
+	if (labels.some((label) => DOCS_LABELS.has(label))) {
+		return "Docs";
+	}
+
+	if (labels.some((label) => STANDARD_LABELS.has(label))) {
+		return "Standard";
+	}
+
+	if (
+		/standard schema|validator mode|@arkenv\/standard|\/standard\b/i.test(
+			title,
+		)
+	) {
+		return "Standard";
+	}
+
+	if (/^feat\((nuxt|nextjs|vite|bun)/i.test(title)) {
+		return "Integrations";
+	}
+
+	return "Core";
+}
+
+/**
+ * Group items by topic in `ROADMAP_TOPICS` order; omit empty buckets.
+ */
+export function groupByTopic<T extends { topic: RoadmapTopic }>(
+	items: readonly T[],
+): { topic: RoadmapTopic; items: T[] }[] {
+	const buckets = new Map<RoadmapTopic, T[]>(
+		ROADMAP_TOPICS.map((topic) => [topic, []]),
+	);
+	for (const item of items) {
+		buckets.get(item.topic)?.push(item);
+	}
+	return ROADMAP_TOPICS.flatMap((topic) => {
+		const group = buckets.get(topic) ?? [];
+		return group.length > 0 ? [{ topic, items: group }] : [];
+	});
+}

--- a/apps/www/lib/roadmap/topics.ts
+++ b/apps/www/lib/roadmap/topics.ts
@@ -84,9 +84,7 @@ export function topicFromIssue(
 	}
 
 	if (
-		/standard schema|validator mode|@arkenv\/standard|\/standard\b/i.test(
-			title,
-		)
+		/standard schema|validator mode|@arkenv\/standard|\/standard\b/i.test(title)
 	) {
 		return "Standard";
 	}

--- a/apps/www/lib/roadmap/types.ts
+++ b/apps/www/lib/roadmap/types.ts
@@ -1,3 +1,5 @@
+import type { RoadmapTopic } from "~/lib/roadmap/topics";
+
 /**
  * One row on the public roadmap checklist.
  */
@@ -6,8 +8,15 @@ export type RoadmapItem = {
 	 * Stable key for React lists (`issue:123` or `extra:release-v1`).
 	 */
 	id: string;
+	/**
+	 * Display title (milestone `(v1)` markers stripped).
+	 */
 	title: string;
 	done: boolean;
+	/**
+	 * Topic bucket for grouping under Up next / Done.
+	 */
+	topic: RoadmapTopic;
 	/**
 	 * GitHub issue URL when the row comes from the milestone.
 	 */


### PR DESCRIPTION
## Summary
- Group roadmap checklist by topic (Core / Standard / Integrations / CLI / Docs); strip `(v1)` and `docs:`-style prefixes; omit GitHub sub-issues
- Hero progress chip reuses `AnnouncementBadge` (incl. →) and hides a false `0%` when GitHub is stale
- Docs-matching heading weight — beat `.home-aurora :is(h1,h2,h3) { font-weight: 600 }`

Follow-up to #1692 (squash already on `v1`).

## Test plan
- [ ] `/roadmap` headings match docs page title weight
- [ ] Topics group correctly; sub-issues absent; `(v1)` stripped from titles
- [ ] Hero chip shows → and, with GitHub down, no `0%`
- [ ] `pnpm --filter www exec vitest run lib/roadmap components/page/roadmap-progress-card`


Made with [Cursor](https://cursor.com)