### PR TITLE
Support Vite 6 Environment API in ssr transform guard

### DIFF
--- a/.changeset/pre/vite6-environment-api-ssr-guard.md
+++ b/.changeset/pre/vite6-environment-api-ssr-guard.md
@@ -1,0 +1,7 @@
+---
+"@arkenv/vite-plugin": minor
+---
+
+#### Add Vite 6 Environment API support to the SSR transform guard
+
+The Vite plugin now detects server graphs through the Vite 6 Environment API. Environments with `consumer: "server"` (or named `ssr`) keep the real `env.ts` module so validation runs at boot; everything else gets the client rewrite with inlined `VITE_*` values. On Vite 4 and 5 the legacy `ssr` transform flag is still used as a fallback.

--- a/apps/www/content/docs/frameworks/vite.mdx
+++ b/apps/www/content/docs/frameworks/vite.mdx
@@ -130,6 +130,10 @@ Vite maintains two distinct module graphs when building and serving full-stack o
 - **Server graph:** During SSR execution and dev server requests, `env.ts` executes real `@arkenv/core` runtime validation at boot. It ensures private secrets (such as `DATABASE_URL`) and public configuration validate before handling requests.
 - **Client graph:** During client compilation, `@arkenv/vite-plugin` intercepts and transforms `env.ts`. It inlines public `VITE_*` values as static literals and replaces private server keys with throwing runtime stubs. Client bundles omit the validator engine.
 
+On Vite 6+, the Environment API drives this split: server consumers and custom
+`ssr` environments keep the real module, everything else gets the client rewrite.
+On Vite 4 and 5, the plugin falls back to the legacy SSR transform flag.
+
 ## Next steps
 
 <Cards>

--- a/packages/vite-plugin/src/env-module.test.ts
+++ b/packages/vite-plugin/src/env-module.test.ts
@@ -215,6 +215,152 @@ describe("transform mode plugin", () => {
 		expect(result).toBeNull();
 	});
 
