### PR TITLE
feat(cli): ensure safe execution without @latest and omit @latest from marketing

### DIFF
--- a/.changeset/safe-cli-freshness-check.md
+++ b/.changeset/safe-cli-freshness-check.md
@@ -1,0 +1,13 @@
+---
+"arkenv": minor
+"@arkenv/build": patch
+"@arkenv/agent-plugin": patch
+---
+
+#### Add version freshness pre-flight check and prompt to run latest version on init
+
+- Implement pre-flight version check in the CLI during interactive `init` execution against the npm registry with a 1000ms timeout.
+- Prompt the user when an outdated CLI version is executed to run the latest published release via the active package manager's DLX tool (`pnpm dlx`, `bunx`, `yarn dlx`, or `npx`).
+- Forward process signals (`SIGINT`, `SIGTERM`) and standard I/O to the spawned child process, and exit cleanly on completion.
+- Fail open silently without blocking in non-interactive/CI environments or when network errors occur.
+- Simplify marketing copy and error message hints to omit `@latest` (e.g. `npx arkenv init`).

--- a/.changeset/safe-cli-freshness-check.md
+++ b/.changeset/safe-cli-freshness-check.md
@@ -4,10 +4,20 @@
 "@arkenv/agent-plugin": patch
 ---
 
-#### Add version freshness pre-flight check and prompt to run latest version on init
+#### Add version freshness pre-flight check to CLI init
 
-- Implement pre-flight version check in the CLI during interactive `init` execution against the npm registry with a 1000ms timeout.
-- Prompt the user when an outdated CLI version is executed to run the latest published release via the active package manager's DLX tool (`pnpm dlx`, `bunx`, `yarn dlx`, or `npx`).
-- Forward process signals (`SIGINT`, `SIGTERM`) and standard I/O to the spawned child process, and exit cleanly on completion.
-- Fail open silently without blocking in non-interactive/CI environments or when network errors occur.
-- Simplify marketing copy and error message hints to omit `@latest` (e.g. `npx arkenv init`).
+`arkenv init` now performs a lightweight pre-flight version freshness check in interactive environments before scaffolding. When an outdated CLI version is detected, users are prompted to seamlessly run the latest release via their package manager's DLX runner (`pnpm dlx`, `bunx`, `yarn dlx`, or `npx`).
+
+- The pre-flight check queries the npm registry with a 1000ms timeout and fails open silently in offline or non-interactive/CI environments.
+- Confirmed upgrades invoke the latest version via the active package manager with full TTY stdio inheritance and signal forwarding (`SIGINT`/`SIGTERM`).
+- Marketing copy and missing-schema error hints now omit `@latest` across the ecosystem (e.g. `npx arkenv init`).
+
+Usage:
+
+```sh
+# Run init interactively (prompts automatically if outdated)
+npx arkenv init
+
+# Non-interactive / CI runs bypass the prompt automatically
+npx arkenv init --yes
+```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 <summary>npm</summary>
 
 ```sh
-npx arkenv@latest init
+npx arkenv init
 ```
 
 </details>
@@ -58,7 +58,7 @@ npx arkenv@latest init
 <summary>pnpm</summary>
 
 ```sh
-pnx arkenv@latest init
+pnpm dlx arkenv init
 ```
 
 </details>
@@ -67,7 +67,7 @@ pnx arkenv@latest init
 <summary>Yarn</summary>
 
 ```sh
-yarn dlx arkenv@latest init
+yarn dlx arkenv init
 ```
 
 </details>
@@ -76,7 +76,7 @@ yarn dlx arkenv@latest init
 <summary>Bun</summary>
 
 ```sh
-bunx arkenv@latest init
+bunx arkenv init
 ```
 
 </details>

