### PR TITLE
perf(core): claw back default gzip vs v0

### DIFF
--- a/.changeset/core-gzip-clawback.md
+++ b/.changeset/core-gzip-clawback.md
@@ -1,24 +1,25 @@
 ---
 "@arkenv/core": major
+"@arkenv/standard": major
 ---
 
-#### Move issue helpers and safe parsing off the default `@arkenv/core` import
+#### Move issue helpers and safe parsing off the default import
 
-The default `@arkenv/core` import is now the throw path only. `formatIssues`,
-`getSchemaKeys`, and the `EnvIssue` types moved to `@arkenv/core/issues`.
-`{ safe: true }` is no longer accepted on `arkenv()`; use `tryArkenv` from
-`@arkenv/core/safe` instead.
+The default `@arkenv/core` and `@arkenv/standard` imports are now the throw
+path only. `formatIssues`, `getSchemaKeys`, and the `EnvIssue` types moved
+to `@arkenv/core/issues` (core). `{ safe: true }` is no longer accepted on
+either package's main `arkenv()`; import `arkenv` from `/safe` instead.
 
 ```ts
 import arkenv from "@arkenv/core";
 import { formatIssues } from "@arkenv/core/issues";
-import { tryArkenv } from "@arkenv/core/safe";
+import arkenvSafe from "@arkenv/core/safe";
 
 export const env = arkenv({
   PORT: "number.port = 3000",
 });
 
-const result = tryArkenv(
+const result = arkenvSafe(
   { PORT: "number.port" },
   { env: { PORT: "invalid" } },
 );
@@ -28,17 +29,33 @@ if (!result.success) {
 }
 ```
 
-`@arkenv/core` now sets `"sideEffects": false` so bundlers can tree-shake
-unused subpaths.
+`@arkenv/standard` mirrors the same shape:
 
-**BREAKING CHANGE**: Issue helpers moved to `@arkenv/core/issues`, and
-`{ safe: true }` is now `tryArkenv` from `@arkenv/core/safe`.
+```ts
+import arkenv from "@arkenv/standard";
+import arkenvSafe from "@arkenv/standard/safe";
+```
+
+`@arkenv/core` now sets `"sideEffects": false` so bundlers can tree-shake
+unused subpaths. Framework packages (Next.js, Nuxt, Vite, Bun) do **not**
+ship a `/safe` subpath.
+
+**BREAKING CHANGE**: Issue helpers moved to `@arkenv/core/issues`.
+`{ safe: true }` on `arkenv()` is replaced by `arkenv` from
+`@arkenv/core/safe` / `@arkenv/standard/safe`.
 
 ```diff
 - import arkenv, { formatIssues } from "@arkenv/core";
 - const result = arkenv(schema, { safe: true });
 + import arkenv from "@arkenv/core";
 + import { formatIssues } from "@arkenv/core/issues";
-+ import { tryArkenv } from "@arkenv/core/safe";
-+ const result = tryArkenv(schema);
++ import arkenvSafe from "@arkenv/core/safe";
++ const result = arkenvSafe(schema);
+```
+
+```diff
+- import arkenv from "@arkenv/standard";
+- const result = arkenv(schema, { safe: true });
++ import arkenv from "@arkenv/standard/safe";
++ const result = arkenv(schema);
 ```

--- a/.changeset/core-gzip-clawback.md
+++ b/.changeset/core-gzip-clawback.md
@@ -1,0 +1,44 @@
+---
+"@arkenv/core": major
+---
+
+#### Move issue helpers and safe parsing off the default `@arkenv/core` import
+
+The default `@arkenv/core` import is now the throw path only. `formatIssues`,
+`getSchemaKeys`, and the `EnvIssue` types moved to `@arkenv/core/issues`.
+`{ safe: true }` is no longer accepted on `arkenv()`; use `tryArkenv` from
+`@arkenv/core/safe` instead.
+
+```ts
+import arkenv from "@arkenv/core";
+import { formatIssues } from "@arkenv/core/issues";
+import { tryArkenv } from "@arkenv/core/safe";
+
+export const env = arkenv({
+  PORT: "number.port = 3000",
+});
+
+const result = tryArkenv(
+  { PORT: "number.port" },
+  { env: { PORT: "invalid" } },
+);
+
+if (!result.success) {
+  console.error(formatIssues(result.issues));
+}
+```
+
+`@arkenv/core` now sets `"sideEffects": false` so bundlers can tree-shake
+unused subpaths.
+
+**BREAKING CHANGE**: Issue helpers moved to `@arkenv/core/issues`, and
+`{ safe: true }` is now `tryArkenv` from `@arkenv/core/safe`.
+
+```diff
+- import arkenv, { formatIssues } from "@arkenv/core";
+- const result = arkenv(schema, { safe: true });
++ import arkenv from "@arkenv/core";
++ import { formatIssues } from "@arkenv/core/issues";
++ import { tryArkenv } from "@arkenv/core/safe";
++ const result = tryArkenv(schema);
+```

--- a/apps/www/content/docs/core-concepts/error-reporting.mdx
+++ b/apps/www/content/docs/core-concepts/error-reporting.mdx
@@ -69,14 +69,14 @@ Values for sensitive keys are redacted in error output by default. Leave that al
 
 ## Safe mode
 
-Default `arkenv()` from `@arkenv/core` always throws. Import `tryArkenv`
-from `@arkenv/core/safe` when you want a result object instead of a throw
-(tests, custom boot UI):
+Fail-fast `arkenv()` from `@arkenv/core` (and `@arkenv/standard`) always
+throws. Import `arkenv` from the `/safe` subpath when you want a result
+object instead of a throw (tests, custom boot UI):
 
 ```ts title="./env.ts" twoslash
-import { tryArkenv } from "@arkenv/core/safe";
+import arkenv from "@arkenv/core/safe";
 
-const result = tryArkenv(
+const result = arkenv(
   { PORT: "number.port" },
   { env: { PORT: "nope" } },
 );
@@ -86,9 +86,10 @@ if (!result.success) {
 }
 ```
 
-`@arkenv/standard` still accepts `{ safe: true }` on `arkenv()`. Framework
-integrations do not expose a non-throwing path. Invalid env still fails
-the build or server start there on purpose.
+`@arkenv/standard` mirrors the same shape via `@arkenv/standard/safe`.
+Framework integrations (Next.js, Nuxt, Vite, Bun) do not expose a
+non-throwing path — invalid env still fails the build or server start
+there on purpose.
 
 ## Framework boundary errors
 

--- a/apps/www/content/docs/core-concepts/error-reporting.mdx
+++ b/apps/www/content/docs/core-concepts/error-reporting.mdx
@@ -69,14 +69,16 @@ Values for sensitive keys are redacted in error output by default. Leave that al
 
 ## Safe mode
 
-Pass `{ safe: true }` when you want a result object instead of a throw (tests, custom boot UI):
+Default `arkenv()` from `@arkenv/core` always throws. Import `tryArkenv`
+from `@arkenv/core/safe` when you want a result object instead of a throw
+(tests, custom boot UI):
 
 ```ts title="./env.ts" twoslash
-import arkenv from "@arkenv/core";
+import { tryArkenv } from "@arkenv/core/safe";
 
-const result = arkenv(
+const result = tryArkenv(
   { PORT: "number.port" },
-  { safe: true, env: { PORT: "nope" } },
+  { env: { PORT: "nope" } },
 );
 
 if (!result.success) {
@@ -84,7 +86,9 @@ if (!result.success) {
 }
 ```
 
-Framework integrations do not expose `safe`. Invalid env still fails the build or server start there on purpose.
+`@arkenv/standard` still accepts `{ safe: true }` on `arkenv()`. Framework
+integrations do not expose a non-throwing path. Invalid env still fails
+the build or server start there on purpose.
 
 ## Framework boundary errors
 

--- a/apps/www/content/docs/reference/core.mdx
+++ b/apps/www/content/docs/reference/core.mdx
@@ -40,7 +40,7 @@ non-throwing parser live on subpaths so the default import stays small.
 | `ArkEnvConfig`     | type                       | [Options](/docs/reference/options) object                  |
 | `EnvSchema`        | type                       | Declarative schema map                                     |
 | `Infer`            | type                       | Infer output from a schema                                 |
-| `SafeArkEnvResult` | type                       | Result shape returned by `tryArkenv`                       |
+| `SafeArkEnvResult` | type                       | Result shape returned by `@arkenv/core/safe`               |
 
 ### Subpaths
 
@@ -50,12 +50,12 @@ Issue formatting and the non-throwing parser are separate entries.
 | --------------------- | --------------------------------------------------------------------------------- |
 | `@arkenv/core`        | Throw-path `arkenv()` and `type()`                                                |
 | `@arkenv/core/issues` | `formatIssues`, `getSchemaKeys`, and `EnvIssue` / `EnvIssueCode` / `EnvIssueMeta` |
