### PR TITLE
Migrate all packages to pure ESM-only

### DIFF
--- a/.agents/docs/CONTEXT.md
+++ b/.agents/docs/CONTEXT.md
@@ -104,7 +104,7 @@ The main goal is to provide a developer-friendly way to validate and type-check 
 **Build System:**
 
 - Turborepo for task orchestration and caching
-- `tsdown` for building packages (generates ESM + CJS + types)
+- `tsdown` for building packages (pure ESM-only output: `.js` + `.d.ts`, no CJS)
 - Size limits enforced via `size-limit` (\~2 kB per package)
 - Workspace protocol (`workspace:*`) for internal dependencies
 

--- a/.changeset/publish-pure-esm-only.md
+++ b/.changeset/publish-pure-esm-only.md
@@ -1,0 +1,20 @@
+---
+"@arkenv/core": major
+"@arkenv/standard": major
+"arkenv": major
+"@arkenv/agent-plugin": major
+"@arkenv/build": major
+"@arkenv/bun-plugin": major
+"@arkenv/fumadocs-ui": major
+"@arkenv/nextjs": major
+"@arkenv/nuxt": major
+"@arkenv/vite-plugin": major
+---
+
+#### Migrate all packages to pure ESM-only output
+
+Every package now ships standard `.js` and `.d.ts` files under `"type": "module"`. The dual-published `.mjs`, `.cjs`, `.d.mts`, and `.d.cts` artifacts have been removed, and package `exports` no longer carry `require` conditions.
+
+CommonJS consumers keep working through Node's native `require(esm)`, which resolves each package through its `"default"` export condition. Bundlers (esbuild, Vite, Rollup, webpack) continue to transpile and inline the ESM output cleanly.
+
+**BREAKING CHANGE**: ArkEnv packages no longer ship `.cjs` builds. `require()` now returns the ESM namespace (for example, `require("@arkenv/core").default` is the `arkenv` function) and requires Node.js 20.19+, 22.12+, or 24. Projects that load ArkEnv from CommonJS on older Node versions need to upgrade Node or move to `import` syntax.

--- a/apps/www/app/globals.css
+++ b/apps/www/app/globals.css
@@ -10,7 +10,7 @@
 
 @plugin "tailwindcss-animate";
 @source "../node_modules/fumadocs-ui/dist/**/*.js";