--- a/apps/www/components/page/cli-command.test.tsx
+++ b/apps/www/components/page/cli-command.test.tsx
@@ -22,7 +22,7 @@ describe("CLICommand", () => {
 	it("should render with syntax highlighting spans", () => {
 		render(<CLICommand />);
 		expect(screen.getByText("npx")).toBeInTheDocument();
-		expect(screen.getByText("arkenv@latest init")).toBeInTheDocument();
+		expect(screen.getByText("arkenv init")).toBeInTheDocument();
 	});
 
 	it("should copy command when clicking the container", async () => {

--- a/apps/www/components/page/cli-command.tsx
+++ b/apps/www/components/page/cli-command.tsx
@@ -4,7 +4,7 @@ import { Check, Copy, Terminal } from "lucide-react";
 import { useCopyCommand } from "~/hooks/use-copy-command";
 
 export function CLICommand() {
-	const command = "npx arkenv@latest init";
+	const command = "npx arkenv init";
 	const { copied, copy } = useCopyCommand(command);
 
 	return (
@@ -17,7 +17,7 @@ export function CLICommand() {
 			<Terminal className="w-4 h-4 text-blue-500 dark:text-blue-400 opacity-70 group-hover:opacity-100 transition-opacity shrink-0" />
 			<code className="text-sm font-mono whitespace-nowrap overflow-hidden text-ellipsis text-left">
 				<span className="text-amber-800 dark:text-amber-400">npx </span>
-				<span>arkenv@latest init</span>
+				<span>arkenv init</span>
 			</code>
 			<div className="ml-auto border-l border-slate-200 dark:border-slate-700/50 pl-2.5 pr-1 shrink-0">
 				{copied ? (

--- a/apps/www/components/page/install-panel.test.tsx
+++ b/apps/www/components/page/install-panel.test.tsx
@@ -9,7 +9,7 @@ describe("InstallPanel", () => {
 
 		expect(
 			screen.getByRole("button", { name: "Copy install command" }),
-		).toHaveTextContent("npx arkenv@latest init");
+		).toHaveTextContent("npx arkenv init");
 		expect(screen.getByRole("button", { name: "Copy prompt" })).toBeVisible();
 		const repo = screen.getByRole("link", { name: "View repo" });
 		expect(repo).toBeVisible();

--- a/apps/www/components/page/install-panel.tsx
+++ b/apps/www/components/page/install-panel.tsx
@@ -6,10 +6,10 @@ import { SparklesIcon } from "~/components/icons/sparkles-icon";
 import { useCopyCommand } from "~/hooks/use-copy-command";
 import { getGithubRepoUrl } from "~/lib/github-links";
 
-const INSTALL_COMMAND = "npx arkenv@latest init";
+const INSTALL_COMMAND = "npx arkenv init";
 
 const INSTALL_PROMPT =
-	"Set up ArkEnv with `npx arkenv@latest init --agent`. Install any missing dependencies, wire the env schema into the app entry, start the app, and tell me when validation works from editor to runtime.";
+	"Set up ArkEnv with `npx arkenv init --agent`. Install any missing dependencies, wire the env schema into the app entry, start the app, and tell me when validation works from editor to runtime.";
 
 type InstallPanelProps = {
 	variant?: "hero" | "outro";
@@ -36,9 +36,7 @@ export function InstallPanel({ variant = "hero" }: InstallPanelProps) {
 				<span className="home-aurora__install-prompt-symbol" aria-hidden="true">
 					$
 				</span>
-				<code className="home-aurora__install-code">
-					npx arkenv@latest init
-				</code>
+				<code className="home-aurora__install-code">npx arkenv init</code>
 				<span
 					className="home-aurora__install-copy-affordance"
 					aria-hidden="true"

--- a/apps/www/content/docs/core-concepts/hosting-presets.mdx
+++ b/apps/www/content/docs/core-concepts/hosting-presets.mdx
@@ -23,7 +23,7 @@ When bootstrapping a project, select your hosting provider from the interactive
 wizard or specify the `--preset` flag:
 
 ```package-install
-npx arkenv@latest init --preset vercel
+npx arkenv init --preset vercel
 ```
 
 Accepted values: `none`, `vercel`, `netlify`, `cloudflare`, `railway`, `render`, `fly`.
@@ -39,7 +39,7 @@ You can apply, refresh, or remove hosting presets at any time using the
 ### Apply or refresh a preset
 
 ```package-install
-npx arkenv@latest preset apply vercel
+npx arkenv preset apply vercel
 ```
 
 When you run `preset apply`, the CLI:
@@ -53,13 +53,13 @@ When you run `preset apply`, the CLI:
 To specify a custom schema path explicitly, pass `--file`:
 
 ```package-install
-npx arkenv@latest preset apply vercel --file ./src/config/env.ts
+npx arkenv preset apply vercel --file ./src/config/env.ts
 ```
 
 ### Remove a preset
 
 ```package-install
-npx arkenv@latest preset remove vercel
+npx arkenv preset remove vercel
 ```
 
 The `preset remove` command strips the delimited preset block from your schema
@@ -107,8 +107,8 @@ Comment markers are plain TypeScript/JavaScript comments. They have **zero perfo
 You can apply multiple presets to the same schema by running `preset apply` for each provider:
 
 ```bash
-npx arkenv@latest preset apply vercel
-npx arkenv@latest preset apply railway
+npx arkenv preset apply vercel
+npx arkenv preset apply railway
 ```
 
 Both blocks coexist independently in your schema file. You can refresh or remove either preset without affecting the other.

--- a/apps/www/content/docs/frameworks/bun.mdx
+++ b/apps/www/content/docs/frameworks/bun.mdx
@@ -14,7 +14,7 @@ Continue reading if you're using `Bun.serve()` or `Bun.build()`. Otherwise, the 
 Scaffold Bun integration in an existing project using the interactiveCLI:
 
 ```package-install
-npx arkenv@latest init
+npx arkenv init
 ```
 
 The CLI installs `@arkenv/bun-plugin` and creates your initial `env.ts` schema file.

--- a/apps/www/content/docs/frameworks/nextjs.mdx
+++ b/apps/www/content/docs/frameworks/nextjs.mdx
@@ -14,7 +14,7 @@ For high-level architectural trade-offs, see
 Scaffold Next.js integration in an existing project using the CLI:
 
 ```package-install
-npx arkenv@latest init
+npx arkenv init
 ```
 
 The CLI detects Next.js, installs the required packages, wraps `next.config`

--- a/apps/www/content/docs/frameworks/nuxt.mdx
+++ b/apps/www/content/docs/frameworks/nuxt.mdx
@@ -15,7 +15,7 @@ For high-level architectural trade-offs, see
 Scaffold Nuxt integration in an existing project using the CLI:
 
 ```package-install
-npx arkenv@latest init
+npx arkenv init
 ```
 
 The CLI registers `@arkenv/nuxt/module` in your Nuxt config and creates your initial

--- a/apps/www/content/docs/frameworks/vite.mdx
+++ b/apps/www/content/docs/frameworks/vite.mdx
@@ -15,7 +15,7 @@ For high-level architectural trade-offs, see
 Scaffold Vite integration in an existing project using the CLI:
 
 ```package-install
-npx arkenv@latest init
+npx arkenv init
 ```
 
 The CLI installs `@arkenv/vite-plugin`, configures `vite.config.ts`, and scaffolds

--- a/apps/www/content/docs/getting-started/examples.mdx
+++ b/apps/www/content/docs/getting-started/examples.mdx
@@ -6,7 +6,7 @@ description: Start with an example ArkEnv project.
 Use the interactive CLI to bootstrap an example with your favorite tooling:
 
 ```package-install
-npx arkenv@latest init --example <example-name>
+npx arkenv init --example <example-name>
 ```
 
 Run it in an **empty directory**, or pass `--force` to overwrite.

--- a/apps/www/content/docs/getting-started/index.mdx
+++ b/apps/www/content/docs/getting-started/index.mdx
@@ -13,7 +13,7 @@ If you're new to ArkEnv, you can follow these steps to get started.
     wire the matching plugin.
 
     ```package-install
-    npx arkenv@latest init
+    npx arkenv init
     ```
 
     To learn more about installing ArkEnv, see the

--- a/apps/www/content/docs/getting-started/installation.mdx
+++ b/apps/www/content/docs/getting-started/installation.mdx
@@ -14,20 +14,20 @@ ArkEnv provides an interactive CLI that detects your stack, writes a
 schema, and wires framework config.
 
 ```package-install
-npx arkenv@latest init
+npx arkenv init
 ```
 
 Omit a project name to mutate the current directory. Pass a name to
 create a new folder (optionally from `--example`):
 
 ```package-install
-npx arkenv@latest init my-app --example with-vite-react -H vercel
+npx arkenv init my-app --example with-vite-react -H vercel
 ```
 
 For agent sessions, use `--agent` (implies `--yes --quiet --json`):
 
 ```package-install
-npx arkenv@latest init --agent
+npx arkenv init --agent
 ```
 
 Install a local binary when you want `arkenv` on the project PATH:
@@ -48,7 +48,7 @@ When the CLI finds a `package.json`, it adopts the repo incrementally.
     ### Run the interactive CLI
 
     ```package-install
-    npx arkenv@latest init
+    npx arkenv init
     ```
 
     The CLI refuses a dirty git working tree. Commit or stash

--- a/apps/www/content/docs/guides/ai.mdx
+++ b/apps/www/content/docs/guides/ai.mdx
@@ -82,13 +82,13 @@ public prefixes, and skip a `runtimeEnv` map.
 **Greenfield setup**
 
 ```text
-Add ArkEnv to this repo. Run `npx arkenv@latest init --agent`, parse the JSON on stdout, and only retry with flags from `retryWith` if a refusal is safe to bypass. Do not hand-write next.config or env.ts unless init fails.
+Add ArkEnv to this repo. Run `npx arkenv init --agent`, parse the JSON on stdout, and only retry with flags from `retryWith` if a refusal is safe to bypass. Do not hand-write next.config or env.ts unless init fails.
 ```
 
 **Existing keys**
 
 ```text
-We already have a .env.example. Run `npx arkenv@latest init --agent` and accept the detected keys for the schema. Keep .env.example values empty or placeholder-only; never copy secrets from .env into git.
+We already have a .env.example. Run `npx arkenv init --agent` and accept the detected keys for the schema. Keep .env.example values empty or placeholder-only; never copy secrets from .env into git.
 ```
 
 **Migrate raw process.env usage**
@@ -106,7 +106,7 @@ Add DATABASE_URL to the ArkEnv schema with the right type, update .env.example w
 **Hosting preset**
 
 ```text
-Add the Vercel hosting preset with `npx arkenv@latest preset apply vercel --agent` and merge any new system vars into the schema.
+Add the Vercel hosting preset with `npx arkenv preset apply vercel --agent` and merge any new system vars into the schema.
 ```
 
 ## Machine-readable documentation

--- a/apps/www/content/docs/guides/migrating-from-a-getenv-helper.mdx
+++ b/apps/www/content/docs/guides/migrating-from-a-getenv-helper.mdx
@@ -128,7 +128,7 @@ env.DEBUG; // boolean
 To scaffold ArkEnv in your project:
 
 ```package-install
-npx arkenv@latest init
+npx arkenv init
 ```
 
 ## Next steps

--- a/apps/www/content/docs/guides/migrating-to-v1.mdx
+++ b/apps/www/content/docs/guides/migrating-to-v1.mdx
@@ -217,7 +217,7 @@ and the [Next.js](/docs/frameworks/nextjs) /
 
 ## Strict layout removed (alpha hard cut)
 
-Earlier alphas shipped `npx arkenv@latest init --strict` plus
+Earlier alphas shipped `npx arkenv init --strict` plus
 `@arkenv/nextjs/server` / `@arkenv/nuxt/client` (and related subpaths).
 That layout engine is gone. Flat `env.ts` is the only first-class path.
 

--- a/apps/www/content/docs/reference/agent-plugin.mdx
+++ b/apps/www/content/docs/reference/agent-plugin.mdx
@@ -45,7 +45,7 @@ Do not pass `--force` unless a refusal lists it in `retryWith`.
 
 ### `/arkenv:init`
 
-Delegates to `npx arkenv@latest init --agent`.
+Delegates to `npx arkenv init --agent`.
 
 ### `/arkenv:audit`
 

--- a/apps/www/content/docs/reference/check.mdx
+++ b/apps/www/content/docs/reference/check.mdx
@@ -8,15 +8,15 @@ schema. Use it as a standalone verification step in CI/CD pipelines,
 local verification scripts, or pre-commit hooks.
 
 ```package-install
-npx arkenv@latest check
+npx arkenv check
 ```
 
 ```package-install
-npx arkenv@latest check --env-file .env.production
+npx arkenv check --env-file .env.production
 ```
 
 ```package-install
-npx arkenv@latest check --schema ./src/env.ts --env-file .env --env-file .env.local
+npx arkenv check --schema ./src/env.ts --env-file .env --env-file .env.local
 ```
 
 [Global flags](/docs/reference#global-flags) (`--quiet`, `--json`,
@@ -61,7 +61,7 @@ Explicit path to the schema module. Overrides `"arkenv"` in `package.json`
 and convention discovery.
 
 ```package-install
-npx arkenv@latest check --schema ./src/config/env.ts
+npx arkenv check --schema ./src/config/env.ts
 ```
 
 ### `--env-file <file>`
@@ -71,7 +71,7 @@ files are loaded in sequence with later files taking precedence over
 earlier ones.
 
 ```package-install
-npx arkenv@latest check --env-file .env --env-file .env.local
+npx arkenv check --env-file .env --env-file .env.local
 ```
 
 Values from `--env-file` are merged over `process.env`. Missing files fail

--- a/apps/www/content/docs/reference/example.mdx
+++ b/apps/www/content/docs/reference/example.mdx
@@ -9,11 +9,11 @@ that file whenever the schema changes — in CI, a pre-commit hook, or
 right after you add a variable.
 
 ```package-install
-npx arkenv@latest example
+npx arkenv example
 ```
 
 ```package-install
-npx arkenv@latest example --schema ./src/env.ts
+npx arkenv example --schema ./src/env.ts
 ```
 
 [Global flags](/docs/reference#global-flags) (`--quiet`, `--json`,
@@ -92,7 +92,7 @@ Explicit path to the schema module. Overrides `"arkenv"` in
 `package.json` and convention discovery.
 
 ```package-install
-npx arkenv@latest example --schema ./src/config/env.ts
+npx arkenv example --schema ./src/config/env.ts
 ```
 
 ### `--json` / `-j`

--- a/apps/www/content/docs/reference/init.mdx
+++ b/apps/www/content/docs/reference/init.mdx
@@ -9,7 +9,7 @@ the walkthrough, see
 [Installation](/docs/getting-started/installation).
 
 ```package-install
-npx arkenv@latest init
+npx arkenv init
 ```
 
 ## Usage

--- a/apps/www/content/docs/reference/nextjs.mdx
+++ b/apps/www/content/docs/reference/nextjs.mdx
@@ -83,7 +83,7 @@ specifier; codegen keeps `.arkenv/index.ts` re-exporting that file so
 `tsc --noEmit` matches.
 
 Skip generation during CLI scaffolds with
-`npx arkenv@latest init --no-codegen`.
+`npx arkenv init --no-codegen`.
 
 ### Programmatic codegen
 

--- a/apps/www/content/docs/reference/preset.mdx
+++ b/apps/www/content/docs/reference/preset.mdx
@@ -8,11 +8,11 @@ hosting provider. Use it to add platform variables, refresh them when
 the provider list changes, or strip a provider when you switch hosts.
 
 ```package-install
-npx arkenv@latest preset apply vercel
+npx arkenv preset apply vercel
 ```
 
 ```package-install
-npx arkenv@latest preset remove vercel
+npx arkenv preset remove vercel
 ```
 
 [Global flags](/docs/reference#global-flags) (`--yes`, `--quiet`,
@@ -42,7 +42,7 @@ Point at a schema file. This overrides the `"arkenv"` pointer in
 `package.json`.
 
 ```package-install
-npx arkenv@latest preset apply vercel --file ./src/config/env.ts
+npx arkenv preset apply vercel --file ./src/config/env.ts
 ```
 
 ### `--force` / `-f`
@@ -50,7 +50,7 @@ npx arkenv@latest preset apply vercel --file ./src/config/env.ts
 Bypass the clean git working tree check.
 
 ```package-install
-npx arkenv@latest preset apply vercel --force
+npx arkenv preset apply vercel --force
 ```
 
 ### `--yes` / `-y`

--- a/packages/agent-plugin/commands/init.md
+++ b/packages/agent-plugin/commands/init.md
@@ -4,7 +4,7 @@ description: Scaffold ArkEnv with the CLI in agent mode.
 
 Scaffold ArkEnv in the current project.
 
-1. Prefer the MCP `init` tool. If MCP is unavailable, run `npx arkenv@latest init --agent` in the project root.
+1. Prefer the MCP `init` tool. If MCP is unavailable, run `npx arkenv init --agent` in the project root.
 2. Parse JSON on stdout. Success is `"status": "success"`.
 3. On `"status": "error"`, branch on `code` and only retry with flags listed in `retryWith`. Never pass `--force` unless the user accepts that refusal.
 4. Do not hand-write `env.ts` or framework config unless init fails.

--- a/packages/agent-plugin/skills/arkenv/SKILL.md
+++ b/packages/agent-plugin/skills/arkenv/SKILL.md
@@ -8,7 +8,7 @@ description: "Use when setting up or changing environment variable validation wi
 ArkEnv v1's only application surface is `import { env } from "./env"`.
 
 - Runtime: `@arkenv/core` (ArkType) or `@arkenv/standard` (Zod, Valibot, Standard Schema).
-- CLI: `npx arkenv@latest init --agent`. Parse JSON on stdout. Never pass `--force` unless `retryWith` lists it after a refusal.
+- CLI: `npx arkenv init --agent`. Parse JSON on stdout. Never pass `--force` unless `retryWith` lists it after a refusal.
 - Do not read `process.env` or `import.meta.env` in application components.
 - Do not add ambient `.d.ts` `ProcessEnv` / `ImportMetaEnv` augmentations.
 - Public prefixes: `NEXT_PUBLIC_`, `NUXT_PUBLIC_`, `VITE_`, `BUN_PUBLIC_`. Never put secrets behind those prefixes.

--- a/packages/agent-plugin/src/mcp/init.ts
+++ b/packages/agent-plugin/src/mcp/init.ts
@@ -44,7 +44,7 @@ export async function initProject(
 }
 
 /**
- * Resolve the local `arkenv` binary or fall back to `npx arkenv@latest`.
+ * Resolve the local `arkenv` binary or fall back to `npx arkenv`.
  *
  * @param cwd Project directory
  * @returns Command plus args that precede `init`
@@ -61,7 +61,7 @@ export async function resolveArkEnvCommand(
 		await access(localBin);
 		return { command: localBin, prefixArgs: [] };
 	} catch {
-		return { command: "npx", prefixArgs: ["--yes", "arkenv@latest"] };
+		return { command: "npx", prefixArgs: ["--yes", "arkenv"] };
 	}
 }
 

--- a/packages/agent-plugin/src/mcp/init.ts
+++ b/packages/agent-plugin/src/mcp/init.ts
@@ -44,7 +44,7 @@ export async function initProject(
 }
 
 /**
- * Resolve the local `arkenv` binary or fall back to `npx arkenv`.
+ * Resolve the local `arkenv` binary or fall back to `npx arkenv@latest`.
  *
  * @param cwd Project directory
  * @returns Command plus args that precede `init`
@@ -61,7 +61,7 @@ export async function resolveArkEnvCommand(
 		await access(localBin);
 		return { command: localBin, prefixArgs: [] };
 	} catch {
-		return { command: "npx", prefixArgs: ["--yes", "arkenv"] };
+		return { command: "npx", prefixArgs: ["--yes", "arkenv@latest"] };
 	}
 }
 

--- a/packages/arkenv/README.md
+++ b/packages/arkenv/README.md
@@ -13,7 +13,7 @@ The interactive, zero-dependency scaffolding experience for the [ArkEnv](https:/
 <br />
 
 ```sh
-npx arkenv@latest init
+npx arkenv init
 ```
 
 ## Related

--- a/packages/arkenv/src/adapters/node-project-scanner/utils/requirements.ts
+++ b/packages/arkenv/src/adapters/node-project-scanner/utils/requirements.ts
@@ -1,23 +1,8 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
 import type { RequirementCheckResult } from "@/shared/ports";
+import { compareSemver } from "@/shared/semver";
 import { checkTsConfig } from "./tsconfig";
-
-/**
- * Simple semver comparison.
- * Returns 1 if v1 > v2, -1 if v1 < v2, 0 if equal.
- */
-function compareSemver(v1: string, v2: string): number {
-	const p1 = v1.replace(/^v/, "").split(".").map(Number);
-	const p2 = v2.replace(/^v/, "").split(".").map(Number);
-	for (let i = 0; i < 3; i++) {
-		const n1 = p1[i] || 0;
-		const n2 = p2[i] || 0;
-		if (n1 > n2) return 1;
-		if (n1 < n2) return -1;
-	}
-	return 0;
-}
 
 /**
  * Normalizes a semver string by removing leading 'v' and ensuring it has 3 parts (major.minor.patch).

--- a/packages/arkenv/src/cli/commands/init.test.ts
+++ b/packages/arkenv/src/cli/commands/init.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ERROR_CODES } from "@/shared/errors";
 import type {
 	LoggerPort,
@@ -652,8 +652,12 @@ describe("InitUseCase", () => {
 		let versionChecker: any;
 		let spawner: any;
 		let exit: any;
+		let originalCI: string | undefined;
+		let originalTTY: boolean | undefined;
 
 		beforeEach(() => {
+			originalCI = process.env.CI;
+			originalTTY = process.stdout.isTTY;
 			versionChecker = {
 				checkFreshness: vi.fn().mockResolvedValue({ isOutdated: false }),
 			};
@@ -661,9 +665,16 @@ describe("InitUseCase", () => {
 			exit = vi.fn();
 		});
 
+		afterEach(() => {
+			if (originalCI !== undefined) {
+				process.env.CI = originalCI;
+			} else {
+				delete process.env.CI;
+			}
+			process.stdout.isTTY = originalTTY as boolean;
+		});
+
 		it("prompts to run latest and spawns dlx runner when user confirms", async () => {
-			const originalCI = process.env.CI;
-			const originalTTY = process.stdout.isTTY;
 			delete process.env.CI;
 			process.stdout.isTTY = true;
 
@@ -706,14 +717,9 @@ describe("InitUseCase", () => {
 			);
 			expect(exit).toHaveBeenCalledWith(0);
 			expect(success).toBe(true);
-
-			process.env.CI = originalCI;
-			process.stdout.isTTY = originalTTY;
 		});
 
 		it("proceeds with current version when user declines upgrade prompt", async () => {
-			const originalCI = process.env.CI;
-			const originalTTY = process.stdout.isTTY;
 			delete process.env.CI;
 			process.stdout.isTTY = true;
 
@@ -752,14 +758,9 @@ describe("InitUseCase", () => {
 			expect(spawner).not.toHaveBeenCalled();
 			expect(exit).not.toHaveBeenCalled();
 			expect(success).toBe(true);
-
-			process.env.CI = originalCI;
-			process.stdout.isTTY = originalTTY;
 		});
 
 		it("cancels operation cleanly when user aborts the prompt", async () => {
-			const originalCI = process.env.CI;
-			const originalTTY = process.stdout.isTTY;
 			delete process.env.CI;
 			process.stdout.isTTY = true;
 
@@ -792,13 +793,9 @@ describe("InitUseCase", () => {
 			expect(spawner).not.toHaveBeenCalled();
 			expect(exit).not.toHaveBeenCalled();
 			expect(success).toBe(false);
-
-			process.env.CI = originalCI;
-			process.stdout.isTTY = originalTTY;
 		});
 
 		it("skips check in CI environment", async () => {
-			const originalCI = process.env.CI;
 			process.env.CI = "true";
 
 			const customUseCase = new InitUseCase(
@@ -829,8 +826,6 @@ describe("InitUseCase", () => {
 
 			expect(versionChecker.checkFreshness).not.toHaveBeenCalled();
 			expect(spawner).not.toHaveBeenCalled();
-
-			process.env.CI = originalCI;
 		});
 	});
 });

--- a/packages/arkenv/src/cli/commands/init.test.ts
+++ b/packages/arkenv/src/cli/commands/init.test.ts
@@ -647,4 +647,190 @@ describe("InitUseCase", () => {
 		expect(result.options.installSkill).toBe(false);
 		expect(result.options.skillDetected).toBe(true);
 	});
+
+	describe("version freshness pre-flight check", () => {
+		let versionChecker: any;
+		let spawner: any;
+		let exit: any;
+
+		beforeEach(() => {
+			versionChecker = {
+				checkFreshness: vi.fn().mockResolvedValue({ isOutdated: false }),
+			};
+			spawner = vi.fn().mockResolvedValue(0);
+			exit = vi.fn();
+		});
+
+		it("prompts to run latest and spawns dlx runner when user confirms", async () => {
+			const originalCI = process.env.CI;
+			const originalTTY = process.stdout.isTTY;
+			delete process.env.CI;
+			process.stdout.isTTY = true;
+
+			versionChecker.checkFreshness.mockResolvedValue({
+				isOutdated: true,
+				latestVersion: "1.0.0-alpha.18",
+			});
+			vi.mocked(prompt.confirm).mockResolvedValue(true);
+
+			const customUseCase = new InitUseCase(
+				logger,
+				workspace,
+				prompt,
+				scanner,
+				undefined,
+				undefined,
+				versionChecker,
+				spawner,
+				exit,
+			);
+
+			const success = await customUseCase.execute({
+				isYes: false,
+				isForce: false,
+				isQuiet: false,
+				isAgent: false,
+			});
+
+			expect(versionChecker.checkFreshness).toHaveBeenCalled();
+			expect(prompt.confirm).toHaveBeenCalledWith(
+				expect.stringContaining("Version 1.0.0-alpha.18 is available"),
+				true,
+				"Yes (Recommended)",
+			);
+			expect(spawner).toHaveBeenCalledWith(
+				expect.objectContaining({
+					packageName: "arkenv",
+					args: expect.arrayContaining(["init"]),
+				}),
+			);
+			expect(exit).toHaveBeenCalledWith(0);
+			expect(success).toBe(true);
+
+			process.env.CI = originalCI;
+			process.stdout.isTTY = originalTTY;
+		});
+
+		it("proceeds with current version when user declines upgrade prompt", async () => {
+			const originalCI = process.env.CI;
+			const originalTTY = process.stdout.isTTY;
+			delete process.env.CI;
+			process.stdout.isTTY = true;
+
+			versionChecker.checkFreshness.mockResolvedValue({
+				isOutdated: true,
+				latestVersion: "1.0.0-alpha.18",
+			});
+			vi.mocked(prompt.confirm).mockResolvedValue(false);
+			vi.mocked(prompt.runWizard).mockResolvedValue({
+				path: "./env.ts",
+				validator: "arktype",
+				framework: "vanilla",
+				language: "ts",
+			});
+
+			const customUseCase = new InitUseCase(
+				logger,
+				workspace,
+				prompt,
+				scanner,
+				undefined,
+				undefined,
+				versionChecker,
+				spawner,
+				exit,
+			);
+
+			const success = await customUseCase.execute({
+				isYes: false,
+				isForce: false,
+				isQuiet: false,
+				isAgent: false,
+			});
+
+			expect(versionChecker.checkFreshness).toHaveBeenCalled();
+			expect(spawner).not.toHaveBeenCalled();
+			expect(exit).not.toHaveBeenCalled();
+			expect(success).toBe(true);
+
+			process.env.CI = originalCI;
+			process.stdout.isTTY = originalTTY;
+		});
+
+		it("cancels operation cleanly when user aborts the prompt", async () => {
+			const originalCI = process.env.CI;
+			const originalTTY = process.stdout.isTTY;
+			delete process.env.CI;
+			process.stdout.isTTY = true;
+
+			versionChecker.checkFreshness.mockResolvedValue({
+				isOutdated: true,
+				latestVersion: "1.0.0-alpha.18",
+			});
+			vi.mocked(prompt.confirm).mockResolvedValue(null);
+
+			const customUseCase = new InitUseCase(
+				logger,
+				workspace,
+				prompt,
+				scanner,
+				undefined,
+				undefined,
+				versionChecker,
+				spawner,
+				exit,
+			);
+
+			const success = await customUseCase.execute({
+				isYes: false,
+				isForce: false,
+				isQuiet: false,
+				isAgent: false,
+			});
+
+			expect(logger.cancel).toHaveBeenCalledWith("Operation cancelled.");
+			expect(spawner).not.toHaveBeenCalled();
+			expect(exit).not.toHaveBeenCalled();
+			expect(success).toBe(false);
+
+			process.env.CI = originalCI;
+			process.stdout.isTTY = originalTTY;
+		});
+
+		it("skips check in CI environment", async () => {
+			const originalCI = process.env.CI;
+			process.env.CI = "true";
+
+			const customUseCase = new InitUseCase(
+				logger,
+				workspace,
+				prompt,
+				scanner,
+				undefined,
+				undefined,
+				versionChecker,
+				spawner,
+				exit,
+			);
+
+			vi.mocked(prompt.runWizard).mockResolvedValue({
+				path: "./env.ts",
+				validator: "arktype",
+				framework: "vanilla",
+				language: "ts",
+			});
+
+			await customUseCase.execute({
+				isYes: false,
+				isForce: false,
+				isQuiet: false,
+				isAgent: false,
+			});
+
+			expect(versionChecker.checkFreshness).not.toHaveBeenCalled();
+			expect(spawner).not.toHaveBeenCalled();
+
+			process.env.CI = originalCI;
+		});
+	});
 });

--- a/packages/arkenv/src/cli/commands/init.ts
+++ b/packages/arkenv/src/cli/commands/init.ts
@@ -3,7 +3,7 @@ import { shake } from "radashi";
 import { code } from "@/cli/ui";
 import { type CollectedState, createPlan, Executor } from "@/features/scaffold";
 import type { HostPreset } from "@/features/scaffold/presets";
-import { RegistryClient } from "@/shared/clients";
+import { RegistryClient, VersionCheckerClient } from "@/shared/clients";
 import { ERROR_CODES } from "@/shared/errors";
 import type {
 	LoggerPort,
@@ -11,6 +11,8 @@ import type {
 	PromptPort,
 	WorkspacePort,
 } from "@/shared/ports";
+import { spawnLatest } from "@/shared/spawner";
+import { name as pkgName, version as pkgVersion } from "../../../package.json";
 import type { ExampleUseCase } from "./example";
 
 /**
@@ -41,12 +43,59 @@ export class InitUseCase {
 		private readonly scanner: ProjectScannerPort,
 		private readonly registry = new RegistryClient(),
 		private readonly exampleUseCase?: ExampleUseCase,
+		private readonly versionChecker = new VersionCheckerClient(),
+		private readonly spawner: (options: {
+			packageName: string;
+			args: string[];
+		}) => Promise<number> = spawnLatest,
+		private readonly exit: (code: number) => void = (code) =>
+			process.exit(code),
 	) {}
 
 	/**
 	 * Collects init options, creates a scaffolding plan, and executes it.
 	 */
 	async execute(input: InitInput): Promise<boolean> {
+		const isInteractive =
+			!process.env.CI &&
+			Boolean(process.stdout.isTTY) &&
+			!input.isQuiet &&
+			!input.isAgent &&
+			!input.isYes;
+
+		if (isInteractive) {
+			const freshness = await this.versionChecker.checkFreshness({
+				currentVersion: pkgVersion,
+				packageName: pkgName,
+				timeoutMs: 1000,
+			});
+
+			if (freshness.isOutdated && freshness.latestVersion) {
+				const confirmLatest = await this.prompt.confirm(
+					`Version ${freshness.latestVersion} is available (running ${pkgVersion}). Run latest instead?`,
+					true,
+					"Yes (Recommended)",
+				);
+
+				if (confirmLatest === null) {
+					this.logger.cancel("Operation cancelled.");
+					return false;
+				}
+
+				if (confirmLatest) {
+					const rawArgs = process.argv.slice(2);
+					const forwardedArgs =
+						rawArgs[0] === "init" ? rawArgs : ["init", ...rawArgs];
+					const exitCode = await this.spawner({
+						packageName: pkgName,
+						args: forwardedArgs,
+					});
+					this.exit(exitCode);
+					return true;
+				}
+			}
+		}
+
 		const state = await this.collect(input);
 		if (!state) return false;
 

--- a/packages/arkenv/src/index.ts
+++ b/packages/arkenv/src/index.ts
@@ -4,19 +4,19 @@ throw new Error(
 	`🚨 ${formatBuildError(
 		"You imported the 'arkenv' package as a library. " +
 			"Starting with v1.0.0, the 'arkenv' package is exclusively the interactive CLI. " +
-			"If you want to validate environment variables in your code, please install and import '@arkenv/core' (or '@arkenv/standard') instead, or run `npx arkenv@latest init` to guide you through setup.",
+			"If you want to validate environment variables in your code, please install and import '@arkenv/core' (or '@arkenv/standard') instead, or run `npx arkenv init` to guide you through setup.",
 	)}`,
 );
 
 /**
  * @deprecated The 'arkenv' package is exclusively an interactive CLI in v1.0.0+.
- * If you want to validate environment variables in your code, please install and import '@arkenv/core' (or '@arkenv/standard') instead, or run `npx arkenv@latest init`.
+ * If you want to validate environment variables in your code, please install and import '@arkenv/core' (or '@arkenv/standard') instead, or run `npx arkenv init`.
  */
 declare const arkenv: never;
 
 /**
  * @deprecated The 'arkenv' package is exclusively an interactive CLI in v1.0.0+.
- * If you want to validate environment variables in your code, please install and import '@arkenv/core' (or '@arkenv/standard') instead, or run `npx arkenv@latest init`.
+ * If you want to validate environment variables in your code, please install and import '@arkenv/core' (or '@arkenv/standard') instead, or run `npx arkenv init`.
  */
 export type Arkenv = never;
 

--- a/packages/arkenv/src/shared/clients/index.ts
+++ b/packages/arkenv/src/shared/clients/index.ts
@@ -1,2 +1,7 @@
 export type { Example, ExampleRegistry } from "./registry.client";
 export { RegistryClient } from "./registry.client";
+export type {
+	FreshnessCheckOptions,
+	FreshnessCheckResult,
+} from "./version-checker.client";
+export { VersionCheckerClient } from "./version-checker.client";

--- a/packages/arkenv/src/shared/clients/version-checker.client.test.ts
+++ b/packages/arkenv/src/shared/clients/version-checker.client.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VersionCheckerClient } from "./version-checker.client";
+
+describe("VersionCheckerClient", () => {
+	let client: VersionCheckerClient;
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		client = new VersionCheckerClient();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	it("returns isOutdated: true when registry version is newer", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ version: "1.0.0-alpha.18" }),
+		} as Response);
+
+		const result = await client.checkFreshness({
+			currentVersion: "1.0.0-alpha.17",
+			packageName: "arkenv",
+		});
+
+		expect(result).toEqual({
+			isOutdated: true,
+			latestVersion: "1.0.0-alpha.18",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"https://registry.npmjs.org/arkenv/latest",
+			expect.objectContaining({
+				headers: { Accept: "application/json" },
+			}),
+		);
+	});
+
+	it("returns isOutdated: false when current version is equal to or newer than registry", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ version: "1.0.0-alpha.17" }),
+		} as Response);
+
+		const result = await client.checkFreshness({
+			currentVersion: "1.0.0-alpha.17",
+			packageName: "arkenv",
+		});
+
+		expect(result).toEqual({
+			isOutdated: false,
+			latestVersion: "1.0.0-alpha.17",
+		});
+	});
+
+	it("handles pre-release versions accurately", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ version: "1.0.0-beta.11" }),
+		} as Response);
+
+		const result = await client.checkFreshness({
+			currentVersion: "1.0.0-beta.2",
+			packageName: "arkenv",
+		});
+
+		expect(result).toEqual({
+			isOutdated: true,
+			latestVersion: "1.0.0-beta.11",
+		});
+	});
+
+	it("fails open silently when fetch returns non-200 status", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 404,
+		} as Response);
+
+		const result = await client.checkFreshness({
+			currentVersion: "1.0.0-alpha.17",
+			packageName: "arkenv",
+		});
+
+		expect(result).toEqual({ isOutdated: false });
+	});
+
+	it("fails open silently on network / DNS failure", async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error("ENOTFOUND"));
+
+		const result = await client.checkFreshness({
+			currentVersion: "1.0.0-alpha.17",
+			packageName: "arkenv",
+		});
+
+		expect(result).toEqual({ isOutdated: false });
+	});
+
+	it("fails open silently on timeout / abort error", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockRejectedValue(
+				new DOMException("The operation was aborted", "TimeoutError"),
+			);
+
+		const result = await client.checkFreshness({
+			currentVersion: "1.0.0-alpha.17",
+			packageName: "arkenv",
+			timeoutMs: 50,
+		});
+
+		expect(result).toEqual({ isOutdated: false });
+	});
+
+	it("fails open silently when JSON payload is missing version or malformed", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({}),
+		} as Response);
+
+		const result = await client.checkFreshness({
+			currentVersion: "1.0.0-alpha.17",
+			packageName: "arkenv",
+		});
+
+		expect(result).toEqual({ isOutdated: false });
+	});
+});

