### PR TITLE
docs(tanstack-start): lean field-report DX fixes

### DIFF
--- a/apps/playgrounds/tanstack-start/README.md
+++ b/apps/playgrounds/tanstack-start/README.md
@@ -14,19 +14,25 @@ import arkenv from "@arkenv/core";
 
 export const env = arkenv({
   DATABASE_URL: "string = 'postgres://localhost:5432/tanstackstart'",
-  VITE_APP_NAME: "string = 'ArkEnv + TanStack Start'",
-  VITE_APP_RELEASE: "string = 'local'",
+  PORT: "number.port = 3000",
+  VITE_API_URL: "string = 'https://api.example.com'",
   NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });
 ```
 
 ```ts title="vite.config.ts"
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import viteReact from "@vitejs/plugin-react";
 import arkenvVitePlugin from "@arkenv/vite-plugin";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [tanstackStart({ srcDirectory: "src" }), arkenvVitePlugin()],
+  plugins: [
+    tanstackStart({ srcDirectory: "src" }),
+    // React's Vite plugin must come after Start's plugin
+    viteReact(),
+    arkenvVitePlugin(),
+  ],
 });
 ```
 
@@ -40,7 +46,7 @@ const readDatabaseUrl = createServerFn({ method: "GET" }).handler(() => {
   return env.DATABASE_URL; // server-only: real value, validated at boot
 });
 
-env.VITE_APP_NAME; // string (inlined on the client)
+env.VITE_API_URL; // string (inlined on the client)
 env.DATABASE_URL; // throws in the browser; works in SSR and server functions
 ```
 

