### PR TITLE
feat(cli): ensure safe execution without @latest and omit @latest from marketing

### DIFF
--- a/.changeset/safe-cli-freshness-check.md
+++ b/.changeset/safe-cli-freshness-check.md
@@ -1,0 +1,12 @@
+---
+"@arkenv/cli": patch
+"@arkenv/build": patch
+---
+
+#### Add version freshness pre-flight check and prompt to run latest version on init
+
+- Implement pre-flight version check in the CLI during interactive `init` execution against the npm registry with a 1000ms timeout.
+- Prompt the user when an outdated CLI version is executed to run the latest published release via the active package manager's DLX tool (`pnpm dlx`, `bunx`, `yarn dlx`, or `npx`).
+- Forward process signals (`SIGINT`, `SIGTERM`) and standard I/O to the spawned child process, and exit cleanly on completion.
+- Fail open silently without blocking in non-interactive/CI environments or when network errors occur.
+- Simplify marketing copy and error message hints to omit `@latest` (e.g. `npx @arkenv/cli init`).

--- a/apps/www/components/page/cli-command.test.tsx
+++ b/apps/www/components/page/cli-command.test.tsx
@@ -22,7 +22,7 @@ describe("CLICommand", () => {
 	it("should render with syntax highlighting spans", () => {
 		render(<CLICommand />);
 		expect(screen.getByText("npx")).toBeInTheDocument();
-		expect(screen.getByText("@arkenv/cli@latest init")).toBeInTheDocument();
+		expect(screen.getByText("@arkenv/cli init")).toBeInTheDocument();
 	});
 
 	it("should copy command when clicking the container", async () => {

--- a/apps/www/components/page/cli-command.tsx
+++ b/apps/www/components/page/cli-command.tsx
@@ -4,7 +4,7 @@ import { Check, Copy, Terminal } from "lucide-react";
 import { useCopyCommand } from "~/hooks/use-copy-command";
 
 export function CLICommand() {
-	const command = "npx @arkenv/cli@latest init";
+	const command = "npx @arkenv/cli init";
 	const { copied, copy } = useCopyCommand(command);
 
 	return (
@@ -17,7 +17,7 @@ export function CLICommand() {
 			<Terminal className="w-4 h-4 text-blue-500 dark:text-blue-400 opacity-70 group-hover:opacity-100 transition-opacity shrink-0" />
 			<code className="text-sm font-mono whitespace-nowrap overflow-hidden text-ellipsis text-left">
 				<span className="text-amber-800 dark:text-amber-400">npx </span>
-				<span>@arkenv/cli@latest init</span>
+				<span>@arkenv/cli init</span>
 			</code>
 			<div className="ml-auto border-l border-slate-200 dark:border-slate-700/50 pl-2.5 pr-1 shrink-0">
 				{copied ? (

--- a/apps/www/content/docs/arkenv/examples.mdx
+++ b/apps/www/content/docs/arkenv/examples.mdx
@@ -9,7 +9,7 @@ import { SiGithub as GitHub } from "@icons-pack/react-simple-icons";
 Use the [ArkEnv CLI](/docs/cli) to bootstrap an example with your favorite tooling.
 
 ```npm
-npx @arkenv/cli@latest init --example <example-name>
+npx @arkenv/cli init --example <example-name>
 ```
 
 <include cwd>../../examples/README.md#examples</include>

--- a/apps/www/content/docs/arkenv/faq.mdx
+++ b/apps/www/content/docs/arkenv/faq.mdx
@@ -12,7 +12,7 @@ We’ve seen teams struggle with environment variables in JavaScript projects. B
 
 But hope is not an architecture: variables go mysteriously missing during a CI/CD deployment, a boolean flags as `"false"` (a truthy string) and breaks your conditional logic. At some point, someone introduces a new variable without announcing it, leaving everyone else to chase down mysterious runtime errors.
 
-We built ArkEnv to **eliminate this exact class of failures**. With a single initialization command (`npx @arkenv/cli@latest init`), you establish a **fail-safe mechanism** that guarantees your runtime configuration exactly mirrors your technical specification **before a single line of application code executes**.
+We built ArkEnv to **eliminate this exact class of failures**. With a single initialization command (`npx @arkenv/cli init`), you establish a **fail-safe mechanism** that guarantees your runtime configuration exactly mirrors your technical specification **before a single line of application code executes**.
 
 ArkEnv delivers native framework plugins, automated type coercion, and schema-aware AI agent support out-of-the-box. Read our full design philosophy in the [intro](/docs/arkenv) section.
 

--- a/apps/www/content/docs/arkenv/quickstart.mdx
+++ b/apps/www/content/docs/arkenv/quickstart.mdx
@@ -12,7 +12,7 @@ ArkEnv is tested on [**Next.js** **16.x**](https://github.com/yamcodes/arkenv/tr
 The easiest way to get started is with the [ArkEnv CLI](/docs/cli). It automatically configures ArkEnv for your project, installs dependencies, and scaffolds your initial schema.
 
 ```npm
-npx @arkenv/cli@latest init
+npx @arkenv/cli init
 ```
 
 <Accordions>

--- a/apps/www/content/docs/bun-plugin/index.mdx
+++ b/apps/www/content/docs/bun-plugin/index.mdx
@@ -21,7 +21,7 @@ To keep client bundles secure, only variables prefixed with `BUN_PUBLIC_` (and `
 The easiest way to get started is with the [ArkEnv CLI](/docs/cli). It automatically configures `@arkenv/bun-plugin` for your existing Bun project, or spins up a new one from a template.
 
 ```npm
-npx @arkenv/cli@latest init
+npx @arkenv/cli init
 ```
 
 <Accordions>

--- a/apps/www/content/docs/cli/hosting-presets.mdx
+++ b/apps/www/content/docs/cli/hosting-presets.mdx
@@ -34,13 +34,13 @@ Choosing **None** (the default) leaves your schema untouched.
 To skip the prompt - for example in scripts or with `--agent` - pass the `--host-preset` flag (or its `-H` alias):
 
 ```npm
-npx @arkenv/cli@latest init --host-preset vercel
+npx @arkenv/cli init --host-preset vercel
 ```
 
 The flag accepts `none`, `vercel`, `netlify`, `cloudflare`, `railway`, `render`, or `fly`. The following is equivalent:
 
 ```npm
-npx @arkenv/cli@latest init -H vercel
+npx @arkenv/cli init -H vercel
 ```
 
 ## Add host to an existing schema
@@ -48,13 +48,13 @@ npx @arkenv/cli@latest init -H vercel
 If you already ran `init` (or hand-wrote a schema) and want to add a hosting preset later, use `add host`:
 
 ```npm
-npx @arkenv/cli@latest add host vercel
+npx @arkenv/cli add host vercel
 ```
 
 Omit the provider to pick interactively:
 
 ```npm
-npx @arkenv/cli@latest add host
+npx @arkenv/cli add host
 ```
 
 The command auto-detects your layout ([flat](#layouts) or [strict](#layouts)), framework prefix, and validator (ArkType, Zod, or Valibot), then merges the preset fields into your schema. If the schema is missing or unparseable, it prints the proposed fields so you can paste them in manually. Keys that are already present are left unchanged.

--- a/apps/www/content/docs/cli/index.mdx
+++ b/apps/www/content/docs/cli/index.mdx
@@ -13,7 +13,7 @@ The ArkEnv CLI provides commands to scaffold a new ArkEnv setup and to mutate an
 Set up ArkEnv in a project (or create a new one from an example).
 
 ```npm
-npx @arkenv/cli@latest init [project-name] [options]
+npx @arkenv/cli init [project-name] [options]
 ```
 
 The command adjusts its workflow depending on where it is executed:
@@ -35,7 +35,7 @@ The command adjusts its workflow depending on where it is executed:
 Add a hosting provider preset (Vercel, Netlify, Cloudflare, Railway, Render, or Fly.io) to an existing schema.
 
 ```npm
-npx @arkenv/cli@latest add host [provider]
+npx @arkenv/cli add host [provider]
 ```
 
 See [Hosting presets](/docs/cli/hosting-presets#add-host-to-an-existing-schema) for behavior, interactive selection, and fallbacks when the schema is missing or unparseable.

--- a/apps/www/content/docs/nextjs/configuration.mdx
+++ b/apps/www/content/docs/nextjs/configuration.mdx
@@ -82,7 +82,7 @@ By default, ArkEnv generates an `env.gen.ts` helper so you don't have to write a
 Pass the `--no-codegen` flag when bootstrapping with the CLI:
 
 ```bash
-npx @arkenv/cli@latest init --no-codegen
+npx @arkenv/cli init --no-codegen
 ```
 
 Or set it up manually by passing the `{ codegen: false }` option to `withArkEnv` in `next.config.ts`, and importing `createEnv` directly from `@arkenv/nextjs` in your schema file. You then become responsible for keeping `runtimeEnv` in sync with your schema.

--- a/apps/www/content/docs/nextjs/index.mdx
+++ b/apps/www/content/docs/nextjs/index.mdx
@@ -15,7 +15,7 @@ The `@arkenv/nextjs` integration provides end-to-end environment validation for 
 The fastest way to get started is with the [ArkEnv CLI](/docs/cli). It automatically configures `@arkenv/nextjs` for your existing Next.js project.
 
 ```npm
-npx @arkenv/cli@latest init
+npx @arkenv/cli init
 ```
 
 ## Layout strategies

--- a/apps/www/content/docs/nextjs/layouts/flat.mdx
+++ b/apps/www/content/docs/nextjs/layouts/flat.mdx
@@ -28,7 +28,7 @@ The values themselves are *not* shipped to the client! But if exposing your serv
 The easiest way to bootstrap the flat layout is with the [ArkEnv CLI](/docs/cli). It automatically configures `@arkenv/nextjs` for your existing Next.js project and generates your `env.ts` file.
 
 ```npm
-npx @arkenv/cli@latest init
+npx @arkenv/cli init
 ```
 
 ## Your schema

--- a/apps/www/content/docs/nextjs/layouts/strict.mdx
+++ b/apps/www/content/docs/nextjs/layouts/strict.mdx
@@ -22,7 +22,7 @@ By importing `arkenv` from `@/env/client` in client-side code and `@/env/server`
 The easiest way to bootstrap the strict layout is with the [ArkEnv CLI](/docs/cli). It automatically configures `@arkenv/nextjs` for your existing Next.js project using the **strict layout** option.
 
 ```npm
-npx @arkenv/cli@latest init --strict
+npx @arkenv/cli init --strict
 ```
 
 ## Your schema

--- a/apps/www/content/docs/nuxt/index.mdx
+++ b/apps/www/content/docs/nuxt/index.mdx
@@ -15,7 +15,7 @@ The `@arkenv/nuxt` integration provides end-to-end environment validation for bo
 The fastest way to get started is with the [ArkEnv CLI](/docs/cli). It automatically configures `@arkenv/nuxt` for your existing Nuxt project.
 
 ```npm
-npx @arkenv/cli@latest init
+npx @arkenv/cli init
 ```
 
 ## Layout strategies

--- a/apps/www/content/docs/nuxt/layouts/flat.mdx
+++ b/apps/www/content/docs/nuxt/layouts/flat.mdx
@@ -27,7 +27,7 @@ The values themselves are *not* shipped to the client! But if exposing your serv
 The easiest way to bootstrap the flat layout is with the [ArkEnv CLI](/docs/cli). It automatically configures `@arkenv/nuxt` for your existing Nuxt project and generates your `env.ts` file.
 
 ```npm
-npx @arkenv/cli@latest init
+npx @arkenv/cli init
 ```
 
 ## Your schema

--- a/apps/www/content/docs/nuxt/layouts/strict.mdx
+++ b/apps/www/content/docs/nuxt/layouts/strict.mdx
@@ -21,7 +21,7 @@ By importing `env` from `~/env/client` in client-side code and `~/env/server` in
 The easiest way to bootstrap the strict layout is with the [ArkEnv CLI](/docs/cli). It automatically configures `@arkenv/nuxt` for your existing Nuxt project using the **strict layout** option.
 
 ```npm
-npx @arkenv/cli@latest init --strict
+npx @arkenv/cli init --strict
 ```
 
 ## Your schema

--- a/apps/www/content/docs/vite-plugin/index.mdx
+++ b/apps/www/content/docs/vite-plugin/index.mdx
@@ -17,7 +17,7 @@ By matching Vite's default security model, only variables prefixed with `VITE_` 
 The easiest way to get started is with the [ArkEnv CLI](/docs/cli). It automatically configures `@arkenv/vite-plugin` for your existing Vite project, or spins up a new one from a template.
 
 ```npm
-npx @arkenv/cli@latest init
+npx @arkenv/cli init
 ```
 
 <Accordions>

--- a/packages/arkenv/README.md
+++ b/packages/arkenv/README.md
@@ -44,7 +44,7 @@
 <summary>npm</summary>
 
 ```sh
-npx @arkenv/cli@latest init
+npx @arkenv/cli init
 ```
 
 </details>
@@ -53,7 +53,7 @@ npx @arkenv/cli@latest init
 <summary>pnpm</summary>
 
 ```sh
-pnx @arkenv/cli@latest init
+pnpm dlx @arkenv/cli init
 ```
 
 </details>
@@ -62,7 +62,7 @@ pnx @arkenv/cli@latest init
 <summary>Yarn</summary>
 
 ```sh
-yarn dlx @arkenv/cli@latest init
+yarn dlx @arkenv/cli init
 ```
 
 </details>
@@ -71,7 +71,7 @@ yarn dlx @arkenv/cli@latest init
 <summary>Bun</summary>
 
 ```sh
-bunx @arkenv/cli@latest init
+bunx @arkenv/cli init
 ```
 
 </details>

--- a/packages/build/src/index.test.ts
+++ b/packages/build/src/index.test.ts
@@ -227,7 +227,7 @@ describe("formatMissingSchemaError", () => {
 		});
 
 		expect(message).toBe(
-			"[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in setupArkEnv options (or run `npx @arkenv/cli@latest init`).",
+			"[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in setupArkEnv options (or run `npx @arkenv/cli init`).",
 		);
 		expect(message).not.toMatch(/```/);
 		expect(message).not.toMatch(/Example/);
@@ -242,7 +242,7 @@ describe("formatMissingSchemaError", () => {
 		});
 
 		expect(message).toContain(
-			"@arkenv/bun-plugin: Could not find schema file at ./missing-env.ts. Please specify 'schemaPath' in plugin options (or run `npx @arkenv/cli@latest init`).",
+			"@arkenv/bun-plugin: Could not find schema file at ./missing-env.ts. Please specify 'schemaPath' in plugin options (or run `npx @arkenv/cli init`).",
 		);
 		expect(message).toContain("Checked paths:");
 		expect(message).toContain(" - /proj/src/env.ts");

--- a/packages/build/src/missing-schema-error.ts
+++ b/packages/build/src/missing-schema-error.ts
@@ -40,7 +40,7 @@ export function formatMissingSchemaError(
 ): string {
 	const prefix = options.prefix ?? "[ArkEnv]";
 	const location = options.schemaPath || DEFAULT_SCHEMA_LOCATIONS;
-	let message = `${prefix} Could not find schema file at ${location}. Please specify 'schemaPath' in ${options.optionsHint} (or run \`npx @arkenv/cli@latest init\`).`;
+	let message = `${prefix} Could not find schema file at ${location}. Please specify 'schemaPath' in ${options.optionsHint} (or run \`npx @arkenv/cli init\`).`;
 
 	if (options.checkedPaths?.length) {
 		const pathsList = options.checkedPaths.map((p) => ` - ${p}`).join("\n");

--- a/packages/bun-plugin/src/plugin.test.ts
+++ b/packages/bun-plugin/src/plugin.test.ts
@@ -101,7 +101,7 @@ describe("Bun Plugin", () => {
 
 		expect(message).toMatch(/@arkenv\/bun-plugin: Could not find schema file/);
 		expect(message).toMatch(/Checked paths:/);
-		expect(message).toMatch(/npx @arkenv\/cli@latest init/);
+		expect(message).toMatch(/npx @arkenv\/cli init/);
 		expect(message).not.toMatch(/Example `src\/env\.ts`/);
 		expect(message).not.toMatch(/```/);
 		expect(message).not.toMatch(/import \{ type \} from "arktype"/);

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,7 +13,7 @@ The interactive, zero-dependency scaffolding experience for the [ArkEnv](https:/
 <br />
 
 ```sh
-npx @arkenv/cli@latest init
+npx @arkenv/cli init
 ```
 
 ## Related

--- a/packages/cli/src/adapters/node-project-scanner/utils/requirements.ts
+++ b/packages/cli/src/adapters/node-project-scanner/utils/requirements.ts
@@ -1,23 +1,8 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
 import type { RequirementCheckResult } from "@/shared/ports";
+import { compareSemver } from "@/shared/semver";
 import { checkTsConfig } from "./tsconfig";
-
-/**
- * Simple semver comparison.
- * Returns 1 if v1 > v2, -1 if v1 < v2, 0 if equal.
- */
-function compareSemver(v1: string, v2: string): number {
-	const p1 = v1.replace(/^v/, "").split(".").map(Number);
-	const p2 = v2.replace(/^v/, "").split(".").map(Number);
-	for (let i = 0; i < 3; i++) {
-		const n1 = p1[i] || 0;
-		const n2 = p2[i] || 0;
-		if (n1 > n2) return 1;
-		if (n1 < n2) return -1;
-	}
-	return 0;
-}
 
 /**
  * Normalizes a semver string by removing leading 'v' and ensuring it has 3 parts (major.minor.patch).

--- a/packages/cli/src/cli/commands/init.test.ts
+++ b/packages/cli/src/cli/commands/init.test.ts
@@ -612,4 +612,186 @@ describe("InitUseCase", () => {
 		expect(result.options.installSkill).toBe(false);
 		expect(result.options.skillDetected).toBe(true);
 	});
+
+	describe("version freshness pre-flight check", () => {
+		let versionChecker: any;
+		let spawner: any;
+		let exit: any;
+
+		beforeEach(() => {
+			versionChecker = {
+				checkFreshness: vi.fn().mockResolvedValue({ isOutdated: false }),
+			};
+			spawner = vi.fn().mockResolvedValue(0);
+			exit = vi.fn();
+		});
+
+		it("prompts to run latest and spawns dlx runner when user confirms", async () => {
+			const originalCI = process.env.CI;
+			const originalTTY = process.stdout.isTTY;
+			delete process.env.CI;
+			process.stdout.isTTY = true;
+
+			versionChecker.checkFreshness.mockResolvedValue({
+				isOutdated: true,
+				latestVersion: "0.6.0",
+			});
+			vi.mocked(prompt.confirm).mockResolvedValue(true);
+
+			const customUseCase = new InitUseCase(
+				logger,
+				workspace,
+				prompt,
+				scanner,
+				undefined,
+				versionChecker,
+				spawner,
+				exit,
+			);
+
+			const success = await customUseCase.execute({
+				isYes: false,
+				isForce: false,
+				isQuiet: false,
+				isAgent: false,
+			});
+
+			expect(versionChecker.checkFreshness).toHaveBeenCalled();
+			expect(prompt.confirm).toHaveBeenCalledWith(
+				expect.stringContaining("Version 0.6.0 is available"),
+				true,
+				"Yes (Recommended)",
+			);
+			expect(spawner).toHaveBeenCalledWith(
+				expect.objectContaining({
+					packageName: "@arkenv/cli",
+					args: expect.arrayContaining(["init"]),
+				}),
+			);
+			expect(exit).toHaveBeenCalledWith(0);
+			expect(success).toBe(true);
+
+			process.env.CI = originalCI;
+			process.stdout.isTTY = originalTTY;
+		});
+
+		it("proceeds with current version when user declines upgrade prompt", async () => {
+			const originalCI = process.env.CI;
+			const originalTTY = process.stdout.isTTY;
+			delete process.env.CI;
+			process.stdout.isTTY = true;
+
+			versionChecker.checkFreshness.mockResolvedValue({
+				isOutdated: true,
+				latestVersion: "0.6.0",
+			});
+			vi.mocked(prompt.confirm).mockResolvedValue(false);
+			vi.mocked(prompt.runWizard).mockResolvedValue({
+				path: "./env.ts",
+				validator: "arktype",
+				framework: "vanilla",
+				language: "ts",
+			});
+
+			const customUseCase = new InitUseCase(
+				logger,
+				workspace,
+				prompt,
+				scanner,
+				undefined,
+				versionChecker,
+				spawner,
+				exit,
+			);
+
+			const success = await customUseCase.execute({
+				isYes: false,
+				isForce: false,
+				isQuiet: false,
+				isAgent: false,
+			});
+
+			expect(versionChecker.checkFreshness).toHaveBeenCalled();
+			expect(spawner).not.toHaveBeenCalled();
+			expect(exit).not.toHaveBeenCalled();
+			expect(success).toBe(true);
+
+			process.env.CI = originalCI;
+			process.stdout.isTTY = originalTTY;
+		});
+
+		it("cancels operation cleanly when user aborts the prompt", async () => {
+			const originalCI = process.env.CI;
+			const originalTTY = process.stdout.isTTY;
+			delete process.env.CI;
+			process.stdout.isTTY = true;
+
+			versionChecker.checkFreshness.mockResolvedValue({
+				isOutdated: true,
+				latestVersion: "0.6.0",
+			});
+			vi.mocked(prompt.confirm).mockResolvedValue(null);
+
+			const customUseCase = new InitUseCase(
+				logger,
+				workspace,
+				prompt,
+				scanner,
+				undefined,
+				versionChecker,
+				spawner,
+				exit,
+			);
+
+			const success = await customUseCase.execute({
+				isYes: false,
+				isForce: false,
+				isQuiet: false,
+				isAgent: false,
+			});
+
+			expect(logger.cancel).toHaveBeenCalledWith("Operation cancelled.");
+			expect(spawner).not.toHaveBeenCalled();
+			expect(exit).not.toHaveBeenCalled();
+			expect(success).toBe(false);
+
+			process.env.CI = originalCI;
+			process.stdout.isTTY = originalTTY;
+		});
+
+		it("skips check in CI environment", async () => {
+			const originalCI = process.env.CI;
+			process.env.CI = "true";
+
+			const customUseCase = new InitUseCase(
+				logger,
+				workspace,
+				prompt,
+				scanner,
+				undefined,
+				versionChecker,
+				spawner,
+				exit,
+			);
+
+			vi.mocked(prompt.runWizard).mockResolvedValue({
+				path: "./env.ts",
+				validator: "arktype",
+				framework: "vanilla",
+				language: "ts",
+			});
+
+			await customUseCase.execute({
+				isYes: false,
+				isForce: false,
+				isQuiet: false,
+				isAgent: false,
+			});
+
+			expect(versionChecker.checkFreshness).not.toHaveBeenCalled();
+			expect(spawner).not.toHaveBeenCalled();
+
+			process.env.CI = originalCI;
+		});
+	});
 });

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -8,7 +8,7 @@ import {
 	type Framework,
 	type HostPreset,
 } from "@/features/scaffold";
-import { RegistryClient } from "@/shared/clients";
+import { RegistryClient, VersionCheckerClient } from "@/shared/clients";
 import { ERROR_CODES } from "@/shared/errors";
 import type {
 	LoggerPort,
@@ -16,6 +16,8 @@ import type {
 	PromptPort,
 	WorkspacePort,
 } from "@/shared/ports";
+import { spawnLatest } from "@/shared/spawner";
+import { name as pkgName, version as pkgVersion } from "../../../package.json";
 
 /**
  * Input parameters for the 'init' command.
@@ -47,12 +49,59 @@ export class InitUseCase {
 		private readonly prompt: PromptPort,
 		private readonly scanner: ProjectScannerPort,
 		private readonly registry = new RegistryClient(),
+		private readonly versionChecker = new VersionCheckerClient(),
+		private readonly spawner: (options: {
+			packageName: string;
+			args: string[];
+		}) => Promise<number> = spawnLatest,
+		private readonly exit: (code: number) => void = (code) =>
+			process.exit(code),
 	) {}
 
 	/**
 	 * Collects init options, creates a scaffolding plan, and executes it.
 	 */
 	async execute(input: InitInput): Promise<boolean> {
+		const isInteractive =
+			!process.env.CI &&
+			Boolean(process.stdout.isTTY) &&
+			!input.isQuiet &&
+			!input.isAgent &&
+			!input.isYes;
+
+		if (isInteractive) {
+			const freshness = await this.versionChecker.checkFreshness({
+				currentVersion: pkgVersion,
+				packageName: pkgName,
+				timeoutMs: 1000,
+			});
+
+			if (freshness.isOutdated && freshness.latestVersion) {
+				const confirmLatest = await this.prompt.confirm(
+					`Version ${freshness.latestVersion} is available (running ${pkgVersion}). Run latest instead?`,
+					true,
+					"Yes (Recommended)",
+				);
+
+				if (confirmLatest === null) {
+					this.logger.cancel("Operation cancelled.");
+					return false;
+				}
+
+				if (confirmLatest) {
+					const rawArgs = process.argv.slice(2);
+					const forwardedArgs =
+						rawArgs[0] === "init" ? rawArgs : ["init", ...rawArgs];
+					const exitCode = await this.spawner({
+						packageName: pkgName,
+						args: forwardedArgs,
+					});
+					this.exit(exitCode);
+					return true;
+				}
+			}
+		}
+
 		const state = await this.collect(input);
 		if (!state) return false;
 

--- a/packages/cli/src/shared/clients/index.ts
+++ b/packages/cli/src/shared/clients/index.ts
@@ -1,2 +1,7 @@
 export type { Example, ExampleRegistry } from "./registry.client";
 export { RegistryClient } from "./registry.client";
+export type {
+	FreshnessCheckOptions,
+	FreshnessCheckResult,
+} from "./version-checker.client";
+export { VersionCheckerClient } from "./version-checker.client";

--- a/packages/cli/src/shared/clients/version-checker.client.test.ts
+++ b/packages/cli/src/shared/clients/version-checker.client.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VersionCheckerClient } from "./version-checker.client";
+
+describe("VersionCheckerClient", () => {
+	let client: VersionCheckerClient;
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		client = new VersionCheckerClient();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	it("returns isOutdated: true when registry version is newer", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ version: "0.6.0" }),
+		} as Response);
+
+		const result = await client.checkFreshness({
+			currentVersion: "0.5.4",
+			packageName: "@arkenv/cli",
+		});
+
+		expect(result).toEqual({
+			isOutdated: true,
+			latestVersion: "0.6.0",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"https://registry.npmjs.org/%40arkenv%2Fcli/latest",
+			expect.objectContaining({
+				headers: { Accept: "application/json" },
+			}),
+		);
+	});
+
+	it("returns isOutdated: false when current version is equal to or newer than registry", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ version: "0.5.4" }),
+		} as Response);
+
+		const result = await client.checkFreshness({
+			currentVersion: "0.5.4",
+			packageName: "@arkenv/cli",
+		});
+
+		expect(result).toEqual({
+			isOutdated: false,
+			latestVersion: "0.5.4",
+		});
+	});
+
+	it("handles pre-release versions accurately", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ version: "1.0.0-beta.11" }),
+		} as Response);
+
+		const result = await client.checkFreshness({
+			currentVersion: "1.0.0-beta.2",
+			packageName: "@arkenv/cli",
+		});
+
+		expect(result).toEqual({
+			isOutdated: true,
+			latestVersion: "1.0.0-beta.11",
+		});
+	});
+
+	it("fails open silently when fetch returns non-200 status", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 404,
+		} as Response);
+
+		const result = await client.checkFreshness({
+			currentVersion: "0.5.4",
+			packageName: "@arkenv/cli",
+		});
+
+		expect(result).toEqual({ isOutdated: false });
+	});
+
+	it("fails open silently on network / DNS failure", async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error("ENOTFOUND"));
+
+		const result = await client.checkFreshness({
+			currentVersion: "0.5.4",
+			packageName: "@arkenv/cli",
+		});
+
+		expect(result).toEqual({ isOutdated: false });
+	});
+
+	it("fails open silently on timeout / abort error", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockRejectedValue(
+				new DOMException("The operation was aborted", "TimeoutError"),
+			);
+
+		const result = await client.checkFreshness({
+			currentVersion: "0.5.4",
+			packageName: "@arkenv/cli",
+			timeoutMs: 50,
+		});
+
+		expect(result).toEqual({ isOutdated: false });
+	});
+
+	it("fails open silently when JSON payload is missing version or malformed", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({}),
+		} as Response);
+
+		const result = await client.checkFreshness({
+			currentVersion: "0.5.4",
+			packageName: "@arkenv/cli",
+		});
+
+		expect(result).toEqual({ isOutdated: false });
+	});
+});

--- a/packages/cli/src/shared/clients/version-checker.client.ts
+++ b/packages/cli/src/shared/clients/version-checker.client.ts
@@ -1,0 +1,77 @@
+import { compareSemver } from "@/shared/semver";
+
+/**
+ * Options for performing a version freshness check.
+ */
+export type FreshnessCheckOptions = {
+	/** Current running package version. */
+	currentVersion: string;
+	/** Target package name to check on npm (e.g. "@arkenv/cli" or "arkenv"). */
+	packageName?: string;
+	/** Abort timeout in milliseconds (defaults to 1000ms). */
+	timeoutMs?: number;
+};
+
+/**
+ * Result of a version freshness check.
+ */
+export type FreshnessCheckResult = {
+	/** True if the latest published version on npm is strictly greater than the current version. */
+	isOutdated: boolean;
+	/** Latest version available on npm if successfully fetched and evaluated. */
+	latestVersion?: string;
+};
+
+/**
+ * Client for checking whether the running CLI is outdated compared to the npm registry.
+ */
+export class VersionCheckerClient {
+	/**
+	 * Checks if a newer version of the package exists on the npm registry.
+	 * Fails open silently returning `{ isOutdated: false }` upon any error or timeout.
+	 *
+	 * @param options Freshness check options.
+	 * @returns A promise resolving to the freshness check result.
+	 */
+	async checkFreshness(
+		options: FreshnessCheckOptions,
+	): Promise<FreshnessCheckResult> {
+		const {
+			currentVersion,
+			packageName = "@arkenv/cli",
+			timeoutMs = 1000,
+		} = options;
+
+		try {
+			const encodedName = encodeURIComponent(packageName);
+			const url = `https://registry.npmjs.org/${encodedName}/latest`;
+
+			const response = await fetch(url, {
+				signal: AbortSignal.timeout(timeoutMs),
+				headers: {
+					Accept: "application/json",
+				},
+			});
+
+			if (!response.ok) {
+				return { isOutdated: false };
+			}
+
+			const data = (await response.json()) as { version?: string };
+			const latestVersion = data?.version;
+
+			if (!latestVersion || typeof latestVersion !== "string") {
+				return { isOutdated: false };
+			}
+
+			const isOutdated = compareSemver(latestVersion, currentVersion) > 0;
+			return {
+				isOutdated,
+				latestVersion,
+			};
+		} catch {
+			// Fail open on timeouts, offline environments, DNS errors, etc.
+			return { isOutdated: false };
+		}
+	}
+}

--- a/packages/cli/src/shared/semver.test.ts
+++ b/packages/cli/src/shared/semver.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { compareSemver, parseSemver } from "./semver";
+
+describe("semver", () => {
+	describe("parseSemver", () => {
+		it("parses normal semver versions", () => {
+			expect(parseSemver("1.2.3")).toEqual({
+				major: 1,
+				minor: 2,
+				patch: 3,
+				prerelease: [],
+				build: undefined,
+			});
+			expect(parseSemver("v0.5.4")).toEqual({
+				major: 0,
+				minor: 5,
+				patch: 4,
+				prerelease: [],
+				build: undefined,
+			});
+		});
+
+		it("parses versions with pre-release identifiers and build metadata", () => {
+			expect(parseSemver("1.0.0-beta.2+exp.sha.5114f85")).toEqual({
+				major: 1,
+				minor: 0,
+				patch: 0,
+				prerelease: ["beta", 2],
+				build: "exp.sha.5114f85",
+			});
+		});
+
+		it("parses short version strings", () => {
+			expect(parseSemver("22")).toEqual({
+				major: 22,
+				minor: 0,
+				patch: 0,
+				prerelease: [],
+				build: undefined,
+			});
+			expect(parseSemver("v5.1")).toEqual({
+				major: 5,
+				minor: 1,
+				patch: 0,
+				prerelease: [],
+				build: undefined,
+			});
+		});
+
+		it("returns null for invalid versions", () => {
+			expect(parseSemver("invalid")).toBeNull();
+			expect(parseSemver("")).toBeNull();
+		});
+	});
+
+	describe("compareSemver", () => {
+		it("compares major, minor, patch versions", () => {
+			expect(compareSemver("1.0.0", "2.0.0")).toBe(-1);
+			expect(compareSemver("2.0.0", "1.0.0")).toBe(1);
+			expect(compareSemver("1.1.0", "1.2.0")).toBe(-1);
+			expect(compareSemver("1.2.3", "1.2.3")).toBe(0);
+			expect(compareSemver("0.5.4", "0.5.5")).toBe(-1);
+			expect(compareSemver("0.5.5", "0.5.4")).toBe(1);
+		});
+
+		it("handles pre-release precedence over normal release", () => {
+			// Normal release has higher precedence than pre-release
+			expect(compareSemver("1.0.0-alpha", "1.0.0")).toBe(-1);
+			expect(compareSemver("1.0.0", "1.0.0-alpha")).toBe(1);
+		});
+
+		it("compares pre-release versions with numeric segments accurately", () => {
+			// 1.0.0-beta.2 < 1.0.0-beta.11 (numeric segment comparison)
+			expect(compareSemver("1.0.0-beta.2", "1.0.0-beta.11")).toBe(-1);
+			expect(compareSemver("1.0.0-beta.11", "1.0.0-beta.2")).toBe(1);
+			expect(compareSemver("1.0.0-beta.1", "1.0.0-beta.2")).toBe(-1);
+		});
+
+		it("compares alphanumeric pre-release identifiers", () => {
+			// 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0
+			expect(compareSemver("1.0.0-alpha", "1.0.0-alpha.1")).toBe(-1);
+			expect(compareSemver("1.0.0-alpha.1", "1.0.0-alpha.beta")).toBe(-1);
+			expect(compareSemver("1.0.0-alpha.beta", "1.0.0-beta")).toBe(-1);
+			expect(compareSemver("1.0.0-beta", "1.0.0-beta.2")).toBe(-1);
+			expect(compareSemver("1.0.0-beta.2", "1.0.0-beta.11")).toBe(-1);
+			expect(compareSemver("1.0.0-beta.11", "1.0.0-rc.1")).toBe(-1);
+			expect(compareSemver("1.0.0-rc.1", "1.0.0")).toBe(-1);
+		});
+
+		it("ignores build metadata in precedence comparison", () => {
+			expect(compareSemver("1.0.0+build1", "1.0.0+build2")).toBe(0);
+			expect(compareSemver("1.0.0-alpha+001", "1.0.0-alpha+exp")).toBe(0);
+		});
+
+		it("handles leading 'v' prefix", () => {
+			expect(compareSemver("v1.0.0", "1.0.0")).toBe(0);
+			expect(compareSemver("v0.5.4", "v0.5.5")).toBe(-1);
+		});
+	});
+});

--- a/packages/cli/src/shared/semver.ts
+++ b/packages/cli/src/shared/semver.ts
@@ -1,0 +1,134 @@
+/**
+ * Represents a parsed SemVer 2.0 version.
+ */
+export type SemVer = {
+	major: number;
+	minor: number;
+	patch: number;
+	prerelease: (string | number)[];
+	build?: string;
+};
+
+/**
+ * Parses a semantic version string into its components according to SemVer 2.0.
+ *
+ * @param version The version string to parse (e.g., "1.2.3-beta.1+build").
+ * @returns The parsed SemVer object or null if parsing fails.
+ */
+export function parseSemver(version: string): SemVer | null {
+	const trimmed = version.trim().replace(/^v/, "");
+	// Regex matching standard SemVer 2.0: MAJOR.MINOR.PATCH(-PRERELEASE)?(+BUILD)?
+	const match = trimmed.match(
+		/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/,
+	);
+
+	if (!match) {
+		// Fallback for short versions like "1.2" or "1"
+		const shortMatch = trimmed.match(
+			/^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/,
+		);
+		if (!shortMatch) return null;
+
+		const major = Number.parseInt(shortMatch[1], 10);
+		const minor =
+			shortMatch[2] !== undefined ? Number.parseInt(shortMatch[2], 10) : 0;
+		const patch =
+			shortMatch[3] !== undefined ? Number.parseInt(shortMatch[3], 10) : 0;
+		const prereleaseRaw = shortMatch[4];
+		const build = shortMatch[5];
+
+		if (Number.isNaN(major) || Number.isNaN(minor) || Number.isNaN(patch)) {
+			return null;
+		}
+
+		const prerelease = prereleaseRaw
+			? prereleaseRaw
+					.split(".")
+					.map((id) => (/^\d+$/.test(id) ? Number.parseInt(id, 10) : id))
+			: [];
+
+		return { major, minor, patch, prerelease, build };
+	}
+
+	const major = Number.parseInt(match[1], 10);
+	const minor = Number.parseInt(match[2], 10);
+	const patch = Number.parseInt(match[3], 10);
+	const prereleaseRaw = match[4];
+	const build = match[5];
+
+	if (Number.isNaN(major) || Number.isNaN(minor) || Number.isNaN(patch)) {
+		return null;
+	}
+
+	const prerelease = prereleaseRaw
+		? prereleaseRaw
+				.split(".")
+				.map((id) => (/^\d+$/.test(id) ? Number.parseInt(id, 10) : id))
+		: [];
+
+	return { major, minor, patch, prerelease, build };
+}
+
+/**
+ * Compares two semantic version strings according to SemVer 2.0 precedence rules.
+ *
+ * Precedence is determined by comparing major, minor, patch, and pre-release identifiers:
+ * - 1.0.0-beta.2 < 1.0.0-beta.11 (numeric comparison for numeric identifiers)
+ * - 1.0.0-alpha < 1.0.0-beta (lexical comparison for string identifiers)
+ * - 1.0.0-alpha < 1.0.0 (normal version has higher precedence than pre-release)
+ * - Build metadata is ignored.
+ *
+ * @param v1 First version string.
+ * @param v2 Second version string.
+ * @returns 1 if v1 > v2, -1 if v1 < v2, 0 if equal or either is unparseable.
+ */
+export function compareSemver(v1: string, v2: string): number {
+	const s1 = parseSemver(v1);
+	const s2 = parseSemver(v2);
+
+	if (!s1 || !s2) return 0;
+
+	// Compare major, minor, patch
+	if (s1.major !== s2.major) return s1.major > s2.major ? 1 : -1;
+	if (s1.minor !== s2.minor) return s1.minor > s2.minor ? 1 : -1;
+	if (s1.patch !== s2.patch) return s1.patch > s2.patch ? 1 : -1;
+
+	// When major, minor, patch are equal:
+	// A normal version has greater precedence than a pre-release version.
+	const hasPre1 = s1.prerelease.length > 0;
+	const hasPre2 = s2.prerelease.length > 0;
+
+	if (!hasPre1 && hasPre2) return 1; // 1.0.0 > 1.0.0-alpha
+	if (hasPre1 && !hasPre2) return -1; // 1.0.0-alpha < 1.0.0
+	if (!hasPre1 && !hasPre2) return 0; // 1.0.0 == 1.0.0
+
+	// Both have pre-release identifiers; compare each identifier segment
+	const minLen = Math.min(s1.prerelease.length, s2.prerelease.length);
+	for (let i = 0; i < minLen; i++) {
+		const id1 = s1.prerelease[i];
+		const id2 = s2.prerelease[i];
+
+		if (id1 === id2) continue;
+
+		const isNum1 = typeof id1 === "number";
+		const isNum2 = typeof id2 === "number";
+
+		// Numeric identifiers always have lower precedence than non-numeric identifiers
+		if (isNum1 && !isNum2) return -1;
+		if (!isNum1 && isNum2) return 1;
+
+		if (isNum1 && isNum2) {
+			return id1 > id2 ? 1 : -1;
+		}
+
+		// Both are strings; compare lexically in ASCII sort order
+		return (id1 as string).localeCompare(id2 as string);
+	}
+
+	// A larger set of pre-release fields has a higher precedence than a smaller set
+	if (s1.prerelease.length !== s2.prerelease.length) {
+		return s1.prerelease.length > s2.prerelease.length ? 1 : -1;
+	}
+
+	return 0;
+}

--- a/packages/cli/src/shared/spawner.test.ts
+++ b/packages/cli/src/shared/spawner.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { resolveDlxCommand } from "./spawner";
+
+describe("spawner", () => {
+	describe("resolveDlxCommand", () => {
+		it("resolves pnpm dlx when user agent contains pnpm", () => {
+			const res = resolveDlxCommand(
+				"@arkenv/cli",
+				["init", "--strict"],
+				"pnpm/9.0.0 npm/? node/v22.0.0 darwin arm64",
+			);
+			expect(res).toEqual({
+				command: "pnpm",
+				dlxArgs: ["dlx", "@arkenv/cli@latest", "init", "--strict"],
+			});
+		});
+
+		it("resolves bunx when user agent contains bun", () => {
+			const res = resolveDlxCommand(
+				"@arkenv/cli",
+				["init", "--strict"],
+				"bun/1.1.0 npm/? node/v22.0.0 darwin arm64",
+			);
+			expect(res).toEqual({
+				command: "bunx",
+				dlxArgs: ["@arkenv/cli@latest", "init", "--strict"],
+			});
+		});
+
+		it("resolves yarn dlx when user agent contains yarn", () => {
+			const res = resolveDlxCommand(
+				"@arkenv/cli",
+				["init", "--strict"],
+				"yarn/4.0.0 npm/? node/v22.0.0 darwin arm64",
+			);
+			expect(res).toEqual({
+				command: "yarn",
+				dlxArgs: ["dlx", "@arkenv/cli@latest", "init", "--strict"],
+			});
+		});
+
+		it("falls back to npx when user agent is npm or empty/missing", () => {
+			const resNpm = resolveDlxCommand(
+				"@arkenv/cli",
+				["init", "--strict"],
+				"npm/10.0.0 node/v22.0.0 darwin arm64",
+			);
+			expect(resNpm).toEqual({
+				command: "npx",
+				dlxArgs: ["@arkenv/cli@latest", "init", "--strict"],
+			});
+
+			const resEmpty = resolveDlxCommand("@arkenv/cli", ["init"], "");
+			expect(resEmpty).toEqual({
+				command: "npx",
+				dlxArgs: ["@arkenv/cli@latest", "init"],
+			});
+		});
+	});
+});

--- a/packages/cli/src/shared/spawner.ts
+++ b/packages/cli/src/shared/spawner.ts
@@ -1,0 +1,103 @@
+import { spawn } from "node:child_process";
+
+export type SpawnLatestOptions = {
+	packageName: string;
+	args: string[];
+	userAgent?: string;
+};
+
+export type SpawnerPort = {
+	spawnLatest(options: SpawnLatestOptions): Promise<number>;
+};
+
+/**
+ * Resolves the runner command and arguments based on the package manager user agent.
+ *
+ * @param packageName Target package name (e.g. "@arkenv/cli").
+ * @param args Initial CLI arguments to forward.
+ * @param userAgent The `npm_config_user_agent` string.
+ * @returns The executable command and its arguments.
+ */
+export function resolveDlxCommand(
+	packageName: string,
+	args: string[],
+	userAgent = process.env.npm_config_user_agent || "",
+): { command: string; dlxArgs: string[] } {
+	const target = `${packageName}@latest`;
+
+	if (userAgent.includes("pnpm")) {
+		return {
+			command: "pnpm",
+			dlxArgs: ["dlx", target, ...args],
+		};
+	}
+
+	if (userAgent.includes("bun")) {
+		return {
+			command: "bunx",
+			dlxArgs: [target, ...args],
+		};
+	}
+
+	if (userAgent.includes("yarn")) {
+		return {
+			command: "yarn",
+			dlxArgs: ["dlx", target, ...args],
+		};
+	}
+
+	// Fallback to npx
+	return {
+		command: "npx",
+		dlxArgs: [target, ...args],
+	};
+}
+
+/**
+ * Spawns the latest version of the CLI using the active package manager's DLX tool,
+ * inheriting stdio and forwarding termination signals.
+ *
+ * @param options Spawn options containing package name, args, and optional user agent.
+ * @returns A promise resolving to the exit code of the spawned child process.
+ */
+export async function spawnLatest(
+	options: SpawnLatestOptions,
+): Promise<number> {
+	const { command, dlxArgs } = resolveDlxCommand(
+		options.packageName,
+		options.args,
+		options.userAgent,
+	);
+
+	return new Promise<number>((resolve, reject) => {
+		const child = spawn(command, dlxArgs, {
+			stdio: "inherit",
+			shell: process.platform === "win32",
+		});
+
+		const onSigint = () => {
+			child.kill("SIGINT");
+		};
+		const onSigterm = () => {
+			child.kill("SIGTERM");
+		};
+
+		process.on("SIGINT", onSigint);
+		process.on("SIGTERM", onSigterm);
+
+		const cleanup = () => {
+			process.off("SIGINT", onSigint);
+			process.off("SIGTERM", onSigterm);
+		};
+
+		child.on("error", (err) => {
+			cleanup();
+			reject(err);
+		});
+
+		child.on("close", (code) => {
+			cleanup();
+			resolve(code ?? 0);
+		});
+	});
+}

--- a/packages/nextjs/src/config.test.ts
+++ b/packages/nextjs/src/config.test.ts
@@ -314,7 +314,7 @@ describe("withArkEnv wrapper", () => {
 		}
 
 		expect(message).toMatch(/\[ArkEnv\] Could not find schema file/);
-		expect(message).toMatch(/npx @arkenv\/cli@latest init/);
+		expect(message).toMatch(/npx @arkenv\/cli init/);
 		expect(message).not.toMatch(/Example `src\/env\.ts`/);
 		expect(message).not.toMatch(/```/);
 	});

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -50,7 +50,7 @@ describe("Nuxt module integration", () => {
 			expect(message).toMatch(
 				/\[ArkEnv\] Could not find schema file at src\/env\.ts or env\.ts/,
 			);
-			expect(message).toMatch(/npx @arkenv\/cli@latest init/);
+			expect(message).toMatch(/npx @arkenv\/cli init/);
 			expect(message).not.toMatch(/Example `src\/env\.ts`/);
 			expect(message).not.toMatch(/```/);
 			expect(mockNuxt.hook).not.toHaveBeenCalled();

--- a/skills/arkenv/SKILL.md
+++ b/skills/arkenv/SKILL.md
@@ -25,7 +25,7 @@ ArkEnv is a typesafe environment variable validator for modern JavaScript runtim
 
 ### CLI (setup & DevOps)
 
-- Initialize ArkEnv in new or existing projects using `pnpm dlx @arkenv/cli@latest init`.
+- Initialize ArkEnv in new or existing projects using `pnpm dlx @arkenv/cli init`.
 - Scaffold schema files and detect framework-specific configurations (`Next.js`, `Vite`, `Bun`, etc.).
 - Support layout selection (`--strict` for 3-file split vs `--simple` for a single file).
 - Support option to skip codegen (`--no-codegen`).
@@ -35,7 +35,7 @@ ArkEnv is a typesafe environment variable validator for modern JavaScript runtim
 
 AI agents SHOULD always use the CLI for project initialization to ensure consistency and reliability. Use the `--agent` flag for a fully automated, machine-readable experience.
 
-- **Command**: `pnpm dlx @arkenv/cli@latest init --agent`
+- **Command**: `pnpm dlx @arkenv/cli init --agent`
 - **Behavior**: The `--agent` flag automatically enables the following behaviors:
   - **`--yes`**: Bypasses all interactive prompts and uses recommended defaults.
   - **`--quiet`**: Suppresses spinners and ANSI formatting for cleaner terminal logs.
@@ -67,14 +67,14 @@ AI agents SHOULD always use the CLI for project initialization to ensure consist
    - Check for framework config files (`next.config.ts`, `next.config.js`, `vite.config.ts`, `bunfig.toml`, `package.json` scripts) to recommend appropriate plugins.
 2. **Setup**:
    - If ArkEnv is not present or a fresh setup is requested, trigger the **Setup Workflow**.
-   - Prefer using the CLI for initialization: `pnpm dlx @arkenv/cli@latest init`.
+   - Prefer using the CLI for initialization: `pnpm dlx @arkenv/cli init`.
    - If the CLI cannot be used or fails, fall back to manual configuration.
 
 ## Setup workflow
 
 When setting up ArkEnv, follow these steps:
 
-1. **Initialize**: Run `pnpm dlx @arkenv/cli@latest init --agent` (optionally appending `--strict` or `--simple` based on layout preference). This will detect the environment, install dependencies, and scaffold schemas.
+1. **Initialize**: Run `pnpm dlx @arkenv/cli init --agent` (optionally appending `--strict` or `--simple` based on layout preference). This will detect the environment, install dependencies, and scaffold schemas.
 2. **Review & Refine Schemas**:
    - **Simple Layout**: Inspect and refine the generated `env.ts`. Ensure it captures the required environment variables.
    - **Strict Layout**: Inspect and refine the generated files under the `env/` directory: `client.ts` (client-only variables), `server.ts` (server-only variables), and `internal/shared.ts` (variables shared between client and server).
@@ -226,7 +226,7 @@ declare global {
 Set up ArkEnv in your project. It detects your framework and configures the appropriate plugin and type augmentations.
 
 ```bash
-pnpm dlx @arkenv/cli@latest init [options]
+pnpm dlx @arkenv/cli init [options]
 ```
 
 #### Options:


### PR DESCRIPTION
Fixes #1720

### Summary of Changes

- **CLI Version Freshness Pre-Flight Check**: Added zero-dependency SemVer 2.0 comparator and registry checker with strict 1000ms timeout that fails open silently.
- **Interactive Upgrade Prompt & DLX Runner**: Interactively prompts user on outdated CLI versions during interactive TTY `init` executions to run latest release via package-manager-aware runner (`pnpm dlx`, `bunx`, `yarn dlx`, or `npx`) with full `stdio: 'inherit'` and signal forwarding.
- **Marketing & Documentation Cleanup**: Omitted `@latest` across website install pills, documentation MDX guides, package READMEs, and missing-schema error hints.