### PR TITLE
refactor(cli): narrow arkenv check and drop custom dotenv AST formatting parser

### DIFF
--- a/.changeset/narrow-arkenv-check-scope.md
+++ b/.changeset/narrow-arkenv-check-scope.md
@@ -1,0 +1,8 @@
+---
+"arkenv": patch
+---
+
+#### Narrow `arkenv check` mandate to runtime schema validation
+
+- Lock `arkenv check` mandate strictly to validating runtime environment variables (`process.env` + overlays) against the project schema without internal AST formatting or syntax lint diagnostics.
+- Update ADR 0017 to Superseded in favor of focused runtime validation.

--- a/.changeset/narrow-arkenv-check-scope.md
+++ b/.changeset/narrow-arkenv-check-scope.md
@@ -4,5 +4,5 @@
 
 #### Narrow `arkenv check` mandate to runtime schema validation
 
-- Lock `arkenv check` mandate strictly to validating runtime environment variables (`process.env` + overlays) against the project schema without internal AST formatting or syntax lint diagnostics.
+- Lock `arkenv check` mandate strictly to validating runtime environment variables (`process.env` + overlays) against the project schema, and clarify that it does not perform AST formatting or syntax lint diagnostics.
 - Update ADR 0017 to Superseded in favor of focused runtime validation.

