### PR TITLE
docs(www): link homepage announcement badge to v1 alpha docs

### DIFF
--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -26,8 +26,8 @@ export default function HomePage() {
 			<div className="flex flex-col lg:flex-row items-center justify-center px-4 sm:px-6 lg:pl-20 lg:pr-6 max-w-screen-2xl mx-auto w-full gap-4 md:gap-8 lg:gap-12 lg:mt-20">
 				<div className="flex flex-col items-center lg:items-start text-center lg:text-left lg:flex-[1.4] relative z-20 mt-12 w-full max-w-full">
 					<div className="lg:mb-6 mb-0">
-						<AnnouncementBadge href="docs/cli/hosting-presets" new>
-							Presets: Vercel, Netlify and more
+						<AnnouncementBadge href="https://arkenv-v1.vercel.app/" new>
+							ArkEnv v1 is in alpha!
 						</AnnouncementBadge>
 					</div>
 					<h1 className="mb-4 mt-6 lg:mt-0 w-full max-w-2xl">

--- a/apps/www/components/announcement-badge.tsx
+++ b/apps/www/components/announcement-badge.tsx
@@ -24,10 +24,14 @@ export function AnnouncementBadge({
 	 */
 	href: ArkenvUrl;
 }>) {
+	const isExternal = isExternalUrl(href);
+
 	return (
 		<Link
 			href={href}
 			data-no-underline
+			target={isExternal ? "_blank" : undefined}
+			rel={isExternal ? "noopener noreferrer" : undefined}
 			className="group relative flex items-center gap-1.5 rounded-full border border-blue-500/20 bg-blue-500/5 px-1 py-1 text-sm font-medium text-blue-900 transition-all hover:bg-blue-500/10 dark:text-blue-200 backdrop-blur-sm shadow-sm hover:shadow-md hover:border-blue-500/30"
 		>
 			{newBadge && (


### PR DESCRIPTION
## Summary

Updates the homepage announcement badge on [arkenv.js.org](https://arkenv.js.org) to link to the new ArkEnv v1 alpha documentation at https://arkenv-v1.vercel.app/, consistent with the README announcement callout.

- Uses existing `AnnouncementBadge` component with the `new` prop
- Points href to `https://arkenv-v1.vercel.app/` (renders external link arrow icon automatically)
- Sets copy to `ArkEnv v1 is in alpha!`

## Verification

- `pnpm check` passed
- `pnpm --filter www test` passed
- `pnpm typecheck` passed