--- a/packages/arkenv/src/shared/clients/version-checker.client.ts
+++ b/packages/arkenv/src/shared/clients/version-checker.client.ts
@@ -1,0 +1,77 @@
+import { compareSemver } from "@/shared/semver";
+
+/**
+ * Options for performing a version freshness check.
+ */
+export type FreshnessCheckOptions = {
+	/** Current running package version. */
+	currentVersion: string;
+	/** Target package name to check on npm (defaults to "arkenv"). */
+	packageName?: string;
+	/** Abort timeout in milliseconds (defaults to 1000ms). */
+	timeoutMs?: number;
+};
+
+/**
+ * Result of a version freshness check.
+ */
+export type FreshnessCheckResult = {
+	/** True if the latest published version on npm is strictly greater than the current version. */
+	isOutdated: boolean;
+	/** Latest version available on npm if successfully fetched and evaluated. */
+	latestVersion?: string;
+};
+
+/**
+ * Client for checking whether the running CLI is outdated compared to the npm registry.
+ */
+export class VersionCheckerClient {
+	/**
+	 * Checks if a newer version of the package exists on the npm registry.
+	 * Fails open silently returning `{ isOutdated: false }` upon any error or timeout.
+	 *
+	 * @param options Freshness check options.
+	 * @returns A promise resolving to the freshness check result.
+	 */
+	async checkFreshness(
+		options: FreshnessCheckOptions,
+	): Promise<FreshnessCheckResult> {
+		const {
+			currentVersion,
+			packageName = "arkenv",
+			timeoutMs = 1000,
+		} = options;
+
+		try {
+			const encodedName = encodeURIComponent(packageName);
+			const url = `https://registry.npmjs.org/${encodedName}/latest`;
+
+			const response = await fetch(url, {
+				signal: AbortSignal.timeout(timeoutMs),
+				headers: {
+					Accept: "application/json",
+				},
+			});
+
+			if (!response.ok) {
+				return { isOutdated: false };
+			}
+
+			const data = (await response.json()) as { version?: string };
+			const latestVersion = data?.version;
+
+			if (!latestVersion || typeof latestVersion !== "string") {
+				return { isOutdated: false };
+			}
+
+			const isOutdated = compareSemver(latestVersion, currentVersion) > 0;
+			return {
+				isOutdated,
+				latestVersion,
+			};
+		} catch {
+			// Fail open on timeouts, offline environments, DNS errors, etc.
+			return { isOutdated: false };
+		}
+	}
+}

