### PR TITLE
feat(cli): ensure safe execution without @latest and omit @latest from marketing

### DIFF
--- a/apps/www/content/docs/getting-started/installation.mdx
+++ b/apps/www/content/docs/getting-started/installation.mdx
@@ -52,6 +52,8 @@ npm install -D arkenv
 - **Zero latency & offline execution**: Executions run instantly from `node_modules/.bin/arkenv` without querying npm, working completely offline.
 - **CI/CD reliability**: Pipelines execute the version frozen in the lockfile instead of dynamically resolving `@latest`.
 
+Once installed locally, running `npx arkenv <command>` (or `pnpm arkenv`, `bun arkenv`) inside your project automatically executes your locked local binary from `node_modules/.bin`.
+
 ### Wire into `package.json` scripts
 
 Add `arkenv check` to your project scripts to validate environment variables before builds:

--- a/apps/www/content/docs/getting-started/installation.mdx
+++ b/apps/www/content/docs/getting-started/installation.mdx
@@ -30,10 +30,37 @@ For agent sessions, use `--agent` (implies `--yes --quiet --json`):
 npx arkenv init --agent
 ```
 
-Install a local binary when you want `arkenv` on the project PATH:
+## Local installation (recommended workflow)
+
+Installing the CLI as a `devDependency` alongside the runtime validation engine is the recommended standard for team repositories and CI/CD pipelines:
 
 ```package-install
-npm install -D arkenv
+npm install -D arkenv @arkenv/core
+```
+
+If you are using Standard Schema (Zod or Valibot):
+
+```package-install
+npm install -D arkenv @arkenv/standard
+```
+
+### Why install locally?
+
+- **Deterministic versioning**: Locks the exact CLI version in `package-lock.json` or `pnpm-lock.yaml`, ensuring absolute consistency across team members and CI pipelines.
+- **Zero latency & offline execution**: Executions run instantly from `node_modules/.bin/arkenv` without querying npm, working completely offline.
+- **CI/CD reliability**: Pipelines execute the version frozen in the lockfile instead of dynamically resolving `@latest`.
+
+### Wire into `package.json` scripts
+
+Add `arkenv check` to your project scripts to validate environment variables before builds:
+
+```json title="package.json"
+{
+  "scripts": {
+    "build": "arkenv check && next build",
+    "env:check": "arkenv check"
+  }
+}
 ```
 
 Flags, output files, and refusal codes live in

--- a/apps/www/content/docs/getting-started/installation.mdx
+++ b/apps/www/content/docs/getting-started/installation.mdx
@@ -32,16 +32,18 @@ npx arkenv init --agent
 
 ## Local installation (recommended workflow)
 
-Installing the CLI as a `devDependency` alongside the runtime validation engine is the recommended standard for team repositories and CI/CD pipelines:
+Install the runtime validation engine as a dependency, and the `arkenv` CLI as a `devDependency`:
 
 ```package-install
-npm install -D arkenv @arkenv/core
+npm install @arkenv/core
+npm install -D arkenv
 ```
 
 If you are using Standard Schema (Zod or Valibot):
 
 ```package-install
-npm install -D arkenv @arkenv/standard
+npm install @arkenv/standard
+npm install -D arkenv
 ```
 
 ### Why install locally?

--- a/docs/LAUNCH_RUNBOOK.md
+++ b/docs/LAUNCH_RUNBOOK.md
@@ -17,6 +17,8 @@ This runbook outlines the operational, DNS, npm registry, and deployment steps r
   - Update all alpha links (`arkenv-v1.vercel.app`) in READMEs and docs to `arkenv.js.org`.
 - [ ] **Changelog Epoch Warnings**:
   - Verify epoch migration warnings are prepended in `packages/arkenv/CHANGELOG.md` and `packages/core/CHANGELOG.md`.
+- [ ] **Local Installation Standard**:
+  - Verify docs and installation snippets recommend installing `arkenv` as a local `devDependency` alongside `@arkenv/core` / `@arkenv/standard` for deterministic lockfile-pinned CI builds.
 
 ---
 

--- a/packages/arkenv/README.md
+++ b/packages/arkenv/README.md
@@ -19,7 +19,8 @@ npx arkenv init
 ### Local installation (Daily driver & CI)
 
 ```sh
