### PR TITLE
perf: reduce package install sizes monorepo-wide by omitting maps and externalizing core types

### DIFF
--- a/.changeset/reduce-install-sizes.md
+++ b/.changeset/reduce-install-sizes.md
@@ -1,0 +1,14 @@
+---
+"arkenv": patch
+"@arkenv/cli": patch
+"@arkenv/build": patch
+"@arkenv/bun-plugin": patch
+"@arkenv/fumadocs-ui": patch
+"@arkenv/nextjs": patch
+"@arkenv/nuxt": patch
+"@arkenv/vite-plugin": patch
+---
+
+#### Reduce package install sizes by omitting sourcemaps and externalizing core types
+
+Omit declaration maps (`.d.ts.map`, `.d.mts.map`, `.d.cts.map`) and runtime JavaScript sourcemaps (`*.map`) monorepo-wide across published packages. Externalize public ArkType type contracts in `arkenv` declarations to avoid inlining internal AST definitions into `dist/index.d.mts`.

--- a/packages/arkenv/src/index.ts
+++ b/packages/arkenv/src/index.ts
@@ -1,4 +1,5 @@
 import { $ } from "@repo/scope";
+import type { Scope } from "arktype";
 import { createEnv } from "./create-env";
 import { getSchemaKeys } from "./schema";
 
@@ -12,7 +13,7 @@ export { createEnv, getSchemaKeys };
  * See ArkType's docs for the full API:
  * https://arktype.io/docs/type-api
  */
-export const type = $.type;
+export const type: Scope<$>["type"] = $.type;
 export type {
 	ArkEnvConfig,
 	EnvSchema,

--- a/packages/arkenv/tsconfig.json
+++ b/packages/arkenv/tsconfig.json
@@ -16,7 +16,7 @@
 			"@/*": ["./src/*"]
 		},
 		"declaration": true,
-		"declarationMap": true,
+		"declarationMap": false,
 		"allowImportingTsExtensions": true,
 		"types": ["node"],
 		"lib": ["es2020", "es2022.object"]

--- a/packages/arkenv/tsdown.config.ts
+++ b/packages/arkenv/tsdown.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
 	platform: "node",
 	minify: true,
 	fixedExtension: true,
+	sourcemap: false,
 	deps: {
 		alwaysBundle: ["@repo/scope", "@repo/types"],
 		neverBundle: ["arktype"],

--- a/packages/build/tsconfig.json
+++ b/packages/build/tsconfig.json
@@ -13,7 +13,7 @@
 		"resolveJsonModule": true,
 		"rootDir": "src",
 		"declaration": true,
-		"declarationMap": true,
+		"declarationMap": false,
 		"types": ["node"]
 	},
 	"include": ["src"]

--- a/packages/build/tsdown.config.ts
+++ b/packages/build/tsdown.config.ts
@@ -5,4 +5,5 @@ export default defineConfig({
 	format: ["esm", "cjs"],
 	minify: true,
 	fixedExtension: false,
+	sourcemap: false,
 });

--- a/packages/bun-plugin/tsconfig.json
+++ b/packages/bun-plugin/tsconfig.json
@@ -12,6 +12,6 @@
 		"outDir": "dist",
 		"resolveJsonModule": true,
 		"declaration": true,
-		"declarationMap": true
+		"declarationMap": false
 	}
 }

--- a/packages/bun-plugin/tsdown.config.ts
+++ b/packages/bun-plugin/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
 	format: ["esm", "cjs"],
 	minify: true,
 	fixedExtension: false,
-	sourcemap: true,
+	sourcemap: false,
 	deps: {
 		alwaysBundle: ["@repo/types"],
 	},

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -16,7 +16,7 @@
 			"@/*": ["./src/*"]
 		},
 		"declaration": true,
-		"declarationMap": true,
+		"declarationMap": false,
 		"allowImportingTsExtensions": true,
 		"types": ["node"]
 	},

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
 	minify: true,
 	fixedExtension: true,
 	shims: true,
+	sourcemap: false,
 	deps: {
 		alwaysBundle: ["@clack/prompts", "picocolors"],
 	},

--- a/packages/fumadocs-ui/tsdown.config.ts
+++ b/packages/fumadocs-ui/tsdown.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 	entry: ["src/components/index.ts", "src/utils/index.ts", "src/mdx/index.tsx"],
 	format: ["esm", "cjs"],
 	minify: true,
+	sourcemap: false,
 	dts: true,
 	plugins: [preserveUseClient()],
 });

--- a/packages/internal/scope/src/root.ts
+++ b/packages/internal/scope/src/root.ts
@@ -1,12 +1,7 @@
-import { scope, type } from "arktype";
+import { type Scope, scope, type } from "arktype";
 import { host, port } from "./keywords";
 
