### PR TITLE
docs: drive examples page from registry.json

### DIFF
--- a/apps/www/components/docs/example-cards.tsx
+++ b/apps/www/components/docs/example-cards.tsx
@@ -1,0 +1,39 @@
+import { Card, Cards } from "fumadocs-ui/components/card";
+import { getGithubRepoUrl } from "~/lib/github-links";
+import registry from "../../../../examples/registry.json";
+
+type Example = {
+	id: string;
+	name: string;
+	description?: string;
+	framework: string;
+};
+
+const examples = (registry as { examples: Example[] }).examples;
+
+function exampleTreeUrl(id: string): string {
+	const ref =
+		process.env.VERCEL_GIT_COMMIT_REF ??
+		process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF ??
+		"main";
+	return `${getGithubRepoUrl()}/tree/${encodeURIComponent(ref)}/examples/${id}`;
+}
+
+/**
+ * Renders the Getting Started example cards from `examples/registry.json`
+ * so the docs site and `arkenv init --example` share one source of truth.
+ */
+export function ExampleCards() {
+	return (
+		<Cards>
+			{examples.map((example) => (
+				<Card
+					key={example.id}
+					href={exampleTreeUrl(example.id)}
+					title={example.id}
+					description={example.description ?? example.name}
+				/>
+			))}
+		</Cards>
+	);
+}

--- a/apps/www/components/docs/example-cards.tsx
+++ b/apps/www/components/docs/example-cards.tsx
@@ -1,5 +1,6 @@
 import { Card, Cards } from "fumadocs-ui/components/card";
 import { getGithubRepoUrl } from "~/lib/github-links";
