### PR TITLE
fix(fumadocs-ui): prevent sidebar focus ring clipping with overflow-clip

### DIFF
--- a/.changeset/fix-sidebar-tab-ring-overflow.md
+++ b/.changeset/fix-sidebar-tab-ring-overflow.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/fumadocs-ui": patch
+---
+
+#### Fix keyboard focus ring truncation in sidebar navigation
+
+The drill-in sidebar slide container now uses `overflow: clip` with an expanded clip margin instead of `overflow: hidden`, preventing keyboard focus rings from being clipped along the left and right edges.

--- a/apps/www/app/docs/docs-chrome.css
+++ b/apps/www/app/docs/docs-chrome.css
@@ -47,10 +47,8 @@
 		padding-inline: 0.25rem;
 	}
 
-	[data-docs-sidebar-slide] > nav {
+	[data-docs-sidebar-slide] > nav.absolute {
 		width: auto;
-		left: 0.25rem;
-		right: 0.25rem;
 		inset-inline: 0.25rem;
 	}
 }

--- a/apps/www/app/docs/docs-chrome.css
+++ b/apps/www/app/docs/docs-chrome.css
@@ -37,7 +37,8 @@
 }
 
 [data-docs-sidebar-slide] {
-	overflow: hidden;
+	overflow: clip;
+	overflow-clip-margin: 0.5rem;
 }
 
 /*

--- a/apps/www/app/docs/docs-chrome.css
+++ b/apps/www/app/docs/docs-chrome.css
@@ -41,6 +41,20 @@
 	overflow-clip-margin: 0.5rem;
 }
 
+@supports not (overflow-clip-margin: 0.5rem) {
+	[data-docs-sidebar-slide] {
+		margin-inline: -0.25rem;
+		padding-inline: 0.25rem;
+	}
+
+	[data-docs-sidebar-slide] > nav {
+		width: auto;
+		left: 0.25rem;
+		right: 0.25rem;
+		inset-inline: 0.25rem;
+	}
+}
+
 /*
  * Right-middle + far-right. No inline padding on the column so the TOC spy
  * can sit on the start rail and the feedback hairline can span rail-to-rail.

--- a/packages/fumadocs-ui/css/theme.css
+++ b/packages/fumadocs-ui/css/theme.css
@@ -466,8 +466,8 @@ aside .theme-toggle {
 /*
  * WebKit / Safari fallback: WebKit supports overflow: clip but does not yet
  * support overflow-clip-margin (WebKit bug 236153). Pad the slide container
- * and compensate on child navs so the 4px focus ring paints inside the
- * element padding box while preserving exact 24px active-pill rail alignment.
+ * and compensate on absolutely-positioned child panels so the 4px focus ring
+ * paints inside the element padding box without shifting resting or drilled navs.
  */
 @supports not (overflow-clip-margin: 0.5rem) {
 	#nd-sidebar [data-docs-sidebar-slide],
@@ -476,11 +476,9 @@ aside .theme-toggle {
 		padding-inline: 0.25rem;
 	}
 
-	#nd-sidebar [data-docs-sidebar-slide] > nav,
-	#nd-sidebar-mobile [data-docs-sidebar-slide] > nav {
+	#nd-sidebar [data-docs-sidebar-slide] > nav.absolute,
+	#nd-sidebar-mobile [data-docs-sidebar-slide] > nav.absolute {
 		width: auto;
-		left: 0.25rem;
-		right: 0.25rem;
 		inset-inline: 0.25rem;
 	}
 }

--- a/packages/fumadocs-ui/css/theme.css
+++ b/packages/fumadocs-ui/css/theme.css
@@ -416,7 +416,7 @@ aside .theme-toggle {
 		color 150ms,
 		background-color 150ms;
 	/* Kill the UA outline (tinted by global `outline-ring/50`) — it is
-	   rectangular and gets clipped by the drill-in `overflow-hidden` pane. */
+	   rectangular and gets clipped by the drill-in slide pane. */
 	outline: none;
 }
 
@@ -461,6 +461,28 @@ aside .theme-toggle {
 #nd-sidebar-mobile [data-docs-sidebar-slide] {
 	overflow: clip;
 	overflow-clip-margin: 0.5rem;
+}
+
+/*
+ * WebKit / Safari fallback: WebKit supports overflow: clip but does not yet
+ * support overflow-clip-margin (WebKit bug 236153). Pad the slide container
+ * and compensate on child navs so the 4px focus ring paints inside the
+ * element padding box while preserving exact 24px active-pill rail alignment.
+ */
+@supports not (overflow-clip-margin: 0.5rem) {
+	#nd-sidebar [data-docs-sidebar-slide],
+	#nd-sidebar-mobile [data-docs-sidebar-slide] {
+		margin-inline: -0.25rem;
+		padding-inline: 0.25rem;
+	}
+
+	#nd-sidebar [data-docs-sidebar-slide] > nav,
+	#nd-sidebar-mobile [data-docs-sidebar-slide] > nav {
+		width: auto;
+		left: 0.25rem;
+		right: 0.25rem;
+		inset-inline: 0.25rem;
+	}
 }
 
 #nd-sidebar [data-sidebar-mode],

--- a/packages/fumadocs-ui/css/theme.css
+++ b/packages/fumadocs-ui/css/theme.css
@@ -459,7 +459,8 @@ aside .theme-toggle {
  */
 #nd-sidebar [data-docs-sidebar-slide],
 #nd-sidebar-mobile [data-docs-sidebar-slide] {
-	overflow: hidden;
+	overflow: clip;
+	overflow-clip-margin: 0.5rem;
 }
 
 #nd-sidebar [data-sidebar-mode],

--- a/packages/fumadocs-ui/src/components/drill-in-sidebar.tsx
+++ b/packages/fumadocs-ui/src/components/drill-in-sidebar.tsx
@@ -503,7 +503,7 @@ function DrillInTree() {
 
 	return (
 		<div
-			className="relative overflow-hidden"
+			className="relative overflow-clip"
 			data-docs-sidebar-slide=""
 			style={height != null ? { height } : undefined}
 		>


### PR DESCRIPTION
## Summary

Fixes an issue where keyboard focus-visible rings on drill-in sidebar items were being truncated along their left and right edges.

### Root Cause
`[data-docs-sidebar-slide]` used `overflow: hidden`, clipping the 4px outer box-shadow focus ring of full-width sidebar items along the left and right boundaries, despite having 23px of column gutter padding available outside the container.

### Changes
- Changed `overflow: hidden` to `overflow: clip; overflow-clip-margin: 0.5rem;` on `[data-docs-sidebar-slide]` in `packages/fumadocs-ui/css/theme.css` and `apps/www/app/docs/docs-chrome.css`.
- Replaced `overflow-hidden` with `overflow-clip` in `packages/fumadocs-ui/src/components/drill-in-sidebar.tsx`.
- Audited other focusable surfaces across the site (mobile drawer, TOC links and footers, AI actions and popovers, code block tabs and copy buttons, homepage tabs) and verified they do not suffer from clipping.
- Added patch changeset for `@arkenv/fumadocs-ui`.

### Verification
- Tested with Playwright visual inspection on desktop and mobile viewports. Focus rings now render with complete, uncut rounded corners on all 4 sides.
- Verified drill-in animations and slide transitions operate cleanly without leaking parked panels.
- `pnpm check` and `pnpm typecheck` pass with zero errors.