-@source "../node_modules/@arkenv/fumadocs-ui/dist/**/*.mjs";
+@source "../node_modules/@arkenv/fumadocs-ui/dist/**/*.js";
 
 .dark body,
 .dark html {

--- a/apps/www/bin/postinstall.js
+++ b/apps/www/bin/postinstall.js
@@ -36,7 +36,7 @@ try {
 
 // Avoid running when @arkenv/fumadocs-ui is not built yet (e.g. fresh CI install)
 try {
-	require.resolve("@arkenv/fumadocs-ui/dist/utils/index.mjs");
+	require.resolve("@arkenv/fumadocs-ui/dist/utils/index.js");
 } catch {
 	console.warn(
 		"Skipping fumadocs-mdx: @arkenv/fumadocs-ui is not built (dist missing).",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"test:cli": "node scripts/test-cli.js",
 		"verify-artifacts": "node scripts/verify-artifacts.js",
 		"test:e2e:package": "node scripts/test-e2e-package.js",
-		"arkenv": "pnpm run build --filter arkenv && node packages/arkenv/dist/index.cjs"
+		"arkenv": "pnpm run build --filter arkenv && node packages/arkenv/dist/bin.js"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.14",

--- a/packages/agent-plugin/package.json
+++ b/packages/agent-plugin/package.json
@@ -6,14 +6,14 @@
 	"bin": {
 		"arkenv-agent-plugin": "./dist/bin.js"
 	},
-	"main": "./dist/index.cjs",
+	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"default": "./dist/index.js"
 		}
 	},
 	"files": [

--- a/packages/agent-plugin/tsdown.config.ts
+++ b/packages/agent-plugin/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	entry: ["src/index.ts", "src/bin.ts"],
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	platform: "node",
 	minify: false,
 	fixedExtension: false,

--- a/packages/arkenv/package.json
+++ b/packages/arkenv/package.json
@@ -4,16 +4,16 @@
 	"version": "1.0.0-alpha.20",
 	"description": "Interactive CLI for scaffolding ArkEnv projects",
 	"bin": {
-		"arkenv": "./dist/bin.cjs"
+		"arkenv": "./dist/bin.js"
 	},
-	"main": "./dist/index.cjs",
+	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"default": "./dist/index.js"
 		},
 		"./*": "./dist/*"
 	},
@@ -22,7 +22,7 @@
 	],
 	"scripts": {
 		"build": "tsdown",
-		"start": "node ./dist/bin.cjs init",
+		"start": "node ./dist/bin.js init",
 		"dev": "tsdown --watch",
 		"test": "vitest",
 		"test:run": "vitest run",

--- a/packages/arkenv/src/smoke.test.ts
+++ b/packages/arkenv/src/smoke.test.ts
@@ -9,9 +9,8 @@ import { describe, expect, it } from "vitest";
 const exec = promisify(execCallback);
 const require = createRequire(import.meta.url);
 
-const cliPath = path.resolve(__dirname, "../dist/bin.cjs");
+const cliPath = path.resolve(__dirname, "../dist/bin.js");
 const esmIndexPath = path.resolve(__dirname, "../dist/index.js");
-const cjsIndexPath = path.resolve(__dirname, "../dist/index.cjs");
 
 describe("library import guard", () => {
 	it("importing ESM entry throws migration error", async () => {
@@ -20,8 +19,8 @@ describe("library import guard", () => {
 		);
 	});
 
-	it("requiring CJS entry throws migration error", () => {
-		expect(() => require(cjsIndexPath)).toThrow(
+	it("requiring the ESM entry via native require(esm) throws migration error", () => {
+		expect(() => require(esmIndexPath)).toThrow(
 			"You imported the 'arkenv' package as a library",
 		);
 	});
@@ -40,7 +39,7 @@ describe("library import guard", () => {
 
 	it("running node with CJS require throws migration error", async () => {
 		await expect(
-			exec(`node -e "require('${cjsIndexPath.replace(/\\/g, "\\\\")}')"`),
+			exec(`node -e "require('${esmIndexPath.replace(/\\/g, "\\\\")}')"`),
 		).rejects.toMatchObject({
 			stderr: expect.stringContaining(
 				"You imported the 'arkenv' package as a library",

--- a/packages/arkenv/tsdown.config.ts
+++ b/packages/arkenv/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	entry: ["src/index.ts", "src/bin.ts"],
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	platform: "node",
 	minify: true,
 	fixedExtension: false,

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -3,14 +3,14 @@
 	"version": "1.0.0-alpha.6",
 	"description": "Shared build and codegen utilities for ArkEnv framework plugins",
 	"type": "module",
-	"main": "./dist/index.cjs",
+	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"default": "./dist/index.js"
 		}
 	},
 	"scripts": {

--- a/packages/build/tsdown.config.ts
+++ b/packages/build/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	entry: ["src/index.ts"],
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	minify: true,
 	fixedExtension: false,
 	sourcemap: false,

--- a/packages/bun-plugin/package.json
+++ b/packages/bun-plugin/package.json
@@ -6,7 +6,7 @@
 		"type": "git",
 		"url": "git+https://github.com/yamcodes/arkenv.git"
 	},
-	"main": "./dist/index.cjs",
+	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"dependencies": {
 		"@arkenv/build": "workspace:*",
@@ -50,12 +50,12 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"default": "./dist/index.js"
 		},
 		"./standard": {
 			"types": "./dist/standard.d.ts",
 			"import": "./dist/standard.js",
-			"require": "./dist/standard.cjs"
+			"default": "./dist/standard.js"
 		}
 	},
 	"bugs": "https://github.com/yamcodes/arkenv/labels/%40arkenv%2Fbun-plugin",

--- a/packages/bun-plugin/tsdown.config.ts
+++ b/packages/bun-plugin/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	entry: ["src/index.ts", "src/standard.ts"],
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	minify: true,
 	fixedExtension: false,
 	sourcemap: false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,17 +3,14 @@
 	"type": "module",
 	"version": "1.0.0-alpha.9",
 	"description": "Typesafe environment variables parsing and validation with ArkType",
-	"main": "./dist/index.cjs",
-	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.mts",
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": {
-				"import": "./dist/index.d.mts",
-				"require": "./dist/index.d.cts"
-			},
-			"import": "./dist/index.mjs",
-			"require": "./dist/index.cjs"
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
 		}
 	},
 	"scripts": {
@@ -76,7 +73,7 @@
 	"size-limit": [
 		{
 			"name": "@arkenv/core",
-			"path": "dist/index.mjs",
+			"path": "dist/index.js",
 			"limit": "2.9 kB",
 			"import": "*",
 			"ignore": [

--- a/packages/core/test/bundling-interop.test.ts
+++ b/packages/core/test/bundling-interop.test.ts
@@ -7,6 +7,7 @@ import {
 	rmSync,
 	writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -14,7 +15,7 @@ describe("arkenv bundling interop", () => {
 	const projectRoot = join(__dirname, "..");
 	const esbuildPath = join(projectRoot, "../../node_modules/.bin/esbuild");
 
-	it("should work when @arkenv/core is external in a CJS bundle", () => {
+	it("should work when @arkenv/core is inlined into a CJS bundle", () => {
 		const tempDir = mkdtempSync(
 			join(projectRoot, `test/temp-interop-${randomUUID()}`),
 		);
@@ -32,9 +33,9 @@ console.log('SUCCESS');
 `,
 			);
 
-			// Bundle it with esbuild as CJS, marking @arkenv/core as external
+			// Bundle it with esbuild as CJS, inlining the ESM-only @arkenv/core
 			execSync(
-				`${esbuildPath} ${testFile} --bundle --format=cjs --platform=node --external:@arkenv/core --outfile=${outFile}`,
+				`${esbuildPath} ${testFile} --bundle --format=cjs --platform=node --outfile=${outFile}`,
 				{ cwd: tempDir, stdio: "ignore" },
 			);
 
@@ -91,5 +92,54 @@ console.log('SUCCESS');
 				rmSync(tempDir, { recursive: true, force: true });
 			}
 		}
+	});
+
+	it("should inline @arkenv/core into an ESM bundle with no CJS dependencies", () => {
+		const tempDir = mkdtempSync(
+			join(projectRoot, `test/temp-interop-${randomUUID()}`),
+		);
+
+		try {
+			const testFile = join(tempDir, "test.ts");
+			const outFile = join(tempDir, "test.mjs");
+
+			// Create a test script that esbuild inlines fully (no externals)
+			writeFileSync(
+				testFile,
+				`import arkenv from "@arkenv/core";
+const env = arkenv({ PORT: 'number.port' }, { env: { PORT: '3000' } });
+console.log('SUCCESS');
+`,
+			);
+
+			// Bundle it with esbuild as ESM, inlining @arkenv/core
+			execSync(
+				`${esbuildPath} ${testFile} --bundle --format=esm --platform=node --outfile=${outFile}`,
+				{ cwd: tempDir, stdio: "ignore" },
+			);
+
+			// The inlined bundle must not pull in any CommonJS interop artifacts
+			const bundle = readFileSync(outFile, "utf8");
+			expect(bundle).not.toMatch(/require\(\s*["']/);
+			expect(bundle).not.toContain("module.exports");
+			expect(bundle).not.toContain("__toCommonJS");
+
+			const output = execSync(`node ${outFile}`, {
+				encoding: "utf8",
+				cwd: tempDir,
+			});
+			expect(output.trim()).toBe("SUCCESS");
+		} finally {
+			if (existsSync(tempDir)) {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("should load @arkenv/core via native require(esm)", () => {
+		const require = createRequire(import.meta.url);
+		const mod = require("../dist/index.js");
+		const arkenv = mod.default ?? mod.arkenv;
+		expect(typeof arkenv).toBe("function");
 	});
 });

--- a/packages/core/test/bundling-interop.test.ts
+++ b/packages/core/test/bundling-interop.test.ts
@@ -138,7 +138,7 @@ console.log('SUCCESS');
 
 	it("should load @arkenv/core via native require(esm)", () => {
 		const require = createRequire(import.meta.url);
-		const mod = require("../dist/index.js");
+		const mod = require("@arkenv/core");
 		const arkenv = mod.default ?? mod.arkenv;
 		expect(typeof arkenv).toBe("function");
 	});

--- a/packages/core/test/dist.test.ts
+++ b/packages/core/test/dist.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it, vi } from "vitest";
@@ -16,7 +16,7 @@ let standardArkEnvError: any;
 
 beforeAll(async () => {
 	const distDir = join(__dirname, "../dist");
-	if (!existsSync(distDir) || !existsSync(join(distDir, "index.mjs"))) {
+	if (!existsSync(distDir) || !existsSync(join(distDir, "index.js"))) {
 		// Automatically compile the package if dist is missing
 		execSync("pnpm run build", {
 			cwd: join(__dirname, ".."),
@@ -37,7 +37,7 @@ beforeAll(async () => {
 	}
 
 	// Dynamically load to prevent compile-time module resolution errors if dist/ is missing initially
-	const index = await import("../dist/index.mjs");
+	const index = await import("../dist/index.js");
 	defaultArkenv = index.default;
 	namedArkenv = index.arkenv;
 
@@ -50,6 +50,21 @@ beforeAll(async () => {
 });
 
 describe("Distribution Built Outputs", () => {
+	describe("ESM-only dist", () => {
+		it("ships standard .js and .d.ts files with no CJS artifacts", () => {
+			const distDir = join(__dirname, "../dist");
+			const files = readdirSync(distDir, { recursive: true });
+
+			expect(files).toContain("index.js");
+			expect(files).toContain("index.d.ts");
+
+			const cjsArtifacts = files.filter(
+				(file) => file.endsWith(".cjs") || file.endsWith(".d.cts"),
+			);
+			expect(cjsArtifacts).toEqual([]);
+		});
+	});
+
 	describe("Core Tier (arkenv/core)", () => {
 		it("should export ArkEnvError and format validation issues correctly", () => {
 			const error = new ArkEnvError([

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -2,17 +2,10 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	entry: ["src/index.ts"],
-	format: {
-		esm: {},
-		cjs: {
-			define: {
-				"import.meta": "{}",
-			},
-		},
-	},
+	format: ["esm"],
 	platform: "node",
 	minify: false,
-	fixedExtension: true,
+	fixedExtension: false,
 	sourcemap: false,
 	deps: {
 		alwaysBundle: ["@repo/scope", "@repo/types", "@repo/utils"],
@@ -20,17 +13,5 @@ export default defineConfig({
 	},
 	outputOptions: {
 		exports: "named",
-	},
-	footer: ({ format }) => {
-		// TODO: Avoid this, this is a hack
-		if (format === "cjs") {
-			return `
-// CJS Interop Shim
-if (module.exports && module.exports.default) {
-    Object.assign(module.exports.default, module.exports);
-    module.exports = module.exports.default;
-}
-      `;
-		}
 	},
 });

--- a/packages/fumadocs-ui/package.json
+++ b/packages/fumadocs-ui/package.json
@@ -9,28 +9,19 @@
 	"exports": {
 		"./css/*": "./css/*",
 		"./mdx": {
-			"types": {
-				"import": "./dist/mdx/index.d.mts",
-				"require": "./dist/mdx/index.d.cts"
-			},
-			"import": "./dist/mdx/index.mjs",
-			"require": "./dist/mdx/index.cjs"
+			"types": "./dist/mdx/index.d.ts",
+			"import": "./dist/mdx/index.js",
+			"default": "./dist/mdx/index.js"
 		},
 		"./components": {
-			"types": {
-				"import": "./dist/components/index.d.mts",
-				"require": "./dist/components/index.d.cts"
-			},
-			"import": "./dist/components/index.mjs",
-			"require": "./dist/components/index.cjs"
+			"types": "./dist/components/index.d.ts",
+			"import": "./dist/components/index.js",
+			"default": "./dist/components/index.js"
 		},
 		"./utils": {
-			"types": {
-				"import": "./dist/utils/index.d.mts",
-				"require": "./dist/utils/index.d.cts"
-			},
-			"import": "./dist/utils/index.mjs",
-			"require": "./dist/utils/index.cjs"
+			"types": "./dist/utils/index.d.ts",
+			"import": "./dist/utils/index.js",
+			"default": "./dist/utils/index.js"
 		}
 	},
 	"files": [

--- a/packages/fumadocs-ui/tsdown.config.ts
+++ b/packages/fumadocs-ui/tsdown.config.ts
@@ -3,8 +3,9 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	entry: ["src/components/index.ts", "src/utils/index.ts", "src/mdx/index.tsx"],
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	minify: true,
+	fixedExtension: false,
 	sourcemap: false,
 	dts: true,
 	plugins: [preserveUseClient()],

--- a/packages/internal/log/package.json
+++ b/packages/internal/log/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"type": "module",
 	"version": "0.0.1",
-	"main": "./dist/index.cjs",
+	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"description": "Injectable logger for ArkEnv (internal usage)",
@@ -11,7 +11,7 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"default": "./dist/index.js"
 		}
 	},
 	"scripts": {

--- a/packages/internal/log/tsdown.config.ts
+++ b/packages/internal/log/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	minify: true,
 	fixedExtension: false,
 	sourcemap: false,

--- a/packages/internal/scope/package.json
+++ b/packages/internal/scope/package.json
@@ -3,14 +3,14 @@
 	"private": true,
 	"type": "module",
 	"version": "0.1.3",
-	"main": "./dist/index.cjs",
+	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"description": "ArkEnv scope (internal usage)",
 	"exports": {
 		"types": "./dist/index.d.ts",
 		"import": "./dist/index.js",
-		"require": "./dist/index.cjs"
+		"default": "./dist/index.js"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/packages/internal/scope/tsdown.config.ts
+++ b/packages/internal/scope/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	minify: true,
 	fixedExtension: false,
 	sourcemap: false,

--- a/packages/internal/utils/package.json
+++ b/packages/internal/utils/package.json
@@ -3,24 +3,24 @@
 	"private": true,
 	"type": "module",
 	"version": "0.1.3",
-	"main": "./dist/index.cjs",
+	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"default": "./dist/index.js"
 		},
 		"./log": {
 			"types": "./dist/log.d.ts",
 			"import": "./dist/log.js",
-			"require": "./dist/log.cjs"
+			"default": "./dist/log.js"
 		},
 		"./boundary-access-error": {
 			"types": "./dist/boundary-access-error.d.ts",
 			"import": "./dist/boundary-access-error.js",
-			"require": "./dist/boundary-access-error.cjs"
+			"default": "./dist/boundary-access-error.js"
 		}
 	},
 	"scripts": {

--- a/packages/internal/utils/src/utils/load-arktype-bundle.test.ts
+++ b/packages/internal/utils/src/utils/load-arktype-bundle.test.ts
@@ -19,7 +19,7 @@ describe("load-arktype bundling compatibility", () => {
 			? process.cwd()
 			: join(process.cwd(), "packages/core");
 
-		const arkenvDistPath = join(projectRoot, "dist/index.mjs");
+		const arkenvDistPath = join(projectRoot, "dist/index.js");
 		const esbuildPath = join(projectRoot, "../../node_modules/.bin/esbuild");
 
 		// Create a small script that uses the ESM version of arkenv

--- a/packages/internal/utils/tsdown.config.ts
+++ b/packages/internal/utils/tsdown.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
 		log: "src/utils/log-helpers.ts",
 		"boundary-access-error": "src/utils/boundary-access-error.ts",
 	},
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	// Unminified: published packages alwaysBundle this package. Pre-minified
 	// chunks (index + boundary-access-error) collide when concatenated into one
 	// module scope (Nuxt/Vite: "Identifier h has already been declared").

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -6,7 +6,7 @@
 		"type": "git",
 		"url": "git+https://github.com/yamcodes/arkenv.git"
 	},
-	"main": "./dist/index.cjs",
+	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"dependencies": {
 		"@arkenv/build": "workspace:*",
@@ -55,28 +55,28 @@
 			"react-server": {
 				"types": "./dist/react-server.d.ts",
 				"import": "./dist/react-server.js",
-				"require": "./dist/react-server.cjs"
+				"default": "./dist/react-server.js"
 			},
 			"default": {
 				"types": "./dist/index.d.ts",
 				"import": "./dist/index.js",
-				"require": "./dist/index.cjs"
+				"default": "./dist/index.js"
 			}
 		},
 		"./config": {
 			"types": "./dist/config/index.d.ts",
 			"import": "./dist/config/index.js",
-			"require": "./dist/config/index.cjs"
+			"default": "./dist/config/index.js"
 		},
 		"./standard": {
 			"types": "./dist/standard/index.d.ts",
 			"import": "./dist/standard/index.js",
-			"require": "./dist/standard/index.cjs"
+			"default": "./dist/standard/index.js"
 		},
 		"./standard/config": {
 			"types": "./dist/standard/config.d.ts",
 			"import": "./dist/standard/config.js",
-			"require": "./dist/standard/config.cjs"
+			"default": "./dist/standard/config.js"
 		}
 	},
 	"bugs": "https://github.com/yamcodes/arkenv/labels/%40arkenv%2Fnextjs",

--- a/packages/nextjs/tsdown.config.ts
+++ b/packages/nextjs/tsdown.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 		"src/standard/index.ts",
 		"src/standard/config.ts",
 	],
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	minify: true,
 	fixedExtension: false,
 	sourcemap: false,

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -118,7 +118,8 @@
 	"imports": {
 		"#arkenv/server-boot": {
 			"types": "./dist/empty-server-boot.d.ts",
-			"import": "./dist/empty-server-boot.js"
+			"import": "./dist/empty-server-boot.js",
+			"default": "./dist/empty-server-boot.js"
 		}
 	}
 }

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -6,7 +6,7 @@
 		"type": "git",
 		"url": "git+https://github.com/yamcodes/arkenv.git"
 	},
-	"main": "./dist/index.cjs",
+	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"dependencies": {
 		"@arkenv/build": "workspace:*",
@@ -56,32 +56,32 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"default": "./dist/index.js"
 		},
 		"./module": {
 			"types": "./dist/module.d.ts",
 			"import": "./dist/module.js",
-			"require": "./dist/module.cjs"
+			"default": "./dist/module.js"
 		},
 		"./config": {
 			"types": "./dist/config.d.ts",
 			"import": "./dist/config.js",
-			"require": "./dist/config.cjs"
+			"default": "./dist/config.js"
 		},
 		"./standard": {
 			"types": "./dist/standard/index.d.ts",
 			"import": "./dist/standard/index.js",
-			"require": "./dist/standard/index.cjs"
+			"default": "./dist/standard/index.js"
 		},
 		"./standard/module": {
 			"types": "./dist/standard/module.d.ts",
 			"import": "./dist/standard/module.js",
-			"require": "./dist/standard/module.cjs"
+			"default": "./dist/standard/module.js"
 		},
 		"./standard/config": {
 			"types": "./dist/standard/config.d.ts",
 			"import": "./dist/standard/config.js",
-			"require": "./dist/standard/config.cjs"
+			"default": "./dist/standard/config.js"
 		}
 	},
 	"bugs": "https://github.com/yamcodes/arkenv/labels/%40arkenv%2Fnuxt",
@@ -118,8 +118,7 @@
 	"imports": {
 		"#arkenv/server-boot": {
 			"types": "./dist/empty-server-boot.d.ts",
-			"import": "./dist/empty-server-boot.js",
-			"require": "./dist/empty-server-boot.cjs"
+			"import": "./dist/empty-server-boot.js"
 		}
 	}
 }

--- a/packages/nuxt/src/boot-gate-load.ts
+++ b/packages/nuxt/src/boot-gate-load.ts
@@ -80,9 +80,7 @@ export function buildSchemaJitiAliases(
 		path.join(packageDir, "mock-imports.ts"),
 	)
 		? path.join(packageDir, "mock-imports.ts")
-		: fs.existsSync(path.join(packageDir, "mock-imports.js"))
-			? path.join(packageDir, "mock-imports.js")
-			: path.join(packageDir, "mock-imports.cjs");
+		: path.join(packageDir, "mock-imports.js");
 
 	const emptyServerBootPath = fs.existsSync(
 		path.join(packageDir, "empty-server-boot.ts"),

--- a/packages/nuxt/tsdown.config.ts
+++ b/packages/nuxt/tsdown.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
 		"src/standard/module.ts",
 		"src/standard/config.ts",
 	],
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	// Unminified: alwaysBundle of @repo/utils (index + boundary-access-error) then
 	// minify produced a chunk Vite/Rollup rejects ("Identifier h has already been
 	// declared") when Nuxt playgrounds rebundle the published ESM.

--- a/packages/standard/package.json
+++ b/packages/standard/package.json
@@ -3,24 +3,24 @@
 	"type": "module",
 	"version": "1.0.0-alpha.9",
 	"description": "Dependency-free, typesafe environment variables validation based on Standard Schema",
-	"main": "./dist/index.cjs",
+	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"default": "./dist/index.js"
 		},
 		"./valibot": {
 			"types": "./dist/valibot.d.ts",
 			"import": "./dist/valibot.js",
-			"require": "./dist/valibot.cjs"
+			"default": "./dist/valibot.js"
 		},
 		"./zod-mini": {
 			"types": "./dist/zod-mini.d.ts",
 			"import": "./dist/zod-mini.js",
-			"require": "./dist/zod-mini.cjs"
+			"default": "./dist/zod-mini.js"
 		}
 	},
 	"peerDependencies": {

--- a/packages/standard/tsdown.config.ts
+++ b/packages/standard/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	entry: ["src/index.ts", "src/valibot.ts", "src/zod-mini.ts"],
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	minify: true,
 	fixedExtension: false,
 	sourcemap: false,

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -6,7 +6,7 @@
 		"type": "git",
 		"url": "git+https://github.com/yamcodes/arkenv.git"
 	},
-	"main": "./dist/index.cjs",
+	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"dependencies": {
 		"@arkenv/build": "workspace:*",
@@ -49,12 +49,12 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"default": "./dist/index.js"
 		},
 		"./standard": {
 			"types": "./dist/standard.d.ts",
 			"import": "./dist/standard.js",
-			"require": "./dist/standard.cjs"
+			"default": "./dist/standard.js"
 		}
 	},
 	"bugs": "https://github.com/yamcodes/arkenv/labels/%40arkenv%2Fvite-plugin",

--- a/packages/vite-plugin/tsdown.config.ts
+++ b/packages/vite-plugin/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	entry: ["src/index.ts", "src/standard.ts"],
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	minify: true,
 	fixedExtension: false,
 	sourcemap: false,

--- a/scripts/standard-isolation.js
+++ b/scripts/standard-isolation.js
@@ -205,7 +205,7 @@ export async function assertStandardEntryIsolated(entryFile, context = {}) {
  * @returns {Promise<{ packageName: string, checked: string[] }>}
  */
 export async function assertPackageStandardIsolation(packageDir, options = {}) {
-	const conditions = options.conditions ?? ["import", "require"];
+	const conditions = options.conditions ?? ["import"];
 	const packageJson = JSON.parse(
 		readFileSync(join(packageDir, "package.json"), "utf8"),
 	);

--- a/scripts/test-cli.js
+++ b/scripts/test-cli.js
@@ -135,7 +135,7 @@ const extraArgs = process.argv.slice(process.argv[2] === mode ? 3 : 2);
 console.log(`Running arkenv init inside ${tempDir}...\n`);
 try {
 	execSync(
-		`node ${path.resolve(rootDir, "packages/arkenv/dist/bin.cjs")} init ${extraArgs.join(" ")}`,
+		`node ${path.resolve(rootDir, "packages/arkenv/dist/bin.js")} init ${extraArgs.join(" ")}`,
 		{
 			cwd: tempDir,
 			stdio: "inherit",

--- a/scripts/verify-artifacts.js
+++ b/scripts/verify-artifacts.js
@@ -13,7 +13,6 @@ const rootDir = path.join(__dirname, "..");
 
 const targets = [
 	"packages/standard/dist/index.js",
-	"packages/standard/dist/index.cjs",
 	"packages/standard/dist/index.d.ts",
 ];
 


### PR DESCRIPTION
Fixes #1751

Migrates every workspace package from dual CJS/ESM publishing to pure ESM-only output:

- All `tsdown.config.ts` files now use `format: ["esm"]` with standard `.js`/`.d.ts` extensions (`fixedExtension: false`)
- Deleted the CJS interop footer shim and `import.meta` polyfill from `@arkenv/core`
- `package.json` exports drop all `require` conditions; `main`/`types`/`bin` point at `.js`/`.d.ts` (CLI bin: `./dist/bin.js`)
- Updated dist assertions (no `.cjs`/`.d.cts` artifacts), bundler inlining checks, and native `require(esm)` coverage
- Updated `www` postinstall/css globs, root `arkenv` script, and CI scripts

Verification: `pnpm build`, `pnpm test -- --run` (1290 tests), `pnpm typecheck`, `pnpm check`, and `scripts/verify-artifacts.js` all pass.