--- a/packages/arkenv/src/shared/semver.test.ts
+++ b/packages/arkenv/src/shared/semver.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { compareSemver, parseSemver } from "./semver";
+
+describe("semver", () => {
+	describe("parseSemver", () => {
+		it("parses normal semver versions", () => {
+			expect(parseSemver("1.2.3")).toEqual({
+				major: 1,
+				minor: 2,
+				patch: 3,
+				prerelease: [],
+				build: undefined,
+			});
+			expect(parseSemver("v1.0.0-alpha.17")).toEqual({
+				major: 1,
+				minor: 0,
+				patch: 0,
+				prerelease: ["alpha", 17],
+				build: undefined,
+			});
+		});
+
+		it("parses versions with pre-release identifiers and build metadata", () => {
+			expect(parseSemver("1.0.0-beta.2+exp.sha.5114f85")).toEqual({
+				major: 1,
+				minor: 0,
+				patch: 0,
+				prerelease: ["beta", 2],
+				build: "exp.sha.5114f85",
+			});
+		});
+
+		it("parses short version strings", () => {
+			expect(parseSemver("22")).toEqual({
+				major: 22,
+				minor: 0,
+				patch: 0,
+				prerelease: [],
+				build: undefined,
+			});
+			expect(parseSemver("v5.1")).toEqual({
+				major: 5,
+				minor: 1,
+				patch: 0,
+				prerelease: [],
+				build: undefined,
+			});
+		});
+
+		it("returns null for invalid versions", () => {
+			expect(parseSemver("invalid")).toBeNull();
+			expect(parseSemver("")).toBeNull();
+		});
+	});
+
+	describe("compareSemver", () => {
+		it("compares major, minor, patch versions", () => {
+			expect(compareSemver("1.0.0", "2.0.0")).toBe(-1);
+			expect(compareSemver("2.0.0", "1.0.0")).toBe(1);
+			expect(compareSemver("1.1.0", "1.2.0")).toBe(-1);
+			expect(compareSemver("1.2.3", "1.2.3")).toBe(0);
+		});
+
+		it("handles pre-release precedence over normal release", () => {
+			expect(compareSemver("1.0.0-alpha", "1.0.0")).toBe(-1);
+			expect(compareSemver("1.0.0", "1.0.0-alpha")).toBe(1);
+		});
+
+		it("compares pre-release versions with numeric segments accurately", () => {
+			expect(compareSemver("1.0.0-beta.2", "1.0.0-beta.11")).toBe(-1);
+			expect(compareSemver("1.0.0-beta.11", "1.0.0-beta.2")).toBe(1);
+			expect(compareSemver("1.0.0-beta.1", "1.0.0-beta.2")).toBe(-1);
+		});
+
+		it("compares alphanumeric pre-release identifiers", () => {
+			expect(compareSemver("1.0.0-alpha", "1.0.0-alpha.1")).toBe(-1);
+			expect(compareSemver("1.0.0-alpha.1", "1.0.0-alpha.beta")).toBe(-1);
+			expect(compareSemver("1.0.0-alpha.beta", "1.0.0-beta")).toBe(-1);
+			expect(compareSemver("1.0.0-beta", "1.0.0-beta.2")).toBe(-1);
+			expect(compareSemver("1.0.0-beta.2", "1.0.0-beta.11")).toBe(-1);
+			expect(compareSemver("1.0.0-beta.11", "1.0.0-rc.1")).toBe(-1);
+			expect(compareSemver("1.0.0-rc.1", "1.0.0")).toBe(-1);
+		});
+
+		it("ignores build metadata in precedence comparison", () => {
+			expect(compareSemver("1.0.0+build1", "1.0.0+build2")).toBe(0);
+			expect(compareSemver("1.0.0-alpha+001", "1.0.0-alpha+exp")).toBe(0);
+		});
+
+		it("handles leading 'v' prefix", () => {
+			expect(compareSemver("v1.0.0", "1.0.0")).toBe(0);
+			expect(compareSemver("v1.0.0-alpha.16", "v1.0.0-alpha.17")).toBe(-1);
+		});
+	});
+});