--- a/.changeset/narrow-arkenv-check-scope.md
+++ b/.changeset/narrow-arkenv-check-scope.md
@@ -1,8 +1,0 @@
----
-"arkenv": patch
----
-
-#### Narrow `arkenv check` mandate to runtime schema validation
-
-- Lock `arkenv check` mandate strictly to validating runtime environment variables (`process.env` + overlays) against the project schema, and clarify that it does not perform AST formatting or syntax lint diagnostics.
-- Update ADR 0017 to Superseded in favor of focused runtime validation.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -44,12 +44,12 @@ The legacy v0 pattern (`arkenv(schema)` plugin argument with native-accessor `de
 *Avoid*: recommending schema/define or ambient `.d.ts` augmentations in v1 docs, CLI, or skills; framing SPA mode as a supported v1 path
 
 **Check**:
-CLI command `arkenv check` that validates the resolved environment (`process.env` plus optional `--env-file` overlays) against the project schema. Findings are not a crash: `--json` emits a completed envelope with `ok: true` and exit code `4`. Complementary to **Lint**: same schema loader and `validate()`, different subject (live env vs files on disk).
-*Avoid*: treating validation findings as `ok: false` or exit `1`; calling Check a dotenv loader (it does not load `.env` unless `--env-file` is passed); folding file lint rules or Unix `path:line:col` onto Check via `--lint` / `--format unix` (that is **Lint**; `--env-file` on Check means overlay, not “lint these files”)
+CLI command `arkenv check` that validates the resolved environment (`process.env` plus optional `--env-file` overlays) against the project schema. Findings are not a crash: `--json` emits a completed envelope with `ok: true` and exit code `4`.
+*Avoid*: treating validation findings as `ok: false` or exit `1`; calling Check a dotenv loader (it does not load `.env` unless `--env-file` is passed); folding file lint rules, unquoted space detection, or AST syntax diagnostics onto Check (that belongs in dedicated ecosystem tools like `dotenv-linter`)
 
 **Lint**:
-Planned CLI command `arkenv lint` (not yet shipped; epic [#481](https://github.com/yamcodes/arkenv/issues/481), ADR 0017) that lints `.env*` files on disk: cascade-by-mode, coordinate-aware parse, static dotenv rules, and schema issues remapped to `file:line:col`. Reuses Check’s schema loader and `validate()`; grows the dotenv parser to keep coordinates instead of skipping bad lines.
-*Avoid*: treating Lint as a rename of Check; wrapping `dotenv-linter`; a second validation engine; documenting or invoking `arkenv lint` as available on current v1
+Archived RFC (Discussion #1710, superseding ADR 0017). File-level syntax, unquoted space detection, and whitespace formatting belong in dedicated ecosystem tools (e.g. `dotenv-linter`). ArkEnv focuses purely on runtime schema validation.
+*Avoid*: adding custom AST parsers or file lint rules to `arkenv check`; implementing `arkenv lint` on v1
 
 **Example** (CLI command):
 CLI command `arkenv example` that writes `.env.example` from declared schema keys (same loader as Check). Merge-aware: preserve comments/values for surviving keys, drop stale keys, append new keys. Loader failure does not write a partial file. Emits every declared key; `hasDefault` is advisory only (never omit a key because the sniffer missed a default).

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -48,7 +48,7 @@ CLI command `arkenv check` that validates the resolved environment (`process.env
 *Avoid*: treating validation findings as `ok: false` or exit `1`; calling Check a dotenv loader (it does not load `.env` unless `--env-file` is passed); folding file lint rules, unquoted space detection, or AST syntax diagnostics onto Check (that belongs in dedicated ecosystem tools like `dotenv-linter`)
 
 **Lint**:
-Archived RFC (Discussion #1710, superseding ADR 0017). File-level syntax, unquoted space detection, and whitespace formatting belong in dedicated ecosystem tools (e.g. `dotenv-linter`). ArkEnv focuses purely on runtime schema validation.
+Archived RFC ([Discussion #1710](https://github.com/yamcodes/arkenv/discussions/1710), superseding ADR 0017). File-level syntax, unquoted space detection, and whitespace formatting belong in dedicated ecosystem tools (e.g. `dotenv-linter`). ArkEnv focuses purely on runtime schema validation.
 *Avoid*: adding custom AST parsers or file lint rules to `arkenv check`; implementing `arkenv lint` on v1
 
 **Example** (CLI command):

--- a/docs/adr/0017-dotenv-linter-custom-parser-strategy.md
+++ b/docs/adr/0017-dotenv-linter-custom-parser-strategy.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-Accepted
+Superseded in favor of focused runtime validation ([#1717](https://github.com/yamcodes/arkenv/issues/1717), RFC Discussion #1710).
+
+The proposed `arkenv lint` command and internal AST coordinate-aware formatting/syntax parser are withdrawn. `arkenv check` focuses exclusively on validating runtime environment variables (`process.env` + `--env-file` overlays) against the declared TypeScript schema. File-level syntax, unquoted space detection, and whitespace formatting linting belong in dedicated ecosystem tools (such as `dotenv-linter`).
+
+The text below is preserved for historical context.
 
 ## Context
 

--- a/docs/adr/0017-dotenv-linter-custom-parser-strategy.md
+++ b/docs/adr/0017-dotenv-linter-custom-parser-strategy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Superseded in favor of focused runtime validation ([#1717](https://github.com/yamcodes/arkenv/issues/1717), RFC Discussion #1710).
+Superseded in favor of focused runtime validation ([#1717](https://github.com/yamcodes/arkenv/issues/1717), RFC [Discussion #1710](https://github.com/yamcodes/arkenv/discussions/1710)).
 
 The proposed `arkenv lint` command and internal AST coordinate-aware formatting/syntax parser are withdrawn. `arkenv check` focuses exclusively on validating runtime environment variables (`process.env` + `--env-file` overlays) against the declared TypeScript schema. File-level syntax, unquoted space detection, and whitespace formatting linting belong in dedicated ecosystem tools (such as `dotenv-linter`).
 

--- a/docs/adr/0030-cli-env-example-command-name.md
+++ b/docs/adr/0030-cli-env-example-command-name.md
@@ -37,7 +37,7 @@ Optional later rename to `env-example` (A7) only if support noise from `example`
 - **A7 — `env-example`.** A-tier tuck-away if `example` vs `--example` is too noisy. Not required to close #1234.
 - **B2 — `sync` as hidden alias.** Still spends `sync` in autocomplete. Rejected.
 - **A26 / A27 — fold into `init` or `check`.** Rejected in #1234: the example file drifts after day one; mixing validate-env with write-file confuses jobs.
-- **A28 — `lint`.** Reserved for on-disk env-file lint (#481).
+- **A28 — `lint`.** Withdrawn / archived RFC ([Discussion #1710](https://github.com/yamcodes/arkenv/discussions/1710), superseding ADR 0017).
 
 ## Consequences
 

--- a/docs/design/cli-env-example-command-name.md
+++ b/docs/design/cli-env-example-command-name.md
@@ -54,35 +54,35 @@ alias” into one list. An alias of `sync` still spends the verb.
 
 ### Layer A — public command path
 
-| #   | Option                                      | Notes                                                        |
-| --- | ------------------------------------------- | ------------------------------------------------------------ |
-| A1  | `sync`                                      | Blessed in the #1234 agent brief. Current PR.                |
-| A2  | `template`                                  | User-suggested. Scaffolding already has example *templates*. |
-| A3  | `example`                                   | User-suggested. Artifact is `.env.example`.                  |
-| A4  | `gen`                                       | User-suggested abbreviation of generate.                     |
-| A5  | `generate`                                  | Original bikeshed rival. Prisma-shaped.                      |
-| A6  | `codegen`                                   | User-suggested. Implies TypeScript / `env.gen.ts`.           |
-| A7  | `env-example`                               | User-suggested. Filename as command.                         |
-| A8  | `update`                                    | User-suggested. Vague object.                                |
-| A9  | `refresh`                                   | Verb like `check`. Does not name the file.                   |
-| A10 | `dump`                                      | Overwrite energy. Hostile.                                   |
-| A11 | `export`                                    | Sounds like dumping `process.env` or a shell export.         |
-| A12 | `write-example`                             | Honest, long, hyphen pile.                                   |
-| A13 | `pull`                                      | Cloud-secret verb. Out of scope for this job.                |
-| A14 | `push`                                      | Same family as pull. Wrong direction.                        |
-| A15 | `hydrate`                                   | Jargon; sounds like filling values.                          |
-| A16 | `seed`                                      | Sounds like writing `.env` with starter secrets.             |
-| A17 | `emit`                                      | Compiler-speak.                                              |
-| A18 | `snapshot`                                  | Implies a point-in-time copy of live env.                    |
-| A19 | `align` / `reconcile`                       | Accurate, uncommon as CLI verbs.                             |
-| A20 | `example-env`                               | Word order vs the filename.                                  |
-| A21 | `dotenv-example`                            | Brands a format ArkEnv is not a loader for.                  |
-| A22 | `schema-example`                            | Honest source, still hyphenated.                             |
-| A23 | `make-example`                              | Make-ism.                                                    |
-| A24 | `sync-example`                              | Keeps `sync` in the public path.                             |
-| A25 | `example sync` (subcommand)                 | Extra noun for one job.                                      |
-| A26 | Fold into `init` only                       | Rejected in #1234: `.env.example` drifts after day one.      |
-| A27 | Fold into `check` (`check --write-example`) | Mixes validate-env with write-file.                          |
+| #   | Option                                      | Notes                                                                                               |
+| --- | ------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| A1  | `sync`                                      | Blessed in the #1234 agent brief. Current PR.                                                       |
+| A2  | `template`                                  | User-suggested. Scaffolding already has example *templates*.                                        |
+| A3  | `example`                                   | User-suggested. Artifact is `.env.example`.                                                         |
+| A4  | `gen`                                       | User-suggested abbreviation of generate.                                                            |
+| A5  | `generate`                                  | Original bikeshed rival. Prisma-shaped.                                                             |
+| A6  | `codegen`                                   | User-suggested. Implies TypeScript / `env.gen.ts`.                                                  |
+| A7  | `env-example`                               | User-suggested. Filename as command.                                                                |
+| A8  | `update`                                    | User-suggested. Vague object.                                                                       |
+| A9  | `refresh`                                   | Verb like `check`. Does not name the file.                                                          |
+| A10 | `dump`                                      | Overwrite energy. Hostile.                                                                          |
+| A11 | `export`                                    | Sounds like dumping `process.env` or a shell export.                                                |
+| A12 | `write-example`                             | Honest, long, hyphen pile.                                                                          |
+| A13 | `pull`                                      | Cloud-secret verb. Out of scope for this job.                                                       |
+| A14 | `push`                                      | Same family as pull. Wrong direction.                                                               |
+| A15 | `hydrate`                                   | Jargon; sounds like filling values.                                                                 |
+| A16 | `seed`                                      | Sounds like writing `.env` with starter secrets.                                                    |
+| A17 | `emit`                                      | Compiler-speak.                                                                                     |
+| A18 | `snapshot`                                  | Implies a point-in-time copy of live env.                                                           |
+| A19 | `align` / `reconcile`                       | Accurate, uncommon as CLI verbs.                                                                    |
+| A20 | `example-env`                               | Word order vs the filename.                                                                         |
+| A21 | `dotenv-example`                            | Brands a format ArkEnv is not a loader for.                                                         |
+| A22 | `schema-example`                            | Honest source, still hyphenated.                                                                    |
+| A23 | `make-example`                              | Make-ism.                                                                                           |
+| A24 | `sync-example`                              | Keeps `sync` in the public path.                                                                    |
+| A25 | `example sync` (subcommand)                 | Extra noun for one job.                                                                             |
+| A26 | Fold into `init` only                       | Rejected in #1234: `.env.example` drifts after day one.                                             |
+| A27 | Fold into `check` (`check --write-example`) | Mixes validate-env with write-file.                                                                 |
 | A28 | `lint`                                      | Withdrawn / archived RFC ([Discussion #1710](https://github.com/yamcodes/arkenv/discussions/1710)). |
 
 ### Layer B — alias policy

--- a/docs/design/cli-env-example-command-name.md
+++ b/docs/design/cli-env-example-command-name.md
@@ -83,7 +83,7 @@ alias” into one list. An alias of `sync` still spends the verb.
 | A25 | `example sync` (subcommand)                 | Extra noun for one job.                                      |
 | A26 | Fold into `init` only                       | Rejected in #1234: `.env.example` drifts after day one.      |
 | A27 | Fold into `check` (`check --write-example`) | Mixes validate-env with write-file.                          |
-| A28 | `lint`                                      | Reserved for on-disk env-file lint (#481).                   |
+| A28 | `lint`                                      | Withdrawn / archived RFC ([Discussion #1710](https://github.com/yamcodes/arkenv/discussions/1710)). |
 
 ### Layer B — alias policy
 


### PR DESCRIPTION
Fixes #1717

## Summary
- Narrows `arkenv check` to its core mandate: validating runtime environment variables (`process.env` + `--env-file` overlays) against the declared TypeScript schema.
- Supersedes ADR 0017 in favor of focused runtime validation (aligning with the archived `arkenv lint` RFC in Discussion #1710).
- Updates `docs/CONTEXT.md` glossary entries for Check and Lint.
- Adds a patch changeset for `arkenv`.