-| `@arkenv/core/safe`   | `tryArkenv` — result object instead of a throw                                    |
+| `@arkenv/core/safe`   | `arkenv` — result object instead of a throw (default + named export)              |
 
 ```ts title="./env.ts" twoslash
-import { tryArkenv } from "@arkenv/core/safe";
+import arkenv from "@arkenv/core/safe";
 
-const result = tryArkenv(
+const result = arkenv(
   { PORT: "number.port" },
   { env: { PORT: "invalid" } },
 );

--- a/apps/www/content/docs/reference/core.mdx
+++ b/apps/www/content/docs/reference/core.mdx
@@ -29,18 +29,41 @@ export const env = arkenv({
 
 ## Exports
 
+The main entry is the throw-path runtime. Issue helpers and the
+non-throwing parser live on subpaths so the default import stays small.
+
 | Export             | Kind                       | Role                                                       |
 | ------------------ | -------------------------- | ---------------------------------------------------------- |
 | `arkenv`           | function (default + named) | Validate and return a typed env object                     |
 | `type`             | function                   | ArkType `type` with [`keywords`](/docs/reference/keywords) |
 | `ArkEnvError`      | class                      | Thrown on validation failure                               |
-| `formatIssues`     | function                   | Format `EnvIssue[]` for display                            |
-| `getSchemaKeys`    | function                   | List keys declared on a schema                             |
 | `ArkEnvConfig`     | type                       | [Options](/docs/reference/options) object                  |
 | `EnvSchema`        | type                       | Declarative schema map                                     |
 | `Infer`            | type                       | Infer output from a schema                                 |
-| `SafeArkEnvResult` | type                       | Result shape when `safe: true`                             |
-| `EnvIssue`         | type                       | Structured validation issue                                |
+| `SafeArkEnvResult` | type                       | Result shape returned by `tryArkenv`                       |
+
+### Subpaths
+
+Issue formatting and the non-throwing parser are separate entries.
+
+| Import                | Role                                                                              |
+| --------------------- | --------------------------------------------------------------------------------- |
+| `@arkenv/core`        | Throw-path `arkenv()` and `type()`                                                |
+| `@arkenv/core/issues` | `formatIssues`, `getSchemaKeys`, and `EnvIssue` / `EnvIssueCode` / `EnvIssueMeta` |
+| `@arkenv/core/safe`   | `tryArkenv` — result object instead of a throw                                    |
+
+```ts title="./env.ts" twoslash
+import { tryArkenv } from "@arkenv/core/safe";
+
+const result = tryArkenv(
+  { PORT: "number.port" },
+  { env: { PORT: "invalid" } },
+);
+
+if (!result.success) {
+  console.error(result.issues);
+}
+```
 
 ## Next steps
 

--- a/apps/www/content/docs/reference/env.mdx
+++ b/apps/www/content/docs/reference/env.mdx
@@ -35,11 +35,11 @@ Default `arkenv()` returns a validated object and throws `ArkEnvError` on
 failure. For a result object from `@arkenv/core`, use `tryArkenv` from
 `@arkenv/core/safe`.
 
-| Call                                      | Return type                                               |
-| ----------------------------------------- | --------------------------------------------------------- |
-| `arkenv()`                                | Validated object; throws `ArkEnvError` on failure         |
-| `tryArkenv()` (`@arkenv/core/safe`)       | `{ success: true, data }` or `{ success: false, issues }` |
-| `@arkenv/standard` with `{ safe: true }`  | Same result object as `tryArkenv`                         |
+| Call                                     | Return type                                               |
+| ---------------------------------------- | --------------------------------------------------------- |
+| `arkenv()`                               | Validated object; throws `ArkEnvError` on failure         |
+| `tryArkenv()` (`@arkenv/core/safe`)      | `{ success: true, data }` or `{ success: false, issues }` |
+| `@arkenv/standard` with `{ safe: true }` | Same result object as `tryArkenv`                         |
 
 Core and `@arkenv/standard` return a plain object. Next.js and Nuxt wrap
 that object in a Proxy.

--- a/apps/www/content/docs/reference/env.mdx
+++ b/apps/www/content/docs/reference/env.mdx
@@ -31,12 +31,15 @@ populate the source before `arkenv()` runs. See
 
 ## Return shape
 
-How `arkenv()` reports success or failure depends on `safe`.
+Default `arkenv()` returns a validated object and throws `ArkEnvError` on
+failure. For a result object from `@arkenv/core`, use `tryArkenv` from
+`@arkenv/core/safe`.
 
-| Mode                    | Return type                                               |
-| ----------------------- | --------------------------------------------------------- |
-| Default (`safe: false`) | Validated object; throws `ArkEnvError` on failure         |
-| `safe: true`            | `{ success: true, data }` or `{ success: false, issues }` |
+| Call                                      | Return type                                               |
+| ----------------------------------------- | --------------------------------------------------------- |
+| `arkenv()`                                | Validated object; throws `ArkEnvError` on failure         |
+| `tryArkenv()` (`@arkenv/core/safe`)       | `{ success: true, data }` or `{ success: false, issues }` |
+| `@arkenv/standard` with `{ safe: true }`  | Same result object as `tryArkenv`                         |
 
 Core and `@arkenv/standard` return a plain object. Next.js and Nuxt wrap
 that object in a Proxy.

--- a/apps/www/content/docs/reference/env.mdx
+++ b/apps/www/content/docs/reference/env.mdx
@@ -35,10 +35,10 @@ Default `arkenv()` returns a validated object and throws `ArkEnvError` on
 failure. For a result object, import `arkenv` from `@arkenv/core/safe` or
 `@arkenv/standard/safe`.
 
-| Call                         | Return type                                               |
-| ---------------------------- | --------------------------------------------------------- |
-| `arkenv()`                   | Validated object; throws `ArkEnvError` on failure         |
-| `arkenv` from `/safe`        | `{ success: true, data }` or `{ success: false, issues }` |
+| Call                  | Return type                                               |
+| --------------------- | --------------------------------------------------------- |
+| `arkenv()`            | Validated object; throws `ArkEnvError` on failure         |
+| `arkenv` from `/safe` | `{ success: true, data }` or `{ success: false, issues }` |
 
 Core and `@arkenv/standard` return a plain object. Next.js and Nuxt wrap
 that object in a Proxy.

--- a/apps/www/content/docs/reference/env.mdx
+++ b/apps/www/content/docs/reference/env.mdx
@@ -32,14 +32,13 @@ populate the source before `arkenv()` runs. See
 ## Return shape
 
 Default `arkenv()` returns a validated object and throws `ArkEnvError` on
-failure. For a result object from `@arkenv/core`, use `tryArkenv` from
-`@arkenv/core/safe`.
+failure. For a result object, import `arkenv` from `@arkenv/core/safe` or
+`@arkenv/standard/safe`.
 
-| Call                                     | Return type                                               |
-| ---------------------------------------- | --------------------------------------------------------- |
-| `arkenv()`                               | Validated object; throws `ArkEnvError` on failure         |
-| `tryArkenv()` (`@arkenv/core/safe`)      | `{ success: true, data }` or `{ success: false, issues }` |
-| `@arkenv/standard` with `{ safe: true }` | Same result object as `tryArkenv`                         |
+| Call                         | Return type                                               |
+| ---------------------------- | --------------------------------------------------------- |
+| `arkenv()`                   | Validated object; throws `ArkEnvError` on failure         |
+| `arkenv` from `/safe`        | `{ success: true, data }` or `{ success: false, issues }` |
 
 Core and `@arkenv/standard` return a plain object. Next.js and Nuxt wrap
 that object in a Proxy.

--- a/apps/www/content/docs/reference/options.mdx
+++ b/apps/www/content/docs/reference/options.mdx
@@ -4,8 +4,9 @@ description: Configuration object passed as the second argument to arkenv().
 ---
 
 The second argument to `arkenv()` is an optional configuration object.
-Shared fields exist on both engines: `env`, `coerce`, `safe`,
+Shared fields exist on both engines: `env`, `coerce`,
 `emptyAsUndefined`, `onUndeclaredKey`, `arrayFormat`, and `debugSecrets`.
+`safe` is reserved for call-site compat (`false` or omit only).
 `toJsonSchema` exists only on
 [`@arkenv/standard`](/docs/reference/standard). ArkType already exposes
 JSON Schema, so [`@arkenv/core`](/docs/reference/core) has nothing to fall
@@ -146,14 +147,14 @@ export const env = arkenv(
 
 Default: `false`
 
-`arkenv()` from `@arkenv/core` always throws on validation failure. Pass
-`false` or omit this field. For a result object, import `tryArkenv` from
-`@arkenv/core/safe`.
+Reserved on the main `arkenv()` entry. Pass `false` or omit — `{ safe: true }`
+is not accepted. For a result object, import `arkenv` from
+`@arkenv/core/safe` or `@arkenv/standard/safe`.
 
 ```ts title="./env.ts" twoslash
-import { tryArkenv } from "@arkenv/core/safe";
+import arkenv from "@arkenv/core/safe";
 