+	it("passes through the env module in Vite 6 server environments", async () => {
+		const fixtureDir = join(__dirname, "__fixtures__", "transform-env");
+		const plugin = arkenvPlugin({ schemaPath: join(fixtureDir, "env.ts") });
+
+		const mockContext = {
+			meta: {
+				framework: "vite",
+				version: "1.0.0",
+				rollupVersion: "4.0.0",
+				viteVersion: "6.0.0",
+			},
+			error: () => {},
+			warn: () => {},
+			info: () => {},
+			debug: () => {},
+			environment: {
+				name: "ssr",
+				config: { consumer: "server" },
+			},
+		} as any;
+
+		if (plugin.config && typeof plugin.config === "function") {
+			plugin.config.call(
+				mockContext,
+				{ root: fixtureDir, envDir: fixtureDir },
+				{ mode: "test", command: "build" },
+			);
+		}
+		if (plugin.configResolved && typeof plugin.configResolved === "function") {
+			await plugin.configResolved.call(mockContext, {
+				root: fixtureDir,
+				envDir: fixtureDir,
+				envPrefix: "VITE_",
+			} as any);
+		}
+
+		const original = readFileSync(join(fixtureDir, "env.ts"), "utf8");
+		let result: any = null;
+		if (plugin.transform && typeof plugin.transform === "function") {
+			result = await plugin.transform.call(
+				mockContext,
+				original,
+				join(fixtureDir, "env.ts"),
+			);
+		}
+		expect(result).toBeNull();
+	});
+
+	it("passes through the env module for custom server-consumer environments", async () => {
+		const fixtureDir = join(__dirname, "__fixtures__", "transform-env");
+		const plugin = arkenvPlugin({ schemaPath: join(fixtureDir, "env.ts") });
+
+		const mockContext = {
+			meta: {
+				framework: "vite",
+				version: "1.0.0",
+				rollupVersion: "4.0.0",
+				viteVersion: "6.0.0",
+			},
+			error: () => {},
+			warn: () => {},
+			info: () => {},
+			debug: () => {},
+			environment: {
+				name: "cloudflare-workers",
+				config: { consumer: "server" },
+			},
+		} as any;
+
+		if (plugin.config && typeof plugin.config === "function") {
+			plugin.config.call(
+				mockContext,
+				{ root: fixtureDir, envDir: fixtureDir },
+				{ mode: "test", command: "build" },
+			);
+		}
+		if (plugin.configResolved && typeof plugin.configResolved === "function") {
+			await plugin.configResolved.call(mockContext, {
+				root: fixtureDir,
+				envDir: fixtureDir,
+				envPrefix: "VITE_",
+			} as any);
+		}
+
+		const original = readFileSync(join(fixtureDir, "env.ts"), "utf8");
+		let result: any = null;
+		if (plugin.transform && typeof plugin.transform === "function") {
+			result = await plugin.transform.call(
+				mockContext,
+				original,
+				join(fixtureDir, "env.ts"),
+			);
+		}
+		expect(result).toBeNull();
+	});
+
+	it("rewrites the env module in Vite 6 client environments", async () => {
+		const fixtureDir = join(__dirname, "__fixtures__", "transform-env");
+		const plugin = arkenvPlugin({ schemaPath: join(fixtureDir, "env.ts") });
+
+		const mockContext = {
+			meta: {
+				framework: "vite",
+				version: "1.0.0",
+				rollupVersion: "4.0.0",
+				viteVersion: "6.0.0",
+			},
+			error: () => {},
+			warn: () => {},
+			info: () => {},
+			debug: () => {},
+			environment: {
+				name: "client",
+				config: { consumer: "client" },
+			},
+		} as any;
+
+		if (plugin.config && typeof plugin.config === "function") {
+			plugin.config.call(
+				mockContext,
+				{ root: fixtureDir, envDir: fixtureDir },
+				{ mode: "test", command: "build" },
+			);
+		}
+		if (plugin.configResolved && typeof plugin.configResolved === "function") {
+			await plugin.configResolved.call(mockContext, {
+				root: fixtureDir,
+				envDir: fixtureDir,
+				envPrefix: "VITE_",
+			} as any);
+		}
+
+		let result: any = null;
+		if (plugin.transform && typeof plugin.transform === "function") {
+			result = await plugin.transform.call(
+				mockContext,
+				"export const env = {}",
+				join(fixtureDir, "env.ts"),
+			);
+		}
+
+		expect(result?.code).toContain("VITE_API_URL");
+		expect(result?.code).toContain('get ["DATABASE_URL"]()');
+		expect(result?.code).not.toContain("@arkenv/core");
+	});
+
 	it("rejects the schema/define path", () => {
 		expect(() =>
 			(arkenvPlugin as (a?: unknown) => unknown)({ VITE_TEST: "string" }),

--- a/packages/vite-plugin/src/transform-plugin.ts
+++ b/packages/vite-plugin/src/transform-plugin.ts
@@ -128,11 +128,22 @@ export function createTransformPlugin(
 		 * Rewrite the env module in the client graph only.
 		 *
 		 * @remarks
+		 * Vite 6+ discriminates module graphs through the Environment API:
+		 * server consumers (or environments named `ssr`) keep the real module,
+		 * everything else gets the client rewrite. On Vite 4/5, where
+		 * `this.environment` is undefined, the legacy `options.ssr` flag is used
+		 * as a fallback.
+		 *
 		 * ADR 0021 (canonical env object surface): do not reintroduce `env.gen.ts`
 		 * codegen, client-side re-validation, or `runtimeEnv` wiring here.
 		 */
 		transform(_code, id, options) {
-			if (options?.ssr) return null;
+			const isServer = this.environment
+				? this.environment.config?.consumer === "server" ||
+					this.environment.name === "ssr"
+				: Boolean(options?.ssr);
+
+			if (isServer) return null;
 			if (!state.schemaPath) return null;
 			if (!isEnvModuleId(id, state.schemaPath)) return null;
 


### PR DESCRIPTION
## Description

The `transform` hook now discriminates server graphs via the Vite 6 Environment API (`consumer === "server"` or an environment named `ssr`) instead of relying on the deprecated `options.ssr` flag. Vite 4/5 fall back to `Boolean(options?.ssr)` when `this.environment` is undefined.

- `transform-plugin.ts`: environment-aware SSR passthrough with legacy fallback
- Tests: passthrough for `ssr` and custom server-consumer environments, client rewrite for client environments (Vite 6 contexts)
- Docs: SSR section in the Vite framework guide notes the Environment API split
- Changeset: `minor` for `@arkenv/vite-plugin`

Validation: typecheck, 1290/1290 tests, biome/manypkg/mdxlint all pass.

Fixes #1749

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x] My code follows the code style of this project (double quotes, tabs, no parameter reassignment).
- [x] I have written sentence-case imperative commits / PR title (e.g. `Add support for custom error messages` - no `feat:`, no trailing period, capitalized).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have created a changeset using `pnpm changeset` (if this affects a published package).

