### PR TITLE
chore: drop ADR/meta-decision language from public JSDoc

### DIFF
--- a/packages/arkenv/src/features/scaffold/presets.ts
+++ b/packages/arkenv/src/features/scaffold/presets.ts
@@ -1,9 +1,5 @@
 /**
  * Codegen IR for a single hosting-preset field.
- *
- * @remarks See `docs/adr/0018-cli-hosting-preset-field-metadata.md` (ADR 0018).
- * Do not grow this union without an explicit decision - prefer JSON Schema subset
- * or richer dialect rendering if more field kinds are needed.
  */
 export type PresetField =
 	| { readonly type: "string" }

--- a/packages/build/src/generate-client-env-module.ts
+++ b/packages/build/src/generate-client-env-module.ts
@@ -3,9 +3,7 @@ import { boundaryAccessErrorMessage } from "@repo/utils/boundary-access-error";
 /**
  * Build the client-graph replacement module: inlined coerced literals + server-key guards.
  *
- * No validator import is emitted. See ADR 0021 (env-object canonical surface) —
- * contributors must not reintroduce `env.gen.ts`, client-side re-validation, or
- * `runtimeEnv` wiring on hosts that own their transform.
+ * No validator import is emitted.
  *
  * @param clientValues Coerced values for client and shared keys
  * @param serverKeys Server-only keys that must throw when read on the client

--- a/packages/build/src/transform-options.ts
+++ b/packages/build/src/transform-options.ts
@@ -16,8 +16,6 @@ export const TRANSFORM_OPTION_KEYS = new Set([
 
 /**
  * Options for the env-module transform mode.
- *
- * @see docs/adr/0021-env-object-canonical-surface.md — transform design
  */
 export type TransformOptions = {
 	/**

--- a/packages/bun-plugin/src/plugin.ts
+++ b/packages/bun-plugin/src/plugin.ts
@@ -15,10 +15,6 @@ const { arkenvPlugin: arkenvPluginInstance, hybrid: hybridObj } =
  *
  * @param options Transform options (`schemaPath`, `clientPrefix`) plus ArkEnv/logging config
  * @returns The Bun plugin instance
- *
- * @remarks
- * ADR 0021: env.ts is the canonical surface. Do not add `env.gen.ts` codegen,
- * client-side re-validation, or a schema/`define` signature on this host.
  */
 export const arkenvPlugin: ((options?: BunPluginFactoryConfig) => BunPlugin) &
 	BunPlugin = arkenvPluginInstance;

--- a/packages/bun-plugin/src/standard.ts
+++ b/packages/bun-plugin/src/standard.ts
@@ -15,10 +15,6 @@ const { arkenvPlugin: arkenvPluginInstance, hybrid: hybridObj } =
  *
  * @param options Transform options (`schemaPath`, `clientPrefix`) plus ArkEnv/logging config
  * @returns The Bun plugin instance
- *
- * @remarks
- * ADR 0021: env.ts is the canonical surface. Do not add `env.gen.ts` codegen,
- * client-side re-validation, or a schema/`define` signature on this host.
  */
 export const arkenvPlugin: ((options?: BunPluginFactoryConfig) => BunPlugin) &
 	BunPlugin = arkenvPluginInstance;

--- a/packages/bun-plugin/src/transform-plugin.ts
+++ b/packages/bun-plugin/src/transform-plugin.ts
@@ -101,9 +101,6 @@ export function createTransformPlugin(
 			 * Rewrite the env module in browser bundles only.
 			 *
 			 * @remarks
-			 * ADR 0021 (canonical env object surface): do not reintroduce `env.gen.ts`
-			 * codegen, client-side re-validation, or `runtimeEnv` wiring here.
-			 *
 			 * Dev-server refresh: `onStart` re-validates on each `Bun.build` /
 			 * `[serve.static]` rebuild. Bun does not expose a Vite-style
 			 * `handleHotUpdate` hook, so editing `.env` / `env.ts` during an

--- a/packages/fumadocs-ui/src/components/drill-in-sidebar.tsx
+++ b/packages/fumadocs-ui/src/components/drill-in-sidebar.tsx
@@ -551,7 +551,7 @@ function DrillInTree() {
 }
 
 /**
- * Mobile Sidebar Tree: root Sections expand in place (ADR 0026).
+ * Mobile Sidebar Tree: root Sections expand in place.
  * Title → Overview; chevron toggles; Nested Folder / Separator / Leaf unchanged.
  */
 function AccordionSection({
@@ -730,7 +730,7 @@ function DrillInNav({ className }: { className?: string }) {
 			data-docs-sidebar-tree=""
 			className={cn(
 				/* Inline pad is --site-nav-gutter in docs-chrome.css (equal
-				 * gutters; pill left stays on the helm). Do not add Tailwind ps-*. */
+				 * gutters; pill left stays on the helm). */
 				"flex w-full flex-col gap-0.5 pt-12 pb-4",
 				className,
 			)}
@@ -741,7 +741,7 @@ function DrillInNav({ className }: { className?: string }) {
 }
 
 /**
- * Desktop drill-in rail + mobile Sidebar Tree drawer (ADR 0022 / 0026).
+ * Desktop drill-in rail + mobile Sidebar Tree drawer.
  *
  * @see drillInSidebarSlots
  */

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -14,10 +14,6 @@ const arkenvCreator = createVitePlugin("@arkenv/vite-plugin");
  *
  * @param options Transform options (`schemaPath`, `clientPrefix`) plus ArkEnv/logging config
  * @returns The Vite plugin instance
- *
- * @remarks
- * ADR 0021: env.ts is the canonical surface. Do not add `env.gen.ts` codegen,
- * client-side re-validation, or a schema/`define` signature on this host.
  */
 export function arkenvPlugin(options?: VitePluginFactoryConfig): Plugin {
 	return arkenvCreator(options);

--- a/packages/vite-plugin/src/standard.ts
+++ b/packages/vite-plugin/src/standard.ts
@@ -14,10 +14,6 @@ const arkenvCreator = createVitePlugin("@arkenv/vite-plugin/standard");
  *
  * @param options Transform options (`schemaPath`, `clientPrefix`) plus ArkEnv/logging config
  * @returns The Vite plugin instance
- *
- * @remarks
- * ADR 0021: env.ts is the canonical surface. Do not add `env.gen.ts` codegen,
- * client-side re-validation, or a schema/`define` signature on this host.
  */
 export function arkenvPlugin(options?: VitePluginFactoryConfig): Plugin {
 	return arkenvCreator(options);

--- a/packages/vite-plugin/src/transform-plugin.ts
+++ b/packages/vite-plugin/src/transform-plugin.ts
@@ -133,9 +133,6 @@ export function createTransformPlugin(
 		 * everything else gets the client rewrite. On Vite 4/5, where
 		 * `this.environment` is undefined, the legacy `options.ssr` flag is used
 		 * as a fallback.
-		 *
-		 * ADR 0021 (canonical env object surface): do not reintroduce `env.gen.ts`
-		 * codegen, client-side re-validation, or `runtimeEnv` wiring here.
 		 */
 		transform(_code, id, options) {
 			const isServer = this.environment


### PR DESCRIPTION
## Summary
Full sweep of JSDoc / package docs comments on `v1` for meta-decision language (ADR citations, “do not add X”, maintainer process prose). Those belong in `docs/adr`; public API comments keep what the symbol does, params, returns, and useful behavioral remarks.

**10 files**, **~12 sites cleaned** (comment-only; no behavior changes).

### Files touched
- `packages/vite-plugin/src/index.ts`
- `packages/vite-plugin/src/standard.ts`
- `packages/vite-plugin/src/transform-plugin.ts`
- `packages/bun-plugin/src/plugin.ts`
- `packages/bun-plugin/src/standard.ts`
- `packages/bun-plugin/src/transform-plugin.ts`
- `packages/build/src/generate-client-env-module.ts`
- `packages/build/src/transform-options.ts`
- `packages/arkenv/src/features/scaffold/presets.ts`
- `packages/fumadocs-ui/src/components/drill-in-sidebar.tsx`

### Sample before/after (ADR 0021 — `packages/vite-plugin/src/index.ts`)

**Before:**
```ts
/**
 * Create a Vite plugin that rewrites `env.ts` in the client graph.
 *
 * @param options Transform options (`schemaPath`, `clientPrefix`) plus ArkEnv/logging config
 * @returns The Vite plugin instance
 *
 * @remarks
 * ADR 0021: env.ts is the canonical surface. Do not add `env.gen.ts` codegen,
 * client-side re-validation, or a schema/`define` signature on this host.
 */
```

**After:**
```ts
/**
 * Create a Vite plugin that rewrites `env.ts` in the client graph.
 *
 * @param options Transform options (`schemaPath`, `clientPrefix`) plus ArkEnv/logging config
 * @returns The Vite plugin instance
 */
```

Same ADR `@remarks` block removed from `vite-plugin`/`bun-plugin` `standard.ts` + `plugin.ts` entrypoints. Mixed blocks kept useful behavior (Vite Environment API / Bun `onStart` refresh / “No validator import is emitted”) and dropped only the ADR / “do not reintroduce” paragraphs.

### Classification (kept vs stripped)

| Hit | Action |
|-----|--------|
| Vite/Bun plugin entry `@remarks` ADR 0021 | **Strip** entire remarks |
| Vite/Bun `transform-plugin` ADR paragraph | **Strip** ADR; **keep** Environment API / Bun refresh notes |
| `generate-client-env-module` ADR + “contributors must not…” | **Strip** meta; **keep** “No validator import is emitted” |
| `transform-options` `@see docs/adr/0021…` | **Strip** |
| `presets.ts` ADR 0018 + “Do not grow this union…” | **Strip** entire remarks |
| fumadocs-ui `(ADR 0022/0026)` + “Do not add Tailwind ps-*” | **Strip** cites / prohibition; **keep** descriptive text |
| CLI host-preset UI hint “Do not add any hosting-specific…” | **Keep** (user-facing copy, not JSDoc) |
| Next.js `env.gen.ts` API docs | **Keep** (describes real codegen feature) |
| `intentionally ignore missing file` / reserved `-e` | **Keep** (behavior) |
| Test regression comments, CSS ADR in `apps/www`, MDX, ADR markdown files | **Keep / out of scope** |

## Test plan
- [ ] Diff review: comments only; no logic/runtime changes
- [ ] Spot-check public plugin exports still document params/returns
- [ ] Confirm ADR files under `docs/adr` untouched