-const result = tryArkenv(
+const result = arkenv(
   { PORT: "number.port" },
   { env: { PORT: "invalid" } },
 );
@@ -165,12 +166,12 @@ if (!result.success) {
 }
 ```
 
-`@arkenv/standard` still accepts `{ safe: true }` on `arkenv()` itself.
-
 <Callout type="warn">
-  Framework plugins omit `safe` so a failed validation cannot soft-fail
-  into the client bundle. Call `tryArkenv` yourself if you need
-  programmatic failure handling outside a plugin.
+  Framework plugins (Next.js, Nuxt, Vite, Bun) do not ship a `/safe`
+  subpath, so a failed validation cannot soft-fail into the client
+  bundle. Call `arkenv` from `@arkenv/core/safe` or
+  `@arkenv/standard/safe` yourself if you need programmatic failure
+  handling outside a plugin.
 </Callout>
 
 ### debugSecrets

--- a/apps/www/content/docs/reference/options.mdx
+++ b/apps/www/content/docs/reference/options.mdx
@@ -146,15 +146,16 @@ export const env = arkenv(
 
 Default: `false`
 
-Return `{ success, data | issues }` instead of throwing. Use this in
-tests or a custom boot UI when you handle failures yourself.
+`arkenv()` from `@arkenv/core` always throws on validation failure. Pass
+`false` or omit this field. For a result object, import `tryArkenv` from
+`@arkenv/core/safe`.
 
 ```ts title="./env.ts" twoslash
-import arkenv from "@arkenv/core";
+import { tryArkenv } from "@arkenv/core/safe";
 
-const result = arkenv(
+const result = tryArkenv(
   { PORT: "number.port" },
-  { safe: true, env: { PORT: "invalid" } },
+  { env: { PORT: "invalid" } },
 );
 
 if (!result.success) {
@@ -164,9 +165,11 @@ if (!result.success) {
 }
 ```
 
+`@arkenv/standard` still accepts `{ safe: true }` on `arkenv()` itself.
+
 <Callout type="warn">
   Framework plugins omit `safe` so a failed validation cannot soft-fail
-  into the client bundle. Call `arkenv()` yourself if you need
+  into the client bundle. Call `tryArkenv` yourself if you need
   programmatic failure handling outside a plugin.
 </Callout>
 

--- a/apps/www/content/docs/reference/standard.mdx
+++ b/apps/www/content/docs/reference/standard.mdx
@@ -60,9 +60,24 @@ These are the public names from `@arkenv/standard`.
 
 | Import                      | Role                                                                                           |
 | --------------------------- | ---------------------------------------------------------------------------------------------- |
-| `@arkenv/standard`          | Root engine. Dependency-free. Zod works zero-config.                                           |
+| `@arkenv/standard`          | Root engine (throw path). Dependency-free. Zod works zero-config.                              |
+| `@arkenv/standard/safe`     | `arkenv` — result object instead of a throw (default + named export)                           |
 | `@arkenv/standard/valibot`  | Same `arkenv`, pre-configured for Valibot. `valibot` + `@valibot/to-json-schema` are required. |
 | `@arkenv/standard/zod-mini` | Same `arkenv`, pre-configured for Zod Mini. `zod` is required.                                 |
+
+```ts title="./env.ts" twoslash
+import arkenv from "@arkenv/standard/safe";
+import * as z from "zod";
+
+const result = arkenv(
+  { PORT: z.coerce.number() },
+  { env: { PORT: "invalid" } },
+);
+
+if (!result.success) {
+  console.error(result.issues);
+}
+```
 
 ```ts title="./env.ts" twoslash
 import { arkenv } from "@arkenv/standard/valibot";

--- a/packages/arkenv/src/adapters/jiti-schema-loader/jiti-schema-loader.adapter.test.ts
+++ b/packages/arkenv/src/adapters/jiti-schema-loader/jiti-schema-loader.adapter.test.ts
@@ -20,6 +20,7 @@ const requireFromStandard = createRequire(
 
 const jitiAliases = {
 	"@arkenv/core": path.join(packagesDir, "core/src/index.ts"),
+	"@arkenv/core/issues": path.join(packagesDir, "core/src/issues.ts"),
 	"@arkenv/standard": path.join(packagesDir, "standard/src/index.ts"),
 	arktype: requireFromCore.resolve("arktype"),
 	zod: requireFromCore.resolve("zod"),

--- a/packages/arkenv/src/cli/commands/check.test.ts
+++ b/packages/arkenv/src/cli/commands/check.test.ts
@@ -34,6 +34,10 @@ describe("CheckUseCase", () => {
 					__dirname,
 					"../../../../core/src/index.ts",
 				),
+				"@arkenv/core/issues": path.resolve(
+					__dirname,
+					"../../../../core/src/issues.ts",
+				),
 				arkenv: path.resolve(__dirname, "../../../../core/src/index.ts"),
 			},
 		});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,16 @@
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"default": "./dist/index.js"
+		},
+		"./issues": {
+			"types": "./dist/issues.d.ts",
+			"import": "./dist/issues.js",
+			"default": "./dist/issues.js"
+		},
+		"./safe": {
+			"types": "./dist/safe.d.ts",
+			"import": "./dist/safe.js",
+			"default": "./dist/safe.js"
 		}
 	},
 	"scripts": {
@@ -74,11 +84,12 @@
 		{
 			"name": "@arkenv/core",
 			"path": "dist/index.js",
-			"limit": "2.9 kB",
+			"limit": "2.6 kB",
 			"import": "*",
 			"ignore": [
 				"arktype"
 			]
 		}
-	]
+	],
+	"sideEffects": false
 }