-/**
- * The root scope for the ArkEnv library,
- * containing extensions to the ArkType scopes with ArkEnv-specific types
- * like `string.host` and `number.port`.
- */
-export const $ = scope({
+const rawScope = scope({
 	string: type.module({
 		...type.keywords.string,
 		host,
@@ -17,4 +12,11 @@ export const $ = scope({
 	}),
 });
 
-export type $ = (typeof $)["t"];
+export type $ = (typeof rawScope)["t"];
+
+/**
+ * The root scope for the ArkEnv library,
+ * containing extensions to the ArkType scopes with ArkEnv-specific types
+ * like `string.host` and `number.port`.
+ */
+export const $: Scope<$> = rawScope as never;

--- a/packages/internal/scope/tsconfig.json
+++ b/packages/internal/scope/tsconfig.json
@@ -13,7 +13,7 @@
 		"resolveJsonModule": true,
 		"rootDir": "src",
 		"declaration": true,
-		"declarationMap": true
+		"declarationMap": false
 	},
 	"include": ["src"]
 }

--- a/packages/internal/scope/tsdown.config.ts
+++ b/packages/internal/scope/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
 	format: ["esm", "cjs"],
 	minify: true,
 	fixedExtension: false,
+	sourcemap: false,
 	deps: {
 		alwaysBundle: ["@repo/types"],
 	},

--- a/packages/internal/types/tsconfig.json
+++ b/packages/internal/types/tsconfig.json
@@ -9,7 +9,7 @@
 		"exactOptionalPropertyTypes": true,
 		"noImplicitAny": true,
 		"declaration": true,
-		"declarationMap": true,
+		"declarationMap": false,
 		"emitDeclarationOnly": true,
 		"outDir": "./dist",
 		"rootDir": "./src",

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -13,6 +13,6 @@
 		"outDir": "dist",
 		"resolveJsonModule": true,
 		"declaration": true,
-		"declarationMap": true
+		"declarationMap": false
 	}
 }

--- a/packages/nextjs/tsdown.config.ts
+++ b/packages/nextjs/tsdown.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
 	format: ["esm", "cjs"],
 	minify: true,
 	fixedExtension: false,
-	sourcemap: true,
+	sourcemap: false,
 	deps: {
 		alwaysBundle: ["@repo/types"],
 	},

--- a/packages/nuxt/tsconfig.json
+++ b/packages/nuxt/tsconfig.json
@@ -12,6 +12,6 @@
 		"outDir": "dist",
 		"resolveJsonModule": true,
 		"declaration": true,
-		"declarationMap": true
+		"declarationMap": false
 	}
 }

--- a/packages/nuxt/tsdown.config.ts
+++ b/packages/nuxt/tsdown.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
 	format: ["esm", "cjs"],
 	minify: true,
 	fixedExtension: false,
-	sourcemap: true,
+	sourcemap: false,
 	deps: {
 		alwaysBundle: ["@repo/types"],
 		neverBundle: ["@nuxt/kit", "@nuxt/schema", "#imports", "nuxt/app"],

--- a/packages/vite-plugin/tsconfig.json
+++ b/packages/vite-plugin/tsconfig.json
@@ -12,6 +12,6 @@
 		"outDir": "dist",
 		"resolveJsonModule": true,
 		"declaration": true,
-		"declarationMap": true
+		"declarationMap": false
 	}
 }

--- a/packages/vite-plugin/tsdown.config.ts
+++ b/packages/vite-plugin/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
 	format: ["esm", "cjs"],
 	minify: true,
 	fixedExtension: false,
+	sourcemap: false,
 	deps: {
 		alwaysBundle: ["@repo/types"],
 		neverBundle: ["vite"],


### PR DESCRIPTION
Fixes #1726

## Summary
- Omit declaration sourcemaps (`.d.ts.map`, `.d.mts.map`, `.d.cts.map`) and runtime JS sourcemaps (`*.map`) monorepo-wide across published packages.
- Explicitly annotate exported `$` and `type` contracts from `arktype` in `@repo/scope` and `arkenv`, avoiding inlining internal AST definitions in declaration outputs (`dist/index.d.mts`).
- Unpacked install size of `arkenv` drops to ~63.7 kB (18.0 kB packed), with proportional reductions across all published workspace packages.
- Add changeset for all affected packages.

## Verification
- `pnpm build:packages`
- `npm pack --dry-run` across all packages (0 `.map` files, size verified)
- `pnpm --filter arkenv run size` (passed within limits)
- `pnpm run typecheck` & `pnpm --filter arkenv test:types`
- `pnpm test -- --run` (848 tests passed)
- `pnpm run fix`