### PR TITLE
ci: stop preview deploy from dying on multiline commit messages

### DIFF
--- a/.github/workflows/deploy-www-manual.yml
+++ b/.github/workflows/deploy-www-manual.yml
@@ -111,6 +111,7 @@ jobs:
             echo "Deployed $GIT_SHA to production (arkenv.js.org)."
           else
             deploy_log="$(mktemp)"
+            trap 'rm -f "$deploy_log"' EXIT
             node scripts/vercel-wrapper.cjs deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" "${META_ARGS[@]}" \
               | tee "$deploy_log"
             DEPLOYMENT_URL="$(tail -n 1 "$deploy_log")"

--- a/.github/workflows/deploy-www-manual.yml
+++ b/.github/workflows/deploy-www-manual.yml
@@ -57,7 +57,7 @@ jobs:
               exit 1
               ;;
           esac
-          echo "short_msg=$(git log -1 --format=%s "$DEPLOY_SHA" | head -n1)" >> "$GITHUB_OUTPUT"
+          echo "short_msg=$(git log -1 --format=%s "$DEPLOY_SHA")" >> "$GITHUB_OUTPUT"
           echo "author_name=$(git log -1 --format=%an "$DEPLOY_SHA")" >> "$GITHUB_OUTPUT"
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
@@ -110,7 +110,10 @@ jobs:
             node scripts/vercel-wrapper.cjs deploy --prebuilt --prod --archive=tgz --token="$VERCEL_TOKEN" "${META_ARGS[@]}"
             echo "Deployed $GIT_SHA to production (arkenv.js.org)."
           else
-            DEPLOYMENT_URL=$(node scripts/vercel-wrapper.cjs deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" "${META_ARGS[@]}" | tail -n 1)
+            deploy_log="$(mktemp)"
+            node scripts/vercel-wrapper.cjs deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" "${META_ARGS[@]}" \
+              | tee "$deploy_log"
+            DEPLOYMENT_URL="$(tail -n 1 "$deploy_log")"
             echo "Deployment URL: $DEPLOYMENT_URL"
             echo "Aliasing $DEPLOYMENT_URL -> $TARGET"
             node scripts/vercel-wrapper.cjs alias set "$DEPLOYMENT_URL" "$TARGET" --token="$VERCEL_TOKEN"

--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -59,7 +59,7 @@ jobs:
           GIT_COMMIT_AUTHOR_NAME: ${{ github.event.head_commit.author.name || github.actor }}
         run: |
           set -o pipefail
-          SHORT_MSG="$(printf '%s\n' "$GIT_COMMIT_MESSAGE" | head -n1)"
+          SHORT_MSG="${GIT_COMMIT_MESSAGE%%$'\n'*}"
           # --prod already assigns production domains (arkenv.js.org / arkenv.vercel.app).
           # Git meta keeps the deployment linked to main in the Vercel dashboard.
           node scripts/vercel-wrapper.cjs deploy --prebuilt --prod --archive=tgz --token="$VERCEL_TOKEN" \

--- a/.github/workflows/preview-www-reusable.yml
+++ b/.github/workflows/preview-www-reusable.yml
@@ -105,6 +105,7 @@ jobs:
           # First line only. printf|head SIGPIPEs under pipefail on multiline merge messages.
           SHORT_MSG="${GIT_COMMIT_MESSAGE%%$'\n'*}"
           deploy_log="$(mktemp)"
+          trap 'rm -f "$deploy_log"' EXIT
           node scripts/vercel-wrapper.cjs deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" \
             -m githubDeployment=1 \
             -m githubOrg="$GIT_ORG" \

--- a/.github/workflows/preview-www-reusable.yml
+++ b/.github/workflows/preview-www-reusable.yml
@@ -102,8 +102,10 @@ jobs:
           GIT_COMMIT_AUTHOR_NAME: ${{ github.event.head_commit.author.name || github.actor }}
         run: |
           set -o pipefail
-          SHORT_MSG="$(printf '%s\n' "$GIT_COMMIT_MESSAGE" | head -n1)"
-          DEPLOYMENT_URL=$(node scripts/vercel-wrapper.cjs deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" \
+          # First line only. printf|head SIGPIPEs under pipefail on multiline merge messages.
+          SHORT_MSG="${GIT_COMMIT_MESSAGE%%$'\n'*}"
+          deploy_log="$(mktemp)"
+          node scripts/vercel-wrapper.cjs deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" \
             -m githubDeployment=1 \
             -m githubOrg="$GIT_ORG" \
             -m githubRepo="$GIT_REPO" \
@@ -114,7 +116,8 @@ jobs:
             -m githubCommitMessage="$SHORT_MSG" \
             -m githubCommitAuthorName="$GIT_COMMIT_AUTHOR_NAME" \
             -m githubCommitAuthorLogin="$GIT_ACTOR" \
-            | tail -n 1)
+            | tee "$deploy_log"
+          DEPLOYMENT_URL="$(tail -n 1 "$deploy_log")"
           echo "DEPLOYMENT_URL=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
       # Explicit alias so branch domains stay current without native Vercel Git builds (#1460).
       # Only on push to dev/v1 — labeled PR previews keep ephemeral URLs and must not steal these.

--- a/scripts/vercel-wrapper.cjs
+++ b/scripts/vercel-wrapper.cjs
@@ -62,5 +62,7 @@ child.on("close", (code) => {
 			}
 		}
 	}
