### PR TITLE
fix(www): build @arkenv/nextjs in prebuild and predev scripts

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -4,8 +4,8 @@
 	"private": true,
 	"scripts": {
 		"mdx": "node ./bin/mdx",
-		"prebuild": "pnpm -w build --filter @arkenv/fumadocs-ui && pnpm run mdx",
-		"predev": "pnpm -w build --filter @arkenv/fumadocs-ui && pnpm run mdx",
+		"prebuild": "pnpm -w build --filter @arkenv/fumadocs-ui --filter @arkenv/nextjs && pnpm run mdx",
+		"predev": "pnpm -w build --filter @arkenv/fumadocs-ui --filter @arkenv/nextjs && pnpm run mdx",
 		"build": "node ./bin/build next build",
 		"dev": "next dev",
 		"start": "next start",


### PR DESCRIPTION
## Problem
CI run [33895859444](https://github.com/yamcodes/arkenv/actions/runs/33895859444/job/101098212330) failed during the Vercel preview build step with:
```
Error: Cannot find module '.../apps/www/node_modules/@arkenv/nextjs/dist/config/index.js'
```

When Vercel builds `apps/www` in CI, it runs `pnpm run build` directly inside `apps/www`, which triggers the `prebuild` lifecycle script. Previously, `prebuild` and `predev` only built `@arkenv/fumadocs-ui`. Following commit e1bc82db6 (#1796), `apps/www/next.config.ts` imports `withArkEnv` from `@arkenv/nextjs/config`. In a fresh CI environment where `@arkenv/nextjs` hasn't been built yet, Next.js fails to load `next.config.ts` because the dist directory does not exist.

## Solution
Update `prebuild` and `predev` in `apps/www/package.json` to include `--filter @arkenv/nextjs` so that `@arkenv/nextjs` and its workspace dependencies are built prior to running `bin/mdx.js` and `next build`.

## Verification
- Reproduced `MODULE_NOT_FOUND` error on clean build without dist artifacts.
- Verified `pnpm run build` from `apps/www` passes cleanly from a fresh clean state.
- `pnpm check` passed.
- `pnpm typecheck` passed (30/30 tasks successful).
- `pnpm test -- --run` passed (157 test files, 1328 tests passed).