--- a/packages/arkenv/src/shared/semver.ts
+++ b/packages/arkenv/src/shared/semver.ts
@@ -1,0 +1,134 @@
+/**
+ * Represents a parsed SemVer 2.0 version.
+ */
+export type SemVer = {
+	major: number;
+	minor: number;
+	patch: number;
+	prerelease: (string | number)[];
+	build?: string;
+};
+
+/**
+ * Parses a semantic version string into its components according to SemVer 2.0.
+ *
+ * @param version The version string to parse (e.g., "1.2.3-beta.1+build").
+ * @returns The parsed SemVer object or null if parsing fails.
+ */
+export function parseSemver(version: string): SemVer | null {
+	const trimmed = version.trim().replace(/^v/, "");
+	// Regex matching standard SemVer 2.0: MAJOR.MINOR.PATCH(-PRERELEASE)?(+BUILD)?
+	const match = trimmed.match(
+		/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/,
+	);
+
+	if (!match) {
+		// Fallback for short versions like "1.2" or "1"
+		const shortMatch = trimmed.match(
+			/^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/,
+		);
+		if (!shortMatch) return null;
+
+		const major = Number.parseInt(shortMatch[1], 10);
+		const minor =
+			shortMatch[2] !== undefined ? Number.parseInt(shortMatch[2], 10) : 0;
+		const patch =
+			shortMatch[3] !== undefined ? Number.parseInt(shortMatch[3], 10) : 0;
+		const prereleaseRaw = shortMatch[4];
+		const build = shortMatch[5];
+
+		if (Number.isNaN(major) || Number.isNaN(minor) || Number.isNaN(patch)) {
+			return null;
+		}
+
+		const prerelease = prereleaseRaw
+			? prereleaseRaw
+					.split(".")
+					.map((id) => (/^\d+$/.test(id) ? Number.parseInt(id, 10) : id))
+			: [];
+
+		return { major, minor, patch, prerelease, build };
+	}
+
+	const major = Number.parseInt(match[1], 10);
+	const minor = Number.parseInt(match[2], 10);
+	const patch = Number.parseInt(match[3], 10);
+	const prereleaseRaw = match[4];
+	const build = match[5];
+
+	if (Number.isNaN(major) || Number.isNaN(minor) || Number.isNaN(patch)) {
+		return null;
+	}
+
+	const prerelease = prereleaseRaw
+		? prereleaseRaw
+				.split(".")
+				.map((id) => (/^\d+$/.test(id) ? Number.parseInt(id, 10) : id))
+		: [];
+
+	return { major, minor, patch, prerelease, build };
+}
+
+/**
+ * Compares two semantic version strings according to SemVer 2.0 precedence rules.
+ *
+ * Precedence is determined by comparing major, minor, patch, and pre-release identifiers:
+ * - 1.0.0-beta.2 < 1.0.0-beta.11 (numeric comparison for numeric identifiers)
+ * - 1.0.0-alpha < 1.0.0-beta (lexical comparison for string identifiers)
+ * - 1.0.0-alpha < 1.0.0 (normal version has higher precedence than pre-release)
+ * - Build metadata is ignored.
+ *
+ * @param v1 First version string.
+ * @param v2 Second version string.
+ * @returns 1 if v1 > v2, -1 if v1 < v2, 0 if equal or either is unparseable.
+ */
+export function compareSemver(v1: string, v2: string): number {
+	const s1 = parseSemver(v1);
+	const s2 = parseSemver(v2);
+
+	if (!s1 || !s2) return 0;
+
+	// Compare major, minor, patch
+	if (s1.major !== s2.major) return s1.major > s2.major ? 1 : -1;
+	if (s1.minor !== s2.minor) return s1.minor > s2.minor ? 1 : -1;
+	if (s1.patch !== s2.patch) return s1.patch > s2.patch ? 1 : -1;
+
+	// When major, minor, patch are equal:
+	// A normal version has greater precedence than a pre-release version.
+	const hasPre1 = s1.prerelease.length > 0;
+	const hasPre2 = s2.prerelease.length > 0;
+
+	if (!hasPre1 && hasPre2) return 1; // 1.0.0 > 1.0.0-alpha
+	if (hasPre1 && !hasPre2) return -1; // 1.0.0-alpha < 1.0.0
+	if (!hasPre1 && !hasPre2) return 0; // 1.0.0 == 1.0.0
+
+	// Both have pre-release identifiers; compare each identifier segment
+	const minLen = Math.min(s1.prerelease.length, s2.prerelease.length);
+	for (let i = 0; i < minLen; i++) {
+		const id1 = s1.prerelease[i];
+		const id2 = s2.prerelease[i];
+
+		if (id1 === id2) continue;
+
+		const isNum1 = typeof id1 === "number";
+		const isNum2 = typeof id2 === "number";
+
+		// Numeric identifiers always have lower precedence than non-numeric identifiers
+		if (isNum1 && !isNum2) return -1;
+		if (!isNum1 && isNum2) return 1;
+
+		if (isNum1 && isNum2) {
+			return id1 > id2 ? 1 : -1;
+		}
+
+		// Both are strings; compare lexically in ASCII sort order
+		return (id1 as string).localeCompare(id2 as string);
+	}
+
+	// A larger set of pre-release fields has a higher precedence than a smaller set
+	if (s1.prerelease.length !== s2.prerelease.length) {
+		return s1.prerelease.length > s2.prerelease.length ? 1 : -1;
+	}
+
+	return 0;
+}