-	process.exit(code);
+	// Don't process.exit(): the runner captures stdout over a pipe, and a hard
+	// exit can drop the ::error:: annotation written above before it drains.
+	process.exitCode = code ?? 1;
 });

--- a/scripts/vercel-wrapper.cjs
+++ b/scripts/vercel-wrapper.cjs
@@ -1,4 +1,5 @@
 const { spawn } = require("node:child_process");
+const fs = require("node:fs");
 
 const args = process.argv.slice(2);
 
@@ -32,10 +33,33 @@ child.on("close", (code) => {
 			stderr.includes(keyword),
 		);
 
-		if (isRateLimit) {
-			console.log(
-				"\n::error title=Vercel Rate Limit Exceeded::Your Vercel account has reached a rate limit. Please check your Vercel dashboard or documentation for more information: https://vercel.com/docs/platform/limits",
-			);
+		const title = isRateLimit
+			? "Vercel Rate Limit Exceeded"
+			: "Vercel CLI failed";
+		const detail =
+			stderr.trim() ||
+			(isRateLimit
+				? "Your Vercel account has reached a rate limit. See https://vercel.com/docs/platform/limits"
+				: `vercel exited with code ${code}`);
+
+		// Workflow command: percent-encode so the annotation stays one line.
+		const encoded = detail
+			.replace(/%/g, "%25")
+			.replace(/\r/g, "")
+			.replace(/\n/g, "%0A");
+		console.log(`\n::error title=${title}::${encoded}`);
+
+		const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+		if (summaryPath) {
+			const heading = isRateLimit
+				? "Vercel rate limit exceeded"
+				: "Vercel CLI failed";
+			const md = `\n## ${heading}\n\nExit code \`${code}\`.\n\n\`\`\`\n${detail}\n\`\`\`\n`;
+			try {
+				fs.appendFileSync(summaryPath, md);
+			} catch {
+				// Annotation already emitted; keep the original exit code.
+			}
 		}
 	}
 	process.exit(code);


### PR DESCRIPTION
Preview www died before vercel deploy: set -o pipefail plus printf|head SIGPIPEs on multiline merge messages (Co-authored-by). See https://github.com/yamcodes/arkenv/actions/runs/33796870137/job/100786583965 (printf: write error: Broken pipe), so arkenv-dev.vercel.app never updated after #1757.

This PR takes the first commit-message line via parameter expansion, tees deploy stdout into the job log, applies the same SHORT_MSG fix on deploy-www.yml and deploy-www-manual.yml, and has vercel-wrapper.cjs emit ::error:: annotations plus GITHUB_STEP_SUMMARY on failure.

CI-only, no changeset. preview-www-default.yml also deploys on push to v1 — worth a forward-port.