### PR TITLE
docs(roadmap): mark v0 alpha banner and CLI import guard as done

### DIFF
--- a/apps/www/lib/roadmap/config.ts
+++ b/apps/www/lib/roadmap/config.ts
@@ -61,7 +61,7 @@ export const ROADMAP_EXTRAS: readonly RoadmapExtra[] = [
 	},
 	{
 		id: "cli-postinstall-guard",
-		title: "Add CLI postinstall guard for v0 upgrades",
+		title: "Add CLI import guard for v0 upgrades",
 		done: true,
 		topic: "CLI",
 	},

--- a/apps/www/lib/roadmap/config.ts
+++ b/apps/www/lib/roadmap/config.ts
@@ -44,7 +44,7 @@ export const ROADMAP_EXTRAS: readonly RoadmapExtra[] = [
 	{
 		id: "v0-alpha-banner",
 		title: "v0 site Alpha banner",
-		done: false,
+		done: true,
 		topic: "Docs",
 	},
 	{
@@ -62,7 +62,7 @@ export const ROADMAP_EXTRAS: readonly RoadmapExtra[] = [
 	{
 		id: "cli-postinstall-guard",
 		title: "Add CLI postinstall guard for v0 upgrades",
-		done: false,
+		done: true,
 		topic: "CLI",
 	},
 	{

--- a/docs/LAUNCH_RUNBOOK.md
+++ b/docs/LAUNCH_RUNBOOK.md
@@ -58,7 +58,7 @@ npm deprecate @arkenv/cli "This package was renamed to 'arkenv' in v1. Please up
 
 ### Step 2.4: Validate CLI Import Guard
 
-- Verify that `npm install arkenv` / `import arkenv from "arkenv"` throws the clear runtime error guiding users to `@arkenv/core`.
+- Verify that importing or requiring `arkenv` as a library (`import arkenv from "arkenv"` / `require("arkenv")`) throws the clear runtime error guiding users to `@arkenv/core`.
 - Test running `npx arkenv init` in a fresh project to ensure it executes without errors.
 
 ---

--- a/docs/LAUNCH_RUNBOOK.md
+++ b/docs/LAUNCH_RUNBOOK.md
@@ -11,7 +11,7 @@ This runbook outlines the operational, DNS, npm registry, and deployment steps r
   - Deploy a frozen snapshot of the `dev` (v0) documentation branch to Vercel/Cloudflare Pages.
   - Assign domain: `v0.arkenv.js.org`.
   - Verify that old links, guides, and v0 API references resolve correctly.
-- [ ] **Alpha Banner on Live v0 Site (`dev` branch)**:
+- [x] **Alpha Banner on Live v0 Site (`dev` branch)**:
   - Add announcement banner to `arkenv.js.org` (pointing to `https://arkenv-v1.vercel.app` and migration guide) during the final testing window.
 - [ ] **README and Production Links**:
   - Update all alpha links (`arkenv-v1.vercel.app`) in READMEs and docs to `arkenv.js.org`.

--- a/docs/LAUNCH_RUNBOOK.md
+++ b/docs/LAUNCH_RUNBOOK.md
@@ -56,7 +56,7 @@ Execute npm deprecation for the old v0 CLI package name:
 npm deprecate @arkenv/cli "This package was renamed to 'arkenv' in v1. Please update your dependencies: 'npm i -D arkenv' and use '@arkenv/core' for runtime validation."
 ```
 
-### Step 2.4: Validate CLI Postinstall & Import Guards
+### Step 2.4: Validate CLI Import Guard
 
 - Verify that `npm install arkenv` / `import arkenv from "arkenv"` throws the clear runtime error guiding users to `@arkenv/core`.
 - Test running `npx arkenv init` in a fresh project to ensure it executes without errors.


### PR DESCRIPTION
## Summary

- Marks **v0 site Alpha banner** as done in `ROADMAP_EXTRAS` (`apps/www/lib/roadmap/config.ts`) and checks off the corresponding item in `docs/LAUNCH_RUNBOOK.md` (fulfilled by live announcement on v0 site pointing to v1 alpha docs).
- Marks **Add CLI import guard for v0 upgrades** as done in `ROADMAP_EXTRAS` (`apps/www/lib/roadmap/config.ts`) (fulfilled by the runtime import guard in `packages/arkenv/src/index.ts` and verified via `packages/arkenv/src/smoke.test.ts`).
- Aligned Step 2.4 in `docs/LAUNCH_RUNBOOK.md` to `Validate CLI Import Guard`.

## Verification

- `pnpm check` passed cleanly
- `pnpm --filter www test -- --run` passed (51 test suites, 202 tests)
- `pnpm typecheck` passed