-npm install -D arkenv @arkenv/core
+npm install @arkenv/core
+npm install -D arkenv
 ```
 
 ## Related

--- a/packages/arkenv/README.md
+++ b/packages/arkenv/README.md
@@ -8,12 +8,18 @@ The interactive, zero-dependency scaffolding experience for the [ArkEnv](https:/
 
 <br />
 
-## [Read the docs →](https://arkenv.js.org/docs/CLI)
+## Quickstart
 
-<br />
+### Scaffolding (Day 1)
 
 ```sh
 npx arkenv init
+```
+
+### Local installation (Daily driver & CI)
+
+```sh
+npm install -D arkenv @arkenv/core
 ```
 
 ## Related

--- a/packages/arkenv/src/cli/commands/init.test.ts
+++ b/packages/arkenv/src/cli/commands/init.test.ts
@@ -681,6 +681,7 @@ describe("InitUseCase", () => {
 			versionChecker.checkFreshness.mockResolvedValue({
 				isOutdated: true,
 				latestVersion: "1.0.0-alpha.18",
+				distTag: "alpha",
 			});
 			vi.mocked(prompt.confirm).mockResolvedValue(true);
 
@@ -713,6 +714,7 @@ describe("InitUseCase", () => {
 				expect.objectContaining({
 					packageName: "arkenv",
 					args: expect.arrayContaining(["init"]),
+					tag: "alpha",
 				}),
 			);
 			expect(exit).toHaveBeenCalledWith(0);

--- a/packages/arkenv/src/cli/commands/init.ts
+++ b/packages/arkenv/src/cli/commands/init.ts
@@ -47,6 +47,7 @@ export class InitUseCase {
 		private readonly spawner: (options: {
 			packageName: string;
 			args: string[];
+			tag?: string | undefined;
 		}) => Promise<number> = spawnLatest,
 		private readonly exit: (code: number) => void = (code) =>
 			process.exit(code),
@@ -89,6 +90,7 @@ export class InitUseCase {
 					const exitCode = await this.spawner({
 						packageName: pkgName,
 						args: forwardedArgs,
+						tag: freshness.distTag,
 					});
 					this.exit(exitCode);
 					return true;

--- a/packages/arkenv/src/shared/clients/version-checker.client.test.ts
+++ b/packages/arkenv/src/shared/clients/version-checker.client.test.ts
@@ -14,7 +14,7 @@ describe("VersionCheckerClient", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("returns isOutdated: true when registry version is newer", async () => {
+	it("returns isOutdated: true when registry version is newer for pre-release tag", async () => {
 		globalThis.fetch = vi.fn().mockResolvedValue({
 			ok: true,
 			json: async () => ({ version: "1.0.0-alpha.18" }),
@@ -28,12 +28,35 @@ describe("VersionCheckerClient", () => {
 		expect(result).toEqual({
 			isOutdated: true,
 			latestVersion: "1.0.0-alpha.18",
+			distTag: "alpha",
 		});
 		expect(globalThis.fetch).toHaveBeenCalledWith(
-			"https://registry.npmjs.org/arkenv/latest",
+			"https://registry.npmjs.org/arkenv/alpha",
 			expect.objectContaining({
 				headers: { Accept: "application/json" },
 			}),
+		);
+	});
+
+	it("uses latest dist-tag for stable versions", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ version: "1.1.0" }),
+		} as Response);
+
+		const result = await client.checkFreshness({
+			currentVersion: "1.0.0",
+			packageName: "arkenv",
+		});
+
+		expect(result).toEqual({
+			isOutdated: true,
+			latestVersion: "1.1.0",
+			distTag: "latest",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"https://registry.npmjs.org/arkenv/latest",
+			expect.any(Object),
 		);
 	});
 
@@ -51,6 +74,7 @@ describe("VersionCheckerClient", () => {
 		expect(result).toEqual({
 			isOutdated: false,
 			latestVersion: "1.0.0-alpha.17",
+			distTag: "alpha",
 		});
 	});
 
@@ -68,6 +92,7 @@ describe("VersionCheckerClient", () => {
 		expect(result).toEqual({
 			isOutdated: true,
 			latestVersion: "1.0.0-beta.11",
+			distTag: "beta",
 		});
 	});
 

--- a/packages/arkenv/src/shared/clients/version-checker.client.ts
+++ b/packages/arkenv/src/shared/clients/version-checker.client.ts
@@ -1,4 +1,4 @@
-import { compareSemver } from "@/shared/semver";
+import { compareSemver, parseSemver } from "@/shared/semver";
 
 /**
  * Options for performing a version freshness check.
@@ -10,6 +10,8 @@ export type FreshnessCheckOptions = {
 	packageName?: string;
 	/** Abort timeout in milliseconds (defaults to 1000ms). */
 	timeoutMs?: number;
+	/** Dist tag to check (defaults to the pre-release tag e.g. "alpha" or "latest"). */
+	distTag?: string;
 };
 
 /**
@@ -20,6 +22,8 @@ export type FreshnessCheckResult = {
 	isOutdated: boolean;
 	/** Latest version available on npm if successfully fetched and evaluated. */
 	latestVersion?: string;
+	/** Tag that was queried. */
+	distTag?: string;
 };
 
 /**
@@ -43,8 +47,14 @@ export class VersionCheckerClient {
 		} = options;
 
 		try {
+			const parsed = parseSemver(currentVersion);
+			const defaultTag =
+				typeof parsed?.prerelease[0] === "string"
+					? parsed.prerelease[0]
+					: "latest";
+			const distTag = options.distTag || defaultTag;
 			const encodedName = encodeURIComponent(packageName);
-			const url = `https://registry.npmjs.org/${encodedName}/latest`;
+			const url = `https://registry.npmjs.org/${encodedName}/${encodeURIComponent(distTag)}`;
 
 			const response = await fetch(url, {
 				signal: AbortSignal.timeout(timeoutMs),
@@ -68,6 +78,7 @@ export class VersionCheckerClient {
 			return {
 				isOutdated,
 				latestVersion,
+				distTag,
 			};
 		} catch {
 			// Fail open on timeouts, offline environments, DNS errors, etc.

--- a/packages/arkenv/src/shared/clients/version-checker.client.ts
+++ b/packages/arkenv/src/shared/clients/version-checker.client.ts
@@ -48,6 +48,9 @@ export class VersionCheckerClient {
 
 		try {
 			const parsed = parseSemver(currentVersion);
+			// Infer the dist-tag from the first prerelease identifier (e.g. "alpha" from "1.0.0-alpha.18")
+			// so pre-release users check against their active release track on npm. Defaults to "latest"
+			// for stable releases or non-string prereleases.
 			const defaultTag =
 				typeof parsed?.prerelease[0] === "string"
 					? parsed.prerelease[0]

--- a/packages/arkenv/src/shared/spawner.test.ts
+++ b/packages/arkenv/src/shared/spawner.test.ts
@@ -56,6 +56,30 @@ describe("spawner", () => {
 				dlxArgs: ["arkenv@latest", "init"],
 			});
 		});
+
+		it("supports custom dist-tag (e.g. alpha)", () => {
+			const resPnpm = resolveDlxCommand(
+				"arkenv",
+				["init"],
+				"pnpm/9.0.0 npm/? node/v22.0.0 darwin arm64",
+				"alpha",
+			);
+			expect(resPnpm).toEqual({
+				command: "pnpm",
+				dlxArgs: ["dlx", "arkenv@alpha", "init"],
+			});
+
+			const resNpx = resolveDlxCommand(
+				"arkenv",
+				["init"],
+				"npm/10.0.0 node/v22.0.0 darwin arm64",
+				"alpha",
+			);
+			expect(resNpx).toEqual({
+				command: "npx",
+				dlxArgs: ["arkenv@alpha", "init"],
+			});
+		});
 	});
 
 	describe("spawnLatest", () => {
@@ -79,6 +103,31 @@ describe("spawner", () => {
 			expect(mockSpawn).toHaveBeenCalledWith(
 				"npx",
 				["arkenv@latest", "init"],
+				expect.objectContaining({ stdio: "inherit" }),
+			);
+		});
+
+		it("forwards custom dist-tag to spawned command", async () => {
+			const { EventEmitter } = await import("node:events");
+			const mockChild = new EventEmitter() as any;
+			mockChild.kill = vi.fn();
+			const mockSpawn = vi.fn().mockReturnValue(mockChild);
+
+			const promise = spawnLatest({
+				packageName: "arkenv",
+				args: ["init"],
+				tag: "alpha",
+				userAgent: "pnpm/9.0.0 node/v22.0.0 darwin arm64",
+				spawnFn: mockSpawn as any,
+			});
+
+			mockChild.emit("close", 0, null);
+
+			const code = await promise;
+			expect(code).toBe(0);
+			expect(mockSpawn).toHaveBeenCalledWith(
+				"pnpm",
+				["dlx", "arkenv@alpha", "init"],
 				expect.objectContaining({ stdio: "inherit" }),
 			);
 		});

--- a/packages/arkenv/src/shared/spawner.ts
+++ b/packages/arkenv/src/shared/spawner.ts
@@ -3,8 +3,9 @@ import { spawn } from "node:child_process";
 export type SpawnLatestOptions = {
 	packageName: string;
 	args: string[];
-	userAgent?: string;
-	spawnFn?: typeof spawn;
+	tag?: string | undefined;
+	userAgent?: string | undefined;
+	spawnFn?: typeof spawn | undefined;
 };
 
 export type SpawnerPort = {
@@ -17,14 +18,16 @@ export type SpawnerPort = {
  * @param packageName Target package name (e.g. "arkenv").
  * @param args Initial CLI arguments to forward.
  * @param userAgent The `npm_config_user_agent` string.
+ * @param tag The dist-tag or version to spawn (defaults to "latest").
  * @returns The executable command and its arguments.
  */
 export function resolveDlxCommand(
 	packageName: string,
 	args: string[],
 	userAgent = process.env.npm_config_user_agent || "",
+	tag = "latest",
 ): { command: string; dlxArgs: string[] } {
-	const target = `${packageName}@latest`;
+	const target = `${packageName}@${tag}`;
 
 	if (userAgent.includes("pnpm")) {
 		return {
@@ -58,7 +61,7 @@ export function resolveDlxCommand(
  * Spawns the latest version of the CLI using the active package manager's DLX tool,
  * inheriting stdio and forwarding termination signals.
  *
- * @param options Spawn options containing package name, args, optional user agent, and optional spawnFn.
+ * @param options Spawn options containing package name, args, optional tag, optional user agent, and optional spawnFn.
  * @returns A promise resolving to the exit code of the spawned child process.
  */
 export async function spawnLatest(
@@ -68,6 +71,7 @@ export async function spawnLatest(
 		options.packageName,
 		options.args,
 		options.userAgent,
+		options.tag,
 	);
 	const spawnFn = options.spawnFn ?? spawn;
 

--- a/skills/arkenv/SKILL.md
+++ b/skills/arkenv/SKILL.md
@@ -113,7 +113,7 @@ pnpm dlx arkenv init [options]
 Apply or refresh a hosting provider preset into an existing ArkEnv schema using managed comment blocks.
 
 ```bash
-pnpm dlx arkenv preset apply <provider> [options]
+pnpm arkenv preset apply <provider> [options]
 ```
 
 #### Options:
@@ -125,7 +125,7 @@ pnpm dlx arkenv preset apply <provider> [options]
 Safely remove a hosting provider preset and its managed block from schema files and `.env.example`.
 
 ```bash
-pnpm dlx arkenv preset remove <provider> [options]
+pnpm arkenv preset remove <provider> [options]
 ```
 
 #### Options:


### PR DESCRIPTION
Fixes #1720

### Summary of Changes

- **CLI Version Freshness Pre-Flight Check**: Added zero-dependency SemVer 2.0 comparator and registry checker with strict 1000ms timeout that fails open silently.
- **Dist-Tag Awareness**: Supports dynamic dist-tag querying (e.g. `alpha` for alpha pre-releases, `latest` for stable releases).
- **Interactive Upgrade Prompt & DLX Runner**: Interactively prompts user on outdated CLI versions during interactive TTY `init` executions to run latest release via package-manager-aware runner (`pnpm dlx`, `bunx`, `yarn dlx`, or `npx`) with full `stdio: 'inherit'` and signal forwarding.
- **Process Signal Exit Codes**: Correctly handles signal terminations (`SIGINT` -> 130, `SIGTERM` -> 143, other signals -> 1).
- **Marketing & Documentation Cleanup**: Omitted `@latest` across website install pills, documentation MDX guides, package READMEs, and missing-schema error hints.
- **Targeted Base**: `v1` branch.