--- a/packages/arkenv/src/shared/semver.ts
+++ b/packages/arkenv/src/shared/semver.ts
@@ -122,7 +122,9 @@ export function compareSemver(v1: string, v2: string): number {
 		}
 
 		// Both are strings; compare lexically in ASCII sort order
-		return (id1 as string).localeCompare(id2 as string);
+		const str1 = id1 as string;
+		const str2 = id2 as string;
+		return str1 < str2 ? -1 : 1;
 	}
 
 	// A larger set of pre-release fields has a higher precedence than a smaller set

--- a/packages/arkenv/src/shared/spawner.test.ts
+++ b/packages/arkenv/src/shared/spawner.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { resolveDlxCommand } from "./spawner";
+
+describe("spawner", () => {
+	describe("resolveDlxCommand", () => {
+		it("resolves pnpm dlx when user agent contains pnpm", () => {
+			const res = resolveDlxCommand(
+				"arkenv",
+				["init"],
+				"pnpm/9.0.0 npm/? node/v22.0.0 darwin arm64",
+			);
+			expect(res).toEqual({
+				command: "pnpm",
+				dlxArgs: ["dlx", "arkenv@latest", "init"],
+			});
+		});
+
+		it("resolves bunx when user agent contains bun", () => {
+			const res = resolveDlxCommand(
+				"arkenv",
+				["init"],
+				"bun/1.1.0 npm/? node/v22.0.0 darwin arm64",
+			);
+			expect(res).toEqual({
+				command: "bunx",
+				dlxArgs: ["arkenv@latest", "init"],
+			});
+		});
+
+		it("resolves yarn dlx when user agent contains yarn", () => {
+			const res = resolveDlxCommand(
+				"arkenv",
+				["init"],
+				"yarn/4.0.0 npm/? node/v22.0.0 darwin arm64",
+			);
+			expect(res).toEqual({
+				command: "yarn",
+				dlxArgs: ["dlx", "arkenv@latest", "init"],
+			});
+		});
+
+		it("falls back to npx when user agent is npm or empty/missing", () => {
+			const resNpm = resolveDlxCommand(
+				"arkenv",
+				["init"],
+				"npm/10.0.0 node/v22.0.0 darwin arm64",
+			);
+			expect(resNpm).toEqual({
+				command: "npx",
+				dlxArgs: ["arkenv@latest", "init"],
+			});
+
+			const resEmpty = resolveDlxCommand("arkenv", ["init"], "");
+			expect(resEmpty).toEqual({
+				command: "npx",
+				dlxArgs: ["arkenv@latest", "init"],
+			});
+		});
+	});
+});

