### PR TITLE
docs: add v1 alpha callout to README

### DIFF
--- a/packages/arkenv/README.md
+++ b/packages/arkenv/README.md
@@ -22,6 +22,10 @@
 </div>
 
 <br />
+
+> [!NOTE]
+> **ArkEnv v1 is in alpha!** Check out the new docs at [arkenv-v1.vercel.app](https://arkenv-v1.vercel.app).
+
 <br />
 
 


### PR DESCRIPTION
Adds a GitHub-style note callout in the README linking to the new ArkEnv v1 docs at https://arkenv-v1.vercel.app.