### PR TITLE
ci: guard PR lookup and handle issue triggers in Pullfrog workflow

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -35,9 +35,13 @@ jobs:
             try {
               const parsed = JSON.parse(context.payload.inputs?.prompt || "{}");
               if (parsed["~pullfrog"]) {
-                prNumber = parsed.event?.issue_number;
                 headRef = parsed.event?.branch;
                 author = parsed.event?.context?.author;
+                // parsed.event.issue_number is present for both issues and PRs.
+                // Only treat as PR if branch or pull_request is present.
+                if (parsed.event?.branch || parsed.event?.pull_request) {
+                  prNumber = parsed.event?.pull_request?.number || parsed.event?.issue_number;
+                }
               }
             } catch (e) {
               // Not JSON, continue to regex
@@ -50,32 +54,34 @@ jobs:
               }
             }
 
-            if (!prNumber) {
-              core.setOutput("skip", "false")
-              return
-            }
-
             // If we don't have headRef or author from the JSON, fetch from API
-            if (!headRef || !author) {
-              const { data: pull } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-              });
-              headRef = pull.head.ref;
-              author = pull.user?.login;
+            if (prNumber && (!headRef || !author)) {
+              try {
+                const { data: pull } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                });
+                headRef = headRef || pull.head.ref;
+                author = author || pull.user?.login;
+              } catch (error) {
+                core.info(`Could not fetch PR #${prNumber} (may be an issue or deleted PR): ${error.message}`);
+              }
             }
 
-            const botLogins = new Set(["arkenv-bot", "arkenv-bot[bot]"])
+            const botLogins = new Set(["arkenv-bot", "arkenv-bot[bot]"]);
             // Also skip the automated Sync PRs and changeset release PRs for dev and v1
-            const skipHeadRefs = new Set(["changeset-release/dev", "dev", "changeset-release/v1", "v1"])
-            const shouldSkip = skipHeadRefs.has(headRef) || botLogins.has(author)
+            const skipHeadRefs = new Set(["changeset-release/dev", "dev", "changeset-release/v1", "v1"]);
+            const shouldSkip = Boolean(
+              (headRef && skipHeadRefs.has(headRef)) ||
+              (author && botLogins.has(author))
+            );
 
             if (shouldSkip) {
-              core.info(`Skipping Pullfrog for ${headRef} by ${author}`)
+              core.info(`Skipping Pullfrog for ${headRef} by ${author}`);
             }
 
-            core.setOutput("skip", String(shouldSkip))
+            core.setOutput("skip", String(shouldSkip));
       - name: Checkout code
         if: steps.check-pr-source.outputs.skip != 'true'
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
Fixes failing Pullfrog workflow runs triggered by non-PR events (such as issue creation, labeling, and enrichment).

### Root Cause
When Pullfrog runs on an issue event:
1. The script extracted `parsed.event?.issue_number` and stored it as `prNumber`.
2. Since issues do not have branch heads (`headRef` is undefined), `!headRef || !author` evaluated to `true`.
3. The script invoked `github.rest.pulls.get({ pull_number: prNumber })` with the issue number, which returned HTTP 404 (`Not Found`).
4. Without error handling, the unhandled HTTP 404 exception terminated the GitHub Actions step and failed the run before subsequent steps could execute.

### Changes
1. **Guard PR Extraction:** In Pullfrog JSON payloads, `issue_number` is only treated as a `prNumber` if `parsed.event?.branch` or `parsed.event?.pull_request` is present.
2. **Safe API Fallback:** Wrapped `github.rest.pulls.get` in a `try/catch` block so that if a pull request cannot be retrieved (or if an issue/nonexistent number is looked up), it logs the notice via `core.info` rather than crashing the workflow.
3. **Guard `prNumber` Check:** Ensured `github.rest.pulls.get` only executes when `prNumber` is truthy and either `headRef` or `author` still needs to be resolved.

## Test plan
- [x] Verified script behavior in Node across multiple payload cases (issue triggers, PR triggers with branch, bot changeset PRs, PR triggers without branch, plain text with PR links, and plain text without PR links).
- [x] Verified YAML syntax with Ruby psych parser and embedded JS with Node compiler.
- [x] Tested graceful recovery on HTTP 404 responses.