--- a/packages/arkenv/src/shared/spawner.test.ts
+++ b/packages/arkenv/src/shared/spawner.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { resolveDlxCommand } from "./spawner";
+import { describe, expect, it, vi } from "vitest";
+import { resolveDlxCommand, spawnLatest } from "./spawner";
 
 describe("spawner", () => {
 	describe("resolveDlxCommand", () => {
@@ -55,6 +55,86 @@ describe("spawner", () => {
 				command: "npx",
 				dlxArgs: ["arkenv@latest", "init"],
 			});
+		});
+	});
+
+	describe("spawnLatest", () => {
+		it("spawns child process and resolves exit code on clean close", async () => {
+			const { EventEmitter } = await import("node:events");
+			const mockChild = new EventEmitter() as any;
+			mockChild.kill = vi.fn();
+			const mockSpawn = vi.fn().mockReturnValue(mockChild);
+
+			const promise = spawnLatest({
+				packageName: "arkenv",
+				args: ["init"],
+				userAgent: "npm/10.0.0 node/v22.0.0 darwin arm64",
+				spawnFn: mockSpawn as any,
+			});
+
+			mockChild.emit("close", 0, null);
+
+			const code = await promise;
+			expect(code).toBe(0);
+			expect(mockSpawn).toHaveBeenCalledWith(
+				"npx",
+				["arkenv@latest", "init"],
+				expect.objectContaining({ stdio: "inherit" }),
+			);
+		});
+
+		it("resolves 130 when child is closed with SIGINT signal", async () => {
+			const { EventEmitter } = await import("node:events");
+			const mockChild = new EventEmitter() as any;
+			mockChild.kill = vi.fn();
+			const mockSpawn = vi.fn().mockReturnValue(mockChild);
+
+			const promise = spawnLatest({
+				packageName: "arkenv",
+				args: ["init"],
+				spawnFn: mockSpawn as any,
+			});
+
+			mockChild.emit("close", null, "SIGINT");
+
+			const code = await promise;
+			expect(code).toBe(130);
+		});
+
+		it("resolves 143 when child is closed with SIGTERM signal", async () => {
+			const { EventEmitter } = await import("node:events");
+			const mockChild = new EventEmitter() as any;
+			mockChild.kill = vi.fn();
+			const mockSpawn = vi.fn().mockReturnValue(mockChild);
+
+			const promise = spawnLatest({
+				packageName: "arkenv",
+				args: ["init"],
+				spawnFn: mockSpawn as any,
+			});
+
+			mockChild.emit("close", null, "SIGTERM");
+
+			const code = await promise;
+			expect(code).toBe(143);
+		});
+
+		it("rejects when child process errors", async () => {
+			const { EventEmitter } = await import("node:events");
+			const mockChild = new EventEmitter() as any;
+			mockChild.kill = vi.fn();
+			const mockSpawn = vi.fn().mockReturnValue(mockChild);
+
+			const promise = spawnLatest({
+				packageName: "arkenv",
+				args: ["init"],
+				spawnFn: mockSpawn as any,
+			});
+
+			const error = new Error("spawn ENOENT");
+			mockChild.emit("error", error);
+
+			await expect(promise).rejects.toThrow("spawn ENOENT");
 		});
 	});
 });