--- a/packages/core/src/arkenv.ts
+++ b/packages/core/src/arkenv.ts
@@ -93,7 +93,7 @@ export type ArkEnvConfig = {
 
 	/**
 	 * Reserved for call-site compat. Pass `false` or omit.
-	 * Use `tryArkenv` from `@arkenv/core/safe` instead of `{ safe: true }`.
+	 * Use `arkenv` from `@arkenv/core/safe` instead of `{ safe: true }`.
 	 *
 	 * @default false
 	 */
@@ -119,10 +119,10 @@ type SchemaCaptureBag = {
 /**
  * Record `def` on the CLI schema-capture bag if capture is active.
  *
- * Shared by `arkenv` and `tryArkenv` so CLI schema inspection keeps working
- * after migrating off `{ safe: true }`.
+ * Shared by `arkenv` (throw path and `@arkenv/core/safe`) so CLI schema
+ * inspection keeps working after migrating off `{ safe: true }`.
  *
- * @param def The schema definition passed to `arkenv()` / `tryArkenv()`
+ * @param def The schema definition passed to `arkenv()`
  * @returns `true` when capture consumed the call
  */
 export function recordIfCapturing(def: unknown): boolean {

--- a/packages/core/src/arkenv.ts
+++ b/packages/core/src/arkenv.ts
@@ -119,10 +119,13 @@ type SchemaCaptureBag = {
 /**
  * Record `def` on the CLI schema-capture bag if capture is active.
  *
- * @param def The schema definition passed to `arkenv()`
+ * Shared by `arkenv` and `tryArkenv` so CLI schema inspection keeps working
+ * after migrating off `{ safe: true }`.
+ *
+ * @param def The schema definition passed to `arkenv()` / `tryArkenv()`
  * @returns `true` when capture consumed the call
  */
-function recordIfCapturing(def: unknown): boolean {
+export function recordIfCapturing(def: unknown): boolean {
 	const state = (
 		globalThis as typeof globalThis & {
 			[SCHEMA_CAPTURE_KEY]?: SchemaCaptureBag;

--- a/packages/core/src/arkenv.ts
+++ b/packages/core/src/arkenv.ts
@@ -123,9 +123,11 @@ type SchemaCaptureBag = {
  * @returns `true` when capture consumed the call
  */
 function recordIfCapturing(def: unknown): boolean {
-	const state = (globalThis as typeof globalThis & {
-		[SCHEMA_CAPTURE_KEY]?: SchemaCaptureBag;
-	})[SCHEMA_CAPTURE_KEY];
+	const state = (
+		globalThis as typeof globalThis & {
+			[SCHEMA_CAPTURE_KEY]?: SchemaCaptureBag;
+		}
+	)[SCHEMA_CAPTURE_KEY];
 	if (!state?.capturing) {
 		return false;
 	}

--- a/packages/core/src/arkenv.ts
+++ b/packages/core/src/arkenv.ts
@@ -5,13 +5,7 @@ import type {
 	SchemaShape,
 	StandardSchemaV1,
 } from "@repo/types";
-import {
-	ArkEnvError,
-	isCapturingSchema,
-	recordSchemaCapture,
-	type SafeArkEnvResult,
-	safeExecute,
-} from "@repo/utils";
+import type { SafeArkEnvResult } from "@repo/utils";
 import type { type as at, distill, Type } from "arktype";
 import { parse } from "./arktype";
 
@@ -98,13 +92,12 @@ export type ArkEnvConfig = {
 	emptyAsUndefined?: boolean;
 
 	/**
-	 * Whether to return a safe result object instead of throwing an error on validation failure.
-	 *
-	 * When enabled, the function returns an object with `{ success: true, data }` or `{ success: false, issues }`.
+	 * Reserved for call-site compat. Pass `false` or omit.
+	 * Use `tryArkenv` from `@arkenv/core/safe` instead of `{ safe: true }`.
 	 *
 	 * @default false
 	 */
-	safe?: boolean;
+	safe?: false;
 };
 
 export type { SafeArkEnvResult };
@@ -116,56 +109,58 @@ export type ArkenvOutput<T extends SchemaShape, D> =
 	| distill.Out<at.infer<T, $>>
 	| InferType<D>;
 
+const SCHEMA_CAPTURE_KEY = Symbol.for("arkenv.schemaCapture.v1");
+
+type SchemaCaptureBag = {
+	capturing: boolean;
+	definitions: unknown[];
+};
+
+/**
+ * Record `def` on the CLI schema-capture bag if capture is active.
+ *
+ * @param def The schema definition passed to `arkenv()`
+ * @returns `true` when capture consumed the call
+ */
+function recordIfCapturing(def: unknown): boolean {
+	const state = (globalThis as typeof globalThis & {
+		[SCHEMA_CAPTURE_KEY]?: SchemaCaptureBag;
+	})[SCHEMA_CAPTURE_KEY];
+	if (!state?.capturing) {
+		return false;
+	}
+	state.definitions.push(def);
+	return true;
+}
+
 /**
  * Parse and validate environment variables using ArkType or Standard Schema.
  *
  * @param def The schema definition
  * @param config The evaluation configuration
- * @returns The parsed environment variables, a SafeArkEnvResult if `{ safe: true }` is configured, or a value-less stub when schema capture is active
- * @throws An {@link ArkEnvError | error} if the environment variables are invalid and `safe` is not enabled
+ * @returns The parsed environment variables, or a value-less stub when schema capture is active
+ * @throws An ArkEnvError if the environment variables are invalid
  */
 export function arkenv<const T extends SchemaShape>(
 	def: EnvSchema<T>,
-	config?: ArkEnvConfig & { safe?: false },
+	config?: ArkEnvConfig,
 ): distill.Out<at.infer<T, $>>;
 export function arkenv<T extends CompiledEnvSchema>(
 	def: T,
-	config?: ArkEnvConfig & { safe?: false },
+	config?: ArkEnvConfig,
 ): InferType<T>;
 export function arkenv<
 	const T extends SchemaShape,
 	const D extends EnvSchema<T> | CompiledEnvSchema,
->(def: D, config?: ArkEnvConfig & { safe?: false }): ArkenvOutput<T, D>;
-export function arkenv<const T extends SchemaShape>(
-	def: EnvSchema<T>,
-	config: ArkEnvConfig & { safe: true },
-): SafeArkEnvResult<distill.Out<at.infer<T, $>>>;
-export function arkenv<T extends CompiledEnvSchema>(
-	def: T,
-	config: ArkEnvConfig & { safe: true },
-): SafeArkEnvResult<InferType<T>>;
+>(def: D, config?: ArkEnvConfig): ArkenvOutput<T, D>;
 export function arkenv<
 	const T extends SchemaShape,
 	const D extends EnvSchema<T> | CompiledEnvSchema,
->(
-	def: D,
-	config: ArkEnvConfig & { safe: true },
-): SafeArkEnvResult<ArkenvOutput<T, D>>;
-export function arkenv<
-	const T extends SchemaShape,
-	const D extends EnvSchema<T> | CompiledEnvSchema,
->(
-	def: D,
-	config: ArkEnvConfig = {},
-): ArkenvOutput<T, D> | SafeArkEnvResult<ArkenvOutput<T, D>> {
-	if (isCapturingSchema()) {
-		recordSchemaCapture(def);
+>(def: D, config: ArkEnvConfig = {}): ArkenvOutput<T, D> {
+	if (recordIfCapturing(def)) {
 		// Capture records the schema only. The returned object has no values, so
 		// schema modules must stay declarative and must not require env at module scope.
 		return {} as ArkenvOutput<T, D>;
-	}
-	if (config.safe) {
-		return safeExecute(() => parse(def as any, config));
 	}
 	// biome-ignore lint/suspicious/noExplicitAny: parse handles both EnvSchema<T> and CompiledEnvSchema at runtime
 	return parse(def as any, config);

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -1,7 +1,7 @@
 import { safeStringify, shouldRedact } from "@repo/utils";
 import { describe, expect, it } from "vitest";
-import { ArkEnvError, type EnvIssue, formatIssues } from "@";
-import { arkenv } from "./arkenv";
+import { ArkEnvError } from "@";
+import { type EnvIssue, formatIssues } from "./issues";
 
 describe("shouldRedact", () => {
 	it("should detect sensitive keys", () => {
@@ -84,7 +84,7 @@ describe("formatIssues", () => {
 	});
 });
 
-describe("ArkEnvError & arkenv safe mode", () => {
+describe("ArkEnvError", () => {
 	it("should create error and store issues", () => {
 		const issues: EnvIssue[] = [
 			{
@@ -97,29 +97,5 @@ describe("ArkEnvError & arkenv safe mode", () => {
 		const error = new ArkEnvError(issues);
 		expect(error.issues).toEqual(issues);
 		expect(error.name).toBe("ArkEnvError");
-	});
-
-	it("should run arkenv safely", () => {
-		const result = arkenv(
-			{ PORT: "number" },
-			{ safe: true, env: { PORT: "3000" } },
-		);
-		expect(result.success).toBe(true);
-		if (result.success) {
-			expect(result.data).toEqual({ PORT: 3000 });
-		}
-	});
-
-	it("should return failure for arkenv safe mode with invalid input", () => {
-		const result = arkenv(
-			{ PORT: "number" },
-			{ safe: true, env: { PORT: "abc" } },
-		);
-		expect(result.success).toBe(false);
-		if (!result.success) {
-			expect(result.issues).toBeDefined();
-			expect(result.issues.length).toBe(1);
-			expect(result.issues[0].path).toBe("PORT");
-		}
 	});
 });

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -57,6 +57,12 @@ describe("index.ts exports", () => {
 		).toThrow();
 	});
 
+	it("does not re-export formatIssues or getSchemaKeys from the main barrel", async () => {
+		const mod = await import(".");
+		expect("formatIssues" in mod).toBe(false);
+		expect("getSchemaKeys" in mod).toBe(false);
+	});
+
 	it("should have same behavior for both default and named imports", () => {
 		// Set test environment variable
 		vi.stubEnv("COMPARISON_TEST", "same-value");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,15 +1,9 @@
 import { $ } from "@repo/scope";
-import {
-	ArkEnvError,
-	type EnvIssue,
-	formatIssues,
-	getSchemaKeys,
-} from "@repo/utils";
+import { ArkEnvError } from "@repo/utils";
 import type { Scope } from "arktype";
 import { arkenv } from "./arkenv";
 
-export type { EnvIssue };
-export { ArkEnvError, arkenv, formatIssues, getSchemaKeys };
+export { ArkEnvError, arkenv };
 /**
  * Like ArkType's `type`, but with ArkEnv's extra keywords, such as:
  *

--- a/packages/core/src/issues.ts
+++ b/packages/core/src/issues.ts
@@ -1,0 +1,7 @@
+export {
+	type EnvIssue,
+	type EnvIssueCode,
+	type EnvIssueMeta,
+	formatIssues,
+	getSchemaKeys,
+} from "@repo/utils";

--- a/packages/core/src/safe.test.ts
+++ b/packages/core/src/safe.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { tryArkenv } from "./safe";
+
+describe("tryArkenv", () => {
+	it("should run arkenv safely", () => {
+		const result = tryArkenv(
+			{ PORT: "number" },
+			{ env: { PORT: "3000" } },
+		);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toEqual({ PORT: 3000 });
+		}
+	});
+
+	it("should return failure with invalid input", () => {
+		const result = tryArkenv(
+			{ PORT: "number" },
+			{ env: { PORT: "abc" } },
+		);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.issues).toBeDefined();
+			expect(result.issues.length).toBe(1);
+			expect(result.issues[0].path).toBe("PORT");
+		}
+	});
+});

--- a/packages/core/src/safe.test.ts
+++ b/packages/core/src/safe.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from "vitest";
+import {
+	beginSchemaCapture,
+	endSchemaCapture,
+	isCapturingSchema,
+} from "@repo/utils";
+import { afterEach, describe, expect, it } from "vitest";
 import { tryArkenv } from "./safe";
 
 describe("tryArkenv", () => {
+	afterEach(() => {
+		endSchemaCapture();
+	});
+
 	it("should run arkenv safely", () => {
 		const result = tryArkenv({ PORT: "number" }, { env: { PORT: "3000" } });
 		expect(result.success).toBe(true);
@@ -18,5 +27,24 @@ describe("tryArkenv", () => {
 			expect(result.issues.length).toBe(1);
 			expect(result.issues[0].path).toBe("PORT");
 		}
+	});
+
+	it("records the schema during CLI capture without validating env", () => {
+		beginSchemaCapture();
+		const result = tryArkenv(
+			{ DATABASE_URL: "string", PORT: "number = 3000" },
+			{ env: {} },
+		);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toEqual({});
+		}
+		expect(isCapturingSchema()).toBe(true);
+		expect(endSchemaCapture()).toEqual([
+			{
+				DATABASE_URL: "string",
+				PORT: "number = 3000",
+			},
+		]);
 	});
 });

--- a/packages/core/src/safe.test.ts
+++ b/packages/core/src/safe.test.ts
@@ -3,10 +3,7 @@ import { tryArkenv } from "./safe";
 
 describe("tryArkenv", () => {
 	it("should run arkenv safely", () => {
-		const result = tryArkenv(
-			{ PORT: "number" },
-			{ env: { PORT: "3000" } },
-		);
+		const result = tryArkenv({ PORT: "number" }, { env: { PORT: "3000" } });
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data).toEqual({ PORT: 3000 });
@@ -14,10 +11,7 @@ describe("tryArkenv", () => {
 	});
 
 	it("should return failure with invalid input", () => {
-		const result = tryArkenv(
-			{ PORT: "number" },
-			{ env: { PORT: "abc" } },
-		);
+		const result = tryArkenv({ PORT: "number" }, { env: { PORT: "abc" } });
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(result.issues).toBeDefined();

--- a/packages/core/src/safe.test.ts
+++ b/packages/core/src/safe.test.ts
@@ -4,15 +4,19 @@ import {
 	isCapturingSchema,
 } from "@repo/utils";
 import { afterEach, describe, expect, it } from "vitest";
-import { tryArkenv } from "./safe";
+import arkenv, { arkenv as namedArkenv } from "./safe";
 
-describe("tryArkenv", () => {
+describe("arkenv from @arkenv/core/safe", () => {
 	afterEach(() => {
 		endSchemaCapture();
 	});
 
+	it("exports the same function as default and named", () => {
+		expect(arkenv).toBe(namedArkenv);
+	});
+
 	it("should run arkenv safely", () => {
-		const result = tryArkenv({ PORT: "number" }, { env: { PORT: "3000" } });
+		const result = arkenv({ PORT: "number" }, { env: { PORT: "3000" } });
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data).toEqual({ PORT: 3000 });
@@ -20,7 +24,7 @@ describe("tryArkenv", () => {
 	});
 
 	it("should return failure with invalid input", () => {
-		const result = tryArkenv({ PORT: "number" }, { env: { PORT: "abc" } });
+		const result = arkenv({ PORT: "number" }, { env: { PORT: "abc" } });
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(result.issues).toBeDefined();
@@ -31,7 +35,7 @@ describe("tryArkenv", () => {
 
 	it("records the schema during CLI capture without validating env", () => {
 		beginSchemaCapture();
-		const result = tryArkenv(
+		const result = arkenv(
 			{ DATABASE_URL: "string", PORT: "number = 3000" },
 			{ env: {} },
 		);

--- a/packages/core/src/safe.ts
+++ b/packages/core/src/safe.ts
@@ -3,6 +3,7 @@ import type { CompiledEnvSchema, InferType, SchemaShape } from "@repo/types";
 import { type SafeArkEnvResult, safeExecute } from "@repo/utils";
 import type { type as at, distill } from "arktype";
 import type { ArkEnvConfig, ArkenvOutput, EnvSchema } from "./arkenv";
+import { recordIfCapturing } from "./arkenv";
 import { parse } from "./arktype";
 
 export type { SafeArkEnvResult };
@@ -11,6 +12,10 @@ type TryArkenvConfig = Omit<ArkEnvConfig, "safe">;
 
 /**
  * Parse environment variables and return a result object instead of throwing.
+ *
+ * While CLI schema capture is active, records `def` and returns a stub
+ * `{ success: true, data: {} }` without validating the environment — same
+ * handshake as `arkenv()`.
  *
  * @param def The schema definition
  * @param config The evaluation configuration
@@ -31,7 +36,15 @@ export function tryArkenv<
 export function tryArkenv<
 	const T extends SchemaShape,
 	const D extends EnvSchema<T> | CompiledEnvSchema,
->(def: D, config: TryArkenvConfig = {}): SafeArkEnvResult<ArkenvOutput<T, D>> {
+>(
+	def: D,
+	config: TryArkenvConfig = {},
+): SafeArkEnvResult<ArkenvOutput<T, D>> {
+	if (recordIfCapturing(def)) {
+		// Capture records the schema only. Stub data has no values, so schema
+		// modules must stay declarative and must not require env at module scope.
+		return { success: true, data: {} as ArkenvOutput<T, D> };
+	}
 	// biome-ignore lint/suspicious/noExplicitAny: parse handles both EnvSchema<T> and CompiledEnvSchema at runtime
 	return safeExecute(() => parse(def as any, config));
 }

--- a/packages/core/src/safe.ts
+++ b/packages/core/src/safe.ts
@@ -1,0 +1,44 @@
+import type { $ } from "@repo/scope";
+import type { CompiledEnvSchema, InferType, SchemaShape } from "@repo/types";
+import { type SafeArkEnvResult, safeExecute } from "@repo/utils";
+import type { type as at, distill } from "arktype";
+import type {
+	ArkEnvConfig,
+	ArkenvOutput,
+	EnvSchema,
+} from "./arkenv";
+import { parse } from "./arktype";
+
+export type { SafeArkEnvResult };
+
+type TryArkenvConfig = Omit<ArkEnvConfig, "safe">;
+
+/**
+ * Parse environment variables and return a result object instead of throwing.
+ *
+ * @param def The schema definition
+ * @param config The evaluation configuration
+ * @returns `{ success: true, data }` or `{ success: false, issues }`
+ */
+export function tryArkenv<const T extends SchemaShape>(
+	def: EnvSchema<T>,
+	config?: TryArkenvConfig,
+): SafeArkEnvResult<distill.Out<at.infer<T, $>>>;
+export function tryArkenv<T extends CompiledEnvSchema>(
+	def: T,
+	config?: TryArkenvConfig,
+): SafeArkEnvResult<InferType<T>>;
+export function tryArkenv<
+	const T extends SchemaShape,
+	const D extends EnvSchema<T> | CompiledEnvSchema,
+>(def: D, config?: TryArkenvConfig): SafeArkEnvResult<ArkenvOutput<T, D>>;
+export function tryArkenv<
+	const T extends SchemaShape,
+	const D extends EnvSchema<T> | CompiledEnvSchema,
+>(
+	def: D,
+	config: TryArkenvConfig = {},
+): SafeArkEnvResult<ArkenvOutput<T, D>> {
+	// biome-ignore lint/suspicious/noExplicitAny: parse handles both EnvSchema<T> and CompiledEnvSchema at runtime
+	return safeExecute(() => parse(def as any, config));
+}

--- a/packages/core/src/safe.ts
+++ b/packages/core/src/safe.ts
@@ -36,10 +36,7 @@ export function tryArkenv<
 export function tryArkenv<
 	const T extends SchemaShape,
 	const D extends EnvSchema<T> | CompiledEnvSchema,
->(
-	def: D,
-	config: TryArkenvConfig = {},
-): SafeArkEnvResult<ArkenvOutput<T, D>> {
+>(def: D, config: TryArkenvConfig = {}): SafeArkEnvResult<ArkenvOutput<T, D>> {
 	if (recordIfCapturing(def)) {
 		// Capture records the schema only. Stub data has no values, so schema
 		// modules must stay declarative and must not require env at module scope.

--- a/packages/core/src/safe.ts
+++ b/packages/core/src/safe.ts
@@ -2,11 +2,7 @@ import type { $ } from "@repo/scope";
 import type { CompiledEnvSchema, InferType, SchemaShape } from "@repo/types";
 import { type SafeArkEnvResult, safeExecute } from "@repo/utils";
 import type { type as at, distill } from "arktype";
-import type {
-	ArkEnvConfig,
-	ArkenvOutput,
-	EnvSchema,
-} from "./arkenv";
+import type { ArkEnvConfig, ArkenvOutput, EnvSchema } from "./arkenv";
 import { parse } from "./arktype";
 
 export type { SafeArkEnvResult };
@@ -35,10 +31,7 @@ export function tryArkenv<
 export function tryArkenv<
 	const T extends SchemaShape,
 	const D extends EnvSchema<T> | CompiledEnvSchema,
->(
-	def: D,
-	config: TryArkenvConfig = {},
-): SafeArkEnvResult<ArkenvOutput<T, D>> {
+>(def: D, config: TryArkenvConfig = {}): SafeArkEnvResult<ArkenvOutput<T, D>> {
 	// biome-ignore lint/suspicious/noExplicitAny: parse handles both EnvSchema<T> and CompiledEnvSchema at runtime
 	return safeExecute(() => parse(def as any, config));
 }

--- a/packages/core/src/safe.ts
+++ b/packages/core/src/safe.ts
@@ -8,35 +8,49 @@ import { parse } from "./arktype";
 
 export type { SafeArkEnvResult };
 
-type TryArkenvConfig = Omit<ArkEnvConfig, "safe">;
+type SafeArkenvConfig = Omit<ArkEnvConfig, "safe">;
 
 /**
  * Parse environment variables and return a result object instead of throwing.
  *
  * While CLI schema capture is active, records `def` and returns a stub
  * `{ success: true, data: {} }` without validating the environment — same
- * handshake as `arkenv()`.
+ * handshake as `arkenv()` from `@arkenv/core`.
  *
  * @param def The schema definition
  * @param config The evaluation configuration
  * @returns `{ success: true, data }` or `{ success: false, issues }`
+ *
+ * @example
+ * ```ts
+ * import arkenv from "@arkenv/core/safe";
+ *
+ * const result = arkenv(
+ *   { PORT: "number.port" },
+ *   { env: { PORT: "invalid" } },
+ * );
+ *
+ * if (!result.success) {
+ *   console.error(result.issues);
+ * }
+ * ```
  */
-export function tryArkenv<const T extends SchemaShape>(
+export function arkenv<const T extends SchemaShape>(
 	def: EnvSchema<T>,
-	config?: TryArkenvConfig,
+	config?: SafeArkenvConfig,
 ): SafeArkEnvResult<distill.Out<at.infer<T, $>>>;
-export function tryArkenv<T extends CompiledEnvSchema>(
+export function arkenv<T extends CompiledEnvSchema>(
 	def: T,
-	config?: TryArkenvConfig,
+	config?: SafeArkenvConfig,
 ): SafeArkEnvResult<InferType<T>>;
-export function tryArkenv<
+export function arkenv<
 	const T extends SchemaShape,
 	const D extends EnvSchema<T> | CompiledEnvSchema,
->(def: D, config?: TryArkenvConfig): SafeArkEnvResult<ArkenvOutput<T, D>>;
-export function tryArkenv<
+>(def: D, config?: SafeArkenvConfig): SafeArkEnvResult<ArkenvOutput<T, D>>;
+export function arkenv<
 	const T extends SchemaShape,
 	const D extends EnvSchema<T> | CompiledEnvSchema,
->(def: D, config: TryArkenvConfig = {}): SafeArkEnvResult<ArkenvOutput<T, D>> {
+>(def: D, config: SafeArkenvConfig = {}): SafeArkEnvResult<ArkenvOutput<T, D>> {
 	if (recordIfCapturing(def)) {
 		// Capture records the schema only. Stub data has no values, so schema
 		// modules must stay declarative and must not require env at module scope.
@@ -45,3 +59,5 @@ export function tryArkenv<
 	// biome-ignore lint/suspicious/noExplicitAny: parse handles both EnvSchema<T> and CompiledEnvSchema at runtime
 	return safeExecute(() => parse(def as any, config));
 }
+
+export default arkenv;

--- a/packages/core/src/standard-mode.test.ts
+++ b/packages/core/src/standard-mode.test.ts
@@ -1,4 +1,5 @@
 import { ArkEnvError, arkenv } from "@arkenv/standard";
+import arkenvSafe from "@arkenv/standard/safe";
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 
 // Mock Standard Schema validators for testing
@@ -486,7 +487,7 @@ describe("Standard Mode emptyAsUndefined", () => {
 		}
 	});
 
-	it("should support arkenv({ safe: true }) standard mode API", () => {
+	it("should support arkenv from @arkenv/standard/safe", () => {
 		const mockZodValidator = {
 			"~standard": {
 				version: 1 as const,
@@ -509,22 +510,22 @@ describe("Standard Mode emptyAsUndefined", () => {
 			},
 		};
 
-		const resultSuccess = arkenv(
+		const resultSuccess = arkenvSafe(
 			{
 				PORT: mockZodValidator,
 			},
-			{ safe: true, env: { PORT: "3000" } },
+			{ env: { PORT: "3000" } },
 		);
 		expect(resultSuccess.success).toBe(true);
 		if (resultSuccess.success) {
 			expect(resultSuccess.data).toEqual({ PORT: "3000" });
 		}
 
-		const resultFail = arkenv(
+		const resultFail = arkenvSafe(
 			{
 				PORT: mockZodValidator,
 			},
-			{ safe: true, env: {} },
+			{ env: {} },
 		);
 		expect(resultFail.success).toBe(false);
 		if (!resultFail.success) {

--- a/packages/core/test/dist.test.ts
+++ b/packages/core/test/dist.test.ts
@@ -193,10 +193,7 @@ describe("Distribution Built Outputs", () => {
 			const safe = await import("../dist/safe.js");
 			expect(typeof safe.arkenv).toBe("function");
 			expect(safe.default).toBe(safe.arkenv);
-			const result = safe.arkenv(
-				{ PORT: "number" },
-				{ env: { PORT: "3000" } },
-			);
+			const result = safe.arkenv({ PORT: "number" }, { env: { PORT: "3000" } });
 			expect(result.success).toBe(true);
 		});
 

--- a/packages/core/test/dist.test.ts
+++ b/packages/core/test/dist.test.ts
@@ -189,10 +189,11 @@ describe("Distribution Built Outputs", () => {
 			expect("getSchemaKeys" in index).toBe(false);
 		});
 
-		it("exports tryArkenv from @arkenv/core/safe", async () => {
+		it("exports arkenv from @arkenv/core/safe as default and named", async () => {
 			const safe = await import("../dist/safe.js");
-			expect(typeof safe.tryArkenv).toBe("function");
-			const result = safe.tryArkenv(
+			expect(typeof safe.arkenv).toBe("function");
+			expect(safe.default).toBe(safe.arkenv);
+			const result = safe.arkenv(
 				{ PORT: "number" },
 				{ env: { PORT: "3000" } },
 			);

--- a/packages/core/test/dist.test.ts
+++ b/packages/core/test/dist.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it, vi } from "vitest";
@@ -173,6 +173,38 @@ describe("Distribution Built Outputs", () => {
 					PORT: "number.port",
 				});
 			}).toThrow(ArkEnvError);
+		});
+	});
+
+	describe("Subpaths", () => {
+		it("exports formatIssues and getSchemaKeys from @arkenv/core/issues", async () => {
+			const issues = await import("../dist/issues.js");
+			expect(typeof issues.formatIssues).toBe("function");
+			expect(typeof issues.getSchemaKeys).toBe("function");
+		});
+
+		it("does not re-export formatIssues or getSchemaKeys from the main barrel", async () => {
+			const index = await import("../dist/index.js");
+			expect("formatIssues" in index).toBe(false);
+			expect("getSchemaKeys" in index).toBe(false);
+		});
+
+		it("exports tryArkenv from @arkenv/core/safe", async () => {
+			const safe = await import("../dist/safe.js");
+			expect(typeof safe.tryArkenv).toBe("function");
+			const result = safe.tryArkenv(
+				{ PORT: "number" },
+				{ env: { PORT: "3000" } },
+			);
+			expect(result.success).toBe(true);
+		});
+
+		it("keeps schema-capture helpers and safeExecute out of the default chunk", () => {
+			const source = readFileSync(join(__dirname, "../dist/index.js"), "utf8");
+			expect(source).not.toContain("isCapturingSchema");
+			expect(source).not.toContain("recordSchemaCapture");
+			expect(source).not.toContain("beginSchemaCapture");
+			expect(source).not.toContain("safeExecute");
 		});
 	});
 });

--- a/packages/core/test/dist.test.ts
+++ b/packages/core/test/dist.test.ts
@@ -197,12 +197,26 @@ describe("Distribution Built Outputs", () => {
 			expect(result.success).toBe(true);
 		});
 
-		it("keeps schema-capture helpers and safeExecute out of the default chunk", () => {
+		it("does not re-export schema-capture helpers or safeExecute from the default entry", () => {
 			const source = readFileSync(join(__dirname, "../dist/index.js"), "utf8");
 			expect(source).not.toContain("isCapturingSchema");
 			expect(source).not.toContain("recordSchemaCapture");
 			expect(source).not.toContain("beginSchemaCapture");
 			expect(source).not.toContain("safeExecute");
+		});
+
+		it("exports arkenv from @arkenv/standard/safe as default and named", async () => {
+			const safe = await import("../../standard/dist/safe.js");
+			expect(typeof safe.arkenv).toBe("function");
+			expect(safe.default).toBe(safe.arkenv);
+			const mock = {
+				"~standard": {
+					version: 1 as const,
+					validate: (value: unknown) => ({ value }),
+				},
+			};
+			const result = safe.arkenv({ PORT: mock }, { env: { PORT: "3000" } });
+			expect(result.success).toBe(true);
 		});
 	});
 });

--- a/packages/core/test/dist.test.ts
+++ b/packages/core/test/dist.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it, vi } from "vitest";

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	entry: ["src/index.ts"],
+	entry: ["src/index.ts", "src/issues.ts", "src/safe.ts"],
 	format: ["esm"],
 	platform: "node",
 	minify: false,
 	fixedExtension: false,
 	sourcemap: false,
+	splitting: false,
 	deps: {
 		alwaysBundle: ["@repo/scope", "@repo/types", "@repo/utils"],
 		neverBundle: ["arktype", "@ark/util", "@ark/schema", "arkregex"],

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
 	minify: false,
 	fixedExtension: false,
 	sourcemap: false,
-	splitting: false,
 	deps: {
 		alwaysBundle: ["@repo/scope", "@repo/types", "@repo/utils"],
 		neverBundle: ["arktype", "@ark/util", "@ark/schema", "arkregex"],

--- a/packages/internal/utils/src/parse-standard.ts
+++ b/packages/internal/utils/src/parse-standard.ts
@@ -147,13 +147,12 @@ export type ParseStandardConfig = {
 	emptyAsUndefined?: boolean;
 
 	/**
-	 * Whether to return a safe result object instead of throwing an error on validation failure.
-	 *
-	 * When enabled, the function returns an object with `{ success: true, data }` or `{ success: false, issues }`.
+	 * Reserved for call-site compat. Pass `false` or omit.
+	 * Use `arkenv` from `@arkenv/standard/safe` (or `@arkenv/core/safe`) instead of `{ safe: true }`.
 	 *
 	 * @default false
 	 */
-	safe?: boolean;
+	safe?: false;
 };
 
 /**

--- a/packages/nextjs/src/arkenv-internal.ts
+++ b/packages/nextjs/src/arkenv-internal.ts
@@ -177,7 +177,6 @@ export function arkenvInternal(
 
 					const validated = coreArkenv(ext as SchemaShape, {
 						env: combinedEnv as Dict<string>,
-						safe: false,
 					});
 					extendedEnvValues = { ...extendedEnvValues, ...validated };
 
@@ -275,7 +274,6 @@ export function arkenvInternal(
 	// Run core validation
 	const validated = coreArkenv(schema as SchemaShape, {
 		env: combinedEnv as Dict<string>,
-		safe: false,
 	});
 
 	const mergedValidated = { ...extendedEnvValues, ...validated };

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -1,5 +1,6 @@
 import type { EnvSchema, Infer } from "@arkenv/core";
-import { arkenv as coreArkenv, getSchemaKeys } from "@arkenv/core";
+import { arkenv as coreArkenv } from "@arkenv/core";
+import { getSchemaKeys } from "@arkenv/core/issues";
 import type { $ } from "@repo/scope";
 import type { SchemaShape } from "@repo/types";
 import type { type as at, distill } from "arktype";

--- a/packages/nextjs/src/react-server.ts
+++ b/packages/nextjs/src/react-server.ts
@@ -1,5 +1,6 @@
 import type { EnvSchema, Infer } from "@arkenv/core";
-import { arkenv as coreArkenv, getSchemaKeys } from "@arkenv/core";
+import { arkenv as coreArkenv } from "@arkenv/core";
+import { getSchemaKeys } from "@arkenv/core/issues";
 import type { $ } from "@repo/scope";
 import type { SchemaShape } from "@repo/types";
 import type { type as at, distill } from "arktype";

--- a/packages/nextjs/src/validation.test.ts
+++ b/packages/nextjs/src/validation.test.ts
@@ -9,6 +9,7 @@ const testAliases = {
 	"@arkenv/nextjs/config": path.join(nextjsSrc, "config/index.ts"),
 	"@arkenv/nextjs": path.join(nextjsSrc, "index.ts"),
 	"@arkenv/core": path.join(nextjsSrc, "../../core/src/index.ts"),
+	"@arkenv/core/issues": path.join(nextjsSrc, "../../core/src/issues.ts"),
 	"@repo/scope": path.join(nextjsSrc, "../../internal/scope/src/index.ts"),
 	"@repo/types": path.join(nextjsSrc, "../../internal/types/src/index.ts"),
 };

--- a/packages/nuxt/src/boot-gate.ts
+++ b/packages/nuxt/src/boot-gate.ts
@@ -137,7 +137,6 @@ export function applyBootGate(
 	const coreArkenv = resolveCoreArkenv(engine);
 	const coerced = coreArkenv(schema, {
 		env: combinedEnv as Dict<string>,
-		safe: false,
 	});
 
 	applyCoercedToRuntimeConfig(runtimeConfig, coerced, publicKeys);

--- a/packages/nuxt/src/resolve-core-arkenv.ts
+++ b/packages/nuxt/src/resolve-core-arkenv.ts
@@ -3,7 +3,7 @@ import { createJiti } from "jiti";
 
 type CoreArkenv = (
 	schema: SchemaShape,
-	config?: { env?: Dict<string>; safe?: boolean },
+	config?: { env?: Dict<string>; safe?: false },
 ) => Record<string, unknown>;
 
 /**

--- a/packages/nuxt/src/validate-schema.ts
+++ b/packages/nuxt/src/validate-schema.ts
@@ -32,6 +32,5 @@ export function validateSchema(
 	const coreArkenv = resolveCoreArkenv(engine);
 	coreArkenv(schema, {
 		env: (typeof process !== "undefined" ? process.env : {}) as Dict<string>,
-		safe: false,
 	});
 }

--- a/packages/nuxt/src/validation.test.ts
+++ b/packages/nuxt/src/validation.test.ts
@@ -10,6 +10,7 @@ const testAliases = {
 	"@arkenv/nuxt/config": path.join(nuxtSrc, "config.ts"),
 	"@arkenv/nuxt": path.join(nuxtSrc, "index.ts"),
 	"@arkenv/core": path.join(coreSrc, "index.ts"),
+	"@arkenv/core/issues": path.join(coreSrc, "issues.ts"),
 	"@repo/scope": path.join(nuxtSrc, "../../internal/scope/src/index.ts"),
 	"@repo/types": path.join(nuxtSrc, "../../internal/types/src/index.ts"),
 	"#imports": path.join(nuxtSrc, "mock-imports.ts"),

--- a/packages/standard/package.json
+++ b/packages/standard/package.json
@@ -12,6 +12,11 @@
 			"import": "./dist/index.js",
 			"default": "./dist/index.js"
 		},
+		"./safe": {
+			"types": "./dist/safe.d.ts",
+			"import": "./dist/safe.js",
+			"default": "./dist/safe.js"
+		},
 		"./valibot": {
 			"types": "./dist/valibot.d.ts",
 			"import": "./dist/valibot.js",

--- a/packages/standard/src/bind-arkenv.ts
+++ b/packages/standard/src/bind-arkenv.ts
@@ -14,10 +14,10 @@ type BoundArkEnv = typeof createArkEnv;
 export function bindArkEnv(
 	defaultToJsonSchema: NonNullable<StandardEnvConfig["toJsonSchema"]>,
 ): BoundArkEnv {
-	function boundArkEnv<
-		const T extends Record<string, StandardSchemaV1>,
-		const Safe extends boolean | undefined = undefined,
-	>(def: T, config?: Omit<StandardEnvConfig, "safe"> & { safe?: Safe }) {
+	function boundArkEnv<const T extends Record<string, StandardSchemaV1>>(
+		def: T,
+		config?: StandardEnvConfig,
+	) {
 		return createArkEnv(def, {
 			...config,
 			toJsonSchema: config?.toJsonSchema ?? defaultToJsonSchema,

--- a/packages/standard/src/index.ts
+++ b/packages/standard/src/index.ts
@@ -12,7 +12,6 @@ import {
 	parseStandard,
 	recordSchemaCapture,
 	type SafeArkEnvResult,
-	safeExecute,
 } from "@repo/utils";
 
 export {
@@ -25,8 +24,19 @@ export {
 
 /**
  * Configuration options for `arkenv` from `@arkenv/standard`.
+ *
+ * `safe` is reserved for call-site compat — pass `false` or omit. Use
+ * `arkenv` from `@arkenv/standard/safe` for a result object.
  */
-export type StandardEnvConfig = ParseStandardConfig;
+export type StandardEnvConfig = Omit<ParseStandardConfig, "safe"> & {
+	/**
+	 * Reserved for call-site compat. Pass `false` or omit.
+	 * Use `arkenv` from `@arkenv/standard/safe` instead of `{ safe: true }`.
+	 *
+	 * @default false
+	 */
+	safe?: false;
+};
 
 type StandardEnvOutput<T extends Record<string, StandardSchemaV1>> = {
 	[K in keyof T]: StandardSchemaV1.InferOutput<T[K]>;
@@ -40,8 +50,8 @@ type StandardEnvOutput<T extends Record<string, StandardSchemaV1>> = {
  *
  * @param def An object mapping variable names to Standard Schema validators
  * @param config Optional configuration
- * @returns The validated environment variables, a SafeArkEnvResult if `{ safe: true }` is configured, or a value-less stub when schema capture is active
- * @throws An {@link ArkEnvError} if validation fails and `safe` is not enabled
+ * @returns The validated environment variables, or a value-less stub when schema capture is active
+ * @throws An {@link ArkEnvError} if validation fails
  *
  * @example
  * ```ts
@@ -54,15 +64,10 @@ type StandardEnvOutput<T extends Record<string, StandardSchemaV1>> = {
  * });
  * ```
  */
-export function arkenv<
-	const T extends Record<string, StandardSchemaV1>,
-	const Safe extends boolean | undefined = undefined,
->(
+export function arkenv<const T extends Record<string, StandardSchemaV1>>(
 	def: T,
-	config?: Omit<StandardEnvConfig, "safe"> & { safe?: Safe },
-): [Safe] extends [true]
-	? SafeArkEnvResult<StandardEnvOutput<T>>
-	: StandardEnvOutput<T> {
+	config?: StandardEnvConfig,
+): StandardEnvOutput<T> {
 	const resolved = (config ?? {}) as StandardEnvConfig;
 	assertStandardSchemaMap(def);
 
@@ -76,28 +81,13 @@ export function arkenv<
 		recordSchemaCapture(def);
 		// Capture records the schema only. The returned object has no values, so
 		// schema modules must stay declarative and must not require env at module scope.
-		return {} as [Safe] extends [true]
-			? SafeArkEnvResult<StandardEnvOutput<T>>
-			: StandardEnvOutput<T>;
+		return {} as StandardEnvOutput<T>;
 	}
 
-	if (resolved.safe) {
-		return safeExecute(
-			() =>
-				parseStandard(
-					def as Record<string, unknown>,
-					resolved,
-				) as StandardEnvOutput<T>,
-		) as [Safe] extends [true]
-			? SafeArkEnvResult<StandardEnvOutput<T>>
-			: StandardEnvOutput<T>;
-	}
-
-	return parseStandard(def as Record<string, unknown>, resolved) as [
-		Safe,
-	] extends [true]
-		? SafeArkEnvResult<StandardEnvOutput<T>>
-		: StandardEnvOutput<T>;
+	return parseStandard(
+		def as Record<string, unknown>,
+		resolved,
+	) as StandardEnvOutput<T>;
 }
 
 export default arkenv;

--- a/packages/standard/src/safe.test.ts
+++ b/packages/standard/src/safe.test.ts
@@ -1,0 +1,56 @@
+import {
+	beginSchemaCapture,
+	endSchemaCapture,
+	isCapturingSchema,
+} from "@repo/utils";
+import { afterEach, describe, expect, it } from "vitest";
+import arkenv, { arkenv as namedArkenv } from "./safe";
+
+const mockString = {
+	"~standard": {
+		version: 1 as const,
+		vendor: "mock",
+		validate: (value: unknown) =>
+			typeof value === "string"
+				? { value }
+				: { issues: [{ message: "Expected string" }] },
+	},
+};
+
+describe("arkenv from @arkenv/standard/safe", () => {
+	afterEach(() => {
+		endSchemaCapture();
+	});
+
+	it("exports the same function as default and named", () => {
+		expect(arkenv).toBe(namedArkenv);
+	});
+
+	it("should run arkenv safely", () => {
+		const result = arkenv({ PORT: mockString }, { env: { PORT: "3000" } });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toEqual({ PORT: "3000" });
+		}
+	});
+
+	it("should return failure with invalid input", () => {
+		const result = arkenv({ PORT: mockString }, { env: {} });
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.issues).toBeDefined();
+			expect(result.issues.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("records the schema during CLI capture without validating env", () => {
+		beginSchemaCapture();
+		const result = arkenv({ DATABASE_URL: mockString }, { env: {} });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toEqual({});
+		}
+		expect(isCapturingSchema()).toBe(true);
+		expect(endSchemaCapture()).toEqual([{ DATABASE_URL: mockString }]);
+	});
+});

--- a/packages/standard/src/safe.ts
+++ b/packages/standard/src/safe.ts
@@ -1,0 +1,78 @@
+import type { StandardSchemaV1 } from "@repo/types";
+import {
+	assertNotArkTypeDsl,
+	assertStandardSchema,
+	assertStandardSchemaMap,
+	isCapturingSchema,
+	parseStandard,
+	recordSchemaCapture,
+	type SafeArkEnvResult,
+	safeExecute,
+} from "@repo/utils";
+import type { StandardEnvConfig } from "./index";
+
+export type { SafeArkEnvResult };
+
+type SafeStandardEnvConfig = Omit<StandardEnvConfig, "safe">;
+
+type StandardEnvOutput<T extends Record<string, StandardSchemaV1>> = {
+	[K in keyof T]: StandardSchemaV1.InferOutput<T[K]>;
+};
+
+/**
+ * Parse environment variables with Standard Schema validators and return a
+ * result object instead of throwing.
+ *
+ * While CLI schema capture is active, records `def` and returns a stub
+ * `{ success: true, data: {} }` without validating the environment — same
+ * handshake as `arkenv()` from `@arkenv/standard`.
+ *
+ * @param def An object mapping variable names to Standard Schema validators
+ * @param config Optional configuration
+ * @returns `{ success: true, data }` or `{ success: false, issues }`
+ *
+ * @example
+ * ```ts
+ * import arkenv from "@arkenv/standard/safe";
+ * import * as z from "zod";
+ *
+ * const result = arkenv(
+ *   { PORT: z.coerce.number() },
+ *   { env: { PORT: "invalid" } },
+ * );
+ *
+ * if (!result.success) {
+ *   console.error(result.issues);
+ * }
+ * ```
+ */
+export function arkenv<const T extends Record<string, StandardSchemaV1>>(
+	def: T,
+	config?: SafeStandardEnvConfig,
+): SafeArkEnvResult<StandardEnvOutput<T>> {
+	const resolved = (config ?? {}) as SafeStandardEnvConfig;
+	assertStandardSchemaMap(def);
+
+	for (const key in def) {
+		const validator = (def as Record<string, unknown>)[key];
+		assertNotArkTypeDsl(key, validator);
+		assertStandardSchema(key, validator);
+	}
+
+	if (isCapturingSchema()) {
+		recordSchemaCapture(def);
+		// Capture records the schema only. Stub data has no values, so schema
+		// modules must stay declarative and must not require env at module scope.
+		return { success: true, data: {} as StandardEnvOutput<T> };
+	}
+
+	return safeExecute(
+		() =>
+			parseStandard(
+				def as Record<string, unknown>,
+				resolved,
+			) as StandardEnvOutput<T>,
+	);
+}
+
+export default arkenv;

--- a/packages/standard/src/standard-mode.test.ts
+++ b/packages/standard/src/standard-mode.test.ts
@@ -7,6 +7,7 @@ import * as zMini from "zod/mini";
 import { z as z3 } from "zod/v3";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { ArkEnvError, arkenv } from "./index";
+import arkenvSafe from "./safe";
 
 // Mock Standard Schema validators for testing
 const createMockStandardSchema = <TOutput>(outputValue: TOutput) => ({
@@ -1001,7 +1002,7 @@ describe("Standard Mode emptyAsUndefined", () => {
 		}
 	});
 
-	it("should support arkenv({ safe: true }) standard mode API", () => {
+	it("should support arkenv from @arkenv/standard/safe", () => {
 		const mockZodValidator = {
 			"~standard": {
 				version: 1 as const,
@@ -1024,11 +1025,11 @@ describe("Standard Mode emptyAsUndefined", () => {
 			},
 		};
 
-		const resultSuccess = arkenv(
+		const resultSuccess = arkenvSafe(
 			{
 				PORT: mockZodValidator,
 			},
-			{ safe: true, env: { PORT: "3000" } },
+			{ env: { PORT: "3000" } },
 		);
 		expect(resultSuccess.success).toBe(true);
 		if (resultSuccess.success) {
@@ -1036,11 +1037,11 @@ describe("Standard Mode emptyAsUndefined", () => {
 		}
 		expectTypeOf(resultSuccess).toHaveProperty("success");
 
-		const resultFail = arkenv(
+		const resultFail = arkenvSafe(
 			{
 				PORT: mockZodValidator,
 			},
-			{ safe: true, env: {} },
+			{ env: {} },
 		);
 		expect(resultFail.success).toBe(false);
 		if (!resultFail.success) {

--- a/packages/standard/src/valibot.ts
+++ b/packages/standard/src/valibot.ts
@@ -19,8 +19,8 @@ const valibotToJsonSchema: NonNullable<StandardEnvConfig["toJsonSchema"]> = (
  *
  * @param def An object mapping variable names to Valibot schemas
  * @param config Optional configuration. Pass `toJsonSchema` to override the bound converter
- * @returns The validated environment variables, or a SafeArkEnvResult if `{ safe: true }` is configured
- * @throws An {@link ArkEnvError} if validation fails and `safe` is not enabled
+ * @returns The validated environment variables
+ * @throws An {@link ArkEnvError} if validation fails
  *
  * @example
  * ```ts

--- a/packages/standard/src/zod-mini.ts
+++ b/packages/standard/src/zod-mini.ts
@@ -20,8 +20,8 @@ const zodMiniToJsonSchema: NonNullable<StandardEnvConfig["toJsonSchema"]> = (
  *
  * @param def An object mapping variable names to Zod Mini schemas
  * @param config Optional configuration. Pass `toJsonSchema` to override the bound converter
- * @returns The validated environment variables, or a SafeArkEnvResult if `{ safe: true }` is configured
- * @throws An {@link ArkEnvError} if validation fails and `safe` is not enabled
+ * @returns The validated environment variables
+ * @throws An {@link ArkEnvError} if validation fails
  *
  * @example
  * ```ts

--- a/packages/standard/tsdown.config.ts
+++ b/packages/standard/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	entry: ["src/index.ts", "src/valibot.ts", "src/zod-mini.ts"],
+	entry: ["src/index.ts", "src/safe.ts", "src/valibot.ts", "src/zod-mini.ts"],
 	format: ["esm"],
 	minify: true,
 	fixedExtension: false,


### PR DESCRIPTION
Fixes #1759

Default `@arkenv/core` import is the throw path only. Issue helpers moved to `@arkenv/core/issues`; throw-free parsing is `arkenv` from `@arkenv/core/safe` (default + named). Schema capture is an inline `Symbol.for("arkenv.schemaCapture.v1")` probe so the CLI helper module stays out of the default chunk. `"sideEffects": false` is set on `@arkenv/core`.

`@arkenv/standard` mirrors the same split: main entry throws only (`safe?: false`); throw-free is `@arkenv/standard/safe`. Both packages get a `major` changeset.

## Size
size-limit (`import "*"`, arktype ignored, minified + brotli): **~2.49 kB** (limit lowered 2.9 → **2.6 kB**). Target was ~2.4–2.5 kB. Redaction, coercion, and keywords stay on the default export.

## API
```ts
import arkenv from "@arkenv/core";
import { formatIssues, getSchemaKeys } from "@arkenv/core/issues";
import arkenv from "@arkenv/core/safe"; // throw-free (default === named)

import arkenv from "@arkenv/standard";
import arkenv from "@arkenv/standard/safe"; // throw-free
```

Next.js imports `getSchemaKeys` from `@arkenv/core/issues`. Next/Nuxt drop redundant `safe: false`.

## Test plan
- [x] `@arkenv/core` vitest (237 passed) + typecheck
- [x] `@arkenv/standard` vitest (45 passed) + typecheck
- [x] `@arkenv/nextjs` vitest (51 passed) + typecheck
- [x] `@arkenv/nuxt` vitest (50 passed)
- [x] CLI vitest (416 passed)
- [x] size-limit ~2.49 kB / 2.6 kB
- [x] `/safe` capture handshake + default===named (core + standard)
- [ ] CI on this PR