+import { breakDownGithubUrl } from "~/lib/utils/github";
 import registry from "../../../../examples/registry.json";
 
 type Example = {
@@ -12,11 +13,8 @@ type Example = {
 const examples = (registry as { examples: Example[] }).examples;
 
 function exampleTreeUrl(id: string): string {
-	const ref =
-		process.env.VERCEL_GIT_COMMIT_REF ??
-		process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF ??
-		"main";
-	return `${getGithubRepoUrl()}/tree/${encodeURIComponent(ref)}/examples/${id}`;
+	const { defaultBranch } = breakDownGithubUrl();
+	return `${getGithubRepoUrl()}/tree/${encodeURIComponent(defaultBranch)}/examples/${id}`;
 }
 
 /**

--- a/apps/www/content/docs/getting-started/examples.mdx
+++ b/apps/www/content/docs/getting-started/examples.mdx
@@ -20,35 +20,7 @@ Run it in an **empty directory**, or pass `--force` to overwrite.
 
 The following examples can be bootstrapped with the CLI. Just use the `--example <example-name>` flag with the corresponding name.
 
-<Cards>
-  <Card href="https://github.com/yamcodes/arkenv/tree/v1/examples/basic" title="basic" description="Minimal Node.js app with ArkType." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/v1/examples/basic-js" title="basic-js" description="Minimal Node.js app in plain JavaScript (runtime validates without TypeScript)." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-zod" title="with-zod" description="Node.js with @arkenv/standard and Zod." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-valibot" title="with-valibot" description="Node.js with @arkenv/standard and Valibot." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/mix-and-match" title="mix-and-match" description="Mixing ArkType, Zod, and Valibot in @arkenv/core." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nextjs" title="with-nextjs" description="Next.js with withArkEnv." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nextjs-zod" title="with-nextjs-zod" description="Next.js with @arkenv/nextjs/standard and Zod." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-nuxt" title="with-nuxt" description="Nuxt with @arkenv/nuxt." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-vite-react" title="with-vite-react" description="Vite + React with @arkenv/vite-plugin." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-vite-react-zod" title="with-vite-react-zod" description="Vite + React with @arkenv/vite-plugin/standard and Zod." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/v1/examples/with-tanstack-start" title="with-tanstack-start" description="TanStack Start with @arkenv/vite-plugin." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/v1/examples/with-solid-start" title="with-solid-start" description="SolidStart with @arkenv/vite-plugin." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-bun" title="with-bun" description="Minimal Bun runtime project." />
-
-  <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-bun-react" title="with-bun-react" description="Bun fullstack + React with @arkenv/bun-plugin." />
-</Cards>
+<ExampleCards />
 
 For a more manual approach, you can clone an example and run it locally using `degit`:
 

--- a/apps/www/content/docs/getting-started/examples.mdx
+++ b/apps/www/content/docs/getting-started/examples.mdx
@@ -41,6 +41,10 @@ The following examples can be bootstrapped with the CLI. Just use the `--example
 
   <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-vite-react-zod" title="with-vite-react-zod" description="Vite + React with @arkenv/vite-plugin/standard and Zod." />
 
+  <Card href="https://github.com/yamcodes/arkenv/tree/v1/examples/with-tanstack-start" title="with-tanstack-start" description="TanStack Start with @arkenv/vite-plugin." />
+
+  <Card href="https://github.com/yamcodes/arkenv/tree/v1/examples/with-solid-start" title="with-solid-start" description="SolidStart with @arkenv/vite-plugin." />
+
   <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-bun" title="with-bun" description="Minimal Bun runtime project." />
 
   <Card href="https://github.com/yamcodes/arkenv/tree/main/examples/with-bun-react" title="with-bun-react" description="Bun fullstack + React with @arkenv/bun-plugin." />

--- a/apps/www/mdx-components.tsx
+++ b/apps/www/mdx-components.tsx
@@ -19,6 +19,7 @@ import { Card, Cards } from "fumadocs-ui/components/card";
 import { File, Files, Folder } from "fumadocs-ui/components/files";
 import type { MDXComponents } from "mdx/types";
 import { type ComponentProps, createElement, isValidElement } from "react";
+import { ExampleCards } from "~/components/docs/example-cards";
 import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/cn";
 
@@ -63,6 +64,7 @@ export function getMDXComponents(components: MDXComponents): MDXComponents {
 		AutoTypeTable,
 		TypeTable,
 		Cards,
+		ExampleCards,
 		Files,
 		Folder,
 		File,

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -37,6 +37,18 @@
 			"framework": "vite"
 		},
 		{
+			"id": "with-tanstack-start",
+			"name": "TanStack Start",
+			"description": "TanStack Start with @arkenv/vite-plugin",
+			"framework": "vite"
+		},
+		{
+			"id": "with-solid-start",
+			"name": "SolidStart",
+			"description": "SolidStart with @arkenv/vite-plugin",
+			"framework": "vite"
+		},
+		{
 			"id": "with-bun",
 			"name": "Bun (Vanilla)",
 			"description": "Minimal Bun project with ArkType",

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -7,6 +7,12 @@
 			"framework": "vanilla"
 		},
 		{
+			"id": "basic-js",
+			"name": "Basic (JavaScript)",
+			"description": "Minimal Node.js app in plain JavaScript (runtime validates without TypeScript)",
+			"framework": "vanilla"
+		},
+		{
 			"id": "with-nextjs",
 			"name": "Next.js",
 			"description": "Minimal Next.js project with ArkType",


### PR DESCRIPTION
## Summary
- Drive `/docs/getting-started/examples` from `examples/registry.json` via a shared `<ExampleCards />` component — one source of truth for the docs site and `arkenv init --example`.
- Register `with-tanstack-start`, `with-solid-start`, and `basic-js` in the registry (they existed on disk / on the old hardcoded page but were missing from the registry).

## Why
#1773 shipped the TanStack Start example + Frameworks guide, but the Getting Started examples page used a hardcoded `<Cards>` list, so the example never appeared there. Updating the registry alone wouldn't have fixed the site either — it only fed the CLI. This makes the registry the single list both surfaces use.

## Test plan
- [ ] Preview www: `/docs/getting-started/examples` renders cards for every registry entry, including TanStack Start and SolidStart
- [ ] Card titles are example ids (what you pass to `--example`); descriptions match registry copy
- [ ] GitHub card links point at the deploy branch's `examples/<id>` tree
- [ ] Adding/removing an entry in `examples/registry.json` is enough to change the docs list (no MDX card edits)
