### PR TITLE
www: Errors you can automate

### DIFF
--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -1854,8 +1854,8 @@
 .home-aurora__payload-chip--port-valid,
 .home-aurora__payload-chip--debug-true,
 .home-aurora__payload-chip--debug-false,
-.home-aurora__payload-chip--loglevel-info,
-.home-aurora__payload-chip--loglevel-debug {
+.home-aurora__payload-chip--theme-light,
+.home-aurora__payload-chip--theme-dark {
 	color: var(--color-ink);
 	text-shadow: 0 0 8px color-mix(in oklch, var(--color-ink) 40%, transparent);
 }
@@ -1867,8 +1867,8 @@
 .home-aurora__payload-chip--port-coerced,
 .home-aurora__payload-chip--debug-true-coerced,
 .home-aurora__payload-chip--debug-false-coerced,
-.home-aurora__payload-chip--loglevel-info-coerced,
-.home-aurora__payload-chip--loglevel-debug-coerced {
+.home-aurora__payload-chip--theme-light-coerced,
+.home-aurora__payload-chip--theme-dark-coerced {
 	color: var(--color-accent);
 	text-shadow: 0 0 10px var(--color-accent);
 }
@@ -1911,32 +1911,29 @@
 }
 
 /* Row 3 Alternating Cadence (8s cycle, phase-shifted vs DEBUG) */
-.home-aurora__payload-chip--loglevel-info {
+.home-aurora__payload-chip--theme-light {
 	animation: debug-travel-true 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
 }
-.home-aurora__payload-chip--loglevel-info-coerced {
+.home-aurora__payload-chip--theme-light-coerced {
 	animation: debug-travel-true-coerced 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
 }
-.home-aurora__payload-chip--loglevel-debug {
+.home-aurora__payload-chip--theme-dark {
 	animation: debug-travel-false 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
 }
-.home-aurora__payload-chip--loglevel-debug-coerced {
+.home-aurora__payload-chip--theme-dark-coerced {
 	animation: debug-travel-false-coerced 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
 }
-.home-aurora__payload-row--loglevel .home-aurora__payload-schema {
+.home-aurora__payload-row--theme .home-aurora__payload-schema {
 	animation: debug-schema-flash 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
-	font-size: 0.6875rem;
 }
-.home-aurora__payload-row--loglevel .home-aurora__payload-dock {
+.home-aurora__payload-row--theme .home-aurora__payload-dock {
 	animation: debug-dock-pulse-mobile 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
-	font-size: 0.6875rem;
-	letter-spacing: 0;
 }
-.home-aurora__payload-row--loglevel .home-aurora__payload-col--left {
-	min-width: 5.75rem;
+.home-aurora__payload-row--theme .home-aurora__payload-col--left {
+	min-width: 4.5rem;
 }
-.home-aurora__payload-row--loglevel .home-aurora__payload-col--right {
-	min-width: 14rem;
+.home-aurora__payload-row--theme .home-aurora__payload-col--right {
+	min-width: 6.5rem;
 	justify-content: flex-end;
 }
 
@@ -1947,7 +1944,7 @@
 	.home-aurora__payload-row--debug .home-aurora__payload-dock {
 		animation: debug-dock-pulse 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 0s;
 	}
-	.home-aurora__payload-row--loglevel .home-aurora__payload-dock {
+	.home-aurora__payload-row--theme .home-aurora__payload-dock {
 		animation: debug-dock-pulse 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
 	}
 }
@@ -2015,23 +2012,23 @@
 	animation: debug-mobile-coerced-false 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 0s;
 }
 
-.home-aurora__payload-carrier--loglevel-info {
+.home-aurora__payload-carrier--theme-light {
 	animation: debug-mobile-travel-true 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
-.home-aurora__payload-carrier--loglevel-info .home-aurora__payload-val--raw {
+.home-aurora__payload-carrier--theme-light .home-aurora__payload-val--raw {
 	animation: debug-mobile-raw-true 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
-.home-aurora__payload-carrier--loglevel-info .home-aurora__payload-val--coerced {
+.home-aurora__payload-carrier--theme-light .home-aurora__payload-val--coerced {
 	animation: debug-mobile-coerced-true 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
 
-.home-aurora__payload-carrier--loglevel-debug {
+.home-aurora__payload-carrier--theme-dark {
 	animation: debug-mobile-travel-false 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
-.home-aurora__payload-carrier--loglevel-debug .home-aurora__payload-val--raw {
+.home-aurora__payload-carrier--theme-dark .home-aurora__payload-val--raw {
 	animation: debug-mobile-raw-false 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
-.home-aurora__payload-carrier--loglevel-debug .home-aurora__payload-val--coerced {
+.home-aurora__payload-carrier--theme-dark .home-aurora__payload-val--coerced {
 	animation: debug-mobile-coerced-false 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
 

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -2899,11 +2899,6 @@
 	border-bottom: 1px dotted color-mix(in oklch, var(--color-ink-2) 55%, transparent);
 }
 
-.home-aurora__json-ellipsis:focus-visible {
-	outline: 2px solid var(--color-accent);
-	outline-offset: 2px;
-}
-
 .home-aurora__json {
 	position: relative;
 }

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -3193,7 +3193,8 @@
 	height: 100%;
 	min-width: 0;
 	overflow: auto;
-	overscroll-behavior: contain;
+	/* Let the wheel continue the page once the pane hits an edge (no scroll trap). */
+	overscroll-behavior: auto;
 	scrollbar-width: thin;
 	scrollbar-color: color-mix(in oklch, var(--color-muted) 55%, transparent) transparent;
 }

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -1854,8 +1854,8 @@
 .home-aurora__payload-chip--port-valid,
 .home-aurora__payload-chip--debug-true,
 .home-aurora__payload-chip--debug-false,
-.home-aurora__payload-chip--nodeenv-prod,
-.home-aurora__payload-chip--nodeenv-dev {
+.home-aurora__payload-chip--loglevel-info,
+.home-aurora__payload-chip--loglevel-debug {
 	color: var(--color-ink);
 	text-shadow: 0 0 8px color-mix(in oklch, var(--color-ink) 40%, transparent);
 }
@@ -1867,8 +1867,8 @@
 .home-aurora__payload-chip--port-coerced,
 .home-aurora__payload-chip--debug-true-coerced,
 .home-aurora__payload-chip--debug-false-coerced,
-.home-aurora__payload-chip--nodeenv-prod-coerced,
-.home-aurora__payload-chip--nodeenv-dev-coerced {
+.home-aurora__payload-chip--loglevel-info-coerced,
+.home-aurora__payload-chip--loglevel-debug-coerced {
 	color: var(--color-accent);
 	text-shadow: 0 0 10px var(--color-accent);
 }
@@ -1911,32 +1911,32 @@
 }
 
 /* Row 3 Alternating Cadence (8s cycle, phase-shifted vs DEBUG) */
-.home-aurora__payload-chip--nodeenv-prod {
+.home-aurora__payload-chip--loglevel-info {
 	animation: debug-travel-true 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
 }
-.home-aurora__payload-chip--nodeenv-prod-coerced {
+.home-aurora__payload-chip--loglevel-info-coerced {
 	animation: debug-travel-true-coerced 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
 }
-.home-aurora__payload-chip--nodeenv-dev {
+.home-aurora__payload-chip--loglevel-debug {
 	animation: debug-travel-false 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
 }
-.home-aurora__payload-chip--nodeenv-dev-coerced {
+.home-aurora__payload-chip--loglevel-debug-coerced {
 	animation: debug-travel-false-coerced 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
 }
-.home-aurora__payload-row--nodeenv .home-aurora__payload-schema {
+.home-aurora__payload-row--loglevel .home-aurora__payload-schema {
 	animation: debug-schema-flash 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
 	font-size: 0.6875rem;
 }
-.home-aurora__payload-row--nodeenv .home-aurora__payload-dock {
+.home-aurora__payload-row--loglevel .home-aurora__payload-dock {
 	animation: debug-dock-pulse-mobile 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 	font-size: 0.6875rem;
 	letter-spacing: 0;
 }
-.home-aurora__payload-row--nodeenv .home-aurora__payload-col--left {
+.home-aurora__payload-row--loglevel .home-aurora__payload-col--left {
 	min-width: 5.75rem;
 }
-.home-aurora__payload-row--nodeenv .home-aurora__payload-col--right {
-	min-width: 12.5rem;
+.home-aurora__payload-row--loglevel .home-aurora__payload-col--right {
+	min-width: 14rem;
 	justify-content: flex-end;
 }
 
@@ -1947,7 +1947,7 @@
 	.home-aurora__payload-row--debug .home-aurora__payload-dock {
 		animation: debug-dock-pulse 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 0s;
 	}
-	.home-aurora__payload-row--nodeenv .home-aurora__payload-dock {
+	.home-aurora__payload-row--loglevel .home-aurora__payload-dock {
 		animation: debug-dock-pulse 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
 	}
 }
@@ -2015,23 +2015,23 @@
 	animation: debug-mobile-coerced-false 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 0s;
 }
 
-.home-aurora__payload-carrier--nodeenv-prod {
+.home-aurora__payload-carrier--loglevel-info {
 	animation: debug-mobile-travel-true 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
-.home-aurora__payload-carrier--nodeenv-prod .home-aurora__payload-val--raw {
+.home-aurora__payload-carrier--loglevel-info .home-aurora__payload-val--raw {
 	animation: debug-mobile-raw-true 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
-.home-aurora__payload-carrier--nodeenv-prod .home-aurora__payload-val--coerced {
+.home-aurora__payload-carrier--loglevel-info .home-aurora__payload-val--coerced {
 	animation: debug-mobile-coerced-true 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
 
-.home-aurora__payload-carrier--nodeenv-dev {
+.home-aurora__payload-carrier--loglevel-debug {
 	animation: debug-mobile-travel-false 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
-.home-aurora__payload-carrier--nodeenv-dev .home-aurora__payload-val--raw {
+.home-aurora__payload-carrier--loglevel-debug .home-aurora__payload-val--raw {
 	animation: debug-mobile-raw-false 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
-.home-aurora__payload-carrier--nodeenv-dev .home-aurora__payload-val--coerced {
+.home-aurora__payload-carrier--loglevel-debug .home-aurora__payload-val--coerced {
 	animation: debug-mobile-coerced-false 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
 

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -2904,6 +2904,33 @@
 	outline-offset: 2px;
 }
 
+.home-aurora__json {
+	position: relative;
+}
+
+.home-aurora__json-lang {
+	position: absolute;
+	top: 0.55rem;
+	right: 0.75rem;
+	font-family: var(--font-body);
+	font-size: var(--text-xs);
+	line-height: 1;
+	color: var(--color-muted);
+	pointer-events: none;
+	letter-spacing: 0.02em;
+}
+
+.home-aurora__json-body {
+	margin: 0;
+	padding: var(--space-sm) var(--space-md);
+	font-family: var(--font-outlier);
+	font-size: var(--text-code);
+	line-height: 1.55;
+	color: var(--color-ink-2);
+	min-width: 0;
+}
+
+
 .home-aurora__tty .home-aurora__install-prompt-symbol {
 	font-size: inherit;
 	line-height: inherit;

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -2962,6 +2962,12 @@
 	border-radius: 2px;
 }
 
+@media (hover: hover) and (pointer: fine) {
+	.home-aurora__json-ellipsis {
+		cursor: help;
+	}
+}
+
 .home-aurora__json-ellipsis:focus-visible {
 	outline: 2px solid color-mix(in oklch, var(--color-accent) 70%, transparent);
 	outline-offset: 2px;

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -1853,7 +1853,9 @@
 
 .home-aurora__payload-chip--port-valid,
 .home-aurora__payload-chip--debug-true,
-.home-aurora__payload-chip--debug-false {
+.home-aurora__payload-chip--debug-false,
+.home-aurora__payload-chip--nodeenv-prod,
+.home-aurora__payload-chip--nodeenv-dev {
 	color: var(--color-ink);
 	text-shadow: 0 0 8px color-mix(in oklch, var(--color-ink) 40%, transparent);
 }
@@ -1864,7 +1866,9 @@
 
 .home-aurora__payload-chip--port-coerced,
 .home-aurora__payload-chip--debug-true-coerced,
-.home-aurora__payload-chip--debug-false-coerced {
+.home-aurora__payload-chip--debug-false-coerced,
+.home-aurora__payload-chip--nodeenv-prod-coerced,
+.home-aurora__payload-chip--nodeenv-dev-coerced {
 	color: var(--color-accent);
 	text-shadow: 0 0 10px var(--color-accent);
 }
@@ -1906,12 +1910,45 @@
 	animation: debug-dock-pulse-mobile 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 0s;
 }
 
+/* Row 3 Alternating Cadence (8s cycle, phase-shifted vs DEBUG) */
+.home-aurora__payload-chip--nodeenv-prod {
+	animation: debug-travel-true 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
+}
+.home-aurora__payload-chip--nodeenv-prod-coerced {
+	animation: debug-travel-true-coerced 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
+}
+.home-aurora__payload-chip--nodeenv-dev {
+	animation: debug-travel-false 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
+}
+.home-aurora__payload-chip--nodeenv-dev-coerced {
+	animation: debug-travel-false-coerced 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
+}
+.home-aurora__payload-row--nodeenv .home-aurora__payload-schema {
+	animation: debug-schema-flash 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
+	font-size: 0.6875rem;
+}
+.home-aurora__payload-row--nodeenv .home-aurora__payload-dock {
+	animation: debug-dock-pulse-mobile 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
+	font-size: 0.6875rem;
+	letter-spacing: 0;
+}
+.home-aurora__payload-row--nodeenv .home-aurora__payload-col--left {
+	min-width: 5.75rem;
+}
+.home-aurora__payload-row--nodeenv .home-aurora__payload-col--right {
+	min-width: 12.5rem;
+	justify-content: flex-end;
+}
+
 @container stream-stage (min-width: 28rem) {
 	.home-aurora__payload-row--port .home-aurora__payload-dock {
 		animation: port-dock-pulse 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 0s;
 	}
 	.home-aurora__payload-row--debug .home-aurora__payload-dock {
 		animation: debug-dock-pulse 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 0s;
+	}
+	.home-aurora__payload-row--nodeenv .home-aurora__payload-dock {
+		animation: debug-dock-pulse 8s cubic-bezier(0.25, 1, 0.5, 1) infinite 1.2s;
 	}
 }
 
@@ -1976,6 +2013,26 @@
 }
 .home-aurora__payload-carrier--debug-false .home-aurora__payload-val--coerced {
 	animation: debug-mobile-coerced-false 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 0s;
+}
+
+.home-aurora__payload-carrier--nodeenv-prod {
+	animation: debug-mobile-travel-true 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
+}
+.home-aurora__payload-carrier--nodeenv-prod .home-aurora__payload-val--raw {
+	animation: debug-mobile-raw-true 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
+}
+.home-aurora__payload-carrier--nodeenv-prod .home-aurora__payload-val--coerced {
+	animation: debug-mobile-coerced-true 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
+}
+
+.home-aurora__payload-carrier--nodeenv-dev {
+	animation: debug-mobile-travel-false 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
+}
+.home-aurora__payload-carrier--nodeenv-dev .home-aurora__payload-val--raw {
+	animation: debug-mobile-raw-false 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
+}
+.home-aurora__payload-carrier--nodeenv-dev .home-aurora__payload-val--coerced {
+	animation: debug-mobile-coerced-false 8s cubic-bezier(0.2, 0.8, 0.25, 1) infinite 1.2s;
 }
 
 /* Keyframes for Row 1 Alternating Pipeline */

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -2894,6 +2894,16 @@
 	overflow-x: hidden;
 }
 
+.home-aurora__json-ellipsis {
+	cursor: help;
+	border-bottom: 1px dotted color-mix(in oklch, var(--color-ink-2) 55%, transparent);
+}
+
+.home-aurora__json-ellipsis:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
+}
+
 .home-aurora__tty .home-aurora__install-prompt-symbol {
 	font-size: inherit;
 	line-height: inherit;

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -2888,6 +2888,12 @@
 	overflow-x: auto;
 }
 
+.home-aurora__tty--wrap {
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+	overflow-x: hidden;
+}
+
 .home-aurora__tty .home-aurora__install-prompt-symbol {
 	font-size: inherit;
 	line-height: inherit;

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -2925,7 +2925,6 @@
 	min-width: 0;
 }
 
-
 .home-aurora__tty .home-aurora__install-prompt-symbol {
 	font-size: inherit;
 	line-height: inherit;

--- a/apps/www/app/(home)/aurora.css
+++ b/apps/www/app/(home)/aurora.css
@@ -2949,8 +2949,27 @@
 }
 
 .home-aurora__json-ellipsis {
-	cursor: help;
+	display: inline;
+	margin: 0;
+	padding: 0;
+	border: none;
 	border-bottom: 1px dotted color-mix(in oklch, var(--color-ink-2) 55%, transparent);
+	background: none;
+	font: inherit;
+	line-height: inherit;
+	color: inherit;
+	cursor: pointer;
+	border-radius: 2px;
+}
+
+.home-aurora__json-ellipsis:focus-visible {
+	outline: 2px solid color-mix(in oklch, var(--color-accent) 70%, transparent);
+	outline-offset: 2px;
+}
+
+.home-aurora__json-ellipsis-tip {
+	font-family: var(--font-body);
+	word-break: break-word;
 }
 
 .home-aurora__json {

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -24,7 +24,7 @@ import { fetchRoadmap } from "~/lib/roadmap/fetch-roadmap";
 export const metadata: Metadata = {
 	title: "ArkEnv - Typesafe environment variables for TypeScript",
 	description:
-		"Typesafe environment variables with ArkType, Zod, Valibot, or any Standard Schema. Get a strictly typed env object from the validator you already use. No boilerplate. No additional dependencies.",
+		"Typesafe environment variables with ArkType, Zod, Valibot, or any Standard Schema. Get a strictly typed env object from the validator you already use. No boilerplate. Zero dependencies.",
 };
 
 export const revalidate = 300;
@@ -64,7 +64,8 @@ export default async function HomePage() {
 							style={{ animationDelay: "520ms" }}
 						>
 							Get a strictly typed <HeroEnvHoverSlot /> object from the
-							validator you already use. No boilerplate. No additional dependencies.
+							validator you already use. No boilerplate. Zero
+							dependencies.
 						</p>
 					</div>
 					<div className="home-aurora__hero-ctas">

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -24,7 +24,7 @@ import { fetchRoadmap } from "~/lib/roadmap/fetch-roadmap";
 export const metadata: Metadata = {
 	title: "ArkEnv - Typesafe environment variables for TypeScript",
 	description:
-		"Typesafe environment variables with ArkType, Zod, Valibot, or any Standard Schema. Get a strictly typed env object using your existing TypeScript validator. No boilerplate. Zero runtime dependencies.",
+		"Typesafe environment variables with ArkType, Zod, Valibot, or any Standard Schema. Get a strictly typed env object from the validator you already use. No boilerplate. No additional dependencies.",
 };
 
 export const revalidate = 300;
@@ -63,8 +63,8 @@ export default async function HomePage() {
 							className="home-aurora__summary rise-blur"
 							style={{ animationDelay: "520ms" }}
 						>
-							Get a strictly typed <HeroEnvHoverSlot /> object using your
-							existing TypeScript validator. No boilerplate. Zero runtime
+							Get a strictly typed <HeroEnvHoverSlot /> object from the
+							validator you already use. No boilerplate. No additional
 							dependencies.
 						</p>
 					</div>

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -24,7 +24,7 @@ import { fetchRoadmap } from "~/lib/roadmap/fetch-roadmap";
 export const metadata: Metadata = {
 	title: "ArkEnv - Typesafe environment variables for TypeScript",
 	description:
-		"Typesafe environment variables with ArkType, Zod, Valibot, or any Standard Schema. Get a strictly typed env object from the validator you already use. No boilerplate. Zero dependencies.",
+		"Typesafe environment variables with ArkType, Zod, Valibot, or any Standard Schema. Get a strictly typed env object from the validator you already use. No boilerplate. No additional dependencies.",
 };
 
 export const revalidate = 300;
@@ -64,7 +64,7 @@ export default async function HomePage() {
 							style={{ animationDelay: "520ms" }}
 						>
 							Get a strictly typed <HeroEnvHoverSlot /> object from the
-							validator you already use. No boilerplate. Zero
+							validator you already use. No boilerplate. No additional
 							dependencies.
 						</p>
 					</div>

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -24,7 +24,7 @@ import { fetchRoadmap } from "~/lib/roadmap/fetch-roadmap";
 export const metadata: Metadata = {
 	title: "ArkEnv - Typesafe environment variables for TypeScript",
 	description:
-		"Typesafe environment variables with ArkType, Zod, Valibot, or any Standard Schema. Get a strictly typed env object from the validator you already use. No boilerplate. Zero dependencies.",
+		"Typesafe environment variables with ArkType, Zod, Valibot, or any Standard Schema. Get a strictly typed env object from the validator you already use. No boilerplate. No additional dependencies.",
 };
 
 export const revalidate = 300;
@@ -64,7 +64,7 @@ export default async function HomePage() {
 							style={{ animationDelay: "520ms" }}
 						>
 							Get a strictly typed <HeroEnvHoverSlot /> object from the
-							validator you already use. No boilerplate. Zero dependencies.
+							validator you already use. No boilerplate. No additional dependencies.
 						</p>
 					</div>
 					<div className="home-aurora__hero-ctas">

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -24,7 +24,7 @@ import { fetchRoadmap } from "~/lib/roadmap/fetch-roadmap";
 export const metadata: Metadata = {
 	title: "ArkEnv - Typesafe environment variables for TypeScript",
 	description:
-		"Typesafe environment variables with ArkType, Zod, Valibot, or any Standard Schema. Get a strictly typed env object from the validator you already use. No boilerplate. No additional dependencies.",
+		"Typesafe environment variables with ArkType, Zod, Valibot, or any Standard Schema. Get a strictly typed env object from the validator you already use. No boilerplate. Zero dependencies.",
 };
 
 export const revalidate = 300;
@@ -64,7 +64,7 @@ export default async function HomePage() {
 							style={{ animationDelay: "520ms" }}
 						>
 							Get a strictly typed <HeroEnvHoverSlot /> object from the
-							validator you already use. No boilerplate. No additional
+							validator you already use. No boilerplate. Zero
 							dependencies.
 						</p>
 					</div>

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -64,7 +64,8 @@ export default async function HomePage() {
 							style={{ animationDelay: "520ms" }}
 						>
 							Get a strictly typed <HeroEnvHoverSlot /> object from the
-							validator you already use. No boilerplate. No additional dependencies.
+							validator you already use. No boilerplate. No additional
+							dependencies.
 						</p>
 					</div>
 					<div className="home-aurora__hero-ctas">

--- a/apps/www/app/(home)/page.tsx
+++ b/apps/www/app/(home)/page.tsx
@@ -64,8 +64,7 @@ export default async function HomePage() {
 							style={{ animationDelay: "520ms" }}
 						>
 							Get a strictly typed <HeroEnvHoverSlot /> object from the
-							validator you already use. No boilerplate. Zero
-							dependencies.
+							validator you already use. No boilerplate. Zero dependencies.
 						</p>
 					</div>
 					<div className="home-aurora__hero-ctas">

--- a/apps/www/components/page/declarative-showcase.test.tsx
+++ b/apps/www/components/page/declarative-showcase.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { DeclarativeShowcase } from "./declarative-showcase";
 
 describe("DeclarativeShowcase", () => {
-	it("renders the 3-row alternating payload pipeline with enum NODE_ENV row", () => {
+	it("renders the 3-row alternating payload pipeline with enum LOG_LEVEL row", () => {
 		render(<DeclarativeShowcase />);
 
 		expect(
@@ -17,7 +17,7 @@ describe("DeclarativeShowcase", () => {
 		// Static keys
 		expect(figure).toHaveTextContent("PORT=");
 		expect(figure).toHaveTextContent("DEBUG=");
-		expect(figure).toHaveTextContent("NODE_ENV=");
+		expect(figure).toHaveTextContent("LOG_LEVEL=");
 
 		// Row 1 alternating chips ("3000" success vs "oops" failure)
 		expect(figure).toHaveTextContent('"3000"');
@@ -27,22 +27,22 @@ describe("DeclarativeShowcase", () => {
 		expect(figure).toHaveTextContent('"true"');
 		expect(figure).toHaveTextContent('"false"');
 
-		// Row 3 alternating chips ("production" vs "development")
-		expect(figure).toHaveTextContent('"production"');
-		expect(figure).toHaveTextContent('"development"');
+		// Row 3 alternating chips ("info" vs "debug")
+		expect(figure).toHaveTextContent('"info"');
+		expect(figure).toHaveTextContent('"debug"');
 
 		// Schema Gates
 		expect(figure).toHaveTextContent('"number"');
 		expect(figure).toHaveTextContent('"boolean"');
 		expect(figure).toHaveTextContent(
-			"\"'development' | 'production' | 'test'\"",
+			"\"'debug' | 'info' | 'warn' | 'error'\"",
 		);
 
 		// Destination Type Definitions
 		expect(figure).toHaveTextContent("number");
 		expect(figure).toHaveTextContent("boolean");
 		expect(figure).toHaveTextContent(
-			'"development" | "production" | "test"',
+			'"debug" | "info" | "warn" | "error"',
 		);
 	});
 
@@ -75,16 +75,16 @@ describe("DeclarativeShowcase", () => {
 		expect(debugFalseCarrier).toHaveTextContent('"false"');
 		expect(debugFalseCarrier).toHaveTextContent("false");
 
-		const nodeenvProdCarrier = container.querySelector(
-			".home-aurora__payload-carrier--nodeenv-prod",
+		const loglevelInfoCarrier = container.querySelector(
+			".home-aurora__payload-carrier--loglevel-info",
 		);
-		expect(nodeenvProdCarrier).toBeInTheDocument();
-		expect(nodeenvProdCarrier).toHaveTextContent('"production"');
+		expect(loglevelInfoCarrier).toBeInTheDocument();
+		expect(loglevelInfoCarrier).toHaveTextContent('"info"');
 
-		const nodeenvDevCarrier = container.querySelector(
-			".home-aurora__payload-carrier--nodeenv-dev",
+		const loglevelDebugCarrier = container.querySelector(
+			".home-aurora__payload-carrier--loglevel-debug",
 		);
-		expect(nodeenvDevCarrier).toBeInTheDocument();
-		expect(nodeenvDevCarrier).toHaveTextContent('"development"');
+		expect(loglevelDebugCarrier).toBeInTheDocument();
+		expect(loglevelDebugCarrier).toHaveTextContent('"debug"');
 	});
 });

--- a/apps/www/components/page/declarative-showcase.test.tsx
+++ b/apps/www/components/page/declarative-showcase.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { DeclarativeShowcase } from "./declarative-showcase";
 
 describe("DeclarativeShowcase", () => {
-	it("renders the 3-row alternating payload pipeline with enum LOG_LEVEL row", () => {
+	it("renders the 3-row alternating payload pipeline with enum THEME row", () => {
 		render(<DeclarativeShowcase />);
 
 		expect(
@@ -17,7 +17,7 @@ describe("DeclarativeShowcase", () => {
 		// Static keys
 		expect(figure).toHaveTextContent("PORT=");
 		expect(figure).toHaveTextContent("DEBUG=");
-		expect(figure).toHaveTextContent("LOG_LEVEL=");
+		expect(figure).toHaveTextContent("THEME=");
 
 		// Row 1 alternating chips ("3000" success vs "oops" failure)
 		expect(figure).toHaveTextContent('"3000"');
@@ -27,19 +27,19 @@ describe("DeclarativeShowcase", () => {
 		expect(figure).toHaveTextContent('"true"');
 		expect(figure).toHaveTextContent('"false"');
 
-		// Row 3 alternating chips ("info" vs "debug")
-		expect(figure).toHaveTextContent('"info"');
-		expect(figure).toHaveTextContent('"debug"');
+		// Row 3 alternating chips ("light" vs "dark")
+		expect(figure).toHaveTextContent('"light"');
+		expect(figure).toHaveTextContent('"dark"');
 
 		// Schema Gates
 		expect(figure).toHaveTextContent('"number"');
 		expect(figure).toHaveTextContent('"boolean"');
-		expect(figure).toHaveTextContent("\"'debug' | 'info' | 'warn' | 'error'\"");
+		expect(figure).toHaveTextContent("\"'light' | 'dark'\"");
 
 		// Destination Type Definitions
 		expect(figure).toHaveTextContent("number");
 		expect(figure).toHaveTextContent("boolean");
-		expect(figure).toHaveTextContent('"debug" | "info" | "warn" | "error"');
+		expect(figure).toHaveTextContent('"light" | "dark"');
 	});
 
 	it("renders mobile direct single-wire elements and carrier tokens in the markup", () => {
@@ -71,16 +71,16 @@ describe("DeclarativeShowcase", () => {
 		expect(debugFalseCarrier).toHaveTextContent('"false"');
 		expect(debugFalseCarrier).toHaveTextContent("false");
 
-		const loglevelInfoCarrier = container.querySelector(
-			".home-aurora__payload-carrier--loglevel-info",
+		const themeLightCarrier = container.querySelector(
+			".home-aurora__payload-carrier--theme-light",
 		);
-		expect(loglevelInfoCarrier).toBeInTheDocument();
-		expect(loglevelInfoCarrier).toHaveTextContent('"info"');
+		expect(themeLightCarrier).toBeInTheDocument();
+		expect(themeLightCarrier).toHaveTextContent('"light"');
 
-		const loglevelDebugCarrier = container.querySelector(
-			".home-aurora__payload-carrier--loglevel-debug",
+		const themeDarkCarrier = container.querySelector(
+			".home-aurora__payload-carrier--theme-dark",
 		);
-		expect(loglevelDebugCarrier).toBeInTheDocument();
-		expect(loglevelDebugCarrier).toHaveTextContent('"debug"');
+		expect(themeDarkCarrier).toBeInTheDocument();
+		expect(themeDarkCarrier).toHaveTextContent('"dark"');
 	});
 });

--- a/apps/www/components/page/declarative-showcase.test.tsx
+++ b/apps/www/components/page/declarative-showcase.test.tsx
@@ -34,16 +34,12 @@ describe("DeclarativeShowcase", () => {
 		// Schema Gates
 		expect(figure).toHaveTextContent('"number"');
 		expect(figure).toHaveTextContent('"boolean"');
-		expect(figure).toHaveTextContent(
-			"\"'debug' | 'info' | 'warn' | 'error'\"",
-		);
+		expect(figure).toHaveTextContent("\"'debug' | 'info' | 'warn' | 'error'\"");
 
 		// Destination Type Definitions
 		expect(figure).toHaveTextContent("number");
 		expect(figure).toHaveTextContent("boolean");
-		expect(figure).toHaveTextContent(
-			'"debug" | "info" | "warn" | "error"',
-		);
+		expect(figure).toHaveTextContent('"debug" | "info" | "warn" | "error"');
 	});
 
 	it("renders mobile direct single-wire elements and carrier tokens in the markup", () => {

--- a/apps/www/components/page/declarative-showcase.test.tsx
+++ b/apps/www/components/page/declarative-showcase.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { DeclarativeShowcase } from "./declarative-showcase";
 
 describe("DeclarativeShowcase", () => {
-	it("renders the 2-row alternating payload pipeline with true/false debug toggles", () => {
+	it("renders the 3-row alternating payload pipeline with enum NODE_ENV row", () => {
 		render(<DeclarativeShowcase />);
 
 		expect(
@@ -17,6 +17,7 @@ describe("DeclarativeShowcase", () => {
 		// Static keys
 		expect(figure).toHaveTextContent("PORT=");
 		expect(figure).toHaveTextContent("DEBUG=");
+		expect(figure).toHaveTextContent("NODE_ENV=");
 
 		// Row 1 alternating chips ("3000" success vs "oops" failure)
 		expect(figure).toHaveTextContent('"3000"');
@@ -26,13 +27,23 @@ describe("DeclarativeShowcase", () => {
 		expect(figure).toHaveTextContent('"true"');
 		expect(figure).toHaveTextContent('"false"');
 
+		// Row 3 alternating chips ("production" vs "development")
+		expect(figure).toHaveTextContent('"production"');
+		expect(figure).toHaveTextContent('"development"');
+
 		// Schema Gates
 		expect(figure).toHaveTextContent('"number"');
 		expect(figure).toHaveTextContent('"boolean"');
+		expect(figure).toHaveTextContent(
+			"\"'development' | 'production' | 'test'\"",
+		);
 
 		// Destination Type Definitions
 		expect(figure).toHaveTextContent("number");
 		expect(figure).toHaveTextContent("boolean");
+		expect(figure).toHaveTextContent(
+			'"development" | "production" | "test"',
+		);
 	});
 
 	it("renders mobile direct single-wire elements and carrier tokens in the markup", () => {
@@ -41,7 +52,7 @@ describe("DeclarativeShowcase", () => {
 		const directWires = container.querySelectorAll(
 			".home-aurora__payload-wire--direct",
 		);
-		expect(directWires).toHaveLength(2);
+		expect(directWires).toHaveLength(3);
 
 		const portCarrier = container.querySelector(
 			".home-aurora__payload-carrier--port",
@@ -63,5 +74,17 @@ describe("DeclarativeShowcase", () => {
 		expect(debugFalseCarrier).toBeInTheDocument();
 		expect(debugFalseCarrier).toHaveTextContent('"false"');
 		expect(debugFalseCarrier).toHaveTextContent("false");
+
+		const nodeenvProdCarrier = container.querySelector(
+			".home-aurora__payload-carrier--nodeenv-prod",
+		);
+		expect(nodeenvProdCarrier).toBeInTheDocument();
+		expect(nodeenvProdCarrier).toHaveTextContent('"production"');
+
+		const nodeenvDevCarrier = container.querySelector(
+			".home-aurora__payload-carrier--nodeenv-dev",
+		);
+		expect(nodeenvDevCarrier).toBeInTheDocument();
+		expect(nodeenvDevCarrier).toHaveTextContent('"development"');
 	});
 });

--- a/apps/www/components/page/declarative-showcase.tsx
+++ b/apps/www/components/page/declarative-showcase.tsx
@@ -1,8 +1,9 @@
 /**
  * Automatic coercion showcase.
- * Minimalist 2-row Payload Pipeline:
+ * Minimalist 3-row Payload Pipeline:
  * - Row 1 (PORT=): Alternates between valid ("3000" -> 3000 number) and invalid ("oops" -> stuck at "number" -> error).
  * - Row 2 (DEBUG=): Alternates between true ("true" -> true boolean) and false ("false" -> false boolean).
+ * - Row 3 (NODE_ENV=): Alternates between "production" and "development" enum members.
  */
 export function DeclarativeShowcase() {
 	return (
@@ -252,6 +253,127 @@ export function DeclarativeShowcase() {
 						{/* Right destination dock */}
 						<div className="home-aurora__payload-col home-aurora__payload-col--right">
 							<code className="home-aurora__payload-dock">boolean</code>
+						</div>
+					</div>
+
+					{/* Row 3: NODE_ENV= (alternates between "production" and "development" enum members) */}
+					<div className="home-aurora__payload-row home-aurora__payload-row--nodeenv">
+						{/* Left static key */}
+						<div className="home-aurora__payload-col home-aurora__payload-col--left">
+							<span className="home-aurora__payload-key">NODE_ENV=</span>
+						</div>
+
+						{/* Mobile: Direct Wire (single track without middle gate) */}
+						<div
+							className="home-aurora__payload-wire home-aurora__payload-wire--direct"
+							aria-hidden="true"
+						>
+							<svg
+								className="home-aurora__stream-wire-svg"
+								viewBox="0 0 100 20"
+								preserveAspectRatio="none"
+								aria-hidden="true"
+							>
+								<line
+									x1="0"
+									y1="10"
+									x2="92"
+									y2="10"
+									className="home-aurora__stream-wire-track"
+								/>
+								<polygon
+									points="90,7 98,10 90,13"
+									className="home-aurora__stream-arrow"
+								/>
+							</svg>
+							<div className="home-aurora__payload-carrier home-aurora__payload-carrier--nodeenv-prod">
+								<span className="home-aurora__payload-val home-aurora__payload-val--raw">
+									&quot;production&quot;
+								</span>
+								<span className="home-aurora__payload-val home-aurora__payload-val--coerced">
+									&quot;production&quot;
+								</span>
+							</div>
+							<div className="home-aurora__payload-carrier home-aurora__payload-carrier--nodeenv-dev">
+								<span className="home-aurora__payload-val home-aurora__payload-val--raw">
+									&quot;development&quot;
+								</span>
+								<span className="home-aurora__payload-val home-aurora__payload-val--coerced">
+									&quot;development&quot;
+								</span>
+							</div>
+						</div>
+
+						{/* Wire 1 */}
+						<div
+							className="home-aurora__payload-wire home-aurora__payload-wire--1"
+							aria-hidden="true"
+						>
+							<svg
+								className="home-aurora__stream-wire-svg"
+								viewBox="0 0 100 20"
+								preserveAspectRatio="none"
+								aria-hidden="true"
+							>
+								<line
+									x1="0"
+									y1="10"
+									x2="100"
+									y2="10"
+									className="home-aurora__stream-wire-track"
+								/>
+							</svg>
+							<span className="home-aurora__payload-chip home-aurora__payload-chip--nodeenv-prod">
+								&quot;production&quot;
+							</span>
+							<span className="home-aurora__payload-chip home-aurora__payload-chip--nodeenv-dev">
+								&quot;development&quot;
+							</span>
+						</div>
+
+						{/* Center Schema Gate */}
+						<div className="home-aurora__payload-gate">
+							<code className="home-aurora__payload-schema">
+								&quot;&apos;development&apos; | &apos;production&apos; | &apos;test&apos;&quot;
+							</code>
+						</div>
+
+						{/* Wire 2 */}
+						<div
+							className="home-aurora__payload-wire home-aurora__payload-wire--2"
+							aria-hidden="true"
+						>
+							<svg
+								className="home-aurora__stream-wire-svg"
+								viewBox="0 0 100 20"
+								preserveAspectRatio="none"
+								aria-hidden="true"
+							>
+								<line
+									x1="0"
+									y1="10"
+									x2="92"
+									y2="10"
+									className="home-aurora__stream-wire-track"
+								/>
+								<polygon
+									points="90,7 98,10 90,13"
+									className="home-aurora__stream-arrow"
+								/>
+							</svg>
+							<span className="home-aurora__payload-chip home-aurora__payload-chip--nodeenv-prod-coerced">
+								&quot;production&quot;
+							</span>
+							<span className="home-aurora__payload-chip home-aurora__payload-chip--nodeenv-dev-coerced">
+								&quot;development&quot;
+							</span>
+						</div>
+
+						{/* Right destination dock */}
+						<div className="home-aurora__payload-col home-aurora__payload-col--right">
+							<code className="home-aurora__payload-dock">
+								&quot;development&quot; | &quot;production&quot; | &quot;test&quot;
+							</code>
 						</div>
 					</div>
 				</div>

--- a/apps/www/components/page/declarative-showcase.tsx
+++ b/apps/www/components/page/declarative-showcase.tsx
@@ -3,7 +3,7 @@
  * Minimalist 3-row Payload Pipeline:
  * - Row 1 (PORT=): Alternates between valid ("3000" -> 3000 number) and invalid ("oops" -> stuck at "number" -> error).
  * - Row 2 (DEBUG=): Alternates between true ("true" -> true boolean) and false ("false" -> false boolean).
- * - Row 3 (LOG_LEVEL=): Alternates between "info" and "debug" enum members.
+ * - Row 3 (THEME=): Alternates between "light" and "dark" enum members.
  */
 export function DeclarativeShowcase() {
 	return (
@@ -256,11 +256,11 @@ export function DeclarativeShowcase() {
 						</div>
 					</div>
 
-					{/* Row 3: LOG_LEVEL= (alternates between "info" and "debug" enum members) */}
-					<div className="home-aurora__payload-row home-aurora__payload-row--loglevel">
+					{/* Row 3: THEME= (alternates between "light" and "dark" enum members) */}
+					<div className="home-aurora__payload-row home-aurora__payload-row--theme">
 						{/* Left static key */}
 						<div className="home-aurora__payload-col home-aurora__payload-col--left">
-							<span className="home-aurora__payload-key">LOG_LEVEL=</span>
+							<span className="home-aurora__payload-key">THEME=</span>
 						</div>
 
 						{/* Mobile: Direct Wire (single track without middle gate) */}
@@ -286,20 +286,20 @@ export function DeclarativeShowcase() {
 									className="home-aurora__stream-arrow"
 								/>
 							</svg>
-							<div className="home-aurora__payload-carrier home-aurora__payload-carrier--loglevel-info">
+							<div className="home-aurora__payload-carrier home-aurora__payload-carrier--theme-light">
 								<span className="home-aurora__payload-val home-aurora__payload-val--raw">
-									&quot;info&quot;
+									&quot;light&quot;
 								</span>
 								<span className="home-aurora__payload-val home-aurora__payload-val--coerced">
-									&quot;info&quot;
+									&quot;light&quot;
 								</span>
 							</div>
-							<div className="home-aurora__payload-carrier home-aurora__payload-carrier--loglevel-debug">
+							<div className="home-aurora__payload-carrier home-aurora__payload-carrier--theme-dark">
 								<span className="home-aurora__payload-val home-aurora__payload-val--raw">
-									&quot;debug&quot;
+									&quot;dark&quot;
 								</span>
 								<span className="home-aurora__payload-val home-aurora__payload-val--coerced">
-									&quot;debug&quot;
+									&quot;dark&quot;
 								</span>
 							</div>
 						</div>
@@ -323,19 +323,18 @@ export function DeclarativeShowcase() {
 									className="home-aurora__stream-wire-track"
 								/>
 							</svg>
-							<span className="home-aurora__payload-chip home-aurora__payload-chip--loglevel-info">
-								&quot;info&quot;
+							<span className="home-aurora__payload-chip home-aurora__payload-chip--theme-light">
+								&quot;light&quot;
 							</span>
-							<span className="home-aurora__payload-chip home-aurora__payload-chip--loglevel-debug">
-								&quot;debug&quot;
+							<span className="home-aurora__payload-chip home-aurora__payload-chip--theme-dark">
+								&quot;dark&quot;
 							</span>
 						</div>
 
 						{/* Center Schema Gate */}
 						<div className="home-aurora__payload-gate">
 							<code className="home-aurora__payload-schema">
-								&quot;&apos;debug&apos; | &apos;info&apos; | &apos;warn&apos; |
-								&apos;error&apos;&quot;
+								&quot;&apos;light&apos; | &apos;dark&apos;&quot;
 							</code>
 						</div>
 
@@ -362,19 +361,18 @@ export function DeclarativeShowcase() {
 									className="home-aurora__stream-arrow"
 								/>
 							</svg>
-							<span className="home-aurora__payload-chip home-aurora__payload-chip--loglevel-info-coerced">
-								&quot;info&quot;
+							<span className="home-aurora__payload-chip home-aurora__payload-chip--theme-light-coerced">
+								&quot;light&quot;
 							</span>
-							<span className="home-aurora__payload-chip home-aurora__payload-chip--loglevel-debug-coerced">
-								&quot;debug&quot;
+							<span className="home-aurora__payload-chip home-aurora__payload-chip--theme-dark-coerced">
+								&quot;dark&quot;
 							</span>
 						</div>
 
 						{/* Right destination dock */}
 						<div className="home-aurora__payload-col home-aurora__payload-col--right">
 							<code className="home-aurora__payload-dock">
-								&quot;debug&quot; | &quot;info&quot; | &quot;warn&quot; |
-								&quot;error&quot;
+								&quot;light&quot; | &quot;dark&quot;
 							</code>
 						</div>
 					</div>

--- a/apps/www/components/page/declarative-showcase.tsx
+++ b/apps/www/components/page/declarative-showcase.tsx
@@ -334,7 +334,8 @@ export function DeclarativeShowcase() {
 						{/* Center Schema Gate */}
 						<div className="home-aurora__payload-gate">
 							<code className="home-aurora__payload-schema">
-								&quot;&apos;debug&apos; | &apos;info&apos; | &apos;warn&apos; | &apos;error&apos;&quot;
+								&quot;&apos;debug&apos; | &apos;info&apos; | &apos;warn&apos; |
+								&apos;error&apos;&quot;
 							</code>
 						</div>
 
@@ -372,7 +373,8 @@ export function DeclarativeShowcase() {
 						{/* Right destination dock */}
 						<div className="home-aurora__payload-col home-aurora__payload-col--right">
 							<code className="home-aurora__payload-dock">
-								&quot;debug&quot; | &quot;info&quot; | &quot;warn&quot; | &quot;error&quot;
+								&quot;debug&quot; | &quot;info&quot; | &quot;warn&quot; |
+								&quot;error&quot;
 							</code>
 						</div>
 					</div>

--- a/apps/www/components/page/declarative-showcase.tsx
+++ b/apps/www/components/page/declarative-showcase.tsx
@@ -3,7 +3,7 @@
  * Minimalist 3-row Payload Pipeline:
  * - Row 1 (PORT=): Alternates between valid ("3000" -> 3000 number) and invalid ("oops" -> stuck at "number" -> error).
  * - Row 2 (DEBUG=): Alternates between true ("true" -> true boolean) and false ("false" -> false boolean).
- * - Row 3 (NODE_ENV=): Alternates between "production" and "development" enum members.
+ * - Row 3 (LOG_LEVEL=): Alternates between "info" and "debug" enum members.
  */
 export function DeclarativeShowcase() {
 	return (
@@ -256,11 +256,11 @@ export function DeclarativeShowcase() {
 						</div>
 					</div>
 
-					{/* Row 3: NODE_ENV= (alternates between "production" and "development" enum members) */}
-					<div className="home-aurora__payload-row home-aurora__payload-row--nodeenv">
+					{/* Row 3: LOG_LEVEL= (alternates between "info" and "debug" enum members) */}
+					<div className="home-aurora__payload-row home-aurora__payload-row--loglevel">
 						{/* Left static key */}
 						<div className="home-aurora__payload-col home-aurora__payload-col--left">
-							<span className="home-aurora__payload-key">NODE_ENV=</span>
+							<span className="home-aurora__payload-key">LOG_LEVEL=</span>
 						</div>
 
 						{/* Mobile: Direct Wire (single track without middle gate) */}
@@ -286,20 +286,20 @@ export function DeclarativeShowcase() {
 									className="home-aurora__stream-arrow"
 								/>
 							</svg>
-							<div className="home-aurora__payload-carrier home-aurora__payload-carrier--nodeenv-prod">
+							<div className="home-aurora__payload-carrier home-aurora__payload-carrier--loglevel-info">
 								<span className="home-aurora__payload-val home-aurora__payload-val--raw">
-									&quot;production&quot;
+									&quot;info&quot;
 								</span>
 								<span className="home-aurora__payload-val home-aurora__payload-val--coerced">
-									&quot;production&quot;
+									&quot;info&quot;
 								</span>
 							</div>
-							<div className="home-aurora__payload-carrier home-aurora__payload-carrier--nodeenv-dev">
+							<div className="home-aurora__payload-carrier home-aurora__payload-carrier--loglevel-debug">
 								<span className="home-aurora__payload-val home-aurora__payload-val--raw">
-									&quot;development&quot;
+									&quot;debug&quot;
 								</span>
 								<span className="home-aurora__payload-val home-aurora__payload-val--coerced">
-									&quot;development&quot;
+									&quot;debug&quot;
 								</span>
 							</div>
 						</div>
@@ -323,18 +323,18 @@ export function DeclarativeShowcase() {
 									className="home-aurora__stream-wire-track"
 								/>
 							</svg>
-							<span className="home-aurora__payload-chip home-aurora__payload-chip--nodeenv-prod">
-								&quot;production&quot;
+							<span className="home-aurora__payload-chip home-aurora__payload-chip--loglevel-info">
+								&quot;info&quot;
 							</span>
-							<span className="home-aurora__payload-chip home-aurora__payload-chip--nodeenv-dev">
-								&quot;development&quot;
+							<span className="home-aurora__payload-chip home-aurora__payload-chip--loglevel-debug">
+								&quot;debug&quot;
 							</span>
 						</div>
 
 						{/* Center Schema Gate */}
 						<div className="home-aurora__payload-gate">
 							<code className="home-aurora__payload-schema">
-								&quot;&apos;development&apos; | &apos;production&apos; | &apos;test&apos;&quot;
+								&quot;&apos;debug&apos; | &apos;info&apos; | &apos;warn&apos; | &apos;error&apos;&quot;
 							</code>
 						</div>
 
@@ -361,18 +361,18 @@ export function DeclarativeShowcase() {
 									className="home-aurora__stream-arrow"
 								/>
 							</svg>
-							<span className="home-aurora__payload-chip home-aurora__payload-chip--nodeenv-prod-coerced">
-								&quot;production&quot;
+							<span className="home-aurora__payload-chip home-aurora__payload-chip--loglevel-info-coerced">
+								&quot;info&quot;
 							</span>
-							<span className="home-aurora__payload-chip home-aurora__payload-chip--nodeenv-dev-coerced">
-								&quot;development&quot;
+							<span className="home-aurora__payload-chip home-aurora__payload-chip--loglevel-debug-coerced">
+								&quot;debug&quot;
 							</span>
 						</div>
 
 						{/* Right destination dock */}
 						<div className="home-aurora__payload-col home-aurora__payload-col--right">
 							<code className="home-aurora__payload-dock">
-								&quot;development&quot; | &quot;production&quot; | &quot;test&quot;
+								&quot;debug&quot; | &quot;info&quot; | &quot;warn&quot; | &quot;error&quot;
 							</code>
 						</div>
 					</div>

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -43,7 +43,9 @@ describe("RuntimeBloatShowcase", () => {
 
 		expect(screen.getByTitle(HOST_MESSAGE)).toBeInTheDocument();
 		expect(screen.getByTitle(PORT_MESSAGE)).toBeInTheDocument();
-		expect(screen.queryByRole("button", { name: "Copy" })).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Copy" }),
+		).not.toBeInTheDocument();
 
 		expect(
 			screen.queryByRole("heading", { name: "Errors you can automate" }),

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -3,23 +3,22 @@ import { describe, expect, it } from "vitest";
 import { RuntimeBloatShowcase } from "./runtime-bloat-showcase";
 
 describe("RuntimeBloatShowcase", () => {
-	it("renders structured issues JSON instead of the edge bundle chart", () => {
+	it("renders automatable error JSON instead of the edge bundle chart", () => {
 		render(<RuntimeBloatShowcase />);
 
 		expect(
-			screen.getByRole("heading", { name: "Structured errors" }),
+			screen.getByRole("heading", { name: "Errors you can automate" }),
 		).toBeInTheDocument();
 
 		expect(
-			screen.getByText(/Each issue gets a code that CI and agents can act on/i),
+			screen.getByText(/Beautiful errors in the terminal/i),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(
-				/A missing key and a bad value aren't the same problem/i,
-			),
+			screen.getByText(/Structured JSON for CI and agents/i),
 		).toBeInTheDocument();
 
 		const figure = screen.getByRole("figure");
+		expect(figure).toHaveTextContent("$ arkenv check --json");
 		expect(figure).toHaveTextContent('"success": false');
 		expect(figure).toHaveTextContent("MISSING_VARIABLE");
 		expect(figure).toHaveTextContent("INVALID_TYPE");
@@ -27,18 +26,20 @@ describe("RuntimeBloatShowcase", () => {
 		expect(figure).toHaveTextContent('"path": "PORT"');
 		expect(figure).not.toHaveTextContent("received");
 		expect(figure).not.toHaveTextContent("DATABASE_URL");
-		expect(figure).not.toHaveTextContent("$ arkenv check --json");
 
-		expect(
-			screen.queryByRole("heading", { name: "Errors you can automate" }),
-		).not.toBeInTheDocument();
-		expect(
-			screen.queryByText(/Beautiful errors in the terminal/i),
-		).not.toBeInTheDocument();
-		expect(screen.queryByText(/Same codes as/i)).not.toBeInTheDocument();
-		expect(screen.queryByText(/add it to/i)).not.toBeInTheDocument();
+		expect(screen.getByText(/add it to/i)).toBeInTheDocument();
+		expect(screen.getByText(/fix the value/i)).toBeInTheDocument();
+
 		expect(
 			screen.queryByRole("heading", { name: "Optimized for the edge" }),
 		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("heading", { name: "Structured errors" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(/50% smaller core than T3 Env/i),
+		).not.toBeInTheDocument();
+		expect(screen.queryByText(/varlock/i)).not.toBeInTheDocument();
+		expect(screen.queryByText("@arkenv/standard")).not.toBeInTheDocument();
 	});
 });

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -2,6 +2,9 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { RuntimeBloatShowcase } from "./runtime-bloat-showcase";
 
+const HOST_MESSAGE = 'must be a string or "localhost" (was missing)';
+const PORT_MESSAGE = "must be a number (was a string)";
+
 describe("RuntimeBloatShowcase", () => {
 	it("renders structured issues JSON instead of the edge bundle chart", () => {
 		render(<RuntimeBloatShowcase />);
@@ -19,17 +22,27 @@ describe("RuntimeBloatShowcase", () => {
 			screen.getByText(/Missing keys and bad values aren't the same/i),
 		).toBeInTheDocument();
 
+		expect(screen.getByText("{ safe: true }")).toBeInTheDocument();
+
 		const figure = screen.getByRole("figure");
+		expect(figure).toHaveTextContent('"success": false');
 		expect(figure).toHaveTextContent('"issues"');
 		expect(figure).toHaveTextContent("MISSING_VARIABLE");
 		expect(figure).toHaveTextContent("INVALID_TYPE");
 		expect(figure).toHaveTextContent('"path": "HOST"');
 		expect(figure).toHaveTextContent('"path": "PORT"');
-		expect(figure).not.toHaveTextContent("success");
-		expect(figure).not.toHaveTextContent("message");
+		expect(figure).toHaveTextContent('"message"');
+		expect(figure).toHaveTextContent("…");
+		expect(figure).not.toHaveTextContent(HOST_MESSAGE);
+		expect(figure).not.toHaveTextContent(PORT_MESSAGE);
 		expect(figure).not.toHaveTextContent("received");
 		expect(figure).not.toHaveTextContent("DATABASE_URL");
 		expect(figure).not.toHaveTextContent("$ arkenv check --json");
+		expect(figure).not.toHaveTextContent("ok");
+
+		expect(screen.getByTitle(HOST_MESSAGE)).toBeInTheDocument();
+		expect(screen.getByTitle(PORT_MESSAGE)).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
 
 		expect(
 			screen.queryByRole("heading", { name: "Errors you can automate" }),

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -1,13 +1,23 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RuntimeBloatShowcase } from "./runtime-bloat-showcase";
 
 const HOST_MESSAGE = 'must be a string or "localhost" (was missing)';
 const PORT_MESSAGE = "must be a number (was a string)";
 
+const useIsMobile = vi.fn(() => false);
+
+vi.mock("~/hooks/use-is-mobile", () => ({
+	useIsMobile: () => useIsMobile(),
+}));
+
 describe("RuntimeBloatShowcase", () => {
-	it("renders structured issues JSON instead of the edge bundle chart", () => {
+	beforeEach(() => {
+		useIsMobile.mockReturnValue(false);
+	});
+
+	it("renders compact JSON with hover … triggers on desktop", () => {
 		render(<RuntimeBloatShowcase />);
 
 		expect(
@@ -25,6 +35,7 @@ describe("RuntimeBloatShowcase", () => {
 		expect(screen.getByText("json")).toBeInTheDocument();
 
 		const figure = screen.getByRole("figure");
+		expect(figure).toHaveAttribute("data-layout", "compact");
 		expect(figure).toHaveTextContent('"success": false');
 		expect(figure).toHaveTextContent('"issues"');
 		expect(figure).toHaveTextContent("MISSING_VARIABLE");
@@ -33,8 +44,8 @@ describe("RuntimeBloatShowcase", () => {
 		expect(figure).toHaveTextContent('"path": "PORT"');
 		expect(figure).toHaveTextContent('"message"');
 		expect(figure).toHaveTextContent("…");
-		// stacked fields: each key on its own line in the source string
-		expect(figure).toHaveTextContent(/\{\s*"path": "HOST"/);
+		// compact: issue object stays on one visual line (path after brace+space)
+		expect(figure).toHaveTextContent('{ "path": "HOST"');
 		expect(figure).not.toHaveTextContent(HOST_MESSAGE);
 		expect(figure).not.toHaveTextContent(PORT_MESSAGE);
 		expect(figure).not.toHaveTextContent("received");
@@ -65,7 +76,17 @@ describe("RuntimeBloatShowcase", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("opens the full issue message on tap/click of …", async () => {
+	it("renders stacked JSON on mobile", () => {
+		useIsMobile.mockReturnValue(true);
+		render(<RuntimeBloatShowcase />);
+
+		const figure = screen.getByRole("figure");
+		expect(figure).toHaveAttribute("data-layout", "stacked");
+		expect(figure).toHaveTextContent(/\{\s*"path": "HOST"/);
+	});
+
+	it("opens the full issue message on tap of … on mobile", async () => {
+		useIsMobile.mockReturnValue(true);
 		const user = userEvent.setup();
 		render(<RuntimeBloatShowcase />);
 
@@ -73,5 +94,15 @@ describe("RuntimeBloatShowcase", () => {
 			screen.getByRole("button", { name: `Full message: ${HOST_MESSAGE}` }),
 		);
 		expect(await screen.findByText(HOST_MESSAGE)).toBeInTheDocument();
+	});
+
+	it("shows the full issue message on hover of … on desktop", async () => {
+		const user = userEvent.setup();
+		render(<RuntimeBloatShowcase />);
+
+		await user.hover(
+			screen.getByRole("button", { name: `Full message: ${HOST_MESSAGE}` }),
+		);
+		expect(await screen.findByRole("tooltip")).toHaveTextContent(HOST_MESSAGE);
 	});
 });

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -3,21 +3,22 @@ import { describe, expect, it } from "vitest";
 import { RuntimeBloatShowcase } from "./runtime-bloat-showcase";
 
 describe("RuntimeBloatShowcase", () => {
-	it("renders structured issues JSON instead of the edge bundle chart", () => {
+	it("renders automatable error JSON instead of the edge bundle chart", () => {
 		render(<RuntimeBloatShowcase />);
 
 		expect(
-			screen.getByRole("heading", { name: "Structured errors" }),
+			screen.getByRole("heading", { name: "Errors you can automate" }),
 		).toBeInTheDocument();
 
 		expect(
-			screen.getByText(/Each issue gets a code CI and agents can act on/i),
+			screen.getByText(/Beautiful errors in the terminal/i),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(/Missing isn't the same fix as a bad value/i),
+			screen.getByText(/Structured JSON for CI and agents/i),
 		).toBeInTheDocument();
 
 		const figure = screen.getByRole("figure");
+		expect(figure).toHaveTextContent("$ arkenv check --json");
 		expect(figure).toHaveTextContent('"success": false');
 		expect(figure).toHaveTextContent("MISSING_VARIABLE");
 		expect(figure).toHaveTextContent("INVALID_TYPE");
@@ -25,18 +26,15 @@ describe("RuntimeBloatShowcase", () => {
 		expect(figure).toHaveTextContent('"path": "PORT"');
 		expect(figure).not.toHaveTextContent("received");
 		expect(figure).not.toHaveTextContent("DATABASE_URL");
-		expect(figure).not.toHaveTextContent("$ arkenv check --json");
+
+		expect(screen.getByText(/add it to/i)).toBeInTheDocument();
+		expect(screen.getByText(/fix the value/i)).toBeInTheDocument();
 
 		expect(
-			screen.queryByRole("heading", { name: "Errors you can automate" }),
-		).not.toBeInTheDocument();
-		expect(
-			screen.queryByText(/Beautiful errors in the terminal/i),
-		).not.toBeInTheDocument();
-		expect(screen.queryByText(/Same codes as/i)).not.toBeInTheDocument();
-		expect(screen.queryByText(/add it to/i)).not.toBeInTheDocument();
-		expect(
 			screen.queryByRole("heading", { name: "Optimized for the edge" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("heading", { name: "Structured errors" }),
 		).not.toBeInTheDocument();
 		expect(
 			screen.queryByText(/50% smaller core than T3 Env/i),

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { RuntimeBloatShowcase } from "./runtime-bloat-showcase";
 
@@ -32,6 +33,8 @@ describe("RuntimeBloatShowcase", () => {
 		expect(figure).toHaveTextContent('"path": "PORT"');
 		expect(figure).toHaveTextContent('"message"');
 		expect(figure).toHaveTextContent("…");
+		// stacked fields: each key on its own line in the source string
+		expect(figure).toHaveTextContent(/\{\s*"path": "HOST"/);
 		expect(figure).not.toHaveTextContent(HOST_MESSAGE);
 		expect(figure).not.toHaveTextContent(PORT_MESSAGE);
 		expect(figure).not.toHaveTextContent("received");
@@ -39,8 +42,12 @@ describe("RuntimeBloatShowcase", () => {
 		expect(figure).not.toHaveTextContent("$ arkenv check --json");
 		expect(figure).not.toHaveClass("home-aurora__terminal");
 
-		expect(screen.getByTitle(HOST_MESSAGE)).toBeInTheDocument();
-		expect(screen.getByTitle(PORT_MESSAGE)).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: `Full message: ${HOST_MESSAGE}` }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: `Full message: ${PORT_MESSAGE}` }),
+		).toBeInTheDocument();
 		expect(
 			screen.queryByRole("button", { name: "Copy" }),
 		).not.toBeInTheDocument();
@@ -56,5 +63,15 @@ describe("RuntimeBloatShowcase", () => {
 		expect(
 			screen.queryByRole("heading", { name: "Optimized for the edge" }),
 		).not.toBeInTheDocument();
+	});
+
+	it("opens the full issue message on tap/click of …", async () => {
+		const user = userEvent.setup();
+		render(<RuntimeBloatShowcase />);
+
+		await user.click(
+			screen.getByRole("button", { name: `Full message: ${HOST_MESSAGE}` }),
+		);
+		expect(await screen.findByText(HOST_MESSAGE)).toBeInTheDocument();
 	});
 });

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -3,22 +3,21 @@ import { describe, expect, it } from "vitest";
 import { RuntimeBloatShowcase } from "./runtime-bloat-showcase";
 
 describe("RuntimeBloatShowcase", () => {
-	it("renders automatable error JSON instead of the edge bundle chart", () => {
+	it("renders structured issues JSON instead of the edge bundle chart", () => {
 		render(<RuntimeBloatShowcase />);
 
 		expect(
-			screen.getByRole("heading", { name: "Errors you can automate" }),
+			screen.getByRole("heading", { name: "Structured errors" }),
 		).toBeInTheDocument();
 
 		expect(
-			screen.getByText(/Beautiful errors in the terminal/i),
+			screen.getByText(/Each issue gets a code CI and agents can act on/i),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(/Structured JSON for CI and agents/i),
+			screen.getByText(/Missing isn't the same fix as a bad value/i),
 		).toBeInTheDocument();
 
 		const figure = screen.getByRole("figure");
-		expect(figure).toHaveTextContent("$ arkenv check --json");
 		expect(figure).toHaveTextContent('"success": false');
 		expect(figure).toHaveTextContent("MISSING_VARIABLE");
 		expect(figure).toHaveTextContent("INVALID_TYPE");
@@ -26,11 +25,16 @@ describe("RuntimeBloatShowcase", () => {
 		expect(figure).toHaveTextContent('"path": "PORT"');
 		expect(figure).not.toHaveTextContent("received");
 		expect(figure).not.toHaveTextContent("DATABASE_URL");
+		expect(figure).not.toHaveTextContent("$ arkenv check --json");
 
-		expect(screen.getByText(/add it to/i)).toBeInTheDocument();
-		expect(screen.getByText(/fix the value/i)).toBeInTheDocument();
+		expect(
+			screen.queryByRole("heading", { name: "Errors you can automate" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(/Beautiful errors in the terminal/i),
+		).not.toBeInTheDocument();
 		expect(screen.queryByText(/Same codes as/i)).not.toBeInTheDocument();
-
+		expect(screen.queryByText(/add it to/i)).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole("heading", { name: "Optimized for the edge" }),
 		).not.toBeInTheDocument();
@@ -39,10 +43,5 @@ describe("RuntimeBloatShowcase", () => {
 		).not.toBeInTheDocument();
 		expect(screen.queryByText(/varlock/i)).not.toBeInTheDocument();
 		expect(screen.queryByText("@arkenv/standard")).not.toBeInTheDocument();
-		expect(
-			screen.queryByRole("figure", {
-				name: /production runtime bundle size comparison/i,
-			}),
-		).not.toBeInTheDocument();
 	});
 });

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -11,12 +11,12 @@ describe("RuntimeBloatShowcase", () => {
 		).toBeInTheDocument();
 
 		expect(
-			screen.getByText(/Each issue gets a code that CI and agents can act on/i),
+			screen.getByText(
+				/Each issue gets an error code agents and CI can act on/i,
+			),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(
-				/A missing key and a bad value aren't the same problem/i,
-			),
+			screen.getByText(/Missing keys and bad values aren't the same/i),
 		).toBeInTheDocument();
 
 		const figure = screen.getByRole("figure");

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -3,22 +3,21 @@ import { describe, expect, it } from "vitest";
 import { RuntimeBloatShowcase } from "./runtime-bloat-showcase";
 
 describe("RuntimeBloatShowcase", () => {
-	it("renders automatable error JSON instead of the edge bundle chart", () => {
+	it("renders structured issues JSON instead of the edge bundle chart", () => {
 		render(<RuntimeBloatShowcase />);
 
 		expect(
-			screen.getByRole("heading", { name: "Errors you can automate" }),
+			screen.getByRole("heading", { name: "Structured errors" }),
 		).toBeInTheDocument();
 
 		expect(
-			screen.getByText(/Beautiful errors in the terminal/i),
+			screen.getByText(/Each issue gets a code that CI and agents can act on/i),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(/Structured JSON for CI and agents/i),
+			screen.getByText(/A missing key and a bad value aren't the same problem/i),
 		).toBeInTheDocument();
 
 		const figure = screen.getByRole("figure");
-		expect(figure).toHaveTextContent("$ arkenv check --json");
 		expect(figure).toHaveTextContent('"success": false');
 		expect(figure).toHaveTextContent("MISSING_VARIABLE");
 		expect(figure).toHaveTextContent("INVALID_TYPE");
@@ -26,20 +25,18 @@ describe("RuntimeBloatShowcase", () => {
 		expect(figure).toHaveTextContent('"path": "PORT"');
 		expect(figure).not.toHaveTextContent("received");
 		expect(figure).not.toHaveTextContent("DATABASE_URL");
+		expect(figure).not.toHaveTextContent("$ arkenv check --json");
 
-		expect(screen.getByText(/add it to/i)).toBeInTheDocument();
-		expect(screen.getByText(/fix the value/i)).toBeInTheDocument();
-
+		expect(
+			screen.queryByRole("heading", { name: "Errors you can automate" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(/Beautiful errors in the terminal/i),
+		).not.toBeInTheDocument();
+		expect(screen.queryByText(/Same codes as/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/add it to/i)).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole("heading", { name: "Optimized for the edge" }),
 		).not.toBeInTheDocument();
-		expect(
-			screen.queryByRole("heading", { name: "Structured errors" }),
-		).not.toBeInTheDocument();
-		expect(
-			screen.queryByText(/50% smaller core than T3 Env/i),
-		).not.toBeInTheDocument();
-		expect(screen.queryByText(/varlock/i)).not.toBeInTheDocument();
-		expect(screen.queryByText("@arkenv/standard")).not.toBeInTheDocument();
 	});
 });

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -15,14 +15,15 @@ describe("RuntimeBloatShowcase", () => {
 
 		expect(
 			screen.getByText(
-				/Each issue gets an error code that agents and CI can act on/i,
+				/Each issue gets a code that agents and CI can act on/i,
 			),
 		).toBeInTheDocument();
 		expect(
 			screen.getByText(/Missing keys and bad values aren't the same/i),
 		).toBeInTheDocument();
 
-		expect(screen.getByText("{ safe: true }")).toBeInTheDocument();
+		expect(screen.queryByText("{ safe: true }")).not.toBeInTheDocument();
+		expect(screen.getByText("json")).toBeInTheDocument();
 
 		const figure = screen.getByRole("figure");
 		expect(figure).toHaveTextContent('"success": false');
@@ -38,11 +39,11 @@ describe("RuntimeBloatShowcase", () => {
 		expect(figure).not.toHaveTextContent("received");
 		expect(figure).not.toHaveTextContent("DATABASE_URL");
 		expect(figure).not.toHaveTextContent("$ arkenv check --json");
-		expect(figure).not.toHaveTextContent("ok");
+		expect(figure).not.toHaveClass("home-aurora__terminal");
 
 		expect(screen.getByTitle(HOST_MESSAGE)).toBeInTheDocument();
 		expect(screen.getByTitle(PORT_MESSAGE)).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Copy" })).not.toBeInTheDocument();
 
 		expect(
 			screen.queryByRole("heading", { name: "Errors you can automate" }),

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -17,9 +17,7 @@ describe("RuntimeBloatShowcase", () => {
 			screen.getByText(/Structured JSON for CI and agents/i),
 		).toBeInTheDocument();
 
-		const figure = screen.getByRole("img", {
-			name: /arkenv check --json/i,
-		});
+		const figure = screen.getByRole("figure");
 		expect(figure).toHaveTextContent("$ arkenv check --json");
 		expect(figure).toHaveTextContent('"success": false');
 		expect(figure).toHaveTextContent("MISSING_VARIABLE");
@@ -31,7 +29,9 @@ describe("RuntimeBloatShowcase", () => {
 
 		expect(screen.getByText(/add it to/i)).toBeInTheDocument();
 		expect(screen.getByText(/fix the value/i)).toBeInTheDocument();
-		expect(screen.getByText(/Same codes as/i)).toBeInTheDocument();
+		expect(
+			screen.queryByText(/Same codes as/i),
+		).not.toBeInTheDocument();
 
 		expect(
 			screen.queryByRole("heading", { name: "Optimized for the edge" }),

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -12,7 +12,7 @@ describe("RuntimeBloatShowcase", () => {
 
 		expect(
 			screen.getByText(
-				/Each issue gets an error code agents and CI can act on/i,
+				/Each issue gets an error code that agents and CI can act on/i,
 			),
 		).toBeInTheDocument();
 		expect(
@@ -20,11 +20,13 @@ describe("RuntimeBloatShowcase", () => {
 		).toBeInTheDocument();
 
 		const figure = screen.getByRole("figure");
-		expect(figure).toHaveTextContent('"success": false');
+		expect(figure).toHaveTextContent('"issues"');
 		expect(figure).toHaveTextContent("MISSING_VARIABLE");
 		expect(figure).toHaveTextContent("INVALID_TYPE");
 		expect(figure).toHaveTextContent('"path": "HOST"');
 		expect(figure).toHaveTextContent('"path": "PORT"');
+		expect(figure).not.toHaveTextContent("success");
+		expect(figure).not.toHaveTextContent("message");
 		expect(figure).not.toHaveTextContent("received");
 		expect(figure).not.toHaveTextContent("DATABASE_URL");
 		expect(figure).not.toHaveTextContent("$ arkenv check --json");

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -29,9 +29,7 @@ describe("RuntimeBloatShowcase", () => {
 
 		expect(screen.getByText(/add it to/i)).toBeInTheDocument();
 		expect(screen.getByText(/fix the value/i)).toBeInTheDocument();
-		expect(
-			screen.queryByText(/Same codes as/i),
-		).not.toBeInTheDocument();
+		expect(screen.queryByText(/Same codes as/i)).not.toBeInTheDocument();
 
 		expect(
 			screen.queryByRole("heading", { name: "Optimized for the edge" }),

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -3,45 +3,48 @@ import { describe, expect, it } from "vitest";
 import { RuntimeBloatShowcase } from "./runtime-bloat-showcase";
 
 describe("RuntimeBloatShowcase", () => {
-	it("renders the Optimized for the edge heading and comparison copy", () => {
+	it("renders automatable error JSON instead of the edge bundle chart", () => {
 		render(<RuntimeBloatShowcase />);
 
 		expect(
-			screen.getByRole("heading", { name: "Optimized for the edge" }),
+			screen.getByRole("heading", { name: "Errors you can automate" }),
 		).toBeInTheDocument();
 
 		expect(
-			screen.getByText(/50% smaller core than T3 Env/i),
+			screen.getByText(/Beautiful errors in the terminal/i),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(/All engines under 10 kB for strict edge deployments/i),
+			screen.getByText(/Structured JSON for CI and agents/i),
 		).toBeInTheDocument();
 
-		const figure = screen.getByRole("figure", {
-			name: /production runtime bundle size comparison/i,
+		const figure = screen.getByRole("img", {
+			name: /arkenv check --json/i,
 		});
-		expect(figure).toHaveTextContent("@arkenv/standard");
-		expect(figure).toHaveTextContent("1.5 kB");
-		expect(figure).toHaveTextContent("@arkenv/core");
-		expect(figure).toHaveTextContent("7.4 kB");
-		expect(figure).toHaveTextContent("@t3-oss/env-core");
-		expect(figure).toHaveTextContent("14.2 kB");
-		expect(figure).toHaveTextContent("varlock");
-		expect(figure).toHaveTextContent("28.4 kB");
+		expect(figure).toHaveTextContent("$ arkenv check --json");
+		expect(figure).toHaveTextContent('"success": false');
+		expect(figure).toHaveTextContent("MISSING_VARIABLE");
+		expect(figure).toHaveTextContent("INVALID_TYPE");
+		expect(figure).toHaveTextContent('"path": "HOST"');
+		expect(figure).toHaveTextContent('"path": "PORT"');
+		expect(figure).not.toHaveTextContent("received");
+		expect(figure).not.toHaveTextContent("DATABASE_URL");
 
-		// Check npmx links
-		const links = screen.getAllByRole("link");
+		expect(screen.getByText(/add it to/i)).toBeInTheDocument();
+		expect(screen.getByText(/fix the value/i)).toBeInTheDocument();
+		expect(screen.getByText(/Same codes as/i)).toBeInTheDocument();
+
 		expect(
-			links.some(
-				(l) => l.getAttribute("href") === "https://npmx.dev/package/varlock",
-			),
-		).toBe(true);
+			screen.queryByRole("heading", { name: "Optimized for the edge" }),
+		).not.toBeInTheDocument();
 		expect(
-			links.some(
-				(l) =>
-					l.getAttribute("href") ===
-					"https://npmx.dev/package/@arkenv/standard",
-			),
-		).toBe(true);
+			screen.queryByText(/50% smaller core than T3 Env/i),
+		).not.toBeInTheDocument();
+		expect(screen.queryByText(/varlock/i)).not.toBeInTheDocument();
+		expect(screen.queryByText("@arkenv/standard")).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("figure", {
+				name: /production runtime bundle size comparison/i,
+			}),
+		).not.toBeInTheDocument();
 	});
 });

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -14,7 +14,9 @@ describe("RuntimeBloatShowcase", () => {
 			screen.getByText(/Each issue gets a code that CI and agents can act on/i),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(/A missing key and a bad value aren't the same problem/i),
+			screen.getByText(
+				/A missing key and a bad value aren't the same problem/i,
+			),
 		).toBeInTheDocument();
 
 		const figure = screen.getByRole("figure");

--- a/apps/www/components/page/runtime-bloat-showcase.test.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.test.tsx
@@ -14,9 +14,7 @@ describe("RuntimeBloatShowcase", () => {
 		).toBeInTheDocument();
 
 		expect(
-			screen.getByText(
-				/Each issue gets a code that agents and CI can act on/i,
-			),
+			screen.getByText(/Each issue gets a code that agents and CI can act on/i),
 		).toBeInTheDocument();
 		expect(
 			screen.getByText(/Missing keys and bad values aren't the same/i),

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -24,8 +24,8 @@ export function RuntimeBloatShowcase() {
 					Structured errors
 				</h2>
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
-					Each issue gets a code that agents and CI can act on. Missing keys
-					and bad values aren&apos;t the same.
+					Each issue gets a code that agents and CI can act on. Missing keys and
+					bad values aren&apos;t the same.
 				</p>
 			</header>
 
@@ -40,7 +40,9 @@ export function RuntimeBloatShowcase() {
 				</span>
 				<pre className="home-aurora__json-body home-aurora__tty--wrap">
 					<code>
-						{'{\n  "success": false,\n  "issues": [\n    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "'}
+						{
+							'{\n  "success": false,\n  "issues": [\n    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "'
+						}
 						<EllipsisMessage message={HOST_MESSAGE} />
 						{'" },\n    { "path": "PORT", "code": "INVALID_TYPE", "message": "'}
 						<EllipsisMessage message={PORT_MESSAGE} />

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -1,17 +1,9 @@
 const HOST_MESSAGE = 'must be a string or "localhost" (was missing)';
 const PORT_MESSAGE = "must be a number (was a string)";
 
-const PROOF_JSON = `{
-  "success": false,
-  "issues": [
-    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "${HOST_MESSAGE}" },
-    { "path": "PORT", "code": "INVALID_TYPE", "message": "${PORT_MESSAGE}" }
-  ]
-}`;
-
 function EllipsisMessage({ message }: { message: string }) {
 	return (
-		<span className="home-aurora__json-ellipsis" title={message} tabIndex={0}>
+		<span className="home-aurora__json-ellipsis" title={message}>
 			…
 		</span>
 	);

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -1,5 +1,3 @@
-import { WindowChrome } from "./window-chrome";
-
 const HOST_MESSAGE = 'must be a string or "localhost" (was missing)';
 const PORT_MESSAGE = "must be a number (was a string)";
 
@@ -34,19 +32,21 @@ export function RuntimeBloatShowcase() {
 					Structured errors
 				</h2>
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
-					Each issue gets an error code that agents and CI can act on. Missing
-					keys and bad values aren&apos;t the same.
+					Each issue gets a code that agents and CI can act on. Missing keys
+					and bad values aren&apos;t the same.
 				</p>
 			</header>
 
 			<figure
-				className="home-aurora__pitch-visual home-aurora__code-window home-aurora__terminal"
+				className="home-aurora__pitch-visual home-aurora__code-window home-aurora__json"
 				data-reveal
 				style={{ ["--reveal-delay" as string]: "140ms" }}
-				aria-label="Safe result JSON: HOST missing, PORT invalid type"
+				aria-label="JSON issues for HOST missing and PORT invalid type"
 			>
-				<WindowChrome title="{ safe: true }" copyText={PROOF_JSON} />
-				<pre className="home-aurora__tty home-aurora__tty--wrap">
+				<span className="home-aurora__json-lang" aria-hidden="true">
+					json
+				</span>
+				<pre className="home-aurora__json-body home-aurora__tty--wrap">
 					<code>
 						{'{\n  "success": false,\n  "issues": [\n    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "'}
 						<EllipsisMessage message={HOST_MESSAGE} />

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -29,8 +29,8 @@ export function RuntimeBloatShowcase() {
 					Structured errors
 				</h2>
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
-					Each issue gets a code that CI and agents can act on. A missing
-					key and a bad value aren&apos;t the same problem.
+					Each issue gets a code that CI and agents can act on. A missing key
+					and a bad value aren&apos;t the same problem.
 				</p>
 			</header>
 

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -4,8 +4,16 @@
 const PROOF_JSON = `{
   "success": false,
   "issues": [
-    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "must be a string or \\"localhost\\" (was missing)" },
-    { "path": "PORT", "code": "INVALID_TYPE", "message": "must be a number (was a string)" }
+    {
+      "path": "HOST",
+      "code": "MISSING_VARIABLE",
+      "message": "must be a string or \\"localhost\\" (was missing)"
+    },
+    {
+      "path": "PORT",
+      "code": "INVALID_TYPE",
+      "message": "must be a number (was a string)"
+    }
   ]
 }`;
 
@@ -18,10 +26,11 @@ export function RuntimeBloatShowcase() {
 		>
 			<header className="home-aurora__pitch-head">
 				<h2 id="home-errors" data-reveal="blur">
-					Errors you can automate
+					Structured errors
 				</h2>
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
-					Beautiful errors in the terminal. Structured JSON for CI and agents.
+					Each issue gets a code CI and agents can act on. Missing
+					isn&apos;t the same fix as a bad value.
 				</p>
 			</header>
 
@@ -30,26 +39,9 @@ export function RuntimeBloatShowcase() {
 				data-reveal
 				style={{ ["--reveal-delay" as string]: "140ms" }}
 			>
-				<pre className="home-aurora__tty">
-					<code>
-						<span
-							className="home-aurora__install-prompt-symbol"
-							aria-hidden="true"
-						>
-							{"$"}
-						</span>
-						{" arkenv check --json\n\n"}
-						{PROOF_JSON}
-					</code>
+				<pre className="home-aurora__tty home-aurora__tty--wrap">
+					<code>{PROOF_JSON}</code>
 				</pre>
-				<figcaption>
-					<code>HOST</code> <code>MISSING_VARIABLE</code>
-					{" → add it to "}
-					<code>.env</code>
-					{"; "}
-					<code>PORT</code> <code>INVALID_TYPE</code>
-					{" → fix the value, don't touch the schema."}
-				</figcaption>
 			</figure>
 		</section>
 	);

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -1,11 +1,35 @@
+"use client";
+
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "~/components/ui/popover";
+
 const HOST_MESSAGE = 'must be a string or "localhost" (was missing)';
 const PORT_MESSAGE = "must be a number (was a string)";
 
 function EllipsisMessage({ message }: { message: string }) {
 	return (
-		<span className="home-aurora__json-ellipsis" title={message}>
-			…
-		</span>
+		<Popover>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					className="home-aurora__json-ellipsis"
+					aria-label={`Full message: ${message}`}
+				>
+					…
+				</button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="start"
+				side="top"
+				collisionPadding={12}
+				className="home-aurora__json-ellipsis-tip min-w-0 max-w-[min(18rem,calc(100vw-1.5rem))] rounded-md border-fd-border bg-fd-popover p-2 text-xs leading-snug text-fd-popover-foreground shadow-md backdrop-blur-none"
+			>
+				{message}
+			</PopoverContent>
+		</Popover>
 	);
 }
 
@@ -41,12 +65,14 @@ export function RuntimeBloatShowcase() {
 				<pre className="home-aurora__json-body home-aurora__tty--wrap">
 					<code>
 						{
-							'{\n  "success": false,\n  "issues": [\n    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "'
+							'{\n  "success": false,\n  "issues": [\n    {\n      "path": "HOST",\n      "code": "MISSING_VARIABLE",\n      "message": "'
 						}
 						<EllipsisMessage message={HOST_MESSAGE} />
-						{'" },\n    { "path": "PORT", "code": "INVALID_TYPE", "message": "'}
+						{
+							'"\n    },\n    {\n      "path": "PORT",\n      "code": "INVALID_TYPE",\n      "message": "'
+						}
 						<EllipsisMessage message={PORT_MESSAGE} />
-						{'" }\n  ]\n}'}
+						{'"\n    }\n  ]\n}'}
 					</code>
 				</pre>
 			</figure>

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -1,90 +1,60 @@
-const BUNDLE_DATA = [
-	{
-		name: "@arkenv/standard",
-		size: "1.5 kB",
-		width: "8%",
-		tier: "primary",
-	},
-	{
-		name: "@arkenv/core",
-		size: "7.4 kB",
-		width: "28%",
-		tier: "secondary",
-	},
-	{
-		name: "@t3-oss/env-core",
-		size: "14.2 kB",
-		width: "52%",
-		tier: "competitor",
-	},
-	{
-		name: "varlock",
-		size: "28.4 kB",
-		width: "100%",
-		tier: "competitor",
-	},
-];
-
 /**
- * Performance & zero-runtime-bloat showcase with highlighted ArkEnv tiers
- * and muted dark neutral competitor bars.
+ * Machine-readable validation errors for CI and agents.
  */
+const PROOF_JSON = `{
+  "success": false,
+  "issues": [
+    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "must be a string or \\"localhost\\" (was missing)" },
+    { "path": "PORT", "code": "INVALID_TYPE", "message": "must be a number (was a string)" }
+  ]
+}`;
+
 export function RuntimeBloatShowcase() {
 	return (
 		<section
 			className="home-aurora__pitch"
-			aria-labelledby="home-bloat"
-			id="runtime-bloat"
+			aria-labelledby="home-errors"
+			id="errors"
 		>
 			<header className="home-aurora__pitch-head">
-				<h2 id="home-bloat" data-reveal="blur">
-					Optimized for the edge
+				<h2 id="home-errors" data-reveal="blur">
+					Errors you can automate
 				</h2>
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
-					50% smaller core than T3 Env. All engines under 10 kB for strict edge
-					deployments.
+					Beautiful errors in the terminal. Structured JSON for CI and agents.
+				</p>
+				<p data-reveal style={{ ["--reveal-delay" as string]: "100ms" }}>
+					<code>HOST</code> <code>MISSING_VARIABLE</code>
+					{" → add it to "}
+					<code>.env</code>
+					{"; "}
+					<code>PORT</code> <code>INVALID_TYPE</code>
+					{" → fix the value, don't touch the schema."}
+				</p>
+				<p data-reveal style={{ ["--reveal-delay" as string]: "120ms" }}>
+					Same codes as <code>arkenv check --json</code>.
 				</p>
 			</header>
 
 			<figure
-				className="home-aurora__pitch-visual home-aurora__telemetry"
+				className="home-aurora__pitch-visual home-aurora__code-window home-aurora__terminal"
 				data-reveal
 				style={{ ["--reveal-delay" as string]: "140ms" }}
-				aria-label="Production runtime bundle size comparison"
+				role="img"
+				aria-label="Terminal running arkenv check --json, then structured validation issues"
 			>
-				<div className="home-aurora__telemetry-body">
-					<div className="home-aurora__telemetry-list">
-						{BUNDLE_DATA.map((item) => (
-							<div
-								key={item.name}
-								className="home-aurora__telemetry-row"
-								data-tier={item.tier}
-							>
-								<div className="home-aurora__telemetry-track">
-									<div
-										className="home-aurora__telemetry-bar"
-										style={{ width: item.width }}
-										aria-hidden="true"
-									/>
-									<a
-										href={`https://npmx.dev/package/${item.name}`}
-										target="_blank"
-										rel="noopener noreferrer"
-										className="home-aurora__telemetry-link"
-										title={`View ${item.name} on npmx`}
-									>
-										<code className="home-aurora__telemetry-name">
-											{item.name}
-										</code>
-									</a>
-									<span className="home-aurora__telemetry-size">
-										{item.size}
-									</span>
-								</div>
-							</div>
-						))}
-					</div>
-				</div>
+				<pre className="home-aurora__tty">
+					<code>
+						<span
+							className="home-aurora__install-prompt-symbol"
+							aria-hidden="true"
+						>
+							{"$"}
+						</span>
+						{" arkenv check --json\n\n"}
+						{PROOF_JSON}
+					</code>
+				</pre>
 			</figure>
 		</section>
 	);

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -29,8 +29,8 @@ export function RuntimeBloatShowcase() {
 					Structured errors
 				</h2>
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
-					Each issue gets a code CI and agents can act on. Missing
-					isn&apos;t the same fix as a bad value.
+					Each issue gets a code CI and agents can act on. Missing isn&apos;t
+					the same fix as a bad value.
 				</p>
 			</header>
 

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -29,8 +29,8 @@ export function RuntimeBloatShowcase() {
 					Structured errors
 				</h2>
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
-					Each issue gets a code that CI and agents can act on. A missing key
-					and a bad value aren&apos;t the same problem.
+					Each issue gets an error code agents and CI can act on. Missing
+					keys and bad values aren&apos;t the same.
 				</p>
 			</header>
 

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -1,13 +1,27 @@
-/**
- * Machine-readable validation errors for CI and agents.
- */
+import { WindowChrome } from "./window-chrome";
+
+const HOST_MESSAGE = 'must be a string or "localhost" (was missing)';
+const PORT_MESSAGE = "must be a number (was a string)";
+
 const PROOF_JSON = `{
+  "success": false,
   "issues": [
-    { "path": "HOST", "code": "MISSING_VARIABLE" },
-    { "path": "PORT", "code": "INVALID_TYPE" }
+    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "${HOST_MESSAGE}" },
+    { "path": "PORT", "code": "INVALID_TYPE", "message": "${PORT_MESSAGE}" }
   ]
 }`;
 
+function EllipsisMessage({ message }: { message: string }) {
+	return (
+		<span className="home-aurora__json-ellipsis" title={message} tabIndex={0}>
+			…
+		</span>
+	);
+}
+
+/**
+ * Machine-readable validation errors for CI and agents.
+ */
 export function RuntimeBloatShowcase() {
 	return (
 		<section
@@ -29,9 +43,17 @@ export function RuntimeBloatShowcase() {
 				className="home-aurora__pitch-visual home-aurora__code-window home-aurora__terminal"
 				data-reveal
 				style={{ ["--reveal-delay" as string]: "140ms" }}
+				aria-label="Safe result JSON: HOST missing, PORT invalid type"
 			>
+				<WindowChrome title="{ safe: true }" copyText={PROOF_JSON} />
 				<pre className="home-aurora__tty home-aurora__tty--wrap">
-					<code>{PROOF_JSON}</code>
+					<code>
+						{'{\n  "success": false,\n  "issues": [\n    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "'}
+						<EllipsisMessage message={HOST_MESSAGE} />
+						{'" },\n    { "path": "PORT", "code": "INVALID_TYPE", "message": "'}
+						<EllipsisMessage message={PORT_MESSAGE} />
+						{'" }\n  ]\n}'}
+					</code>
 				</pre>
 			</figure>
 		</section>

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -23,25 +23,12 @@ export function RuntimeBloatShowcase() {
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
 					Beautiful errors in the terminal. Structured JSON for CI and agents.
 				</p>
-				<p data-reveal style={{ ["--reveal-delay" as string]: "100ms" }}>
-					<code>HOST</code> <code>MISSING_VARIABLE</code>
-					{" → add it to "}
-					<code>.env</code>
-					{"; "}
-					<code>PORT</code> <code>INVALID_TYPE</code>
-					{" → fix the value, don't touch the schema."}
-				</p>
-				<p data-reveal style={{ ["--reveal-delay" as string]: "120ms" }}>
-					Same codes as <code>arkenv check --json</code>.
-				</p>
 			</header>
 
 			<figure
 				className="home-aurora__pitch-visual home-aurora__code-window home-aurora__terminal"
 				data-reveal
 				style={{ ["--reveal-delay" as string]: "140ms" }}
-				role="img"
-				aria-label="Terminal running arkenv check --json, then structured validation issues"
 			>
 				<pre className="home-aurora__tty">
 					<code>
@@ -55,6 +42,14 @@ export function RuntimeBloatShowcase() {
 						{PROOF_JSON}
 					</code>
 				</pre>
+				<figcaption>
+					<code>HOST</code> <code>MISSING_VARIABLE</code>
+					{" → add it to "}
+					<code>.env</code>
+					{"; "}
+					<code>PORT</code> <code>INVALID_TYPE</code>
+					{" → fix the value, don't touch the schema."}
+				</figcaption>
 			</figure>
 		</section>
 	);

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -29,8 +29,8 @@ export function RuntimeBloatShowcase() {
 					Structured errors
 				</h2>
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
-					Each issue gets an error code agents and CI can act on. Missing
-					keys and bad values aren&apos;t the same.
+					Each issue gets an error code agents and CI can act on. Missing keys
+					and bad values aren&apos;t the same.
 				</p>
 			</header>
 

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -5,27 +5,56 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "~/components/ui/popover";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "~/components/ui/tooltip";
+import { useIsMobile } from "~/hooks/use-is-mobile";
 
 const HOST_MESSAGE = 'must be a string or "localhost" (was missing)';
 const PORT_MESSAGE = "must be a number (was a string)";
 
-function EllipsisMessage({ message }: { message: string }) {
+const tipClassName =
+	"home-aurora__json-ellipsis-tip min-w-0 max-w-[min(18rem,calc(100vw-1.5rem))] rounded-md border-fd-border bg-fd-popover p-2 text-xs leading-snug text-fd-popover-foreground shadow-md backdrop-blur-none";
+
+function EllipsisMessage({
+	message,
+	mode,
+}: {
+	message: string;
+	mode: "hover" | "tap";
+}) {
+	const trigger = (
+		<button
+			type="button"
+			className="home-aurora__json-ellipsis"
+			aria-label={`Full message: ${message}`}
+		>
+			…
+		</button>
+	);
+
+	if (mode === "hover") {
+		return (
+			<Tooltip>
+				<TooltipTrigger asChild>{trigger}</TooltipTrigger>
+				<TooltipContent side="top" sideOffset={6} className={tipClassName}>
+					{message}
+				</TooltipContent>
+			</Tooltip>
+		);
+	}
+
 	return (
 		<Popover>
-			<PopoverTrigger asChild>
-				<button
-					type="button"
-					className="home-aurora__json-ellipsis"
-					aria-label={`Full message: ${message}`}
-				>
-					…
-				</button>
-			</PopoverTrigger>
+			<PopoverTrigger asChild>{trigger}</PopoverTrigger>
 			<PopoverContent
 				align="start"
 				side="top"
 				collisionPadding={12}
-				className="home-aurora__json-ellipsis-tip min-w-0 max-w-[min(18rem,calc(100vw-1.5rem))] rounded-md border-fd-border bg-fd-popover p-2 text-xs leading-snug text-fd-popover-foreground shadow-md backdrop-blur-none"
+				className={tipClassName}
 			>
 				{message}
 			</PopoverContent>
@@ -33,10 +62,55 @@ function EllipsisMessage({ message }: { message: string }) {
 	);
 }
 
+function IssuesJson({
+	layout,
+	mode,
+}: {
+	layout: "compact" | "stacked";
+	mode: "hover" | "tap";
+}) {
+	const host = <EllipsisMessage message={HOST_MESSAGE} mode={mode} />;
+	const port = <EllipsisMessage message={PORT_MESSAGE} mode={mode} />;
+
+	if (layout === "compact") {
+		return (
+			<code>
+				{
+					'{\n  "success": false,\n  "issues": [\n    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "'
+				}
+				{host}
+				{'" },\n    { "path": "PORT", "code": "INVALID_TYPE", "message": "'}
+				{port}
+				{'" }\n  ]\n}'}
+			</code>
+		);
+	}
+
+	return (
+		<code>
+			{
+				'{\n  "success": false,\n  "issues": [\n    {\n      "path": "HOST",\n      "code": "MISSING_VARIABLE",\n      "message": "'
+			}
+			{host}
+			{
+				'"\n    },\n    {\n      "path": "PORT",\n      "code": "INVALID_TYPE",\n      "message": "'
+			}
+			{port}
+			{'"\n    }\n  ]\n}'}
+		</code>
+	);
+}
+
 /**
  * Machine-readable validation errors for CI and agents.
+ * Desktop: hover tooltip + compact issue objects.
+ * Mobile: tap popover + stacked path/code/message.
  */
 export function RuntimeBloatShowcase() {
+	const isMobile = useIsMobile();
+	const mode = isMobile ? "tap" : "hover";
+	const layout = isMobile ? "stacked" : "compact";
+
 	return (
 		<section
 			className="home-aurora__pitch"
@@ -58,22 +132,19 @@ export function RuntimeBloatShowcase() {
 				data-reveal
 				style={{ ["--reveal-delay" as string]: "140ms" }}
 				aria-label="JSON issues for HOST missing and PORT invalid type"
+				data-layout={layout}
 			>
 				<span className="home-aurora__json-lang" aria-hidden="true">
 					json
 				</span>
 				<pre className="home-aurora__json-body home-aurora__tty--wrap">
-					<code>
-						{
-							'{\n  "success": false,\n  "issues": [\n    {\n      "path": "HOST",\n      "code": "MISSING_VARIABLE",\n      "message": "'
-						}
-						<EllipsisMessage message={HOST_MESSAGE} />
-						{
-							'"\n    },\n    {\n      "path": "PORT",\n      "code": "INVALID_TYPE",\n      "message": "'
-						}
-						<EllipsisMessage message={PORT_MESSAGE} />
-						{'"\n    }\n  ]\n}'}
-					</code>
+					{mode === "hover" ? (
+						<TooltipProvider delayDuration={200}>
+							<IssuesJson layout={layout} mode={mode} />
+						</TooltipProvider>
+					) : (
+						<IssuesJson layout={layout} mode={mode} />
+					)}
 				</pre>
 			</figure>
 		</section>

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -4,8 +4,16 @@
 const PROOF_JSON = `{
   "success": false,
   "issues": [
-    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "must be a string or \\"localhost\\" (was missing)" },
-    { "path": "PORT", "code": "INVALID_TYPE", "message": "must be a number (was a string)" }
+    {
+      "path": "HOST",
+      "code": "MISSING_VARIABLE",
+      "message": "must be a string or \\"localhost\\" (was missing)"
+    },
+    {
+      "path": "PORT",
+      "code": "INVALID_TYPE",
+      "message": "must be a number (was a string)"
+    }
   ]
 }`;
 
@@ -18,10 +26,11 @@ export function RuntimeBloatShowcase() {
 		>
 			<header className="home-aurora__pitch-head">
 				<h2 id="home-errors" data-reveal="blur">
-					Errors you can automate
+					Structured errors
 				</h2>
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
-					Beautiful errors in the terminal. Structured JSON for CI and agents.
+					Each issue gets a code that CI and agents can act on. A missing
+					key and a bad value aren&apos;t the same problem.
 				</p>
 			</header>
 
@@ -29,28 +38,10 @@ export function RuntimeBloatShowcase() {
 				className="home-aurora__pitch-visual home-aurora__code-window home-aurora__terminal"
 				data-reveal
 				style={{ ["--reveal-delay" as string]: "140ms" }}
-				aria-label="JSON from arkenv check --json with HOST MISSING_VARIABLE and PORT INVALID_TYPE"
 			>
-				<pre className="home-aurora__tty">
-					<code>
-						<span
-							className="home-aurora__install-prompt-symbol"
-							aria-hidden="true"
-						>
-							{"$"}
-						</span>
-						{" arkenv check --json\n\n"}
-						{PROOF_JSON}
-					</code>
+				<pre className="home-aurora__tty home-aurora__tty--wrap">
+					<code>{PROOF_JSON}</code>
 				</pre>
-				<figcaption>
-					<code>HOST</code> <code>MISSING_VARIABLE</code>
-					{" → add it to "}
-					<code>.env</code>
-					{"; "}
-					<code>PORT</code> <code>INVALID_TYPE</code>
-					{" → fix the value, don't touch the schema."}
-				</figcaption>
 			</figure>
 		</section>
 	);

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -4,16 +4,8 @@
 const PROOF_JSON = `{
   "success": false,
   "issues": [
-    {
-      "path": "HOST",
-      "code": "MISSING_VARIABLE",
-      "message": "must be a string or \\"localhost\\" (was missing)"
-    },
-    {
-      "path": "PORT",
-      "code": "INVALID_TYPE",
-      "message": "must be a number (was a string)"
-    }
+    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "must be a string or \\"localhost\\" (was missing)" },
+    { "path": "PORT", "code": "INVALID_TYPE", "message": "must be a number (was a string)" }
   ]
 }`;
 
@@ -26,11 +18,10 @@ export function RuntimeBloatShowcase() {
 		>
 			<header className="home-aurora__pitch-head">
 				<h2 id="home-errors" data-reveal="blur">
-					Structured errors
+					Errors you can automate
 				</h2>
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
-					Each issue gets a code CI and agents can act on. Missing isn&apos;t
-					the same fix as a bad value.
+					Beautiful errors in the terminal. Structured JSON for CI and agents.
 				</p>
 			</header>
 
@@ -38,10 +29,28 @@ export function RuntimeBloatShowcase() {
 				className="home-aurora__pitch-visual home-aurora__code-window home-aurora__terminal"
 				data-reveal
 				style={{ ["--reveal-delay" as string]: "140ms" }}
+				aria-label="JSON from arkenv check --json with HOST MISSING_VARIABLE and PORT INVALID_TYPE"
 			>
-				<pre className="home-aurora__tty home-aurora__tty--wrap">
-					<code>{PROOF_JSON}</code>
+				<pre className="home-aurora__tty">
+					<code>
+						<span
+							className="home-aurora__install-prompt-symbol"
+							aria-hidden="true"
+						>
+							{"$"}
+						</span>
+						{" arkenv check --json\n\n"}
+						{PROOF_JSON}
+					</code>
 				</pre>
+				<figcaption>
+					<code>HOST</code> <code>MISSING_VARIABLE</code>
+					{" → add it to "}
+					<code>.env</code>
+					{"; "}
+					<code>PORT</code> <code>INVALID_TYPE</code>
+					{" → fix the value, don't touch the schema."}
+				</figcaption>
 			</figure>
 		</section>
 	);

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -4,16 +4,8 @@
 const PROOF_JSON = `{
   "success": false,
   "issues": [
-    {
-      "path": "HOST",
-      "code": "MISSING_VARIABLE",
-      "message": "must be a string or \\"localhost\\" (was missing)"
-    },
-    {
-      "path": "PORT",
-      "code": "INVALID_TYPE",
-      "message": "must be a number (was a string)"
-    }
+    { "path": "HOST", "code": "MISSING_VARIABLE", "message": "must be a string or \\"localhost\\" (was missing)" },
+    { "path": "PORT", "code": "INVALID_TYPE", "message": "must be a number (was a string)" }
   ]
 }`;
 
@@ -26,11 +18,10 @@ export function RuntimeBloatShowcase() {
 		>
 			<header className="home-aurora__pitch-head">
 				<h2 id="home-errors" data-reveal="blur">
-					Structured errors
+					Errors you can automate
 				</h2>
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
-					Each issue gets a code that CI and agents can act on. A missing key
-					and a bad value aren&apos;t the same problem.
+					Beautiful errors in the terminal. Structured JSON for CI and agents.
 				</p>
 			</header>
 
@@ -38,10 +29,28 @@ export function RuntimeBloatShowcase() {
 				className="home-aurora__pitch-visual home-aurora__code-window home-aurora__terminal"
 				data-reveal
 				style={{ ["--reveal-delay" as string]: "140ms" }}
+				aria-label="JSON from arkenv check --json with HOST MISSING_VARIABLE and PORT INVALID_TYPE"
 			>
-				<pre className="home-aurora__tty home-aurora__tty--wrap">
-					<code>{PROOF_JSON}</code>
+				<pre className="home-aurora__tty">
+					<code>
+						<span
+							className="home-aurora__install-prompt-symbol"
+							aria-hidden="true"
+						>
+							{"$"}
+						</span>
+						{" arkenv check --json\n\n"}
+						{PROOF_JSON}
+					</code>
 				</pre>
+				<figcaption>
+					<code>HOST</code> <code>MISSING_VARIABLE</code>
+					{" → add it to "}
+					<code>.env</code>
+					{"; "}
+					<code>PORT</code> <code>INVALID_TYPE</code>
+					{" → fix the value, don't touch the schema."}
+				</figcaption>
 			</figure>
 		</section>
 	);

--- a/apps/www/components/page/runtime-bloat-showcase.tsx
+++ b/apps/www/components/page/runtime-bloat-showcase.tsx
@@ -2,18 +2,9 @@
  * Machine-readable validation errors for CI and agents.
  */
 const PROOF_JSON = `{
-  "success": false,
   "issues": [
-    {
-      "path": "HOST",
-      "code": "MISSING_VARIABLE",
-      "message": "must be a string or \\"localhost\\" (was missing)"
-    },
-    {
-      "path": "PORT",
-      "code": "INVALID_TYPE",
-      "message": "must be a number (was a string)"
-    }
+    { "path": "HOST", "code": "MISSING_VARIABLE" },
+    { "path": "PORT", "code": "INVALID_TYPE" }
   ]
 }`;
 
@@ -29,8 +20,8 @@ export function RuntimeBloatShowcase() {
 					Structured errors
 				</h2>
 				<p data-reveal style={{ ["--reveal-delay" as string]: "80ms" }}>
-					Each issue gets an error code agents and CI can act on. Missing keys
-					and bad values aren&apos;t the same.
+					Each issue gets an error code that agents and CI can act on. Missing
+					keys and bad values aren&apos;t the same.
 				</p>
 			</header>
 


### PR DESCRIPTION
Replaces the homepage “Optimized for the edge” bundle chart with **Structured errors**.

## Copy lock
- Hero: *Get a strictly typed env object from the validator you already use. No boilerplate. Zero dependencies.*
- Feature 6 heading: **Structured errors**
- Subtitle: Each issue gets a code that agents and CI can act on. Missing keys and bad values aren’t the same.
- Widget: compact JSON (`success` + `issues[]`) for HOST `MISSING_VARIABLE` + PORT `INVALID_TYPE`. Messages collapse to `…` with a hover tooltip. Language `json` — no filename, no `$`, no `{ safe: true }` chrome, no twoslash.

## Scope
- Not stacked on #1744. Fail-fast dump untouched.
- Do **not** restore “Errors you can automate” / “Beautiful errors in the terminal” / “No additional dependencies” — those are the previous lock.