--- a/apps/playgrounds/tanstack-start/package.json
+++ b/apps/playgrounds/tanstack-start/package.json
@@ -22,10 +22,10 @@
 		"react-dom": "catalog:"
 	},
 	"devDependencies": {
-		"@vitejs/plugin-react": "catalog:",
 		"@types/node": "catalog:",
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",
+		"@vitejs/plugin-react": "catalog:",
 		"rimraf": "catalog:",
 		"typescript": "catalog:",
 		"vite": "8.0.10"

--- a/apps/playgrounds/tanstack-start/package.json
+++ b/apps/playgrounds/tanstack-start/package.json
@@ -22,6 +22,7 @@
 		"react-dom": "catalog:"
 	},
 	"devDependencies": {
+		"@vitejs/plugin-react": "catalog:",
 		"@types/node": "catalog:",
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",

--- a/apps/playgrounds/tanstack-start/src/env.ts
+++ b/apps/playgrounds/tanstack-start/src/env.ts
@@ -5,7 +5,7 @@ import arkenv from "@arkenv/core";
  */
 export const env = arkenv({
 	DATABASE_URL: "string = 'postgres://localhost:5432/tanstackstart'",
-	VITE_APP_NAME: "string = 'ArkEnv + TanStack Start'",
-	VITE_APP_RELEASE: "string = 'local'",
+	PORT: "number.port = 3000",
+	VITE_API_URL: "string = 'https://api.example.com'",
 	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });

--- a/apps/playgrounds/tanstack-start/src/routes/index.tsx
+++ b/apps/playgrounds/tanstack-start/src/routes/index.tsx
@@ -28,11 +28,8 @@ function Home() {
 
 	return (
 		<main style={{ fontFamily: "system-ui, sans-serif", padding: "2rem" }}>
-			<h1>{env.VITE_APP_NAME}</h1>
-			<p>
-				Public key inlined into the client bundle: {env.VITE_APP_NAME} (release{" "}
-				{env.VITE_APP_RELEASE})
-			</p>
+			<h1>API: {env.VITE_API_URL}</h1>
+			<p>Public key inlined into the client bundle: {env.VITE_API_URL}</p>
 			<p>Database host loaded through createServerFn: {dbHost}</p>
 			<button
 				type="button"

--- a/apps/playgrounds/tanstack-start/vite.config.ts
+++ b/apps/playgrounds/tanstack-start/vite.config.ts
@@ -1,10 +1,16 @@
 import arkenvVitePlugin from "@arkenv/vite-plugin";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import viteReact from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
 	server: {
 		port: 3000,
 	},
-	plugins: [tanstackStart({ srcDirectory: "src" }), arkenvVitePlugin()],
+	plugins: [
+		tanstackStart({ srcDirectory: "src" }),
+		// React's Vite plugin must come after Start's plugin
+		viteReact(),
+		arkenvVitePlugin(),
+	],
 });

--- a/apps/www/content/docs/frameworks/tanstack-start.mdx
+++ b/apps/www/content/docs/frameworks/tanstack-start.mdx
@@ -11,16 +11,30 @@ functions, and throws if client code reads them.
 For high-level architectural trade-offs, see
 [Frameworks](/docs/frameworks).
 
+:::warning[`arkenv` is CLI-only — import `@arkenv/core`]
+Runtime validation lives in `@arkenv/core` (ArkType) or `@arkenv/standard`
+(Zod/Valibot). The `arkenv` package on npm is the interactive CLI only.
+`import arkenv from "arkenv"` throws and points you at `@arkenv/core`.
+See [`init` reference](/docs/reference/init#import-the-validator-from-core).
+:::
+
 ## Quickstart
 
-Scaffold TanStack Start integration in an existing project using the CLI:
+Scaffold TanStack Start integration in an existing project:
 
-```package-install
-npx arkenv init
+```bash title="Terminal"
+pnpm dlx arkenv@alpha init
 ```
+
+Use the runner that matches your lockfile. Init detects the package manager for installs.
 
 The CLI detects `@tanstack/react-start` in your dependencies and installs
 `@arkenv/vite-plugin` the same way it does for Vite projects.
+
+:::info[Pinning alphas]
+Until GA, pin exact `@arkenv/*` alpha versions in the lockfile if you want
+bit-for-bit reproducibility across machines and CI.
+:::
 
 ## Manual installation
 
@@ -47,24 +61,34 @@ npm install -D @arkenv/vite-plugin
 
 ## Configuration
 
-Register the plugin next to `tanstackStart()` in your `vite.config.ts`.
+Register the plugin next to `tanstackStart()` and `@vitejs/plugin-react` in
+your `vite.config.ts`.
 
 ### Register the plugin
 
-Add `arkenvVitePlugin()` to the same `plugins` array as the TanStack Start
-plugin:
+TanStack Start's React recipe expects `viteReact()` after `tanstackStart()`
+(for JSX / Fast Refresh). Add `arkenvVitePlugin()` to the same `plugins`
+array:
 
 ```ts title="./vite.config.ts"
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import viteReact from "@vitejs/plugin-react";
 import arkenvVitePlugin from "@arkenv/vite-plugin";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [tanstackStart({ srcDirectory: "src" }), arkenvVitePlugin()],
+  plugins: [
+    tanstackStart({ srcDirectory: "src" }),
+    // React's Vite plugin must come after Start's plugin
+    viteReact(),
+    arkenvVitePlugin(),
+  ],
 });
 ```
 
-If you aren't using ArkType, import the plugin from `@arkenv/vite-plugin/standard`.
+Install `@vitejs/plugin-react` if it is not already a dependency. If you
+aren't using ArkType, import the ArkEnv plugin from
+`@arkenv/vite-plugin/standard`.
 
 ### Define your schema
 
@@ -76,10 +100,17 @@ import arkenv from "@arkenv/core";
 
 export const env = arkenv({
   DATABASE_URL: "string",
-  VITE_APP_NAME: "string = 'My App'",
+  PORT: "number.port = 3000",
+  VITE_API_URL: "string = 'https://api.example.com'",
   NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });
 ```
+
+:::tip[Pass the schema as an object literal]
+Pass the object literal into `arkenv({ ... })`, or wrap a shared shape with
+`type(...)` from `@arkenv/core`. An untyped intermediate object can break
+overload inference.
+:::
 
 ## Server functions and client access
 
@@ -112,7 +143,7 @@ function Home() {
 
   return (
     <div>
-      <h1>{env.VITE_APP_NAME}</h1>
+      <h1>API: {env.VITE_API_URL}</h1>
       <p>Database Host: {dbHost}</p>
     </div>
   );
@@ -132,7 +163,7 @@ typed and coerced and server secrets stay out of the client bundle.
 Reading a server-only key in the browser throws instead of leaking:
 
 ```tsx
-env.VITE_APP_NAME; // string, inlined into the client bundle
+env.VITE_API_URL; // string, inlined into the client bundle
 env.DATABASE_URL; // throws in the browser; real value on the server
 ```
 

--- a/apps/www/content/docs/frameworks/vite.mdx
+++ b/apps/www/content/docs/frameworks/vite.mdx
@@ -65,7 +65,7 @@ If you aren't using ArkType, import the plugin from `@arkenv/vite-plugin/standar
 
 ### Define your schema
 
-Create an `env.ts` file in your source tree:
+Create an `env.ts` file in your source tree. Import from `@arkenv/core` (or `@arkenv/standard`); the `arkenv` package is CLI-only:
 
 ```ts title="./env.ts" twoslash
 import arkenv from "@arkenv/core";

--- a/examples/with-tanstack-start/README.md
+++ b/examples/with-tanstack-start/README.md
@@ -14,19 +14,25 @@ import arkenv from "@arkenv/core";
 
 export const env = arkenv({
   DATABASE_URL: "string = 'postgres://localhost:5432/tanstackstart'",
-  VITE_APP_NAME: "string = 'ArkEnv + TanStack Start'",
-  VITE_APP_RELEASE: "string = 'local'",
+  PORT: "number.port = 3000",
+  VITE_API_URL: "string = 'https://api.example.com'",
   NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });
 ```
 
 ```ts title="vite.config.ts"
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import viteReact from "@vitejs/plugin-react";
 import arkenvVitePlugin from "@arkenv/vite-plugin";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [tanstackStart({ srcDirectory: "src" }), arkenvVitePlugin()],
+  plugins: [
+    tanstackStart({ srcDirectory: "src" }),
+    // React's Vite plugin must come after Start's plugin
+    viteReact(),
+    arkenvVitePlugin(),
+  ],
 });
 ```
 
@@ -40,7 +46,7 @@ const readDatabaseUrl = createServerFn({ method: "GET" }).handler(() => {
   return env.DATABASE_URL; // server-only: real value, validated at boot
 });
 
-env.VITE_APP_NAME; // string (inlined on the client)
+env.VITE_API_URL; // string (inlined on the client)
 env.DATABASE_URL; // throws in the browser; works in SSR and server functions
 ```
 

--- a/examples/with-tanstack-start/package.json
+++ b/examples/with-tanstack-start/package.json
@@ -21,10 +21,10 @@
 		"react-dom": "^19.2.5"
 	},
 	"devDependencies": {
-		"@vitejs/plugin-react": "^6.0.1",
 		"@types/node": "^24.12.2",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
+		"@vitejs/plugin-react": "^6.0.1",
 		"rimraf": "^6.1.3",
 		"typescript": "^6.0.3",
 		"vite": "8.0.10"

--- a/examples/with-tanstack-start/package.json
+++ b/examples/with-tanstack-start/package.json
@@ -21,6 +21,7 @@
 		"react-dom": "^19.2.5"
 	},
 	"devDependencies": {
+		"@vitejs/plugin-react": "^6.0.1",
 		"@types/node": "^24.12.2",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",

--- a/examples/with-tanstack-start/src/env.ts
+++ b/examples/with-tanstack-start/src/env.ts
@@ -5,7 +5,7 @@ import arkenv from "@arkenv/core";
  */
 export const env = arkenv({
 	DATABASE_URL: "string = 'postgres://localhost:5432/tanstackstart'",
-	VITE_APP_NAME: "string = 'ArkEnv + TanStack Start'",
-	VITE_APP_RELEASE: "string = 'local'",
+	PORT: "number.port = 3000",
+	VITE_API_URL: "string = 'https://api.example.com'",
 	NODE_ENV: "'development' | 'production' | 'test' = 'development'",
 });

--- a/examples/with-tanstack-start/src/routes/index.tsx
+++ b/examples/with-tanstack-start/src/routes/index.tsx
@@ -28,11 +28,8 @@ function Home() {
 
 	return (
 		<main style={{ fontFamily: "system-ui, sans-serif", padding: "2rem" }}>
-			<h1>{env.VITE_APP_NAME}</h1>
-			<p>
-				Public key inlined into the client bundle: {env.VITE_APP_NAME} (release{" "}
-				{env.VITE_APP_RELEASE})
-			</p>
+			<h1>API: {env.VITE_API_URL}</h1>
+			<p>Public key inlined into the client bundle: {env.VITE_API_URL}</p>
 			<p>Database host loaded through createServerFn: {dbHost}</p>
 			<button
 				type="button"

--- a/examples/with-tanstack-start/vite.config.ts
+++ b/examples/with-tanstack-start/vite.config.ts
@@ -1,10 +1,16 @@
 import arkenvVitePlugin from "@arkenv/vite-plugin";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import viteReact from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
 	server: {
 		port: 3000,
 	},
-	plugins: [tanstackStart({ srcDirectory: "src" }), arkenvVitePlugin()],
+	plugins: [
+		tanstackStart({ srcDirectory: "src" }),
+		// React's Vite plugin must come after Start's plugin
+		viteReact(),
+		arkenvVitePlugin(),
+	],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,6 +518,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3


### PR DESCRIPTION
## Summary

Lean TanStack Start docs/DX fixes from a Vite 8 field report (friction was wrong runtime import, missing viteReact, init runner, and schema-literal inference — not Vite 8 support).

- Loud arkenv (CLI-only) vs @arkenv/core / @arkenv/standard callout on the TanStack page; one-line cross-cut on the Vite framework page
- Complete React Start vite.config with viteReact() after tanstackStart(); sync playground + published example deps/config
- Quickstart prefers the project PM runner with arkenv@alpha and notes lockfile-matched runners / PM detection
- Schema-as-literal tip; richer sample schema (DATABASE_URL, PORT/number.port, VITE_API_URL) keeping createServerFn as the server-secret hero
- Optional alpha pin callout (one max)

## Deliberately skipped

- Vite 6 vs 8 peer matrices / pin plugin-react@4 essays / Rolldown / build-ms bragging
- Blog post
- Deep type-system changes for intermediate-object inference
- Wholesale Why ArkEnv / Frameworks marketing rewrites
- SolidStart v2 migration (#1788)
- Package split design changes / unnecessary changesets

## Test plan

- [ ] Preview TanStack Start docs page callouts and code samples
- [ ] Confirm playground/example vite configs match TanStack Start plugin order