--- a/packages/arkenv/src/shared/spawner.ts
+++ b/packages/arkenv/src/shared/spawner.ts
@@ -4,6 +4,7 @@ export type SpawnLatestOptions = {
 	packageName: string;
 	args: string[];
 	userAgent?: string;
+	spawnFn?: typeof spawn;
 };
 
 export type SpawnerPort = {
@@ -57,7 +58,7 @@ export function resolveDlxCommand(
  * Spawns the latest version of the CLI using the active package manager's DLX tool,
  * inheriting stdio and forwarding termination signals.
  *
- * @param options Spawn options containing package name, args, and optional user agent.
+ * @param options Spawn options containing package name, args, optional user agent, and optional spawnFn.
  * @returns A promise resolving to the exit code of the spawned child process.
  */
 export async function spawnLatest(
@@ -68,9 +69,10 @@ export async function spawnLatest(
 		options.args,
 		options.userAgent,
 	);
+	const spawnFn = options.spawnFn ?? spawn;
 
 	return new Promise<number>((resolve, reject) => {
-		const child = spawn(command, dlxArgs, {
+		const child = spawnFn(command, dlxArgs, {
 			stdio: "inherit",
 			shell: process.platform === "win32",
 		});
@@ -95,8 +97,20 @@ export async function spawnLatest(
 			reject(err);
 		});
 
-		child.on("close", (code) => {
+		child.on("close", (code, signal) => {
 			cleanup();
+			if (signal === "SIGINT") {
+				resolve(code ?? 130);
+				return;
+			}
+			if (signal === "SIGTERM") {
+				resolve(code ?? 143);
+				return;
+			}
+			if (signal) {
+				resolve(code ?? 1);
+				return;
+			}
 			resolve(code ?? 0);
 		});
 	});

--- a/packages/arkenv/src/shared/spawner.ts
+++ b/packages/arkenv/src/shared/spawner.ts
@@ -1,0 +1,103 @@
+import { spawn } from "node:child_process";
+
+export type SpawnLatestOptions = {
+	packageName: string;
+	args: string[];
+	userAgent?: string;
+};
+
+export type SpawnerPort = {
+	spawnLatest(options: SpawnLatestOptions): Promise<number>;
+};
+
+/**
+ * Resolves the runner command and arguments based on the package manager user agent.
+ *
+ * @param packageName Target package name (e.g. "arkenv").
+ * @param args Initial CLI arguments to forward.
+ * @param userAgent The `npm_config_user_agent` string.
+ * @returns The executable command and its arguments.
+ */
+export function resolveDlxCommand(
+	packageName: string,
+	args: string[],
+	userAgent = process.env.npm_config_user_agent || "",
+): { command: string; dlxArgs: string[] } {
+	const target = `${packageName}@latest`;
+
+	if (userAgent.includes("pnpm")) {
+		return {
+			command: "pnpm",
+			dlxArgs: ["dlx", target, ...args],
+		};
+	}
+
+	if (userAgent.includes("bun")) {
+		return {
+			command: "bunx",
+			dlxArgs: [target, ...args],
+		};
+	}
+
+	if (userAgent.includes("yarn")) {
+		return {
+			command: "yarn",
+			dlxArgs: ["dlx", target, ...args],
+		};
+	}
+
+	// Fallback to npx
+	return {
+		command: "npx",
+		dlxArgs: [target, ...args],
+	};
+}
+
+/**
+ * Spawns the latest version of the CLI using the active package manager's DLX tool,
+ * inheriting stdio and forwarding termination signals.
+ *
+ * @param options Spawn options containing package name, args, and optional user agent.
+ * @returns A promise resolving to the exit code of the spawned child process.
+ */
+export async function spawnLatest(
+	options: SpawnLatestOptions,
+): Promise<number> {
+	const { command, dlxArgs } = resolveDlxCommand(
+		options.packageName,
+		options.args,
+		options.userAgent,
+	);
+
+	return new Promise<number>((resolve, reject) => {
+		const child = spawn(command, dlxArgs, {
+			stdio: "inherit",
+			shell: process.platform === "win32",
+		});
+
+		const onSigint = () => {
+			child.kill("SIGINT");
+		};
+		const onSigterm = () => {
+			child.kill("SIGTERM");
+		};
+
+		process.on("SIGINT", onSigint);
+		process.on("SIGTERM", onSigterm);
+
+		const cleanup = () => {
+			process.off("SIGINT", onSigint);
+			process.off("SIGTERM", onSigterm);
+		};
+
+		child.on("error", (err) => {
+			cleanup();
+			reject(err);
+		});
+
+		child.on("close", (code) => {
+			cleanup();
+			resolve(code ?? 0);
+		});
+	});
+}

--- a/packages/build/src/core.test.ts
+++ b/packages/build/src/core.test.ts
@@ -101,13 +101,13 @@ describe("@arkenv/build schema discovery", () => {
 });
 
 describe("formatMissingSchemaError", () => {
-	it("formats a short host error with npx arkenv@latest init and no starter", () => {
+	it("formats a short host error with npx arkenv init and no starter", () => {
 		const message = formatMissingSchemaError({
 			optionsHint: "setupArkEnv options",
 		});
 
 		expect(message).toBe(
-			"[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in setupArkEnv options (or run `npx arkenv@latest init`).",
+			"[ArkEnv] Could not find schema file at src/env.ts or env.ts. Please specify 'schemaPath' in setupArkEnv options (or run `npx arkenv init`).",
 		);
 		expect(message).not.toMatch(/```/);
 		expect(message).not.toMatch(/Example/);
@@ -123,6 +123,6 @@ describe("formatMissingSchemaError", () => {
 		expect(message).toContain("ArkEnv Vite plugin: Could not find schema file");
 		expect(message).toContain("Checked paths:");
 		expect(message).toContain(" - /proj/src/env.ts");
-		expect(message).toContain("npx arkenv@latest init");
+		expect(message).toContain("npx arkenv init");
 	});
 });

--- a/packages/build/src/missing-schema-error.ts
+++ b/packages/build/src/missing-schema-error.ts
@@ -37,7 +37,7 @@ export function formatMissingSchemaError(
 ): string {
 	const prefix = options.prefix ?? "[ArkEnv]";
 	const location = options.schemaPath || DEFAULT_SCHEMA_LOCATIONS;
-	let message = `${prefix} Could not find schema file at ${location}. Please specify 'schemaPath' in ${options.optionsHint} (or run \`npx arkenv@latest init\`).`;
+	let message = `${prefix} Could not find schema file at ${location}. Please specify 'schemaPath' in ${options.optionsHint} (or run \`npx arkenv init\`).`;
 
 	if (options.checkedPaths?.length) {
 		const pathsList = options.checkedPaths.map((p) => ` - ${p}`).join("\n");

--- a/packages/bun-plugin/src/env-module.test.ts
+++ b/packages/bun-plugin/src/env-module.test.ts
@@ -331,7 +331,7 @@ describe("missing-schema errors", () => {
 		}
 
 		expect(message).toMatch(/Could not find schema file/);
-		expect(message).toMatch(/npx arkenv@latest init/);
+		expect(message).toMatch(/npx arkenv init/);
 		expect(message).toMatch(/Checked paths:/);
 		expect(message).not.toMatch(/Example `src\/env\.ts`/);
 		expect(message).not.toMatch(/```/);

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -44,7 +44,7 @@
 <summary>npm</summary>
 
 ```sh
-npx arkenv@latest init
+npx arkenv init
 ```
 
 </details>
@@ -53,7 +53,7 @@ npx arkenv@latest init
 <summary>pnpm</summary>
 
 ```sh
-pnx arkenv@latest init
+pnpm dlx arkenv init
 ```
 
 </details>
@@ -62,7 +62,7 @@ pnx arkenv@latest init
 <summary>Yarn</summary>
 
 ```sh
-yarn dlx arkenv@latest init
+yarn dlx arkenv init
 ```
 
 </details>
@@ -71,7 +71,7 @@ yarn dlx arkenv@latest init
 <summary>Bun</summary>
 
 ```sh
-bunx arkenv@latest init
+bunx arkenv init
 ```
 
 </details>

--- a/packages/nuxt/src/module.test.ts
+++ b/packages/nuxt/src/module.test.ts
@@ -264,7 +264,7 @@ describe("Nuxt module integration", () => {
 			expect(message).toMatch(
 				/\[ArkEnv\] Could not find schema file at src\/env\.ts or env\.ts/,
 			);
-			expect(message).toMatch(/npx arkenv@latest init/);
+			expect(message).toMatch(/npx arkenv init/);
 			expect(message).not.toMatch(/Example `src\/env\.ts`/);
 			expect(message).not.toMatch(/```/);
 			expect(mockNuxt.hook).not.toHaveBeenCalled();

--- a/packages/vite-plugin/src/env-module.test.ts
+++ b/packages/vite-plugin/src/env-module.test.ts
@@ -291,7 +291,7 @@ describe("missing-schema errors", () => {
 		}
 
 		expect(message).toMatch(/Could not find schema file/);
-		expect(message).toMatch(/npx arkenv@latest init/);
+		expect(message).toMatch(/npx arkenv init/);
 		expect(message).toMatch(/Checked paths:/);
 		expect(message).not.toMatch(/Example `src\/env\.ts`/);
 		expect(message).not.toMatch(/```/);

--- a/skills/arkenv/SKILL.md
+++ b/skills/arkenv/SKILL.md
@@ -31,7 +31,7 @@ In v1, ArkEnv offers two first-class validation engines:
 
 ### CLI (setup & DevOps)
 
-- Initialize ArkEnv in new or existing projects using `pnpm dlx arkenv@latest init` (or `npx arkenv@latest init`).
+- Initialize ArkEnv in new or existing projects using `pnpm dlx arkenv init` (or `npx arkenv init`).
 - Automatically detect frameworks (`Next.js`, `Nuxt`, `Vite`, `Bun`, etc.) and scaffold `env.ts`.
 - Select hosting provider preset during init (`--preset, -P <provider>` or `--host-preset, -H <provider>`).
 - Apply or refresh hosting presets on Day 2 via `arkenv preset apply <provider>` without overwriting custom user schema fields.
@@ -67,7 +67,7 @@ export const env = arkenv({
 
 AI agents SHOULD always use the CLI for project initialization to ensure consistency and reliability. Use the `--agent` flag for a fully automated, machine-readable experience.
 
-- **Command**: `pnpm dlx arkenv@latest init --agent`
+- **Command**: `pnpm dlx arkenv init --agent`
 - **Behavior**: The `--agent` flag automatically enables the following behaviors:
   - **`--yes`**: Bypasses all interactive prompts and uses recommended defaults.
   - **`--quiet`**: Suppresses spinners and ANSI formatting for cleaner terminal logs.
@@ -101,7 +101,7 @@ AI agents SHOULD always use the CLI for project initialization to ensure consist
 Set up ArkEnv in your project. It detects your framework and configures the appropriate plugin and schema.
 
 ```bash
-pnpm dlx arkenv@latest init [options]
+pnpm dlx arkenv init [options]
 ```
 
 #### Options:
@@ -113,7 +113,7 @@ pnpm dlx arkenv@latest init [options]
 Apply or refresh a hosting provider preset into an existing ArkEnv schema using managed comment blocks.
 
 ```bash
-pnpm dlx arkenv@latest preset apply <provider> [options]
+pnpm dlx arkenv preset apply <provider> [options]
 ```
 
 #### Options:
@@ -125,7 +125,7 @@ pnpm dlx arkenv@latest preset apply <provider> [options]
 Safely remove a hosting provider preset and its managed block from schema files and `.env.example`.
 
 ```bash
-pnpm dlx arkenv@latest preset remove <provider> [options]
+pnpm dlx arkenv preset remove <provider> [options]
 ```
 
 #### Options:


### PR DESCRIPTION
Fixes #1720

### Summary of Changes

- **CLI Version Freshness Pre-Flight Check**: Added zero-dependency SemVer 2.0 comparator and registry checker with strict 1000ms timeout that fails open silently.
- **Interactive Upgrade Prompt & DLX Runner**: Interactively prompts user on outdated CLI versions during interactive TTY `init` executions to run latest release via package-manager-aware runner (`pnpm dlx`, `bunx`, `yarn dlx`, or `npx`) with full `stdio: 'inherit'` and signal forwarding.
- **Marketing & Documentation Cleanup**: Omitted `@latest` across website install pills, documentation MDX guides, package READMEs, and missing-schema error hints.
- **Targeted Base**: `v1` branch.